### PR TITLE
Fix cmake Generate

### DIFF
--- a/examples/cmake/modules/genium/genium/Generate.cmake
+++ b/examples/cmake/modules/genium/genium/Generate.cmake
@@ -153,7 +153,7 @@ function(apigen_generate)
 
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E make_directory ${GENIUM_OUTPUT_DIR} # otherwise java.io.File won't have permissions to create files at configure time
-    COMMAND ${APIGEN_GENIUM_GRADLE_WRAPPER} -Pversion=${apigen_generate_VERSION} run --args="${APIGEN_GENIUM_ARGS}"
+    COMMAND ${APIGEN_GENIUM_GRADLE_WRAPPER} -Pversion=${apigen_generate_VERSION} run --args=${APIGEN_GENIUM_ARGS}
     WORKING_DIRECTORY ${APIGEN_GENIUM_DIR}
     RESULT_VARIABLE GENERATE_RESULT)
   if(NOT "${GENERATE_RESULT}" STREQUAL "0")


### PR DESCRIPTION
When using gradles --arg the arguments must not be escaped in CMake.

This was introduced in genium only when changes to the wrapper were made. The changes need to be backported to genium-cmake separately.