### PR TITLE
Oss review toolkit test exclude

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -1,0 +1,8 @@
+excludes:
+  scopes:
+  - name: "test.*"
+    reason: "TEST_TOOL_OF"
+    comment: "These are dependencies used for testing. They are not distributed in the context of this project."
+  - name: ".*Test.*"
+    reason: "TEST_TOOL_OF"
+    comment: "These are dependencies used for testing. They are not distributed in the context of this project."


### PR DESCRIPTION
Adding settings.gradle to genium-cmake as it's required by oss-review-toolkit and also gradle >= 5.
Also adding standard test excludes for gradle/android project.