### PR TITLE
Update scm URLs for publishing

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -36,8 +36,8 @@ publishing.publications {
                 }
             }
             scm {
-                connection = 'scm:git:git://github.com/heremaps/gluecodium.git'
-                developerConnection = 'scm:git:ssh://github.com/heremaps/gluecodium.git'
+                connection = 'scm:git:https://github.com/heremaps/gluecodium.git'
+                developerConnection = 'scm:git:git@github.com:heremaps/gluecodium.git'
                 url = 'https://github.com/heremaps/gluecodium'
             }
         }


### PR DESCRIPTION
Use https for read access and update write access URL to github format.
