### PR TITLE
Fix JNI conversion include order dependency

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniIncludeResolver.kt
@@ -60,7 +60,10 @@ internal object JniIncludeResolver {
             is LimeMap -> {
                 val templateType = javaType as JavaTemplateTypeRef
                 getConversionIncludes(limeType.keyType, templateType.templateParameters.first()) +
-                    getConversionIncludes(limeType.valueType, templateType.templateParameters.last())
+                        getConversionIncludes(
+                            limeType.valueType,
+                            templateType.templateParameters.last()
+                        )
             }
             else -> emptyList()
         }
@@ -75,7 +78,7 @@ internal object JniIncludeResolver {
 
     private fun collectMethodTypes(jniMethod: JniMethod): List<JniType> {
         return jniMethod.parameters.map { it.type } + jniMethod.returnType +
-            listOfNotNull(jniMethod.exception?.errorType)
+                listOfNotNull(jniMethod.exception?.errorType)
     }
 
     fun createConversionSelfInclude(jniElement: JniTopLevelElement) =
@@ -102,6 +105,5 @@ internal object JniIncludeResolver {
     }
 
     fun collectConversionImplementationIncludes(jniStruct: JniStruct) =
-        jniStruct.fields.map { it.type }.flatMap { it.conversionIncludes } +
-                createConversionSelfInclude(jniStruct)
+        jniStruct.fields.map { it.type }.flatMap { it.conversionIncludes }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -177,9 +177,12 @@ class JniTemplates(
         }
 
     private fun generateInstanceConversionFiles(jniContainer: JniContainer): List<GeneratedFile> {
+        val conversionSelfInclude = JniIncludeResolver.createConversionSelfInclude(jniContainer)
+        val conversionIncludes = JniIncludeResolver.collectImplementationIncludes(jniContainer)
+            .toSet().minus(conversionSelfInclude).sorted()
         val mustacheData = mutableMapOf(
             "model" to jniContainer,
-            INCLUDES_NAME to jniContainer.includes.sorted(),
+            INCLUDES_NAME to jniContainer.includes.sorted() + conversionIncludes,
             "basePackages" to basePackages,
             INTERNAL_PACKAGES_NAME to basePackages + internalPackages,
             INTERNAL_NAMESPACE_NAME to internalNamespace
@@ -192,7 +195,7 @@ class JniTemplates(
             jniNameRules.getHeaderFilePath(fileName)
         )
 
-        val includes = mutableListOf(JniIncludeResolver.createConversionSelfInclude(jniContainer))
+        val includes = mutableListOf(conversionSelfInclude)
         if (jniContainer.containerType == ContainerType.INTERFACE) {
             val proxyFileName =
                 JniNameRules.getJniClassFileName(jniContainer) + JniNameRules.JNI_CPP_PROXY_SUFFIX

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -126,7 +126,8 @@ class JniTemplates(
         jniContainer.structs.flatMap {
             val mustacheData = mutableMapOf(
                 "struct" to it,
-                INCLUDES_NAME to jniContainer.includes.sorted(),
+                INCLUDES_NAME to jniContainer.includes.sorted() +
+                        JniIncludeResolver.collectConversionImplementationIncludes(it),
                 INTERNAL_NAMESPACE_NAME to internalNamespace
             )
 
@@ -138,7 +139,8 @@ class JniTemplates(
             )
 
             mustacheData[INCLUDES_NAME] =
-                JniIncludeResolver.collectConversionImplementationIncludes(it)
+                JniIncludeResolver.collectConversionImplementationIncludes(it) +
+                        JniIncludeResolver.createConversionSelfInclude(it)
             val implFile = generateFile(
                 "jni/StructConversionImplementation",
                 mustacheData,

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android/jni/com_example_package_Class__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android/jni/com_example_package_Class__Conversion.h
@@ -3,6 +3,8 @@
  */
 #pragma once
 #include "package/Class.h"
+#include "com_example_package_Enum__Conversion.h"
+#include "com_example_package_Struct__Conversion.h"
 #include "JniReference.h"
 #include "gluecodium/Optional.h"
 #include <functional>

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android/jni/com_example_package_Struct__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android/jni/com_example_package_Struct__Conversion.h
@@ -3,6 +3,7 @@
  */
 #pragma once
 #include "package/Types.h"
+#include "com_example_package_Enum__Conversion.h"
 #include "JniReference.h"
 #include "gluecodium/Optional.h"
 namespace gluecodium

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Confounder__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Confounder__Conversion.h
@@ -3,6 +3,7 @@
  */
 #pragma once
 #include "smoke/Lambdas.h"
+#include "com_example_smoke_Lambdas_Producer__Conversion.h"
 #include "JniReference.h"
 #include "gluecodium/Optional.h"
 #include <functional>

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListener__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListener__Conversion.h
@@ -3,6 +3,8 @@
  */
 #pragma once
 #include "smoke/CalculatorListener.h"
+#include "com_example_smoke_CalculationResult__Conversion.h"
+#include "com_example_smoke_CalculatorListener_ResultStruct__Conversion.h"
 #include "JniReference.h"
 #include "gluecodium/Optional.h"
 #include <functional>

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_AllTypesStruct__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_AllTypesStruct__Conversion.h
@@ -3,6 +3,7 @@
  */
 #pragma once
 #include "smoke/TypeCollection.h"
+#include "com_example_smoke_Point__Conversion.h"
 #include "JniReference.h"
 #include "gluecodium/Optional.h"
 namespace gluecodium

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_AllTypesStruct__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_AllTypesStruct__Conversion.h
@@ -6,6 +6,7 @@
 #include "foo/Bazz.h"
 #include "non/Sense.h"
 #include "smoke/Structs.h"
+#include "com_example_smoke_Structs_Point__Conversion.h"
 #include "JniReference.h"
 #include "gluecodium/Optional.h"
 namespace gluecodium

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_ExternalStruct__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_ExternalStruct__Conversion.h
@@ -6,6 +6,7 @@
 #include "foo/Bazz.h"
 #include "non/Sense.h"
 #include "smoke/Structs.h"
+#include "com_example_smoke_Structs_AnotherExternalStruct__Conversion.h"
 #include "JniReference.h"
 #include "gluecodium/Optional.h"
 namespace gluecodium


### PR DESCRIPTION
JNI array conversion code relies on all conversion overloads being
visible. This can be easily achieved if all specific headers are
included first before the common headers.
For the case where external genium generated is used, the corresponding
headers need to be included first as well. Simplest solution for this is
to include all dependencies in the conversion headers rather than just
in the implementation file.