### PR TITLE
Add support for class constructors to Dart generator

### DIFF
--- a/examples/libhello/lime/test/Instances.lime
+++ b/examples/libhello/lime/test/Instances.lime
@@ -19,6 +19,7 @@ package test
 
 // Example interface which demonstrates the usage of instances for HelloWorld use case
 class SimpleInstantiableOne {
+    constructor create(value: String)
     fun setStringValue(
         stringValue: String
     )
@@ -26,6 +27,7 @@ class SimpleInstantiableOne {
 }
 
 class SimpleInstantiableTwo {
+    constructor create(value: String)
     fun setStringValue(
         stringValue: String
     )
@@ -33,6 +35,7 @@ class SimpleInstantiableTwo {
 }
 
 class NestedInstantiableOne {
+    constructor create()
     fun setSameTypeInstances(
         instanceOne: SimpleInstantiableOne,
         instanceTwo: SimpleInstantiableOne
@@ -42,6 +45,11 @@ class NestedInstantiableOne {
 }
 
 class NestedInstantiableTwo {
+    constructor proliferate(
+        value1: SimpleInstantiableOne,
+        value2: SimpleInstantiableTwo,
+        value3: NestedInstantiableOne
+    )
     fun setMultipleTypeInstances(
         instanceOne: SimpleInstantiableOne,
         instanceTwo: SimpleInstantiableTwo,

--- a/examples/libhello/src/test/Instances.cpp
+++ b/examples/libhello/src/test/Instances.cpp
@@ -35,6 +35,14 @@ SimpleInstanceOne::get_string_value( )
     return m_value;
 }
 
+std::shared_ptr< SimpleInstantiableOne >
+SimpleInstantiableOne::create( const std::string& value )
+{
+    auto result = std::make_shared< SimpleInstanceOne >( );
+    result->set_string_value( value );
+    return result;
+}
+
 void
 SimpleInstanceTwo::set_string_value( const std::string& string_value )
 {
@@ -45,6 +53,14 @@ std::string
 SimpleInstanceTwo::get_string_value( )
 {
     return m_value;
+}
+
+std::shared_ptr< SimpleInstantiableTwo >
+SimpleInstantiableTwo::create( const std::string& value )
+{
+    auto result = std::make_shared< SimpleInstanceTwo >( );
+    result->set_string_value( value );
+    return result;
 }
 
 void
@@ -66,6 +82,12 @@ std::shared_ptr< SimpleInstantiableOne >
 NestedInstanceOne::get_instance_two( )
 {
     return m_instance_two;
+}
+
+std::shared_ptr< NestedInstantiableOne >
+NestedInstantiableOne::create( )
+{
+    return std::make_shared< NestedInstanceOne >( );
 }
 
 void
@@ -107,6 +129,16 @@ std::shared_ptr< NestedInstantiableOne >
 NestedInstanceTwo::get_nested_instantiable( )
 {
     return m_nested_instance;
+}
+
+std::shared_ptr< NestedInstantiableTwo >
+NestedInstantiableTwo::proliferate( const std::shared_ptr< SimpleInstantiableOne >& value1,
+                                    const std::shared_ptr< SimpleInstantiableTwo >& value2,
+                                    const std::shared_ptr< NestedInstantiableOne >& value3 )
+{
+    auto result = std::make_shared< NestedInstanceTwo >( );
+    result->set_multiple_type_instances( value1, value2, value3 );
+    return result;
 }
 
 }  // namespace test

--- a/examples/platforms/dart/test/Classes_test.dart
+++ b/examples/platforms/dart/test/Classes_test.dart
@@ -26,11 +26,9 @@ final _testSuite = TestSuite("Classes");
 
 void main() {
   _testSuite.test("Set same type instances", () {
-    final input1 = InstancesFactory.createSimpleInstantiableOne();
-    input1.setStringValue("one");
-    final input2 = InstancesFactory.createSimpleInstantiableOne();
-    input2.setStringValue("two");
-    final nested = InstancesFactory.createNestedInstantiableOne();
+    final input1 = SimpleInstantiableOne("one");
+    final input2 = SimpleInstantiableOne("two");
+    final nested = NestedInstantiableOne();
 
     nested.setSameTypeInstances(input1, input2);
     final result1 = nested.getInstanceOne();
@@ -46,9 +44,8 @@ void main() {
     result2.release();
   });
   _testSuite.test("Set same type instances, identical instances", () {
-    final input = InstancesFactory.createSimpleInstantiableOne();
-    input.setStringValue("one");
-    final nested = InstancesFactory.createNestedInstantiableOne();
+    final input = SimpleInstantiableOne("one");
+    final nested = NestedInstantiableOne();
 
     nested.setSameTypeInstances(input, input);
     final result1 = nested.getInstanceOne();
@@ -63,7 +60,7 @@ void main() {
     result2.release();
   });
   _testSuite.test("Get null instances", () {
-    final nested = InstancesFactory.createNestedInstantiableOne();
+    final nested = NestedInstantiableOne();
 
     final result1 = nested.getInstanceOne();
     final result2 = nested.getInstanceTwo();
@@ -74,7 +71,7 @@ void main() {
     nested.release();
   });
   _testSuite.test("Set null instances", () {
-    final nested = InstancesFactory.createNestedInstantiableOne();
+    final nested = NestedInstantiableOne();
 
     nested.setSameTypeInstances(null, null);
     final result1 = nested.getInstanceOne();
@@ -86,17 +83,13 @@ void main() {
     nested.release();
   });
   _testSuite.test("Set multiple type instances", () {
-    final simpleOne1 = InstancesFactory.createSimpleInstantiableOne();
-    final simpleOne2 = InstancesFactory.createSimpleInstantiableOne();
-    final simpleTwo = InstancesFactory.createSimpleInstantiableTwo();
-    final nestedOne = InstancesFactory.createNestedInstantiableOne();
-    final nestedTwo = InstancesFactory.createNestedInstantiableTwo();
-    simpleOne1.setStringValue("one");
-    simpleTwo.setStringValue("two");
-    simpleOne2.setStringValue("other");
+    final simpleOne1 = SimpleInstantiableOne("one");
+    final simpleOne2 = SimpleInstantiableOne("other");
+    final simpleTwo = SimpleInstantiableTwo("two");
+    final nestedOne = NestedInstantiableOne();
+    final nestedTwo = NestedInstantiableTwo(simpleOne1, simpleTwo, nestedOne);
 
     nestedOne.setSameTypeInstances(simpleOne1, simpleOne2);
-    nestedTwo.setMultipleTypeInstances(simpleOne1, simpleTwo, nestedOne);
     final result1 = nestedTwo.getInstantiableOne();
     final result2 = nestedTwo.getInstantiableTwo();
     final result3 = nestedTwo.getNestedInstantiable();
@@ -123,8 +116,7 @@ void main() {
   });
   _testSuite.test("Set self instance", () {
     final nested = InstancesFactory.createNestedInstantiableTwo();
-    final simpleOne = InstancesFactory.createSimpleInstantiableOne();
-    simpleOne.setStringValue("one");
+    final simpleOne = SimpleInstantiableOne("one");
     nested.setMultipleTypeInstances(simpleOne, null, null);
 
     nested.setSelfInstantiable(nested);

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -35,7 +35,11 @@ class {{resolveName visibility}}{{resolveName}} {{!!
 {{#constants}}
 {{prefixPartial "dart/DartConstant" "  "}}
 {{/constants}}
-{{#set parent=this}}{{#functions}}
+{{#set parent=this}}{{#constructors}}
+{{prefixPartial "dart/DartFunctionDocs" "  "}}
+{{prefixPartial "dartConstructor" "  "}}
+{{/constructors}}
+{{#functions}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
 {{prefixPartial "dart/DartFunction" "  "}}
 {{/functions}}{{/set}}
@@ -60,4 +64,9 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) {}
 {{/exceptions}}
 {{#structs}}
 {{>dart/DartStruct}}
-{{/structs}}
+{{/structs}}{{!!
+
+}}{{+dartConstructor}}{{resolveName visibility}}{{resolveName parent}}({{!!
+}}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) : {{!!
+}}this._(_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}));
+{{/dartConstructor}}

--- a/gluecodium/src/main/resources/templates/dart/DartException.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartException.mustache
@@ -1,0 +1,21 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{!! TODO: #85 implement }}

--- a/gluecodium/src/main/resources/templates/dart/DartFunction.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunction.mustache
@@ -26,12 +26,13 @@
   final __result_handle = _{{resolveName}}_ffi({{!!
   }}{{#unless isStatic}}_handle{{#if parameters}}, {{/if}}{{/unless}}{{!!
   }}{{#parameters}}_{{resolveName}}_handle{{#if iter.hasNext}}, {{/if}}{{/parameters}});
-  {{#returnType}}final _result = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
-  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);{{/returnType}}
 {{#parameters}}
   {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle);
 {{/parameters}}
-  return _result;
+  {{#if isConstructor}}return __result_handle;{{/if}}{{#unless isConstructor}}{{!!
+  }}{{#returnType}}final _result = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
+  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);{{/returnType}}
+  return _result;{{/unless}}
 }{{!!
 
 }}{{+ffiApi}}{{resolveName returnType.typeRef "FfiApiTypes"}} Function({{!!

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionSignature.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionSignature.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#if isStatic}}static {{/if}}{{#returnType}}{{#isNotEq typeRef.toString "Void"}}{{resolveName typeRef}} {{/isNotEq}}{{/returnType}}{{!!
-}}{{resolveName visibility}}{{resolveName}}({{>parameterList}}){{!!
-
-}}{{+parameterList}}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{/parameterList}}
+{{#if isStatic}}static {{/if}}{{#if isConstructor}}Pointer<Void> {{/if}}{{!!
+}}{{#unless isConstructor}}{{#returnType}}{{#isNotEq typeRef.toString "Void"}}{{resolveName typeRef}} {{/isNotEq}}{{/returnType}}{{/unless}}{{!!
+}}{{#if isConstructor}}_{{/if}}{{#unless isConstructor}}{{resolveName visibility}}{{/unless}}{{resolveName}}({{!!
+}}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}})

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/BasicTypes.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/BasicTypes.dart
@@ -15,108 +15,108 @@ class BasicTypes {
     final _stringFunction_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_BasicTypes_stringFunction__String');
     final _input_handle = String_toFfi(input);
     final __result_handle = _stringFunction_ffi(_input_handle);
+    String_releaseFfiHandle(_input_handle);
     final _result = String_fromFfi(__result_handle);
     String_releaseFfiHandle(__result_handle);
-    String_releaseFfiHandle(_input_handle);
     return _result;
   }
   static bool boolFunction(bool input) {
     final _boolFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Uint8), int Function(int)>('smoke_BasicTypes_boolFunction__Boolean');
     final _input_handle = Boolean_toFfi(input);
     final __result_handle = _boolFunction_ffi(_input_handle);
+    Boolean_releaseFfiHandle(_input_handle);
     final _result = Boolean_fromFfi(__result_handle);
     Boolean_releaseFfiHandle(__result_handle);
-    Boolean_releaseFfiHandle(_input_handle);
     return _result;
   }
   static double floatFunction(double input) {
     final _floatFunction_ffi = __lib.nativeLibrary.lookupFunction<Float Function(Float), double Function(double)>('smoke_BasicTypes_floatFunction__Float');
     final _input_handle = (input);
     final __result_handle = _floatFunction_ffi(_input_handle);
+    (_input_handle);
     final _result = (__result_handle);
     (__result_handle);
-    (_input_handle);
     return _result;
   }
   static double doubleFunction(double input) {
     final _doubleFunction_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Double), double Function(double)>('smoke_BasicTypes_doubleFunction__Double');
     final _input_handle = (input);
     final __result_handle = _doubleFunction_ffi(_input_handle);
+    (_input_handle);
     final _result = (__result_handle);
     (__result_handle);
-    (_input_handle);
     return _result;
   }
   static int byteFunction(int input) {
     final _byteFunction_ffi = __lib.nativeLibrary.lookupFunction<Int8 Function(Int8), int Function(int)>('smoke_BasicTypes_byteFunction__Byte');
     final _input_handle = (input);
     final __result_handle = _byteFunction_ffi(_input_handle);
+    (_input_handle);
     final _result = (__result_handle);
     (__result_handle);
-    (_input_handle);
     return _result;
   }
   static int shortFunction(int input) {
     final _shortFunction_ffi = __lib.nativeLibrary.lookupFunction<Int16 Function(Int16), int Function(int)>('smoke_BasicTypes_shortFunction__Short');
     final _input_handle = (input);
     final __result_handle = _shortFunction_ffi(_input_handle);
+    (_input_handle);
     final _result = (__result_handle);
     (__result_handle);
-    (_input_handle);
     return _result;
   }
   static int intFunction(int input) {
     final _intFunction_ffi = __lib.nativeLibrary.lookupFunction<Int32 Function(Int32), int Function(int)>('smoke_BasicTypes_intFunction__Int');
     final _input_handle = (input);
     final __result_handle = _intFunction_ffi(_input_handle);
+    (_input_handle);
     final _result = (__result_handle);
     (__result_handle);
-    (_input_handle);
     return _result;
   }
   static int longFunction(int input) {
     final _longFunction_ffi = __lib.nativeLibrary.lookupFunction<Int64 Function(Int64), int Function(int)>('smoke_BasicTypes_longFunction__Long');
     final _input_handle = (input);
     final __result_handle = _longFunction_ffi(_input_handle);
+    (_input_handle);
     final _result = (__result_handle);
     (__result_handle);
-    (_input_handle);
     return _result;
   }
   static int ubyteFunction(int input) {
     final _ubyteFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Uint8), int Function(int)>('smoke_BasicTypes_ubyteFunction__UByte');
     final _input_handle = (input);
     final __result_handle = _ubyteFunction_ffi(_input_handle);
+    (_input_handle);
     final _result = (__result_handle);
     (__result_handle);
-    (_input_handle);
     return _result;
   }
   static int ushortFunction(int input) {
     final _ushortFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint16 Function(Uint16), int Function(int)>('smoke_BasicTypes_ushortFunction__UShort');
     final _input_handle = (input);
     final __result_handle = _ushortFunction_ffi(_input_handle);
+    (_input_handle);
     final _result = (__result_handle);
     (__result_handle);
-    (_input_handle);
     return _result;
   }
   static int uintFunction(int input) {
     final _uintFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Uint32), int Function(int)>('smoke_BasicTypes_uintFunction__UInt');
     final _input_handle = (input);
     final __result_handle = _uintFunction_ffi(_input_handle);
+    (_input_handle);
     final _result = (__result_handle);
     (__result_handle);
-    (_input_handle);
     return _result;
   }
   static int ulongFunction(int input) {
     final _ulongFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint64 Function(Uint64), int Function(int)>('smoke_BasicTypes_ulongFunction__ULong');
     final _input_handle = (input);
     final __result_handle = _ulongFunction_ffi(_input_handle);
+    (_input_handle);
     final _result = (__result_handle);
     (__result_handle);
-    (_input_handle);
     return _result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/ffi/ffi_smoke_Constructors.cpp
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/ffi/ffi_smoke_Constructors.cpp
@@ -1,0 +1,59 @@
+#include "ffi_smoke_Constructors.h"
+#include "ConversionBase.h"
+#include "gluecodium/VectorHash.h"
+#include "smoke/Constructors.h"
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+smoke_Constructors_create() {
+    return gluecodium::ffi::Conversion<std::shared_ptr<smoke::Constructors>>::toFfi(
+        smoke::Constructors::create()
+    );
+}
+FfiOpaqueHandle
+smoke_Constructors_create__Constructors(FfiOpaqueHandle other) {
+    return gluecodium::ffi::Conversion<std::shared_ptr<smoke::Constructors>>::toFfi(
+        smoke::Constructors::create(
+            gluecodium::ffi::Conversion<std::shared_ptr<smoke::Constructors>>::toCpp(other)
+        )
+    );
+}
+FfiOpaqueHandle
+smoke_Constructors_create__String_ULong(FfiOpaqueHandle foo, uint64_t bar) {
+    return gluecodium::ffi::Conversion<std::shared_ptr<smoke::Constructors>>::toFfi(
+        smoke::Constructors::create(
+            gluecodium::ffi::Conversion<std::string>::toCpp(foo),
+            gluecodium::ffi::Conversion<uint64_t>::toCpp(bar)
+        )
+    );
+}
+FfiOpaqueHandle
+smoke_Constructors_create__String(FfiOpaqueHandle input) {
+    return gluecodium::ffi::Conversion<std::shared_ptr<smoke::Constructors>>::toFfi(
+        smoke::Constructors::create(
+            gluecodium::ffi::Conversion<std::string>::toCpp(input)
+        )
+    );
+}
+FfiOpaqueHandle
+smoke_Constructors_create__ListOf_1Double(FfiOpaqueHandle input) {
+    return gluecodium::ffi::Conversion<std::shared_ptr<smoke::Constructors>>::toFfi(
+        smoke::Constructors::create(
+            gluecodium::ffi::Conversion<std::vector<double>>::toCpp(input)
+        )
+    );
+}
+void
+smoke_Constructors_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::Constructors>*>(handle);
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/ffi/ffi_smoke_Constructors.h
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/ffi/ffi_smoke_Constructors.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "Export.h"
+#include "OpaqueHandle.h"
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_Constructors_create();
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_Constructors_create__Constructors(FfiOpaqueHandle other);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_Constructors_create__String_ULong(FfiOpaqueHandle foo, uint64_t bar);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_Constructors_create__String(FfiOpaqueHandle input);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_Constructors_create__ListOf_1Double(FfiOpaqueHandle input);
+_GLUECODIUM_FFI_EXPORT void smoke_Constructors_release_handle(FfiOpaqueHandle handle);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/Constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/Constructors.dart
@@ -1,0 +1,64 @@
+import 'package:library/src/GenericTypes__conversion.dart';
+import 'package:library/src/String__conversion.dart';
+import 'package:library/src/smoke/Constructors_ErrorEnum__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final __release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_Constructors_release_handle');
+class Constructors {
+  final Pointer<Void> _handle;
+  Constructors._(this._handle);
+  void release() => __release_handle(_handle);
+  Constructors() : this._(_create());
+  Constructors(Constructors other) : this._(_create(other));
+  Constructors(String foo, int bar) : this._(_create(foo, bar));
+  Constructors(String input) : this._(_create(input));
+  Constructors(List<double> input) : this._(_create(input));
+  static Pointer<Void> _create() {
+    final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('smoke_Constructors_create');
+    final __result_handle = _create_ffi();
+    return __result_handle;
+  }
+  static Pointer<Void> _create(Constructors other) {
+    final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Constructors_create__Constructors');
+    final _other_handle = smoke_Constructors_toFfi(other);
+    final __result_handle = _create_ffi(_other_handle);
+    smoke_Constructors_releaseFfiHandle(_other_handle);
+    return __result_handle;
+  }
+  static Pointer<Void> _create(String foo, int bar) {
+    final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Uint64), Pointer<Void> Function(Pointer<Void>, int)>('smoke_Constructors_create__String_ULong');
+    final _foo_handle = String_toFfi(foo);
+    final _bar_handle = (bar);
+    final __result_handle = _create_ffi(_foo_handle, _bar_handle);
+    String_releaseFfiHandle(_foo_handle);
+    (_bar_handle);
+    return __result_handle;
+  }
+  static Pointer<Void> _create(String input) {
+    final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Constructors_create__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _create_ffi(_input_handle);
+    String_releaseFfiHandle(_input_handle);
+    return __result_handle;
+  }
+  static Pointer<Void> _create(List<double> input) {
+    final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Constructors_create__ListOf_1Double');
+    final _input_handle = ListOf_Double_toFfi(input);
+    final __result_handle = _create_ffi(_input_handle);
+    ListOf_Double_releaseFfiHandle(_input_handle);
+    return __result_handle;
+  }
+}
+Pointer<Void> smoke_Constructors_toFfi(Constructors value) =>
+  value != null ? value._handle : Pointer<Void>.fromAddress(0);
+Constructors smoke_Constructors_fromFfi(Pointer<Void> handle) =>
+  handle.address != 0 ? Constructors._(handle) : null;
+void smoke_Constructors_releaseFfiHandle(Pointer<Void> handle) {}
+enum Constructors_ErrorEnum {
+    none,
+    crashed
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/Enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/Enums.dart
@@ -18,27 +18,27 @@ class Enums {
     final _methodWithEnumeration_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Uint32), int Function(int)>('smoke_Enums_methodWithEnumeration__SimpleEnum');
     final _input_handle = smoke_Enums_SimpleEnum_toFfi(input);
     final __result_handle = _methodWithEnumeration_ffi(_input_handle);
+    smoke_Enums_SimpleEnum_releaseFfiHandle(_input_handle);
     final _result = smoke_Enums_SimpleEnum_fromFfi(__result_handle);
     smoke_Enums_SimpleEnum_releaseFfiHandle(__result_handle);
-    smoke_Enums_SimpleEnum_releaseFfiHandle(_input_handle);
     return _result;
   }
   static Enums_InternalErrorCode flipEnumValue(Enums_InternalErrorCode input) {
     final _flipEnumValue_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Uint32), int Function(int)>('smoke_Enums_flipEnumValue__InternalErrorCode');
     final _input_handle = smoke_Enums_InternalErrorCode_toFfi(input);
     final __result_handle = _flipEnumValue_ffi(_input_handle);
+    smoke_Enums_InternalErrorCode_releaseFfiHandle(_input_handle);
     final _result = smoke_Enums_InternalErrorCode_fromFfi(__result_handle);
     smoke_Enums_InternalErrorCode_releaseFfiHandle(__result_handle);
-    smoke_Enums_InternalErrorCode_releaseFfiHandle(_input_handle);
     return _result;
   }
   static Enums_InternalErrorCode extractEnumFromStruct(Enums_ErrorStruct input) {
     final _extractEnumFromStruct_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('smoke_Enums_extractEnumFromStruct__ErrorStruct');
     final _input_handle = smoke_Enums_ErrorStruct_toFfi(input);
     final __result_handle = _extractEnumFromStruct_ffi(_input_handle);
+    smoke_Enums_ErrorStruct_releaseFfiHandle(_input_handle);
     final _result = smoke_Enums_InternalErrorCode_fromFfi(__result_handle);
     smoke_Enums_InternalErrorCode_releaseFfiHandle(__result_handle);
-    smoke_Enums_ErrorStruct_releaseFfiHandle(_input_handle);
     return _result;
   }
   static Enums_ErrorStruct createStructWithEnumInside(Enums_InternalErrorCode type, String message) {
@@ -46,19 +46,19 @@ class Enums {
     final _type_handle = smoke_Enums_InternalErrorCode_toFfi(type);
     final _message_handle = String_toFfi(message);
     final __result_handle = _createStructWithEnumInside_ffi(_type_handle, _message_handle);
-    final _result = smoke_Enums_ErrorStruct_fromFfi(__result_handle);
-    smoke_Enums_ErrorStruct_releaseFfiHandle(__result_handle);
     smoke_Enums_InternalErrorCode_releaseFfiHandle(_type_handle);
     String_releaseFfiHandle(_message_handle);
+    final _result = smoke_Enums_ErrorStruct_fromFfi(__result_handle);
+    smoke_Enums_ErrorStruct_releaseFfiHandle(__result_handle);
     return _result;
   }
   static methodWithExternalEnum(Enums_ExternalEnum input) {
     final _methodWithExternalEnum_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Uint32), void Function(int)>('smoke_Enums_methodWithExternalEnum__External_1Enum');
     final _input_handle = smoke_Enums_ExternalEnum_toFfi(input);
     final __result_handle = _methodWithExternalEnum_ffi(_input_handle);
+    smoke_Enums_ExternalEnum_releaseFfiHandle(_input_handle);
     final _result = (__result_handle);
     (__result_handle);
-    smoke_Enums_ExternalEnum_releaseFfiHandle(_input_handle);
     return _result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithBasicTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithBasicTypes.dart
@@ -16,54 +16,54 @@ class GenericTypesWithBasicTypes {
     final _methodWithList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_methodWithList__ListOf_1Int');
     final _input_handle = ListOf_Int_toFfi(input);
     final __result_handle = _methodWithList_ffi(_handle, _input_handle);
+    ListOf_Int_releaseFfiHandle(_input_handle);
     final _result = ListOf_Int_fromFfi(__result_handle);
     ListOf_Int_releaseFfiHandle(__result_handle);
-    ListOf_Int_releaseFfiHandle(_input_handle);
     return _result;
   }
   Map<int, bool> methodWithMap(Map<int, bool> input) {
     final _methodWithMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_methodWithMap__MapOf_1Int_1to_1Boolean');
     final _input_handle = MapOf_Int_to_Boolean_toFfi(input);
     final __result_handle = _methodWithMap_ffi(_handle, _input_handle);
+    MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
     final _result = MapOf_Int_to_Boolean_fromFfi(__result_handle);
     MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
-    MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
     return _result;
   }
   Set<int> methodWithSet(Set<int> input) {
     final _methodWithSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_methodWithSet__SetOf_1Int');
     final _input_handle = SetOf_Int_toFfi(input);
     final __result_handle = _methodWithSet_ffi(_handle, _input_handle);
+    SetOf_Int_releaseFfiHandle(_input_handle);
     final _result = SetOf_Int_fromFfi(__result_handle);
     SetOf_Int_releaseFfiHandle(__result_handle);
-    SetOf_Int_releaseFfiHandle(_input_handle);
     return _result;
   }
   List<String> methodWithListTypeAlias(List<String> input) {
     final _methodWithListTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias__ListOf_1String');
     final _input_handle = ListOf_String_toFfi(input);
     final __result_handle = _methodWithListTypeAlias_ffi(_handle, _input_handle);
+    ListOf_String_releaseFfiHandle(_input_handle);
     final _result = ListOf_String_fromFfi(__result_handle);
     ListOf_String_releaseFfiHandle(__result_handle);
-    ListOf_String_releaseFfiHandle(_input_handle);
     return _result;
   }
   Map<String, String> methodWithMapTypeAlias(Map<String, String> input) {
     final _methodWithMapTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias__MapOf_1String_1to_1String');
     final _input_handle = MapOf_String_to_String_toFfi(input);
     final __result_handle = _methodWithMapTypeAlias_ffi(_handle, _input_handle);
+    MapOf_String_to_String_releaseFfiHandle(_input_handle);
     final _result = MapOf_String_to_String_fromFfi(__result_handle);
     MapOf_String_to_String_releaseFfiHandle(__result_handle);
-    MapOf_String_to_String_releaseFfiHandle(_input_handle);
     return _result;
   }
   Set<String> methodWithSetTypeAlias(Set<String> input) {
     final _methodWithSetTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias__SetOf_1String');
     final _input_handle = SetOf_String_toFfi(input);
     final __result_handle = _methodWithSetTypeAlias_ffi(_handle, _input_handle);
+    SetOf_String_releaseFfiHandle(_input_handle);
     final _result = SetOf_String_fromFfi(__result_handle);
     SetOf_String_releaseFfiHandle(__result_handle);
-    SetOf_String_releaseFfiHandle(_input_handle);
     return _result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithCompoundTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithCompoundTypes.dart
@@ -22,72 +22,72 @@ class GenericTypesWithCompoundTypes {
     final _methodWithStructList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithStructList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct');
     final _input_handle = ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
     final __result_handle = _methodWithStructList_ffi(_handle, _input_handle);
+    ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
     final _result = ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
     ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
-    ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
     return _result;
   }
   Map<String, GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructMap(Map<String, GenericTypesWithCompoundTypes_BasicStruct> input) {
     final _methodWithStructMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithStructMap__MapOf_1String_1to_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct');
     final _input_handle = MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
     final __result_handle = _methodWithStructMap_ffi(_handle, _input_handle);
+    MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
     final _result = MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
     MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
-    MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
     return _result;
   }
   List<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumList(List<GenericTypesWithCompoundTypes_SomeEnum> input) {
     final _methodWithEnumList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithEnumList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
     final _input_handle = ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
     final __result_handle = _methodWithEnumList_ffi(_handle, _input_handle);
+    ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
     final _result = ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
     ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
-    ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
     return _result;
   }
   Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> methodWithEnumMapKey(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> input) {
     final _methodWithEnumMapKey_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey__MapOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum_1to_1Boolean');
     final _input_handle = MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(input);
     final __result_handle = _methodWithEnumMapKey_ffi(_handle, _input_handle);
+    MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(_input_handle);
     final _result = MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi(__result_handle);
     MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(__result_handle);
-    MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(_input_handle);
     return _result;
   }
   Map<int, GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumMapValue(Map<int, GenericTypesWithCompoundTypes_SomeEnum> input) {
     final _methodWithEnumMapValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue__MapOf_1Int_1to_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
     final _input_handle = MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
     final __result_handle = _methodWithEnumMapValue_ffi(_handle, _input_handle);
+    MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
     final _result = MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
     MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
-    MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
     return _result;
   }
   Set<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumSet(Set<GenericTypesWithCompoundTypes_SomeEnum> input) {
     final _methodWithEnumSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithEnumSet__SetOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
     final _input_handle = SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
     final __result_handle = _methodWithEnumSet_ffi(_handle, _input_handle);
+    SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
     final _result = SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
     SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
-    SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
     return _result;
   }
   List<DummyInterface> methodWithInstancesList(List<DummyClass> input) {
     final _methodWithInstancesList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithInstancesList__ListOf_1smoke_1DummyClass');
     final _input_handle = ListOf_smoke_DummyClass_toFfi(input);
     final __result_handle = _methodWithInstancesList_ffi(_handle, _input_handle);
+    ListOf_smoke_DummyClass_releaseFfiHandle(_input_handle);
     final _result = ListOf_smoke_DummyInterface_fromFfi(__result_handle);
     ListOf_smoke_DummyInterface_releaseFfiHandle(__result_handle);
-    ListOf_smoke_DummyClass_releaseFfiHandle(_input_handle);
     return _result;
   }
   Map<int, DummyInterface> methodWithInstancesMap(Map<int, DummyClass> input) {
     final _methodWithInstancesMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap__MapOf_1Int_1to_1smoke_1DummyClass');
     final _input_handle = MapOf_Int_to_smoke_DummyClass_toFfi(input);
     final __result_handle = _methodWithInstancesMap_ffi(_handle, _input_handle);
+    MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(_input_handle);
     final _result = MapOf_Int_to_smoke_DummyInterface_fromFfi(__result_handle);
     MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(__result_handle);
-    MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(_input_handle);
     return _result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithGenericTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithGenericTypes.dart
@@ -15,63 +15,63 @@ class GenericTypesWithGenericTypes {
     final _methodWithListOfLists_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithListOfLists__ListOf_1ListOf_1Int');
     final _input_handle = ListOf_ListOf_Int_toFfi(input);
     final __result_handle = _methodWithListOfLists_ffi(_handle, _input_handle);
+    ListOf_ListOf_Int_releaseFfiHandle(_input_handle);
     final _result = ListOf_ListOf_Int_fromFfi(__result_handle);
     ListOf_ListOf_Int_releaseFfiHandle(__result_handle);
-    ListOf_ListOf_Int_releaseFfiHandle(_input_handle);
     return _result;
   }
   Map<Map<int, bool>, bool> methodWithMapOfMaps(Map<int, Map<int, bool>> input) {
     final _methodWithMapOfMaps_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps__MapOf_1Int_1to_1MapOf_1Int_1to_1Boolean');
     final _input_handle = MapOf_Int_to_MapOf_Int_to_Boolean_toFfi(input);
     final __result_handle = _methodWithMapOfMaps_ffi(_handle, _input_handle);
+    MapOf_Int_to_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
     final _result = MapOf_MapOf_Int_to_Boolean_to_Boolean_fromFfi(__result_handle);
     MapOf_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(__result_handle);
-    MapOf_Int_to_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
     return _result;
   }
   Set<Set<int>> methodWithSetOfSets(Set<Set<int>> input) {
     final _methodWithSetOfSets_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithSetOfSets__SetOf_1SetOf_1Int');
     final _input_handle = SetOf_SetOf_Int_toFfi(input);
     final __result_handle = _methodWithSetOfSets_ffi(_handle, _input_handle);
+    SetOf_SetOf_Int_releaseFfiHandle(_input_handle);
     final _result = SetOf_SetOf_Int_fromFfi(__result_handle);
     SetOf_SetOf_Int_releaseFfiHandle(__result_handle);
-    SetOf_SetOf_Int_releaseFfiHandle(_input_handle);
     return _result;
   }
   Map<int, List<int>> methodWithListAndMap(List<Map<int, bool>> input) {
     final _methodWithListAndMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithListAndMap__ListOf_1MapOf_1Int_1to_1Boolean');
     final _input_handle = ListOf_MapOf_Int_to_Boolean_toFfi(input);
     final __result_handle = _methodWithListAndMap_ffi(_handle, _input_handle);
+    ListOf_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
     final _result = MapOf_Int_to_ListOf_Int_fromFfi(__result_handle);
     MapOf_Int_to_ListOf_Int_releaseFfiHandle(__result_handle);
-    ListOf_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
     return _result;
   }
   Set<List<int>> methodWithListAndSet(List<Set<int>> input) {
     final _methodWithListAndSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithListAndSet__ListOf_1SetOf_1Int');
     final _input_handle = ListOf_SetOf_Int_toFfi(input);
     final __result_handle = _methodWithListAndSet_ffi(_handle, _input_handle);
+    ListOf_SetOf_Int_releaseFfiHandle(_input_handle);
     final _result = SetOf_ListOf_Int_fromFfi(__result_handle);
     SetOf_ListOf_Int_releaseFfiHandle(__result_handle);
-    ListOf_SetOf_Int_releaseFfiHandle(_input_handle);
     return _result;
   }
   Set<Map<int, bool>> methodWithMapAndSet(Map<int, Set<int>> input) {
     final _methodWithMapAndSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithMapAndSet__MapOf_1Int_1to_1SetOf_1Int');
     final _input_handle = MapOf_Int_to_SetOf_Int_toFfi(input);
     final __result_handle = _methodWithMapAndSet_ffi(_handle, _input_handle);
+    MapOf_Int_to_SetOf_Int_releaseFfiHandle(_input_handle);
     final _result = SetOf_MapOf_Int_to_Boolean_fromFfi(__result_handle);
     SetOf_MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
-    MapOf_Int_to_SetOf_Int_releaseFfiHandle(_input_handle);
     return _result;
   }
   Map<List<int>, bool> methodWithMapGenericKeys(Map<Set<int>, bool> input) {
     final _methodWithMapGenericKeys_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys__MapOf_1SetOf_1Int_1to_1Boolean');
     final _input_handle = MapOf_SetOf_Int_to_Boolean_toFfi(input);
     final __result_handle = _methodWithMapGenericKeys_ffi(_handle, _input_handle);
+    MapOf_SetOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
     final _result = MapOf_ListOf_Int_to_Boolean_fromFfi(__result_handle);
     MapOf_ListOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
-    MapOf_SetOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
     return _result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleClass.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleClass.dart
@@ -21,9 +21,9 @@ class SimpleClass {
     final _useSimpleClass_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_SimpleClass_useSimpleClass__SimpleClass');
     final _input_handle = smoke_SimpleClass_toFfi(input);
     final __result_handle = _useSimpleClass_ffi(_handle, _input_handle);
+    smoke_SimpleClass_releaseFfiHandle(_input_handle);
     final _result = smoke_SimpleClass_fromFfi(__result_handle);
     smoke_SimpleClass_releaseFfiHandle(__result_handle);
-    smoke_SimpleClass_releaseFfiHandle(_input_handle);
     return _result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleInterface.dart
@@ -29,9 +29,9 @@ class SimpleInterface__Impl implements SimpleInterface{
     final _useSimpleInterface_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_SimpleInterface_useSimpleInterface__SimpleInterface');
     final _input_handle = smoke_SimpleInterface_toFfi(input);
     final __result_handle = _useSimpleInterface_ffi(_handle, _input_handle);
+    smoke_SimpleInterface_releaseFfiHandle(_input_handle);
     final _result = smoke_SimpleInterface_fromFfi(__result_handle);
     smoke_SimpleInterface_releaseFfiHandle(__result_handle);
-    smoke_SimpleInterface_releaseFfiHandle(_input_handle);
     return _result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/NestedPackages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/NestedPackages.dart
@@ -14,9 +14,9 @@ class NestedPackages {
     final _basicMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_off_NestedPackages_basicMethod__SomeStruct');
     final _input_handle = smoke_off_NestedPackages_SomeStruct_toFfi(input);
     final __result_handle = _basicMethod_ffi(_input_handle);
+    smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(_input_handle);
     final _result = smoke_off_NestedPackages_SomeStruct_fromFfi(__result_handle);
     smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(__result_handle);
-    smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(_input_handle);
     return _result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
@@ -21,18 +21,18 @@ class Structs {
     final _swapPointCoordinates_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Structs_swapPointCoordinates__Point');
     final _input_handle = smoke_Structs_Point_toFfi(input);
     final __result_handle = _swapPointCoordinates_ffi(_input_handle);
+    smoke_Structs_Point_releaseFfiHandle(_input_handle);
     final _result = smoke_Structs_Point_fromFfi(__result_handle);
     smoke_Structs_Point_releaseFfiHandle(__result_handle);
-    smoke_Structs_Point_releaseFfiHandle(_input_handle);
     return _result;
   }
   static Structs_AllTypesStruct returnAllTypesStruct(Structs_AllTypesStruct input) {
     final _returnAllTypesStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Structs_returnAllTypesStruct__AllTypesStruct');
     final _input_handle = smoke_Structs_AllTypesStruct_toFfi(input);
     final __result_handle = _returnAllTypesStruct_ffi(_input_handle);
+    smoke_Structs_AllTypesStruct_releaseFfiHandle(_input_handle);
     final _result = smoke_Structs_AllTypesStruct_fromFfi(__result_handle);
     smoke_Structs_AllTypesStruct_releaseFfiHandle(__result_handle);
-    smoke_Structs_AllTypesStruct_releaseFfiHandle(_input_handle);
     return _result;
   }
   static Structs_ExternalStruct getExternalStruct() {
@@ -61,19 +61,19 @@ class Structs {
     final _x_handle = (x);
     final _y_handle = (y);
     final __result_handle = _createPoint_ffi(_x_handle, _y_handle);
-    final _result = smoke_TypeCollection_Point_fromFfi(__result_handle);
-    smoke_TypeCollection_Point_releaseFfiHandle(__result_handle);
     (_x_handle);
     (_y_handle);
+    final _result = smoke_TypeCollection_Point_fromFfi(__result_handle);
+    smoke_TypeCollection_Point_releaseFfiHandle(__result_handle);
     return _result;
   }
   static AllTypesStruct modifyAllTypesStruct(AllTypesStruct input) {
     final _modifyAllTypesStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Structs_modifyAllTypesStruct__AllTypesStruct');
     final _input_handle = smoke_TypeCollection_AllTypesStruct_toFfi(input);
     final __result_handle = _modifyAllTypesStruct_ffi(_input_handle);
+    smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(_input_handle);
     final _result = smoke_TypeCollection_AllTypesStruct_fromFfi(__result_handle);
     smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(__result_handle);
-    smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(_input_handle);
     return _result;
   }
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeContainer.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeContainer.kt
@@ -34,4 +34,8 @@ abstract class LimeContainer(
     val functions: List<LimeFunction> = emptyList(),
     val properties: List<LimeProperty> = emptyList(),
     val exceptions: List<LimeException> = emptyList()
-) : LimeType(path, visibility, comment, attributes)
+) : LimeType(path, visibility, comment, attributes) {
+
+    val constructors
+        get() = functions.filter { it.isConstructor }
+}


### PR DESCRIPTION
Updated Dart templates to add support for class constructors.
Added/updated smoke and functional tests as appropriate.

Resolves: #66 
