### PR TITLE
Update .md files in .github directory

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,16 +7,13 @@
 
 ## Signing each Commit
 
-Please sign off each commit of a pull request
-[Developer Certificate of Origin](https://developercertificate.org/).
-Any Pull Request with commits that are not signed off will be reject by the
-[DCO check](https://probot.github.io/apps/dco/).
+Please sign off each commit of a pull request. There are two ways to do it:
 
-A DCO is lightweight way for a contributor to confirm that they wrote or otherwise have the right
-to submit code or documentation to a project. Simply add `Signed-off-by` as shown in the example below
-to indicate that you agree with the DCO.
+Automatically: Use `-s` (or `--signoff`) flag of `git commit` command, see example below:
 
-An example signed commit message:
+`$ git commit -s -m 'README.md: Fix minor spelling mistake'`
+
+Manually add `Signed-off-by:`, as shown in the example below:
 
 ```
     README.md: Fix minor spelling mistake
@@ -24,6 +21,6 @@ An example signed commit message:
     Signed-off-by: John Doe <john.doe@example.com>
 ```
 
-Git has the `-s` flag that can sign a commit for you, see example below:
-
-`$ git commit -s -m 'README.md: Fix minor spelling mistake'`
+Any Pull Request with commits that are not signed off will be rejected by the automatic
+[DCO check](https://probot.github.io/apps/dco/). A DCO is lightweight way for a contributor to
+confirm that they wrote or otherwise have the right to submit code or documentation to a project.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-Thank you for reporting this issue!
-
-Make sure to add **all the information needed to understand the bug** so that someone can help. If the info is missing we'll add the 'Needs more information' label and close the issue until there is enough information.
-
-- [ ] Provide a **minimal .fidl/fdepl content needed for reproducing**.
-- [ ] Privide **minimal C++ implmentation** if appropriate.
-- [ ] What's the **version** of Gluecodium you're using?
-- [ ] Is it a **Swift, Java, Kotlin** bug?
-- [ ] Does this occur on iOS, Android, Linux or OSX?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
-- Please format your code first: `./scripts/format-code`
+- Please format your code first: `./gradlew spotlessApply`
 - Please describe *what* you're trying to achieve and *why*
-- Please sign each commit `git commit -s ...` [Developer Certificate of Origin](https://developercertificate.org/).
+- Please sign each commit `git commit -s ...`


### PR DESCRIPTION
Deleted ISSUE_TEMPLATE.md file, moved to the new GitHub issue template
workflow instead (with has template in GitHub web UI instead).

Updated CONTRIBUTING.md and PULL_REQUEST_TEMPLATE.md to clarify the
sign-off policy.

Resolves: #77 