### PR TITLE
Fix Swift doc comments for struct constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed Swift compilation issue for constructor comments of structs with multiline field comments.
+
 ## 6.0.0
 Release date: 2020-01-06
 ### Features:

--- a/gluecodium/src/main/resources/templates/swift/Struct.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Struct.mustache
@@ -54,7 +54,7 @@
 {{#if publicFields}}
     /// - Parameters
 {{#fields}}
-    ///   - {{name}}: {{prefix comment.documentation "      " skipFirstLine=true}}
+    ///   - {{name}}: {{prefix comment.documentation "    ///       " skipFirstLine=true}}
 {{/fields}}
 {{/if}}
 {{/if}}

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -23,6 +23,7 @@ class comments {
     // @constructor This is how easy it is to construct.
     struct SomeStruct {
         // How useful this struct is
+        // remains to be seen
         someField: Usefulness
         // Can be `null`
         nullableField: String?

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
@@ -45,7 +45,8 @@ public final class Comments extends NativeBase {
      */
     public final static class SomeStruct {
         /**
-         * <p>How useful this struct is</p>
+         * <p>How useful this struct is
+         * remains to be seen</p>
          */
         public boolean someField;
         /**
@@ -55,7 +56,8 @@ public final class Comments extends NativeBase {
         public String nullableField;
         /**
          * <p>This is how easy it is to construct.</p>
-         * @param someField <p>How useful this struct is</p>
+         * @param someField <p>How useful this struct is
+         * remains to be seen</p>
          * @param nullableField <p>Can be <code>null</code></p>
          */
         public SomeStruct(final boolean someField, @Nullable final String nullableField) {

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
@@ -41,6 +41,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         /**
          * How useful this struct is
+         * remains to be seen
          */
         ::smoke::Comments::Usefulness some_field;
         /**
@@ -54,6 +55,7 @@ public:
         /**
          * This is how easy it is to construct.
          * @param some_field How useful this struct is
+         * remains to be seen
          * @param nullable_field Can be `null`
          */
         SomeStruct( const ::smoke::Comments::Usefulness some_field, const ::gluecodium::optional< ::std::string >& nullable_field );

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/comments.lime
@@ -16,6 +16,7 @@ class comments {
     // @constructor This is how easy it is to construct.
     struct SomeStruct {
         // How useful this struct is
+        // remains to be seen
         someField: Usefulness
         // Can be `null`
         nullableField: String?

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -39,12 +39,14 @@ public class Comments {
     /// This is some very useful struct.
     public struct SomeStruct {
         /// How useful this struct is
+        /// remains to be seen
         public var someField: Comments.Usefulness
         /// Can be `nil`
         public var nullableField: String?
         /// This is how easy it is to construct.
         /// - Parameters
         ///   - someField: How useful this struct is
+        ///       remains to be seen
         ///   - nullableField: Can be `nil`
         public init(someField: Comments.Usefulness, nullableField: String? = nil) {
             self.someField = someField


### PR DESCRIPTION
Updated template for Swift structs to correctly prefix multiline field
comments with "///" when they are a part for generated constructor
comment.

Added smoke test as a regression test.

Resolves: #76