### PR TITLE
Allow lime dependencies between targets and document these

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Gluecodium project Release Notes
 
 ## Unreleased
-### Features:
+### Features
   * Allow renaming JNI_OnLoad via define.
+  * Enable CMake modules for use of Gluecodium in multiple targets.
 
 ## 6.0.1
 Release date: 2020-01-16

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -8,18 +8,18 @@ projects.
 The modules consist of a platform independent part in `modules/gluecodium/gluecodium`
 and platform specific helpers. To generate code for a target the functions
 `apigen_generate`, `apigen_target_sources` and `apigen_target_include_directories`
-should be called for it.
-Depending on the target platform, there are helpers for `.aar` archives for Android  and
-Apples `.framework` for Swift.
+should be called for that target.
+Depending on the target platform, there are helpers for creating `.aar` archives for
+Android and Swift `.framework` for iOS or macOS.
 For more details check out the [Examples](../examples/README.md).
 
 ## Source sets
 
 Gluecodium distinguishes between two different source sets, "main" and "common". "Main"
-code depends on the input Lime files while "common" code only depends on the Gluecodium
-options like internal namespace etc. In most use cases where there is only one target
-with generated code, not setting a common code directory works just fine, it will then
-be combined with the main code and can be used like this.
+code depends on the input Lime IDL files while "common" code only depends on the
+Gluecodium options like internal namespace etc. In most use cases where there is only one
+target with generated code, not setting a common code directory works just fine, it will
+then be combined with the main code and can be used like this.
 
 If code is generated for more than one target and should be used together, then the
 common code needs to be separated as it would otherwise be duplicated and cause
@@ -28,17 +28,17 @@ compilation issues. For this a separate common output directory must be set for
 others link against. `add_target_sources` and `add_target_link_directories` support
 "MAIN" and "COMMON" options for this use case.
 
-## Lime file dependencies between targets
+## Lime IDL file dependencies between targets
 
-If a target A's lime files depend on the lime files of target B, then these need to
+If a target A's Lime IDL files depend on those from target B, then these need to
 be passed to Gluecodium during generation of A. To do this without generating B's
-code twice and having duplicate symbols, Gluecodium supports auxiliary lime input
-which will not result in generated files. To simplify usage of this feature,
+code twice and having duplicate symbols, Gluecodium supports auxiliary Lime IDL
+input which will not result in generated files. To simplify usage of this feature,
 `apigen_generate` will pass all target `SOURCES` and `INTERFACE_SOURCES` as
 auxiliary sources to Gluecodium. Since `INTERFACE_SOURCES` is resolved
 transitively by CMake this means these can be passed automatically when:
 
-    * target B adds lime files as `INTERFACE_SOURCES`: `target_sources(B INTERFACE b1.lime b2.lime...)`
+    * target B adds its Lime IDL files as `INTERFACE_SOURCES`: `target_sources(B INTERFACE b1.lime b2.lime...)`
     * target A links to B public: `target_link_libraries(A PUBLIC B)`
-   
-In this case also transitive lime dependencies are resolved by CMake.
+
+In this case also transitive Lime IDL dependencies are resolved by CMake.

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -1,6 +1,44 @@
 # Gluecodium CMake toolchain
 
-Version: 1.2.0
-
 This project provides CMake functions to simplify using Gluecodium in CMake-based
 projects.
+
+## Generate code
+
+The modules consist of a platform independent part in `modules/gluecodium/gluecodium`
+and platform specific helpers. To generate code for a target the functions
+`apigen_generate`, `apigen_target_sources` and `apigen_target_include_directories`
+should be called for it.
+Depending on the target platform, there are helpers for `.aar` archives for Android  and
+Apples `.framework` for Swift.
+For more details check out the [Examples](../examples/README.md).
+
+## Source sets
+
+Gluecodium distinguishes between two different source sets, "main" and "common". "Main"
+code depends on the input Lime files while "common" code only depends on the Gluecodium
+options like internal namespace etc. In most use cases where there is only one target
+with generated code, not setting a common code directory works just fine, it will then
+be combined with the main code and can be used like this.
+
+If code is generated for more than one target and should be used together, then the
+common code needs to be separated as it would otherwise be duplicated and cause
+compilation issues. For this a separate common output directory must be set for
+`apigen_generate` and the generated common source only added to one target which all
+others link against. `add_target_sources` and `add_target_link_directories` support
+"MAIN" and "COMMON" options for this use case.
+
+## Lime file dependencies between targets
+
+If a target A's lime files depend on the lime files of target B, then these need to
+be passed to Gluecodium during generation of A. To do this without generating B's
+code twice and having duplicate symbols, Gluecodium supports auxiliary lime input
+which will not result in generated files. To simplify usage of this feature,
+`apigen_generate` will pass all target `SOURCES` and `INTERFACE_SOURCES` as
+auxiliary sources to Gluecodium. Since `INTERFACE_SOURCES` is resolved
+transitively by CMake this means these can be passed automatically when:
+
+    * target B adds lime files as `INTERFACE_SOURCES`: `target_sources(B INTERFACE b1.lime b2.lime...)`
+    * target A links to B public: `target_link_libraries(A PUBLIC B)`
+   
+In this case also transitive lime dependencies are resolved by CMake.

--- a/cmake/modules/gluecodium/gluecodium/Generate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/Generate.cmake
@@ -192,6 +192,8 @@ function(apigen_generate)
         -DAPIGEN_COMMON_OUTPUT_DIR=${APIGEN_COMMON_OUTPUT_DIR}
         -DAPIGEN_BUILD_OUTPUT_DIR=${APIGEN_BUILD_OUTPUT_DIR}
         -DAPIGEN_VERBOSE=${APIGEN_VERBOSE}
+	# Pass on the interface lime files from dependencies, only INTERFACE_SOURCES is propagated trinsitively as of CMake 3.16
+        -DAPIGEN_AUX_FILES=$<TARGET_PROPERTY:${APIGEN_TARGET},INTERFACE_SOURCES>;$<TARGET_PROPERTY:${APIGEN_TARGET},SOURCES>
         -P ${APIGEN_GLUECODIUM_DIR}/runGenerate.cmake
         VERBATIM
     DEPENDS

--- a/cmake/modules/gluecodium/gluecodium/Generate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/Generate.cmake
@@ -192,7 +192,7 @@ function(apigen_generate)
         -DAPIGEN_COMMON_OUTPUT_DIR=${APIGEN_COMMON_OUTPUT_DIR}
         -DAPIGEN_BUILD_OUTPUT_DIR=${APIGEN_BUILD_OUTPUT_DIR}
         -DAPIGEN_VERBOSE=${APIGEN_VERBOSE}
-	# Pass on the interface lime files from dependencies, only INTERFACE_SOURCES is propagated trinsitively as of CMake 3.16
+	# Pass on the interface lime files from dependencies, only INTERFACE_SOURCES is propagated transitively as of CMake 3.16
         -DAPIGEN_AUX_FILES=$<TARGET_PROPERTY:${APIGEN_TARGET},INTERFACE_SOURCES>;$<TARGET_PROPERTY:${APIGEN_TARGET},SOURCES>
         -P ${APIGEN_GLUECODIUM_DIR}/runGenerate.cmake
         VERBATIM

--- a/cmake/modules/gluecodium/gluecodium/GeneratedSources.cmake
+++ b/cmake/modules/gluecodium/gluecodium/GeneratedSources.cmake
@@ -37,6 +37,7 @@ function(apigen_list_generated_sources _sources_list_output)
   cmake_parse_arguments(apigen_list_generated_sources "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
 
+  set(APIGEN_SUPPORTED_GENERATORS cpp android swift dart)
   if(NOT apigen_list_generated_sources_GENERATOR IN_LIST APIGEN_SUPPORTED_GENERATORS)
     message(FATAL_ERROR "Generator ${apigen_list_generated_sources_GENERATOR} is not in list of supported generators: ${APIGEN_SUPPORTED_GENERATORS}")
   endif()

--- a/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
+++ b/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
@@ -38,7 +38,7 @@ cmake_minimum_required(VERSION 3.5)
 #     apigen_target_include_directories(target [MAIN] [COMMON])
 #        <target>    Target for which source was generated via `apigen_generate`
 #        MAIN        Add the include path to the MAIN generated source set, i.e.
-#                    code generated for the input Lime files.
+#                    code generated for the input Lime IDL files.
 #        COMMON      Add the include path to the common generated source set.
 #     If neither MAIN nor COMMON are specified, both are added. Specifying a
 #     source set requires a separate common output directory to be set for

--- a/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
+++ b/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
@@ -83,8 +83,8 @@ function(apigen_target_include_directories target)
     endif()
   endif()
 
-  if(${GENERATOR} MATCHES android)
-    # Check if we are doing a host build (no cross compilation)
+  if(NOT CMAKE_CROSSCOMPILING)
+    # If we're not crosscompiling we need to manually add JNI includes.
     if(NOT(${CMAKE_SYSTEM_NAME} STREQUAL "Android"))
       find_package(JNI REQUIRED)
       target_include_directories(${target}

--- a/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
+++ b/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
@@ -84,7 +84,7 @@ function(apigen_target_include_directories target)
   endif()
 
   if(NOT CMAKE_CROSSCOMPILING)
-    # If we're not crosscompiling we need to manually add JNI includes.
+    # If we're not crosscompiling, we need to manually add JNI includes.
     if(NOT(${CMAKE_SYSTEM_NAME} STREQUAL "Android"))
       find_package(JNI REQUIRED)
       target_include_directories(${target}

--- a/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
+++ b/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
@@ -83,9 +83,9 @@ function(apigen_target_include_directories target)
     endif()
   endif()
 
-  if(NOT CMAKE_CROSSCOMPILING)
+  if(${GENERATOR} MATCHES android)
     # If we're not crosscompiling, we need to manually add JNI includes.
-    if(NOT(${CMAKE_SYSTEM_NAME} STREQUAL "Android"))
+    if(NOT CMAKE_CROSSCOMPILING)
       find_package(JNI REQUIRED)
       target_include_directories(${target}
         PRIVATE $<BUILD_INTERFACE:${JNI_INCLUDE_DIRS}>)

--- a/cmake/modules/gluecodium/gluecodium/TargetSources.cmake
+++ b/cmake/modules/gluecodium/gluecodium/TargetSources.cmake
@@ -38,9 +38,10 @@ cmake_minimum_required(VERSION 3.5)
 #     apigen_target_sources(<target> (MAIN) (COMMON))
 #        <target>    Target for which source was generated via `apigen_generate`
 #        MAIN        Add the MAIN generated source set, i.e. code generated for
-#                    the input Lime files.
+#                    the input Lime IDL files.
 #        COMMON      Add the common generated source set which is independent of
-#                    input lime files and can be shared between different targets
+#                    input Lime IDL files and can be shared between different
+#                    targets
 #     If neither MAIN nor COMMON are specified, both are added. Specifying a
 #     source set requires a separate common output directory to be set for
 #     `apigen_generate`.

--- a/cmake/modules/gluecodium/gluecodium/TargetSources.cmake
+++ b/cmake/modules/gluecodium/gluecodium/TargetSources.cmake
@@ -35,18 +35,39 @@ cmake_minimum_required(VERSION 3.5)
 #
 # The general form of the command is::
 #
-#     apigen_target_sources(target)
+#     apigen_target_sources(<target> (MAIN) (COMMON))
+#        <target>    Target for which source was generated via `apigen_generate`
+#        MAIN        Add the MAIN generated source set, i.e. code generated for
+#                    the input Lime files.
+#        COMMON      Add the common generated source set which is independent of
+#                    input lime files and can be shared between different targets
+#     If neither MAIN nor COMMON are specified, both are added. Specifying a
+#     source set requires a separate common output directory to be set for
+#     `apigen_generate`.
 #
 
 function(apigen_target_sources target)
+  set(options MAIN COMMON)
+  cmake_parse_arguments(apigen_target_sources "${options}" "" "" ${ARGN})
+
   get_target_property(GENERATOR ${target} APIGEN_GENERATOR)
   get_target_property(COMMON_OUTPUT_DIR ${target} APIGEN_COMMON_OUTPUT_DIR)
   get_target_property(BUILD_OUTPUT_DIR ${target} APIGEN_BUILD_OUTPUT_DIR)
 
-  set(_source_sets MAIN)
-  if(COMMON_OUTPUT_DIR)
+  unset(_source_sets)
+  if(NOT apigen_target_sources_MAIN AND NOT apigen_target_sources_COMMON)
+    set(_source_sets MAIN)
+    if(COMMON_OUTPUT_DIR)
+      list(APPEND _source_sets COMMON)
+    endif()
+  endif()
+  if(apigen_target_sources_MAIN)
+    list(APPEND _source_sets MAIN)
+  endif()
+  if(apigen_target_sources_COMMON)
     list(APPEND _source_sets COMMON)
   endif()
+
   apigen_list_generated_sources(_generated_files
     ${_source_sets}
     GENERATOR "${GENERATOR}"

--- a/cmake/modules/gluecodium/gluecodium/runGenerate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/runGenerate.cmake
@@ -37,10 +37,16 @@ function(_generate)
         unset(_gluecodium_time)
     endif()
 
+    list(FILTER APIGEN_AUX_FILES INCLUDE REGEX ".*.lime")
+    foreach(_aux_lime IN LISTS APIGEN_AUX_FILES)
+      string(APPEND APIGEN_GLUECODIUM_ARGS " -auxinput \"${_aux_lime}\"")
+    endforeach()
+    set(_gluecodium_command ${_gluecodium_time} ${APIGEN_GLUECODIUM_GRADLE_WRAPPER} ${_build_local_gluecodium} -Pversion=${APIGEN_GLUECODIUM_VERSION} run --args=${APIGEN_GLUECODIUM_ARGS})
+
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E make_directory ${APIGEN_OUTPUT_DIR} # otherwise java.io.File won't have permissions to create files at configure time
         COMMAND ${CMAKE_COMMAND} -E make_directory ${APIGEN_COMMON_OUTPUT_DIR}
-        COMMAND ${_gluecodium_time} ${APIGEN_GLUECODIUM_GRADLE_WRAPPER} ${_build_local_gluecodium} -Pversion=${APIGEN_GLUECODIUM_VERSION} run --args=${APIGEN_GLUECODIUM_ARGS}
+        COMMAND ${_gluecodium_command}
         WORKING_DIRECTORY ${APIGEN_GLUECODIUM_DIR}
         RESULT_VARIABLE GENERATE_RESULT
         OUTPUT_VARIABLE GENERATE_OUTPUT


### PR DESCRIPTION
Allow adding sources only from specific source set, main or common. Also pass interface sources as auxiliary lime files to allow lime dependencies between targets. Add minimal documentation for these.