### PR TITLE
Update Robolectric to version 3.7.1

### DIFF
--- a/examples/platforms/android/app/build.gradle
+++ b/examples/platforms/android/app/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.0.0'
     testImplementation "org.powermock:powermock-reflect:1.7.1"
-    testImplementation 'org.robolectric:robolectric:3.4.2'
+    testImplementation 'org.robolectric:robolectric:3.7.1'
 
     // Core library
     androidTestImplementation 'androidx.test:core:1.0.0'


### PR DESCRIPTION
Robolectric 3.4.2 started to fail during its Maven dependency resolution
due to Maven Central HTTP access being shut down on 15.01.2020.
Upgrading to the latest 4.x version is infeasible as there are API
incompatibilities. Upgrading to 3.7.1 fixed the HTTP issue.

The HTTP issue is reproducible locally as well as on the legacy CI. Does
not seem to affect Travis CI at the moment, but this might be due to
some additional caching done there.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>