### PR TITLE
Add support for properties to Dart generator

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -173,7 +173,7 @@ feature(Enums cpp android swift dart SOURCES
     lime/test/EnumsTypeCollection.lime
 )
 
-feature(Attributes cpp android swift SOURCES
+feature(Properties cpp android swift dart SOURCES
     src/hello/HelloWorldAttributesImpl.h
     src/hello/HelloWorldAttributesImpl.cpp
     src/test/AttributesInterfaceImpl.h

--- a/examples/platforms/dart/main.dart
+++ b/examples/platforms/dart/main.dart
@@ -25,6 +25,7 @@ import "test/Lists_test.dart" as ListsTests;
 import "test/Maps_test.dart" as MapsTests;
 import "test/PlainDataStructures_test.dart" as PlainDataStructuresTests;
 import "test/PlainDataStructuresTypeCollection_test.dart" as PlainDataStructuresTypeCollectionTests;
+import "test/Properties_test.dart" as PropertiesTests;
 import "test/Sets_test.dart" as SetsTests;
 import "test/StaticBooleanMethods_test.dart" as StaticBooleanMethodsTests;
 import "test/StaticFloatDoubleMethods_test.dart" as StaticFloatDoubleMethodsTests;
@@ -39,6 +40,7 @@ final _allTests = [
   MapsTests.main,
   PlainDataStructuresTests.main,
   PlainDataStructuresTypeCollectionTests.main,
+  PropertiesTests.main,
   SetsTests.main,
   StaticBooleanMethodsTests.main,
   StaticFloatDoubleMethodsTests.main,

--- a/examples/platforms/dart/test/Properties_test.dart
+++ b/examples/platforms/dart/test/Properties_test.dart
@@ -1,0 +1,70 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:hello/hello.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("Properties");
+
+void main() {
+  Attributes attributes;
+  setUp(() {
+    attributes = Attributes();
+  });
+  tearDown(() {
+    attributes.release();
+  });
+
+  _testSuite.test("Primitive type Property round trip", () {
+    attributes.builtInTypeAttribute = 42;
+
+    final result = attributes.builtInTypeAttribute;
+
+    expect(result, equals(42));
+  });
+  _testSuite.test("Primitive type readonly Property", () {
+    final result = attributes.readonlyAttribute;
+
+    final epsilon = 0.000001;
+    expect(result, inInclusiveRange(3.14 - epsilon, 3.14 + epsilon));
+  });
+  _testSuite.test("Struct type Property round trip", () {
+    attributes.structAttribute = Attributes_ExampleStruct(2.71, []);
+
+    final result = attributes.structAttribute;
+
+    expect(result.value, equals(2.71));
+  });
+  _testSuite.test("Static Property round trip", () {
+    Attributes.staticAttribute = "foo";
+
+    final result = Attributes.staticAttribute;
+
+    expect(result, equals("foo"));
+  });
+  _testSuite.test("List type Property round trip", () {
+    attributes.arrayAttribute = ["foo", "bar"];
+
+    final result = attributes.arrayAttribute;
+
+    expect(result, equals(["foo", "bar"]));
+  });
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -113,8 +113,10 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
         val contentTemplateName = selectTemplate(rootElement) ?: return null
 
         val functions = collectFunctions(rootElement)
+        val properties = (rootElement as? LimeContainerWithInheritance)?.properties ?: emptyList()
         val imports = importResolver.resolveImports(rootElement) +
-            functions.flatMap { collectTypeRefs(it) }.flatMap { importResolver.resolveImports(it) }
+            functions.flatMap { collectTypeRefs(it) }.flatMap { importResolver.resolveImports(it) } +
+            properties.flatMap { importResolver.resolveImports(it.typeRef) }
 
         val packagePath = rootElement.path.head.joinToString(separator = "/")
         val filePath = "$packagePath/${nameRules.getName(rootElement)}"

--- a/gluecodium/src/main/resources/templates/dart/DartFunction.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunction.mustache
@@ -18,27 +18,4 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>dart/DartFunctionSignature}} {
-  final _{{resolveName}}_ffi = __lib.nativeLibrary.lookupFunction<{{>ffiApi}}, {{>ffiDart}}>('{{resolveName "Ffi"}}');
-{{#parameters}}
-  final _{{resolveName}}_handle = {{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
-{{/parameters}}
-  final __result_handle = _{{resolveName}}_ffi({{!!
-  }}{{#unless isStatic}}_handle{{#if parameters}}, {{/if}}{{/unless}}{{!!
-  }}{{#parameters}}_{{resolveName}}_handle{{#if iter.hasNext}}, {{/if}}{{/parameters}});
-{{#parameters}}
-  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle);
-{{/parameters}}
-  {{#if isConstructor}}return __result_handle;{{/if}}{{#unless isConstructor}}{{!!
-  }}{{#returnType}}final _result = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
-  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);{{/returnType}}
-  return _result;{{/unless}}
-}{{!!
-
-}}{{+ffiApi}}{{resolveName returnType.typeRef "FfiApiTypes"}} Function({{!!
-}}{{#unless isStatic}}Pointer<Void>{{#if parameters}}, {{/if}}{{/unless}}{{!!
-}}{{#parameters}}{{resolveName typeRef "FfiApiTypes"}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{/ffiApi}}{{!!
-
-}}{{+ffiDart}}{{resolveName returnType.typeRef "FfiDartTypes"}} Function({{!!
-}}{{#unless isStatic}}Pointer<Void>{{#if parameters}}, {{/if}}{{/unless}}{{!!
-}}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{/ffiDart}}
+{{>dart/DartFunctionSignature}}{{>dart/DartFunctionBody}}

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
@@ -1,0 +1,44 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+ {
+  final _{{resolveName}}_ffi = __lib.nativeLibrary.lookupFunction<{{>ffiApi}}, {{>ffiDart}}>('{{resolveName "Ffi"}}');
+{{#parameters}}
+  final _{{resolveName}}_handle = {{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
+{{/parameters}}
+  final __result_handle = _{{resolveName}}_ffi({{!!
+  }}{{#unless isStatic}}_handle{{#if parameters}}, {{/if}}{{/unless}}{{!!
+  }}{{#parameters}}_{{resolveName}}_handle{{#if iter.hasNext}}, {{/if}}{{/parameters}});
+{{#parameters}}
+  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle);
+{{/parameters}}
+  {{#if isConstructor}}return __result_handle;{{/if}}{{#unless isConstructor}}{{!!
+  }}{{#returnType}}final _result = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
+  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);{{/returnType}}
+  return _result;{{/unless}}
+}{{!!
+
+}}{{+ffiApi}}{{resolveName returnType.typeRef "FfiApiTypes"}} Function({{!!
+}}{{#unless isStatic}}Pointer<Void>{{#if parameters}}, {{/if}}{{/unless}}{{!!
+}}{{#parameters}}{{resolveName typeRef "FfiApiTypes"}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{/ffiApi}}{{!!
+
+}}{{+ffiDart}}{{resolveName returnType.typeRef "FfiDartTypes"}} Function({{!!
+}}{{#unless isStatic}}Pointer<Void>{{#if parameters}}, {{/if}}{{/unless}}{{!!
+}}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{/ffiDart}}

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -30,9 +30,9 @@ abstract class {{resolveName visibility}}{{resolveName}} {{!!
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
 {{prefixPartial "dart/DartFunctionSignature" "  "}};
 {{/functions}}{{/set}}
-{{#properties}}
+{{#set skipBody=true}}{{#properties}}
 {{prefixPartial "dart/DartProperty" "  "}}
-{{/properties}}
+{{/properties}}{{/set}}
 }
 
 {{#enumerations}}

--- a/gluecodium/src/main/resources/templates/dart/DartProperty.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartProperty.mustache
@@ -18,4 +18,17 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{!! TODO: APIGEN-1789: implement }}
+{{#set property=this}}
+{{#getter}}
+{{#unless comment.isEmpty}}{{prefix comment "/// "}}
+{{/unless}}
+{{#if isStatic}}static {{/if}}{{resolveName property.typeRef}} get {{resolveName visibility}}{{resolveName property}}{{!!
+}}{{#unless skipBody}}{{>dart/DartFunctionBody}}{{/unless}}{{#if skipBody}};{{/if}}
+{{/getter}}
+{{#setter}}
+{{#unless comment.isEmpty}}{{prefix comment "/// "}}
+{{/unless}}
+{{#if isStatic}}static {{/if}}set {{resolveName visibility}}{{resolveName property}}({{resolveName property.typeRef}} value){{!!
+}}{{#unless skipBody}}{{>dart/DartFunctionBody}}{{/unless}}{{#if skipBody}};{{/if}}
+{{/setter}}
+{{/set}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiHeader.mustache
@@ -31,13 +31,19 @@ extern "C" {
 #endif
 
 {{#model}}
-{{#set parent=this}}{{#functions}}
+{{#functions}}
 {{>ffiFunctionSignature}}
-{{/functions}}{{/set}}
+{{/functions}}
+{{#properties}}{{#getter}}
+{{>ffiFunctionSignature}}
+{{/getter}}{{#setter}}
+{{>ffiFunctionSignature}}
+{{/setter}}
+{{/properties}}
 {{#structs}}
-{{#set parent=this}}{{#functions}}
+{{#functions}}
 {{>ffiFunctionSignature}}
-{{/functions}}{{/set}}
+{{/functions}}
 {{/structs}}
 {{/model}}
 

--- a/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
@@ -36,7 +36,13 @@ extern "C" {
 {{#model}}
 {{#set parent=this}}{{#functions}}
 {{>ffiFunction}}
-{{/functions}}{{/set}}
+{{/functions}}
+{{#properties}}{{#getter}}
+{{>ffiFunction}}
+{{/getter}}{{#setter}}
+{{>ffiFunction}}
+{{/setter}}
+{{/properties}}{{/set}}
 {{#structs}}
 {{#set parent=this}}{{#functions}}
 {{>ffiFunction}}

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithBasicTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithBasicTypes.dart
@@ -66,6 +66,54 @@ class GenericTypesWithBasicTypes {
     SetOf_String_releaseFfiHandle(__result_handle);
     return _result;
   }
+  List<double> get listProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_listProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = ListOf_Float_fromFfi(__result_handle);
+    ListOf_Float_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set listProperty(List<double> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_listProperty_set__ListOf_1Float');
+    final _value_handle = ListOf_Float_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    ListOf_Float_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  Map<double, double> get mapProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_mapProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = MapOf_Float_to_Double_fromFfi(__result_handle);
+    MapOf_Float_to_Double_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set mapProperty(Map<double, double> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_mapProperty_set__MapOf_1Float_1to_1Double');
+    final _value_handle = MapOf_Float_to_Double_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    MapOf_Float_to_Double_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  Set<double> get setProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_setProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = SetOf_Float_fromFfi(__result_handle);
+    SetOf_Float_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set setProperty(Set<double> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_setProperty_set__SetOf_1Float');
+    final _value_handle = SetOf_Float_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    SetOf_Float_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
 }
 Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi(GenericTypesWithBasicTypes value) =>
   value != null ? value._handle : Pointer<Void>.fromAddress(0);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/ffi/ffi_smoke_Properties.cpp
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/ffi/ffi_smoke_Properties.cpp
@@ -1,0 +1,140 @@
+#include "ffi_smoke_Properties.h"
+#include "ConversionBase.h"
+#include "smoke/Properties.h"
+#include <memory>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+uint32_t
+smoke_Properties_builtInTypeProperty_get(FfiOpaqueHandle _self) {
+    return gluecodium::ffi::Conversion<uint32_t>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).get_built_in_type_property()
+    );
+}
+void
+smoke_Properties_builtInTypeProperty_set__UInt(FfiOpaqueHandle _self, uint32_t value) {
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).set_built_in_type_property(
+            gluecodium::ffi::Conversion<uint32_t>::toCpp(value)
+        );
+}
+float
+smoke_Properties_readonlyProperty_get(FfiOpaqueHandle _self) {
+    return gluecodium::ffi::Conversion<float>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).get_readonly_property()
+    );
+}
+FfiOpaqueHandle
+smoke_Properties_structProperty_get(FfiOpaqueHandle _self) {
+    return gluecodium::ffi::Conversion<smoke::Properties::ExampleStruct>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).get_struct_property()
+    );
+}
+void
+smoke_Properties_structProperty_set__ExampleStruct(FfiOpaqueHandle _self, FfiOpaqueHandle value) {
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).set_struct_property(
+            gluecodium::ffi::Conversion<smoke::Properties::ExampleStruct>::toCpp(value)
+        );
+}
+FfiOpaqueHandle
+smoke_Properties_arrayProperty_get(FfiOpaqueHandle _self) {
+    return gluecodium::ffi::Conversion<std::vector<std::string>>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).get_array_property()
+    );
+}
+void
+smoke_Properties_arrayProperty_set__ListOf_1String(FfiOpaqueHandle _self, FfiOpaqueHandle value) {
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).set_array_property(
+            gluecodium::ffi::Conversion<std::vector<std::string>>::toCpp(value)
+        );
+}
+uint32_t
+smoke_Properties_complexTypeProperty_get(FfiOpaqueHandle _self) {
+    return gluecodium::ffi::Conversion<smoke::Properties::InternalErrorCode>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).get_complex_type_property()
+    );
+}
+void
+smoke_Properties_complexTypeProperty_set__InternalErrorCode(FfiOpaqueHandle _self, uint32_t value) {
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).set_complex_type_property(
+            gluecodium::ffi::Conversion<smoke::Properties::InternalErrorCode>::toCpp(value)
+        );
+}
+FfiOpaqueHandle
+smoke_Properties_byteBufferProperty_get(FfiOpaqueHandle _self) {
+    return gluecodium::ffi::Conversion<std::shared_ptr<std::vector<uint8_t>>>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).get_byte_buffer_property()
+    );
+}
+void
+smoke_Properties_byteBufferProperty_set__Blob(FfiOpaqueHandle _self, FfiOpaqueHandle value) {
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).set_byte_buffer_property(
+            gluecodium::ffi::Conversion<std::shared_ptr<std::vector<uint8_t>>>::toCpp(value)
+        );
+}
+FfiOpaqueHandle
+smoke_Properties_instanceProperty_get(FfiOpaqueHandle _self) {
+    return gluecodium::ffi::Conversion<std::shared_ptr<smoke::PropertiesInterface>>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).get_instance_property()
+    );
+}
+void
+smoke_Properties_instanceProperty_set__PropertiesInterface(FfiOpaqueHandle _self, FfiOpaqueHandle value) {
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).set_instance_property(
+            gluecodium::ffi::Conversion<std::shared_ptr<smoke::PropertiesInterface>>::toCpp(value)
+        );
+}
+bool
+smoke_Properties_isBooleanProperty_get(FfiOpaqueHandle _self) {
+    return gluecodium::ffi::Conversion<bool>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).is_boolean_property()
+    );
+}
+void
+smoke_Properties_isBooleanProperty_set__Boolean(FfiOpaqueHandle _self, bool value) {
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Properties>>::toCpp(_self)).set_boolean_property(
+            gluecodium::ffi::Conversion<bool>::toCpp(value)
+        );
+}
+FfiOpaqueHandle
+smoke_Properties_staticProperty_get() {
+    return gluecodium::ffi::Conversion<std::string>::toFfi(
+        smoke::Properties::get_static_property()
+    );
+}
+void
+smoke_Properties_staticProperty_set__String(FfiOpaqueHandle value) {
+            smoke::Properties::set_static_property(
+            gluecodium::ffi::Conversion<std::string>::toCpp(value)
+        );
+}
+FfiOpaqueHandle
+smoke_Properties_staticReadonlyProperty_get() {
+    return gluecodium::ffi::Conversion<smoke::Properties::ExampleStruct>::toFfi(
+        smoke::Properties::get_static_readonly_property()
+    );
+}
+void
+smoke_Properties_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::Properties>*>(handle);
+}
+FfiOpaqueHandle
+smoke_Properties_ExampleStruct_create_handle(double value) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) smoke::Properties::ExampleStruct(
+            gluecodium::ffi::Conversion<double>::toCpp(value)
+        ));
+}
+void
+smoke_Properties_ExampleStruct_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<smoke::Properties::ExampleStruct*>(handle);
+}
+double
+smoke_Properties_ExampleStruct_get_field_value(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<double>::toFfi(
+        reinterpret_cast<smoke::Properties::ExampleStruct*>(handle)->value
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/ffi/ffi_smoke_Properties.h
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/ffi/ffi_smoke_Properties.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "Export.h"
+#include "OpaqueHandle.h"
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+_GLUECODIUM_FFI_EXPORT uint32_t smoke_Properties_builtInTypeProperty_get(FfiOpaqueHandle _self);
+_GLUECODIUM_FFI_EXPORT void smoke_Properties_builtInTypeProperty_set__UInt(FfiOpaqueHandle _self, uint32_t value);
+_GLUECODIUM_FFI_EXPORT float smoke_Properties_readonlyProperty_get(FfiOpaqueHandle _self);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_Properties_structProperty_get(FfiOpaqueHandle _self);
+_GLUECODIUM_FFI_EXPORT void smoke_Properties_structProperty_set__ExampleStruct(FfiOpaqueHandle _self, FfiOpaqueHandle value);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_Properties_arrayProperty_get(FfiOpaqueHandle _self);
+_GLUECODIUM_FFI_EXPORT void smoke_Properties_arrayProperty_set__ListOf_1String(FfiOpaqueHandle _self, FfiOpaqueHandle value);
+_GLUECODIUM_FFI_EXPORT uint32_t smoke_Properties_complexTypeProperty_get(FfiOpaqueHandle _self);
+_GLUECODIUM_FFI_EXPORT void smoke_Properties_complexTypeProperty_set__InternalErrorCode(FfiOpaqueHandle _self, uint32_t value);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_Properties_byteBufferProperty_get(FfiOpaqueHandle _self);
+_GLUECODIUM_FFI_EXPORT void smoke_Properties_byteBufferProperty_set__Blob(FfiOpaqueHandle _self, FfiOpaqueHandle value);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_Properties_instanceProperty_get(FfiOpaqueHandle _self);
+_GLUECODIUM_FFI_EXPORT void smoke_Properties_instanceProperty_set__PropertiesInterface(FfiOpaqueHandle _self, FfiOpaqueHandle value);
+_GLUECODIUM_FFI_EXPORT bool smoke_Properties_isBooleanProperty_get(FfiOpaqueHandle _self);
+_GLUECODIUM_FFI_EXPORT void smoke_Properties_isBooleanProperty_set__Boolean(FfiOpaqueHandle _self, bool value);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_Properties_staticProperty_get();
+_GLUECODIUM_FFI_EXPORT void smoke_Properties_staticProperty_set__String(FfiOpaqueHandle value);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_Properties_staticReadonlyProperty_get();
+_GLUECODIUM_FFI_EXPORT void smoke_Properties_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_Properties_ExampleStruct_create_handle(double);
+_GLUECODIUM_FFI_EXPORT void smoke_Properties_ExampleStruct_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT double smoke_Properties_ExampleStruct_get_field_value(FfiOpaqueHandle handle);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
@@ -1,0 +1,174 @@
+import 'package:library/src/Boolean__conversion.dart';
+import 'package:library/src/GenericTypes__conversion.dart';
+import 'package:library/src/List__conversion.dart';
+import 'package:library/src/String__conversion.dart';
+import 'package:library/src/smoke/PropertiesInterface.dart';
+import 'package:library/src/smoke/Properties_ExampleStruct__conversion.dart';
+import 'package:library/src/smoke/Properties_InternalErrorCode__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final __release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_Properties_release_handle');
+class Properties {
+  final Pointer<Void> _handle;
+  Properties._(this._handle);
+  void release() => __release_handle(_handle);
+  int get builtInTypeProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('smoke_Properties_builtInTypeProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  set builtInTypeProperty(int value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint32), void Function(Pointer<Void>, int)>('smoke_Properties_builtInTypeProperty_set__UInt');
+    final _value_handle = (value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    (_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  double get readonlyProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>), double Function(Pointer<Void>)>('smoke_Properties_readonlyProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  Properties_ExampleStruct get structProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Properties_structProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = smoke_Properties_ExampleStruct_fromFfi(__result_handle);
+    smoke_Properties_ExampleStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set structProperty(Properties_ExampleStruct value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_Properties_structProperty_set__ExampleStruct');
+    final _value_handle = smoke_Properties_ExampleStruct_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    smoke_Properties_ExampleStruct_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  List<String> get arrayProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Properties_arrayProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = ListOf_String_fromFfi(__result_handle);
+    ListOf_String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set arrayProperty(List<String> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_Properties_arrayProperty_set__ListOf_1String');
+    final _value_handle = ListOf_String_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    ListOf_String_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  Properties_InternalErrorCode get complexTypeProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('smoke_Properties_complexTypeProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = smoke_Properties_InternalErrorCode_fromFfi(__result_handle);
+    smoke_Properties_InternalErrorCode_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set complexTypeProperty(Properties_InternalErrorCode value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint32), void Function(Pointer<Void>, int)>('smoke_Properties_complexTypeProperty_set__InternalErrorCode');
+    final _value_handle = smoke_Properties_InternalErrorCode_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    smoke_Properties_InternalErrorCode_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  List<int> get byteBufferProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Properties_byteBufferProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  set byteBufferProperty(List<int> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_Properties_byteBufferProperty_set__Blob');
+    final _value_handle = (value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    (_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  PropertiesInterface get instanceProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Properties_instanceProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = smoke_PropertiesInterface_fromFfi(__result_handle);
+    smoke_PropertiesInterface_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set instanceProperty(PropertiesInterface value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_Properties_instanceProperty_set__PropertiesInterface');
+    final _value_handle = smoke_PropertiesInterface_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    smoke_PropertiesInterface_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  bool get isBooleanProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('smoke_Properties_isBooleanProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set isBooleanProperty(bool value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint8), void Function(Pointer<Void>, int)>('smoke_Properties_isBooleanProperty_set__Boolean');
+    final _value_handle = Boolean_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Boolean_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  static String get staticProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('smoke_Properties_staticProperty_get');
+    final __result_handle = _get_ffi();
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static set staticProperty(String value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('smoke_Properties_staticProperty_set__String');
+    final _value_handle = String_toFfi(value);
+    final __result_handle = _set_ffi(_value_handle);
+    String_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  static Properties_ExampleStruct get staticReadonlyProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('smoke_Properties_staticReadonlyProperty_get');
+    final __result_handle = _get_ffi();
+    final _result = smoke_Properties_ExampleStruct_fromFfi(__result_handle);
+    smoke_Properties_ExampleStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_Properties_toFfi(Properties value) =>
+  value != null ? value._handle : Pointer<Void>.fromAddress(0);
+Properties smoke_Properties_fromFfi(Pointer<Void> handle) =>
+  handle.address != 0 ? Properties._(handle) : null;
+void smoke_Properties_releaseFfiHandle(Pointer<Void> handle) {}
+enum Properties_InternalErrorCode {
+    errorNone,
+    errorFatal
+}
+class Properties_ExampleStruct {
+  double value;
+  Properties_ExampleStruct(this.value);
+}

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/PropertiesInterface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/PropertiesInterface.dart
@@ -1,0 +1,44 @@
+import 'package:library/src/smoke/PropertiesInterface_ExampleStruct__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+abstract class PropertiesInterface {
+  void release();
+  PropertiesInterface_ExampleStruct get structProperty;
+  set structProperty(PropertiesInterface_ExampleStruct value);
+}
+class PropertiesInterface_ExampleStruct {
+  double value;
+  PropertiesInterface_ExampleStruct(this.value);
+}
+// "Private" section, not exported.
+final __release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PropertiesInterface_release_handle');
+class PropertiesInterface__Impl implements PropertiesInterface{
+  final Pointer<Void> _handle;
+  PropertiesInterface__Impl._(this._handle);
+  void release() => __release_handle(_handle);
+  PropertiesInterface_ExampleStruct get structProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_PropertiesInterface_structProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = smoke_PropertiesInterface_ExampleStruct_fromFfi(__result_handle);
+    smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set structProperty(PropertiesInterface_ExampleStruct value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_PropertiesInterface_structProperty_set__ExampleStruct');
+    final _value_handle = smoke_PropertiesInterface_ExampleStruct_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_PropertiesInterface_toFfi(PropertiesInterface__Impl value) =>
+  value != null ? value._handle : Pointer<Void>.fromAddress(0);
+PropertiesInterface smoke_PropertiesInterface_fromFfi(Pointer<Void> handle) =>
+  handle.address != 0 ? PropertiesInterface__Impl._(handle) : null;
+void smoke_PropertiesInterface_releaseFfiHandle(Pointer<Void> handle) {}


### PR DESCRIPTION
Added/updated Dart and FFI templates to support properties.

Updated AntlrLimeModelBuilder to correctly propagate "isStatic" flag
from the property itself to its accessors in the LIME model tree.

Added/updated smoke and functional tests as appropriate.

Resolves: #59
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>