### PR TITLE
Add support for constants in Dart generator

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -304,7 +304,7 @@ feature(UnderscorePackage cpp android swift SOURCES
     lime/test/UseUnderscorePackage.lime
 )
 
-feature(Constants cpp android swift SOURCES
+feature(Constants cpp android swift dart SOURCES
     src/test/Constants.cpp
 
     lime/test/Constants.lime

--- a/examples/libhello/lime/test/Constants.lime
+++ b/examples/libhello/lime/test/Constants.lime
@@ -28,6 +28,13 @@ types Constants {
     const doubleConstant: Double = -3.14
     const stringConstant: String = "Foo bar"
     const enumConstant: StateEnum = StateEnum.ON
+
+    const floatNan: Float = NaN
+    const floatInfinity: Float = Infinity
+    const floatNegativeInfinity: Float = -Infinity
+    const doubleNan: Double = NaN
+    const doubleInfinity: Double = Infinity
+    const doubleNegativeInfinity: Double = -Infinity
 }
 
 class ConstantsInterface {

--- a/examples/platforms/dart/main.dart
+++ b/examples/platforms/dart/main.dart
@@ -19,6 +19,7 @@
 // -------------------------------------------------------------------------------------------------
 
 import "test/Classes_test.dart" as ClassesTests;
+import "test/Constants_test.dart" as ConstantsTests;
 import "test/Enums_test.dart" as EnumsTests;
 import "test/Interfaces_test.dart" as InterfacesTests;
 import "test/Lists_test.dart" as ListsTests;
@@ -34,6 +35,7 @@ import "test/StaticStringMethods_test.dart" as StaticStringMethodsTests;
 
 final _allTests = [
   ClassesTests.main,
+  ConstantsTests.main,
   EnumsTests.main,
   InterfacesTests.main,
   ListsTests.main,

--- a/examples/platforms/dart/test/Constants_test.dart
+++ b/examples/platforms/dart/test/Constants_test.dart
@@ -1,0 +1,80 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:hello/hello.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("Constants");
+
+void main() {
+  _testSuite.test("Int constant", () {
+    final result = intConstant;
+
+    expect(result, equals(-11));
+  });
+  _testSuite.test("Double constant", () {
+    final result = floatConstant;
+
+    expect(result, equals(2.71));
+  });
+  _testSuite.test("String constant", () {
+    final result = stringConstant;
+
+    expect(result, equals("Foo bar"));
+  });
+  _testSuite.test("Enum constant", () {
+    final result = enumConstant;
+
+    expect(result, equals(StateEnum.on));
+  });
+  _testSuite.test("NaN constant", () {
+    final result = floatNan;
+
+    expect(result, isNaN);
+  });
+  _testSuite.test("Infinity constant", () {
+    final result = doubleInfinity;
+
+    expect(result, equals(double.infinity));
+  });
+  _testSuite.test("Negative infinity constant", () {
+    final result = floatNegativeInfinity;
+
+    expect(result, equals(double.negativeInfinity));
+  });
+  _testSuite.test("Constant in class", () {
+    final result = ConstantsInterface.uintConstant;
+
+    expect(result, equals(42));
+  });
+  _testSuite.test("Struct type constant", () {
+    final result = StructConstants.structConstant;
+
+    expect(result.stringField, equals("bar Buzz"));
+    expect(result.floatField, equals(1.41));
+  });
+  _testSuite.test("Struct type constant, nested", () {
+    final result = StructConstants.nestingStructConstant;
+
+    expect(result.structField.stringField, equals("nonsense"));
+    expect(result.structField.floatField, equals(-2.82));
+  });
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -122,9 +122,9 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
         val filePath = "$packagePath/${nameRules.getName(rootElement)}"
         val relativePath = "$SRC_DIR_SUFFIX/$filePath.dart"
 
-        val allSymbols = LimeTypeHelper.getAllTypes(rootElement)
-            .filterNot { it is LimeTypeAlias }
-            .map { dartNameResolver.resolveName(it) }
+        val allTypes = LimeTypeHelper.getAllTypes(rootElement).filterNot { it is LimeTypeAlias }
+        val freeConstants = (rootElement as? LimeTypesCollection)?.constants ?: emptyList()
+        val allSymbols = (allTypes + freeConstants).map { dartNameResolver.resolveName(it) }
         pathsCollector += DartExport(relativePath, allSymbols)
 
         val content = TemplateEngine.render(

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -32,9 +32,9 @@ class {{resolveName visibility}}{{resolveName}} {{!!
 
   void release() => __release_handle(_handle);
 
-{{#constants}}
+{{#set isInClass=true}}{{#constants}}
 {{prefixPartial "dart/DartConstant" "  "}}
-{{/constants}}
+{{/constants}}{{/set}}
 {{#set parent=this}}{{#constructors}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
 {{prefixPartial "dartConstructor" "  "}}

--- a/gluecodium/src/main/resources/templates/dart/DartConstant.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartConstant.mustache
@@ -18,4 +18,5 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{!! TODO: APIGEN-1787: implement }}
+{{>dart/DartDocumentation}}
+{{#if isInClass}}static {{/if}}final {{resolveName typeRef}} {{resolveName visibility}}{{resolveName}} = {{resolveName value}};

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -23,9 +23,9 @@ abstract class {{resolveName visibility}}{{resolveName}} {{!!
 }}{{#if parent}}implements {{resolveName parent}} {{/if}}{
   void release();
 
-{{#constants}}
+{{#set isInClass=true}}{{#constants}}
 {{prefixPartial "dart/DartConstant" "  "}}
-{{/constants}}
+{{/constants}}{{/set}}
 {{#set parent=this}}{{#functions}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
 {{prefixPartial "dart/DartFunctionSignature" "  "}};

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/Constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/Constants.dart
@@ -1,0 +1,14 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+enum StateEnum {
+    off,
+    on
+}
+    final bool boolConstant = true;
+    final int intConstant = -11;
+    final int uintConstant = 4294967295;
+    final double floatConstant = 2.71;
+    final double doubleConstant = -3.14;
+    final String stringConstant = "Foo bar";
+    final StateEnum enumConstant = StateEnum.on;

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/ConstantsInterface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/ConstantsInterface.dart
@@ -1,0 +1,28 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final __release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ConstantsInterface_release_handle');
+class ConstantsInterface {
+  final Pointer<Void> _handle;
+  ConstantsInterface._(this._handle);
+  void release() => __release_handle(_handle);
+  static final bool boolConstant = true;
+  static final int intConstant = -11;
+  static final int uintConstant = 4294967295;
+  static final double floatConstant = 2.71;
+  static final double doubleConstant = -3.14;
+  static final String stringConstant = "Foo bar";
+  static final ConstantsInterface_StateEnum enumConstant = ConstantsInterface_StateEnum.on;
+}
+Pointer<Void> smoke_ConstantsInterface_toFfi(ConstantsInterface value) =>
+  value != null ? value._handle : Pointer<Void>.fromAddress(0);
+ConstantsInterface smoke_ConstantsInterface_fromFfi(Pointer<Void> handle) =>
+  handle.address != 0 ? ConstantsInterface._(handle) : null;
+void smoke_ConstantsInterface_releaseFfiHandle(Pointer<Void> handle) {}
+enum ConstantsInterface_StateEnum {
+    off,
+    on
+}

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/StructConstants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/StructConstants.dart
@@ -1,0 +1,28 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final __release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_StructConstants_release_handle');
+class StructConstants {
+  final Pointer<Void> _handle;
+  StructConstants._(this._handle);
+  void release() => __release_handle(_handle);
+  static final StructConstants_SomeStruct structConstant = StructConstants_SomeStruct("bar Buzz", 1.41);
+  static final StructConstants_NestingStruct nestingStructConstant = StructConstants_NestingStruct(StructConstants_SomeStruct("nonsense", -2.82));
+}
+Pointer<Void> smoke_StructConstants_toFfi(StructConstants value) =>
+  value != null ? value._handle : Pointer<Void>.fromAddress(0);
+StructConstants smoke_StructConstants_fromFfi(Pointer<Void> handle) =>
+  handle.address != 0 ? StructConstants._(handle) : null;
+void smoke_StructConstants_releaseFfiHandle(Pointer<Void> handle) {}
+class StructConstants_SomeStruct {
+  String stringField;
+  double floatField;
+  StructConstants_SomeStruct(this.stringField, this.floatField);
+}
+class StructConstants_NestingStruct {
+  StructConstants_SomeStruct structField;
+  StructConstants_NestingStruct(this.structField);
+}


### PR DESCRIPTION
Updated Dart templates to support constants.

Updated Dart name resolver to support all types of literals for
LimeValue.

Added smoke and functional tests as appropriate.

Resolves: #58
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>