### PR TITLE
Clarify platform specific comments

### DIFF
--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -535,15 +535,17 @@ struct Options {
 
 Parts of documentation comments can be varied per platform (i.e. per output language). Example:
 ```
-// Process something{@Java , maybe}. Returns a {@Cpp generic} result
+// Process something{@Java  the Java way}. Returns a{@Cpp generic } result
 // and throws if something goes wrong{@Swift  but not on iOS}.
 fun process(): GenericResult throws SomethingWrongException
 ```
 
 The resulting documentation will look like this, per language:
 * *C++*: `Process something. Returns a generic result and throws if something goes wrong.`
-* *Java*: `Process something, maybe. Returns a result and throws if something goes wrong.`
+* *Java*: `Process something the Java way. Returns a result and throws if something goes wrong.`
 * *Swift*: `Process something. Returns a result and throws if something goes wrong but not on iOS.`
+Note that one space after the `@Platform` is treated as separator, everything after that, including
+spaces is considered to be part of the comment.
 
 #### Special characters in documentation comments
 


### PR DESCRIPTION
Having a `,` at the beginning of the platform specific comment example
caused confusion when people just skimmed the documentation.

Signed-off-by: Georg Bremer <georg.bremer@here.com>