### PR TITLE
Add @Immutable structs support to Dart generator

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -149,7 +149,7 @@ feature(StructsInTypes cpp android swift dart SOURCES
     lime/test/TypeCollection.lime
 )
 
-feature(StructsImmutable cpp android swift SOURCES
+feature(StructsImmutable cpp android swift dart SOURCES
     src/test/PlainDataStructuresImmutable.cpp
 
     lime/test/PlainDataStructuresImmutable.lime

--- a/examples/libhello/lime/test/ArraysByteBuffer.lime
+++ b/examples/libhello/lime/test/ArraysByteBuffer.lime
@@ -21,6 +21,10 @@ class ArraysByteBuffer {
     struct StructWithByteBuffer {
         image: Blob
     }
+    @Immutable
+    struct ImmutableStructWithByteBuffer {
+        image: Blob
+    }
     struct StructWithImplicitArray {
         image: List<UByte>
     }

--- a/examples/libhello/lime/test/PlainDataStructuresImmutable.lime
+++ b/examples/libhello/lime/test/PlainDataStructuresImmutable.lime
@@ -38,7 +38,6 @@ class PlainDataStructuresImmutable {
         doubleField: Double
         stringField: String
         booleanField: Boolean
-        bytesField: Blob
         pointField: Point
     }
     struct NestingImmutableStruct {
@@ -57,7 +56,13 @@ class PlainDataStructuresImmutable {
     }
     typealias ArrayOfImmutable = List<AllTypesImmutableStruct>
     typealias MapToImmutableStruct = Map<Int, AllTypesImmutableStruct>
-    static fun MapOfImmutablesRoundTrip(
-        input: MapToImmutableStruct
-    ): MapToImmutableStruct
+
+    static fun immutableStructRoundTrip(input: AllTypesImmutableStruct): AllTypesImmutableStruct
+    static fun nestingImmutableStructRoundTrip(
+        input: NestingImmutableStruct
+    ): NestingImmutableStruct
+    static fun immutableStructWithAccessorsRoundTrip(
+        input: ImmutableStructWithCppAccessors
+    ): ImmutableStructWithCppAccessors
+    static fun mapOfImmutablesRoundTrip(input: MapToImmutableStruct): MapToImmutableStruct
 }

--- a/examples/libhello/src/test/PlainDataStructuresImmutable.cpp
+++ b/examples/libhello/src/test/PlainDataStructuresImmutable.cpp
@@ -22,9 +22,30 @@
 
 namespace test
 {
+PlainDataStructuresImmutable::AllTypesImmutableStruct
+PlainDataStructuresImmutable::immutable_struct_round_trip(
+    const PlainDataStructuresImmutable::AllTypesImmutableStruct& input )
+{
+    return input;
+}
+
+PlainDataStructuresImmutable::NestingImmutableStruct
+PlainDataStructuresImmutable::nesting_immutable_struct_round_trip(
+    const PlainDataStructuresImmutable::NestingImmutableStruct& input )
+{
+    return input;
+}
+
+PlainDataStructuresImmutable::ImmutableStructWithCppAccessors
+PlainDataStructuresImmutable::immutable_struct_with_accessors_round_trip(
+    const PlainDataStructuresImmutable::ImmutableStructWithCppAccessors& input )
+{
+    return input;
+}
+
 PlainDataStructuresImmutable::MapToImmutableStruct
 PlainDataStructuresImmutable::map_of_immutables_round_trip(
-    const PlainDataStructuresImmutable::MapToImmutableStruct& input )
+    const PlainDataStructuresImmutable::MapToImmutableStruct& input)
 {
     return input;
 }

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/PlainDataStructuresTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/PlainDataStructuresTest.java
@@ -26,7 +26,6 @@ import android.os.Build;
 import com.example.here.hello.BuildConfig;
 import com.here.android.RobolectricApplication;
 import com.here.android.hello.HelloWorldBuiltinTypes;
-import java.util.Arrays;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -206,7 +205,6 @@ public final class PlainDataStructuresTest {
             1.0,
             "test string",
             true,
-            "hello".getBytes(),
             new PlainDataStructuresImmutable.Point(11.0, 12.0));
 
     PlainDataStructuresImmutable.AllTypesImmutableStruct.Builder builder =
@@ -226,12 +224,10 @@ public final class PlainDataStructuresTest {
             .setDoubleField(1.0)
             .setStringField("test string")
             .setBooleanField(true)
-            .setBytesField("hello".getBytes())
             .setPointField(new PlainDataStructuresImmutable.Point(11.0, 12.0))
             .build();
 
     assertEquals(allTypesStruct.booleanField, result.booleanField);
-    assertTrue(Arrays.equals(allTypesStruct.bytesField, result.bytesField));
     assertEquals(allTypesStruct.doubleField, result.doubleField);
     assertEquals(allTypesStruct.floatField, result.floatField);
     assertEquals(allTypesStruct.int8Field, result.int8Field);

--- a/examples/platforms/dart/main.dart
+++ b/examples/platforms/dart/main.dart
@@ -27,6 +27,7 @@ import "test/Lists_test.dart" as ListsTests;
 import "test/Maps_test.dart" as MapsTests;
 import "test/MethodOverloads_test.dart" as MethodOverloads;
 import "test/PlainDataStructures_test.dart" as PlainDataStructuresTests;
+import "test/PlainDataStructuresImmutable_test.dart" as PlainDataStructuresImmutableTests;
 import "test/PlainDataStructuresTypeCollection_test.dart" as PlainDataStructuresTypeCollectionTests;
 import "test/Properties_test.dart" as PropertiesTests;
 import "test/Sets_test.dart" as SetsTests;
@@ -45,6 +46,7 @@ final _allTests = [
   MapsTests.main,
   MethodOverloads.main,
   PlainDataStructuresTests.main,
+  PlainDataStructuresImmutableTests.main,
   PlainDataStructuresTypeCollectionTests.main,
   PropertiesTests.main,
   SetsTests.main,

--- a/examples/platforms/dart/test/PlainDataStructuresImmutable_test.dart
+++ b/examples/platforms/dart/test/PlainDataStructuresImmutable_test.dart
@@ -1,0 +1,82 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2019 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:hello/hello.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("PlainDataStructuresImmutable");
+
+void main() {
+  _testSuite.test("All types immutable struct round trip", () {
+    final input = PlainDataStructuresImmutable_AllTypesImmutableStruct(-1, 2, -3, 4, -5,
+        6, -7, 8, -9, 10, "foo", true, PlainDataStructuresImmutable_Point(-11, 12));
+
+    final result = PlainDataStructuresImmutable.immutableStructRoundTrip(input);
+
+    expect(result.int8Field, equals(-1));
+    expect(result.uint8Field, equals(2));
+    expect(result.int16Field, equals(-3));
+    expect(result.uint16Field, equals(4));
+    expect(result.int32Field, equals(-5));
+    expect(result.uint32Field, equals(6));
+    expect(result.int64Field, equals(-7));
+    expect(result.uint64Field, equals(8));
+    expect(result.floatField, equals(-9));
+    expect(result.doubleField, equals(10));
+    expect(result.stringField, equals("foo"));
+    expect(result.booleanField, equals(true));
+    expect(result.pointField.x, equals(-11));
+    expect(result.pointField.y, equals(12));
+  });
+  _testSuite.test("Nested immutable struct round trip", () {
+    final input = PlainDataStructuresImmutable_NestingImmutableStruct(
+        PlainDataStructuresImmutable_AllTypesImmutableStruct(
+            -1, 2, -3, 4, -5, 6, -7, 8, -9, 10, "foo", true, 
+            PlainDataStructuresImmutable_Point(-11, 12)
+        )
+    );
+
+    final result = PlainDataStructuresImmutable.nestingImmutableStructRoundTrip(input);
+
+    expect(result.structField.int8Field, equals(-1));
+    expect(result.structField.uint8Field, equals(2));
+    expect(result.structField.int16Field, equals(-3));
+    expect(result.structField.uint16Field, equals(4));
+    expect(result.structField.int32Field, equals(-5));
+    expect(result.structField.uint32Field, equals(6));
+    expect(result.structField.int64Field, equals(-7));
+    expect(result.structField.uint64Field, equals(8));
+    expect(result.structField.floatField, equals(-9));
+    expect(result.structField.doubleField, equals(10));
+    expect(result.structField.stringField, equals("foo"));
+    expect(result.structField.booleanField, equals(true));
+    expect(result.structField.pointField.x, equals(-11));
+    expect(result.structField.pointField.y, equals(12));
+  });
+  _testSuite.test("Immutable struct with accessprs round trip", () {
+    final input =
+        PlainDataStructuresImmutable_ImmutableStructWithCppAccessors("foo");
+
+    final result = PlainDataStructuresImmutable.immutableStructWithAccessorsRoundTrip(input);
+
+    expect(result.stringField, equals("foo"));
+  });
+}

--- a/gluecodium/src/main/resources/templates/dart/DartField.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartField.mustache
@@ -19,4 +19,5 @@
   !
   !}}
 {{>dart/DartDocumentation}}
-{{resolveName typeRef}} {{resolveName visibility}}{{resolveName}}{{#defaultValue}} = {{resolveName}}{{/defaultValue}};
+{{#ifHasAttribute parent "Immutable"}}final {{/ifHasAttribute}}{{!!
+}}{{resolveName typeRef}} {{resolveName visibility}}{{resolveName}}{{#defaultValue}} = {{resolveName}}{{/defaultValue}};

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -21,8 +21,8 @@
 {{#unless comment.isEmpty}}{{prefix comment "/// "}}
 {{/unless}}
 class {{resolveName visibility}}{{resolveName}} {
-{{#fields}}{{prefixPartial "dart/DartField" "  "}}
-{{/fields}}
+{{#set parent=this}}{{#fields}}{{prefixPartial "dart/DartField" "  "}}
+{{/fields}}{{/set}}
 {{#if fields}}  {{resolveName}}({{#fields}}this.{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{/if}}
 {{#constants}}{{prefixPartial "dart/DartConstant" "  "}}

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
@@ -97,20 +97,20 @@ class Structs_Line {
   Structs_Line(this.a, this.b);
 }
 class Structs_AllTypesStruct {
-  int int8Field;
-  int uint8Field;
-  int int16Field;
-  int uint16Field;
-  int int32Field;
-  int uint32Field;
-  int int64Field;
-  int uint64Field;
-  double floatField;
-  double doubleField;
-  String stringField;
-  bool booleanField;
-  List<int> bytesField;
-  Structs_Point pointField;
+  final int int8Field;
+  final int uint8Field;
+  final int int16Field;
+  final int uint16Field;
+  final int int32Field;
+  final int uint32Field;
+  final int int64Field;
+  final int uint64Field;
+  final double floatField;
+  final double doubleField;
+  final String stringField;
+  final bool booleanField;
+  final List<int> bytesField;
+  final Structs_Point pointField;
   Structs_AllTypesStruct(this.int8Field, this.uint8Field, this.int16Field, this.uint16Field, this.int32Field, this.uint32Field, this.int64Field, this.uint64Field, this.floatField, this.doubleField, this.stringField, this.booleanField, this.bytesField, this.pointField);
 }
 class Structs_ExternalStruct {
@@ -141,7 +141,7 @@ class Structs_StructWithArrayOfImmutable {
   Structs_StructWithArrayOfImmutable(this.arrayField);
 }
 class Structs_ImmutableStructWithCppAccessors {
-  String stringField;
+  final String stringField;
   Structs_ImmutableStructWithCppAccessors(this.stringField);
 }
 class Structs_MutableStructWithCppAccessors {


### PR DESCRIPTION
Updated Dart templates to support @Immutable structs. Added/updated
smoke and functional tests as appropriate.

Resolves: #92
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>