### PR TITLE
Upgrade to the latest Artifactory plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50"
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.8.1"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.13.0"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:3.27.0"
     }
 }


### PR DESCRIPTION
The current version is incompatible with recently upgraded Gradle 6.

Signed-off-by: Teemu Kähkönen <teemu.kahkonen@here.com>
