### PR TITLE
Add support for Blob type to Dart generator

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -80,7 +80,7 @@ feature(MethodOverloading cpp android swift dart SOURCES
     lime/test/MethodOverloads.lime
 )
 
-feature(Blob cpp android swift SOURCES
+feature(Blob cpp android swift dart SOURCES
     src/hello/HelloWorldBuiltinTypes.cpp
     src/test/ArraysByteBuffer.cpp
     src/test/StaticByteArrayMethods.cpp

--- a/examples/platforms/dart/main.dart
+++ b/examples/platforms/dart/main.dart
@@ -18,6 +18,7 @@
 //
 // -------------------------------------------------------------------------------------------------
 
+import "test/Blobs_test.dart" as BlobsTests;
 import "test/Classes_test.dart" as ClassesTests;
 import "test/Constants_test.dart" as ConstantsTests;
 import "test/Dates_test.dart" as DatesTests;
@@ -41,6 +42,7 @@ import "test/StructsWithConstants_test.dart" as StructsWithConstantsTests;
 import "test/StructsWithMethods_test.dart" as StructsWithMethodsTests;
 
 final _allTests = [
+  BlobsTests.main,
   ClassesTests.main,
   ConstantsTests.main,
   DatesTests.main,

--- a/examples/platforms/dart/test/Blobs_test.dart
+++ b/examples/platforms/dart/test/Blobs_test.dart
@@ -18,6 +18,7 @@
 //
 // -------------------------------------------------------------------------------------------------
 
+import "dart:typed_data";
 import "package:test/test.dart";
 import "package:hello/hello.dart";
 import "../test_suite.dart";
@@ -26,31 +27,31 @@ final _testSuite = TestSuite("Blobs");
 
 void main() {
   _testSuite.test("methodWithByteBuffer() empty list", () {
-    final result = ArraysByteBuffer.methodWithByteBuffer([]);
+    final result = ArraysByteBuffer.methodWithByteBuffer(Uint8List(0));
 
     expect(result, isEmpty);
   });
   _testSuite.test("methodWithByteBuffer() reverses list", () {
-    final result = ArraysByteBuffer.methodWithByteBuffer([0, 42, 255]);
+    final result = ArraysByteBuffer.methodWithByteBuffer(Uint8List.fromList([0, 42, 255]));
 
     expect(result, [255, 42, 0]);
   });
   _testSuite.test("methodWithByteBufferInStruct() empty list", () {
     final result = ArraysByteBuffer.methodWithByteBufferInStruct(
-        ArraysByteBuffer_StructWithByteBuffer([])
+        ArraysByteBuffer_StructWithByteBuffer(Uint8List(0))
     );
 
     expect(result.image, isEmpty);
   });
   _testSuite.test("methodWithBymethodWithByteBufferInStructteBuffer() reverses list", () {
     final result = ArraysByteBuffer.methodWithByteBufferInStruct(
-        ArraysByteBuffer_StructWithByteBuffer([0, 42, 255])
+        ArraysByteBuffer_StructWithByteBuffer(Uint8List.fromList([0, 42, 255]))
     );
 
-    expect(result.image, [255, 42, 0]);
+    expect(result.image, Uint8List.fromList([255, 42, 0]));
   });
   _testSuite.test("methodThatExplodes() throws", () {
-    List<int> result = null;
+    Uint8List result = null;
     ExplosiveException exception = null;
 
     try {
@@ -64,7 +65,7 @@ void main() {
     expect(exception.error, ExplosiveErrorCode.exploded);
   });
   _testSuite.test("methodThatExplodes() does not throw", () {
-    List<int> result = null;
+    Uint8List result = null;
     ExplosiveException exception = null;
 
     try {
@@ -73,7 +74,7 @@ void main() {
       exception = e;
     }
 
-    expect(result, [0, 1, 2]);
     expect(exception, isNull);
+    expect(result, Uint8List.fromList([0, 1, 2]));
   });
 }

--- a/examples/platforms/dart/test/Blobs_test.dart
+++ b/examples/platforms/dart/test/Blobs_test.dart
@@ -1,0 +1,79 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:hello/hello.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("Blobs");
+
+void main() {
+  _testSuite.test("methodWithByteBuffer() empty list", () {
+    final result = ArraysByteBuffer.methodWithByteBuffer([]);
+
+    expect(result, isEmpty);
+  });
+  _testSuite.test("methodWithByteBuffer() reverses list", () {
+    final result = ArraysByteBuffer.methodWithByteBuffer([0, 42, 255]);
+
+    expect(result, [255, 42, 0]);
+  });
+  _testSuite.test("methodWithByteBufferInStruct() empty list", () {
+    final result = ArraysByteBuffer.methodWithByteBufferInStruct(
+        ArraysByteBuffer_StructWithByteBuffer([])
+    );
+
+    expect(result.image, isEmpty);
+  });
+  _testSuite.test("methodWithBymethodWithByteBufferInStructteBuffer() reverses list", () {
+    final result = ArraysByteBuffer.methodWithByteBufferInStruct(
+        ArraysByteBuffer_StructWithByteBuffer([0, 42, 255])
+    );
+
+    expect(result.image, [255, 42, 0]);
+  });
+  _testSuite.test("methodThatExplodes() throws", () {
+    List<int> result = null;
+    ExplosiveException exception = null;
+
+    try {
+      result = ArraysByteBuffer.methodThatExplodes(true);
+    } on ExplosiveException catch(e) {
+      exception = e;
+    }
+
+    expect(result, isNull);
+    expect(exception, isNotNull);
+    expect(exception.error, ExplosiveErrorCode.exploded);
+  });
+  _testSuite.test("methodThatExplodes() does not throw", () {
+    List<int> result = null;
+    ExplosiveException exception = null;
+
+    try {
+      result = ArraysByteBuffer.methodThatExplodes(false);
+    } on ExplosiveException catch(e) {
+      exception = e;
+    }
+
+    expect(result, [0, 1, 2]);
+    expect(exception, isNull);
+  });
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -216,7 +216,7 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
                 TemplateEngine.render("dart/DartPubspec", templateData),
                 "$ROOT_DIR/pubspec.yaml"
             )
-        ) + listOf("Boolean", "String", "DateTime").map {
+        ) + listOf("Boolean", "String", "DateTime", "Blob").map {
             GeneratedFile(
                 TemplateEngine.render("dart/Dart${it}Conversion", templateData),
                 "$LIB_DIR/$SRC_DIR_SUFFIX/${it}__conversion.dart"
@@ -226,7 +226,7 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
 
     private fun generateFfiCommonFiles(): List<GeneratedFile> {
         val headerOnly = listOf("ConversionBase", "Export", "OpaqueHandle")
-        val headerAndImpl = listOf("StringHandle")
+        val headerAndImpl = listOf("StringHandle", "BlobHandle")
         val data = mapOf(
             "opaqueHandleType" to OPAQUE_HANDLE_TYPE,
             "internalNamespace" to internalNamespace

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImport.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImport.kt
@@ -19,6 +19,15 @@
 
 package com.here.gluecodium.generator.dart
 
-data class DartImport(val filePath: String, val asAlias: String? = null) : Comparable<DartImport> {
-    override fun compareTo(other: DartImport) = filePath.compareTo(other.filePath)
+data class DartImport(
+    val filePath: String,
+    val asAlias: String? = null,
+    val isSystem: Boolean = false
+) : Comparable<DartImport> {
+    override fun compareTo(other: DartImport) =
+        when (val systemComparison = isSystem.compareTo(other.isSystem)) {
+            0 -> filePath.compareTo(other.filePath)
+            // According to Dart style guide, system imports should precede package imports.
+            else -> -systemComparison
+        }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
@@ -64,7 +64,8 @@ internal class DartImportResolver(
         when (limeType.typeId) {
             LimeBasicType.TypeId.BOOLEAN -> listOf(createConversionImport("Boolean"))
             LimeBasicType.TypeId.STRING -> listOf(createConversionImport("String"))
-            LimeBasicType.TypeId.BLOB -> listOf(createConversionImport("Blob"))
+            LimeBasicType.TypeId.BLOB ->
+                listOf(createConversionImport("Blob"), DartImport("typed_data", isSystem = true))
             LimeBasicType.TypeId.DATE -> listOf(createConversionImport("DateTime"))
             else -> emptyList()
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
@@ -64,7 +64,7 @@ internal class DartImportResolver(
         when (limeType.typeId) {
             LimeBasicType.TypeId.BOOLEAN -> listOf(createConversionImport("Boolean"))
             LimeBasicType.TypeId.STRING -> listOf(createConversionImport("String"))
-            LimeBasicType.TypeId.BLOB -> listOf(createConversionImport("List"))
+            LimeBasicType.TypeId.BLOB -> listOf(createConversionImport("Blob"))
             LimeBasicType.TypeId.DATE -> listOf(createConversionImport("DateTime"))
             else -> emptyList()
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -73,7 +73,7 @@ internal class DartNameResolver(
             TypeId.BOOLEAN -> "bool"
             TypeId.FLOAT, TypeId.DOUBLE -> "double"
             TypeId.STRING -> "String"
-            TypeId.BLOB -> "List<int>"
+            TypeId.BLOB -> "Uint8List"
             TypeId.DATE -> "DateTime"
         }
 

--- a/gluecodium/src/main/resources/templates/dart/DartBlobConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartBlobConversion.mustache
@@ -1,0 +1,81 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#if copyrightHeader}}{{prefix copyrightHeader "// "}}{{/if}}
+
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+
+import 'package:{{libraryName}}/src/_library_init.dart' as __lib;
+
+final _Blob_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('blob_create_handle');
+final _Blob_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('blob_release_handle');
+final _Blob_insert = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Uint8),
+    void Function(Pointer<Void>, int)
+  >('blob_insert');
+final _Blob_iterator = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('blob_iterator');
+final _Blob_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('blob_iterator_release_handle');
+final _Blob_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('blob_iterator_is_valid');
+final _Blob_iterator_increment = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('blob_iterator_increment');
+final _Blob_iterator_get = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+>('blob_iterator_get');
+
+Pointer<Void> Blob_toFfi(List<int> value) {
+  final _result = _Blob_create_handle();
+  for (final element in value) {
+    _Blob_insert(_result, element);
+  }
+  return _result;
+}
+
+List<int> Blob_fromFfi(Pointer<Void> handle) {
+  final result = List<int>();
+  final _iterator_handle = _Blob_iterator(handle);
+  while (_Blob_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _element_handle = _Blob_iterator_get(_iterator_handle);
+    result.add(_element_handle);
+    _Blob_iterator_increment(_iterator_handle);
+  }
+  _Blob_iterator_release_handle(_iterator_handle);
+  return result;
+}
+
+void Blob_releaseFfiHandle(Pointer<Void> handle) => _Blob_release_handle(handle);

--- a/gluecodium/src/main/resources/templates/dart/DartBlobConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartBlobConversion.mustache
@@ -21,60 +21,47 @@
 {{#if copyrightHeader}}{{prefix copyrightHeader "// "}}{{/if}}
 
 import 'dart:ffi';
+import 'dart:typed_data';
 import 'package:ffi/ffi.dart';
 
 import 'package:{{libraryName}}/src/_library_init.dart' as __lib;
 
 final _Blob_create_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(),
-    Pointer<Void> Function()
+    Pointer<Void> Function(Uint64),
+    Pointer<Void> Function(int)
   >('blob_create_handle');
 final _Blob_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('blob_release_handle');
-final _Blob_insert = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>, Uint8),
-    void Function(Pointer<Void>, int)
-  >('blob_insert');
-final _Blob_iterator = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
->('blob_iterator');
-final _Blob_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
->('blob_iterator_release_handle');
-final _Blob_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
-    Int8 Function(Pointer<Void>, Pointer<Void>),
-    int Function(Pointer<Void>, Pointer<Void>)
->('blob_iterator_is_valid');
-final _Blob_iterator_increment = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
->('blob_iterator_increment');
-final _Blob_iterator_get = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>),
+final _Blob_get_length = __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('blob_iterator_get');
+>('blob_get_length');
+final _Blob_get_at = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>, Uint64),
+    int Function(Pointer<Void>, int)
+>('blob_get_at');
+final _Blob_set_at = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Uint64, Uint8),
+    void Function(Pointer<Void>, int, int)
+  >('blob_set_at');
 
-Pointer<Void> Blob_toFfi(List<int> value) {
-  final _result = _Blob_create_handle();
-  for (final element in value) {
-    _Blob_insert(_result, element);
+Pointer<Void> Blob_toFfi(Uint8List list) {
+  final length = list.length;
+  final result = _Blob_create_handle(length);
+  for (int i = 0; i < length; ++i) {
+    _Blob_set_at(result, i, list[i]);
   }
-  return _result;
+  return result;
 }
 
-List<int> Blob_fromFfi(Pointer<Void> handle) {
-  final result = List<int>();
-  final _iterator_handle = _Blob_iterator(handle);
-  while (_Blob_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _Blob_iterator_get(_iterator_handle);
-    result.add(_element_handle);
-    _Blob_iterator_increment(_iterator_handle);
+Uint8List Blob_fromFfi(Pointer<Void> handle) {
+  final length = _Blob_get_length(handle);
+  final result = Uint8List(length);
+  for (int i = 0; i < length; ++i) {
+    result[i] = _Blob_get_at(handle, i);
   }
-  _Blob_iterator_release_handle(_iterator_handle);
   return result;
 }
 

--- a/gluecodium/src/main/resources/templates/dart/DartEnumConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumConversion.mustache
@@ -21,7 +21,7 @@
 {{#if copyrightHeader}}{{prefix copyrightHeader "// "}}{{/if}}
 
 {{#imports}}
-import 'package:{{libraryName}}/src/{{filePath}}.dart'{{#asAlias}} as {{.}}{{/asAlias}};
+{{>dart/DartImport}}
 {{/imports}}
 
 {{#model}}

--- a/gluecodium/src/main/resources/templates/dart/DartFfiConversionCall.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFfiConversionCall.mustache
@@ -22,6 +22,7 @@
 }}{{#instanceOf this "LimeBasicType"}}{{!!
 }}{{#isEq typeId.toString "Boolean"}}Boolean_{{call}}{{/isEq}}{{!!
 }}{{#isEq typeId.toString "String"}}String_{{call}}{{/isEq}}{{!!
+}}{{#isEq typeId.toString "Blob"}}Blob_{{call}}{{/isEq}}{{!!
 }}{{#isEq typeId.toString "Date"}}DateTime_{{call}}{{/isEq}}{{!!
 }}{{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeBasicType"}}{{resolveName "Ffi"}}_{{call}}{{/notInstanceOf}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartFile.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFile.mustache
@@ -21,7 +21,7 @@
 {{#if copyrightHeader}}{{prefix copyrightHeader "// "}}{{/if}}
 
 {{#imports}}
-import 'package:{{libraryName}}/src/{{filePath}}.dart'{{#asAlias}} as {{.}}{{/asAlias}};
+{{>dart/DartImport}}
 {{/imports}}
 
 import 'dart:ffi';

--- a/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
@@ -51,40 +51,40 @@ final _{{resolveName "Ffi"}}_insert = __lib.nativeLibrary.lookupFunction<
   >('{{resolveName "Ffi"}}_insert');
 {{/notInstanceOf}}
 final _{{resolveName "Ffi"}}_iterator = __lib.nativeLibrary.lookupFunction<
-  Pointer<Void> Function(Pointer<Void>),
-  Pointer<Void> Function(Pointer<Void>)
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
 >('{{resolveName "Ffi"}}_iterator');
 final _{{resolveName "Ffi"}}_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
-  Void Function(Pointer<Void>),
-  void Function(Pointer<Void>)
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
 >('{{resolveName "Ffi"}}_iterator_release_handle');
 final _{{resolveName "Ffi"}}_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
-  Int8 Function(Pointer<Void>, Pointer<Void>),
-  int Function(Pointer<Void>, Pointer<Void>)
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
 >('{{resolveName "Ffi"}}_iterator_is_valid');
 final _{{resolveName "Ffi"}}_iterator_increment = __lib.nativeLibrary.lookupFunction<
-  Void Function(Pointer<Void>),
-  void Function(Pointer<Void>)
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
 >('{{resolveName "Ffi"}}_iterator_increment');
 {{#instanceOf this "LimeMap"}}
 final _{{resolveName "Ffi"}}_iterator_get_key = __lib.nativeLibrary.lookupFunction<
-  {{resolveName keyType "FfiApiTypes"}} Function(Pointer<Void>),
-  {{resolveName keyType "FfiDartTypes"}} Function(Pointer<Void>)
+    {{resolveName keyType "FfiApiTypes"}} Function(Pointer<Void>),
+    {{resolveName keyType "FfiDartTypes"}} Function(Pointer<Void>)
 >('{{resolveName "Ffi"}}_iterator_get_key');
 final _{{resolveName "Ffi"}}_iterator_get_value = __lib.nativeLibrary.lookupFunction<
-  {{resolveName valueType "FfiApiTypes"}} Function(Pointer<Void>),
-  {{resolveName valueType "FfiDartTypes"}} Function(Pointer<Void>)
+    {{resolveName valueType "FfiApiTypes"}} Function(Pointer<Void>),
+    {{resolveName valueType "FfiDartTypes"}} Function(Pointer<Void>)
 >('{{resolveName "Ffi"}}_iterator_get_value');
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
 final _{{resolveName "Ffi"}}_iterator_get = __lib.nativeLibrary.lookupFunction<
-  {{resolveName elementType "FfiApiTypes"}} Function(Pointer<Void>),
-  {{resolveName elementType "FfiDartTypes"}} Function(Pointer<Void>)
+    {{resolveName elementType "FfiApiTypes"}} Function(Pointer<Void>),
+    {{resolveName elementType "FfiDartTypes"}} Function(Pointer<Void>)
 >('{{resolveName "Ffi"}}_iterator_get');
 {{/notInstanceOf}}
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
-  final _result = _{{resolveName "Ffi"}}_create_handle({{#fields}}_{{resolveName}}_handle{{#if iter.hasNext}}, {{/if}}{{/fields}});
+  final _result = _{{resolveName "Ffi"}}_create_handle();
 {{#instanceOf this "LimeMap"}}
   for (final entry in value.entries) {
     final _key_handle = {{#set typeRef=keyType call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(entry.key);

--- a/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
@@ -21,7 +21,7 @@
 {{#if copyrightHeader}}{{prefix copyrightHeader "// "}}{{/if}}
 
 {{#imports}}
-import 'package:{{libraryName}}/src/{{filePath}}.dart'{{#asAlias}} as {{.}}{{/asAlias}};
+{{>dart/DartImport}}
 {{/imports}}
 
 import 'dart:ffi';

--- a/gluecodium/src/main/resources/templates/dart/DartImport.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartImport.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -18,24 +18,6 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>ffi/FfiCopyrightHeader}}
-
-#pragma once
-
-#include "Export.h"
-#include "OpaqueHandle.h"
-#include <cstdint>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle blob_create_handle(uint64_t length);
-_GLUECODIUM_FFI_EXPORT void blob_release_handle(FfiOpaqueHandle handle);
-_GLUECODIUM_FFI_EXPORT uint64_t blob_get_length(FfiOpaqueHandle iterator_handle);
-_GLUECODIUM_FFI_EXPORT uint8_t blob_get_at(FfiOpaqueHandle iterator_handle, uint64_t index);
-_GLUECODIUM_FFI_EXPORT void blob_set_at(FfiOpaqueHandle handle, uint64_t index, uint8_t value);
-
-#ifdef __cplusplus
-}
-#endif
+import '{{#if isSystem}}dart:{{filePath}}{{/if}}{{!!
+}}{{#unless isSystem}}package:{{libraryName}}/src/{{filePath}}.dart{{/unless}}'{{!!
+}}{{#asAlias}} as {{.}}{{/asAlias}};

--- a/gluecodium/src/main/resources/templates/ffi/FfiBlobHandleHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiBlobHandleHeader.mustache
@@ -1,0 +1,44 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{>ffi/FfiCopyrightHeader}}
+
+#pragma once
+
+#include "Export.h"
+#include "OpaqueHandle.h"
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle blob_create_handle();
+_GLUECODIUM_FFI_EXPORT void blob_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void blob_insert(FfiOpaqueHandle handle, uint8_t value);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle blob_iterator(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void blob_iterator_release_handle(FfiOpaqueHandle iterator_handle);
+_GLUECODIUM_FFI_EXPORT bool blob_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle);
+_GLUECODIUM_FFI_EXPORT void blob_iterator_increment(FfiOpaqueHandle iterator_handle);
+_GLUECODIUM_FFI_EXPORT uint8_t blob_iterator_get(FfiOpaqueHandle iterator_handle);
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/main/resources/templates/ffi/FfiBlobHandleImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiBlobHandleImpl.mustache
@@ -26,8 +26,7 @@
 #include <vector>
 
 namespace {
-using Blob = std::vector<uint8_t>;
-using BlobPtr = std::shared_ptr<Blob>;
+using BlobPtr = std::shared_ptr<std::vector<uint8_t>>;
 }
 
 #ifdef __cplusplus
@@ -35,8 +34,8 @@ extern "C" {
 #endif
 
 FfiOpaqueHandle
-blob_create_handle() {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) BlobPtr(new Blob()));
+blob_create_handle(uint64_t length) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) BlobPtr(new std::vector<uint8_t>(length)));
 }
 
 void
@@ -44,37 +43,19 @@ blob_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<BlobPtr*>(handle);
 }
 
-void
-blob_insert(FfiOpaqueHandle handle, uint8_t value) {
-    (*reinterpret_cast<BlobPtr*>(handle))->push_back(value);
-}
-
-FfiOpaqueHandle
-blob_iterator(FfiOpaqueHandle handle) {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) Blob::iterator(
-        (*reinterpret_cast<BlobPtr*>(handle))->begin()
-    ));
-}
-
-void
-blob_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
-    delete reinterpret_cast<Blob::iterator*>(iterator_handle);
-}
-
-bool
-blob_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
-    return *reinterpret_cast<Blob::iterator*>(iterator_handle) !=
-        (*reinterpret_cast<BlobPtr*>(handle))->end();
-}
-
-void
-blob_iterator_increment(FfiOpaqueHandle iterator_handle) {
-    ++*reinterpret_cast<Blob::iterator*>(iterator_handle);
+uint64_t
+blob_get_length(FfiOpaqueHandle handle) {
+    return (*reinterpret_cast<BlobPtr*>(handle))->size();
 }
 
 uint8_t
-blob_iterator_get(FfiOpaqueHandle iterator_handle) {
-    return **reinterpret_cast<Blob::iterator*>(iterator_handle);
+blob_get_at(FfiOpaqueHandle handle, uint64_t index) {
+    return (*reinterpret_cast<BlobPtr*>(handle))->at(index);
+}
+
+void
+blob_set_at(FfiOpaqueHandle handle, uint64_t index, uint8_t value) {
+    (*reinterpret_cast<BlobPtr*>(handle))->at(index) = value;
 }
 
 #ifdef __cplusplus

--- a/gluecodium/src/main/resources/templates/ffi/FfiBlobHandleImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiBlobHandleImpl.mustache
@@ -1,0 +1,82 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{>ffi/FfiCopyrightHeader}}
+
+#include "BlobHandle.h"
+#include <memory>
+#include <new>
+#include <vector>
+
+namespace {
+using Blob = std::vector<uint8_t>;
+using BlobPtr = std::shared_ptr<Blob>;
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+FfiOpaqueHandle
+blob_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) BlobPtr(new Blob()));
+}
+
+void
+blob_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<BlobPtr*>(handle);
+}
+
+void
+blob_insert(FfiOpaqueHandle handle, uint8_t value) {
+    (*reinterpret_cast<BlobPtr*>(handle))->push_back(value);
+}
+
+FfiOpaqueHandle
+blob_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) Blob::iterator(
+        (*reinterpret_cast<BlobPtr*>(handle))->begin()
+    ));
+}
+
+void
+blob_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<Blob::iterator*>(iterator_handle);
+}
+
+bool
+blob_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<Blob::iterator*>(iterator_handle) !=
+        (*reinterpret_cast<BlobPtr*>(handle))->end();
+}
+
+void
+blob_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<Blob::iterator*>(iterator_handle);
+}
+
+uint8_t
+blob_iterator_get(FfiOpaqueHandle iterator_handle) {
+    return **reinterpret_cast<Blob::iterator*>(iterator_handle);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
@@ -1,3 +1,4 @@
+import 'dart:typed_data';
 import 'package:library/src/Blob__conversion.dart';
 import 'package:library/src/Boolean__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
@@ -86,14 +87,14 @@ class Properties {
     (__result_handle);
     return _result;
   }
-  List<int> get byteBufferProperty {
+  Uint8List get byteBufferProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Properties_byteBufferProperty_get');
     final __result_handle = _get_ffi(_handle);
     final _result = Blob_fromFfi(__result_handle);
     Blob_releaseFfiHandle(__result_handle);
     return _result;
   }
-  set byteBufferProperty(List<int> value) {
+  set byteBufferProperty(Uint8List value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_Properties_byteBufferProperty_set__Blob');
     final _value_handle = Blob_toFfi(value);
     final __result_handle = _set_ffi(_handle, _value_handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
@@ -1,6 +1,6 @@
+import 'package:library/src/Blob__conversion.dart';
 import 'package:library/src/Boolean__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
-import 'package:library/src/List__conversion.dart';
 import 'package:library/src/String__conversion.dart';
 import 'package:library/src/smoke/PropertiesInterface.dart';
 import 'package:library/src/smoke/Properties_InternalErrorCode__conversion.dart';
@@ -89,15 +89,15 @@ class Properties {
   List<int> get byteBufferProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Properties_byteBufferProperty_get');
     final __result_handle = _get_ffi(_handle);
-    final _result = (__result_handle);
-    (__result_handle);
+    final _result = Blob_fromFfi(__result_handle);
+    Blob_releaseFfiHandle(__result_handle);
     return _result;
   }
   set byteBufferProperty(List<int> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_Properties_byteBufferProperty_set__Blob');
-    final _value_handle = (value);
+    final _value_handle = Blob_toFfi(value);
     final __result_handle = _set_ffi(_handle, _value_handle);
-    (_value_handle);
+    Blob_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
@@ -1,3 +1,4 @@
+import 'dart:typed_data';
 import 'package:library/src/Blob__conversion.dart';
 import 'package:library/src/Boolean__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
@@ -182,7 +183,7 @@ class Structs_AllTypesStruct {
   final double doubleField;
   final String stringField;
   final bool booleanField;
-  final List<int> bytesField;
+  final Uint8List bytesField;
   final Structs_Point pointField;
   Structs_AllTypesStruct(this.int8Field, this.uint8Field, this.int16Field, this.uint16Field, this.int32Field, this.uint32Field, this.int64Field, this.uint64Field, this.floatField, this.doubleField, this.stringField, this.booleanField, this.bytesField, this.pointField);
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
@@ -1,6 +1,6 @@
+import 'package:library/src/Blob__conversion.dart';
 import 'package:library/src/Boolean__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
-import 'package:library/src/List__conversion.dart';
 import 'package:library/src/String__conversion.dart';
 import 'package:library/src/smoke/TypeCollection.dart';
 import 'dart:ffi';
@@ -264,7 +264,7 @@ Pointer<Void> smoke_Structs_AllTypesStruct_toFfi(Structs_AllTypesStruct value) {
   final _doubleField_handle = (value.doubleField);
   final _stringField_handle = String_toFfi(value.stringField);
   final _booleanField_handle = Boolean_toFfi(value.booleanField);
-  final _bytesField_handle = (value.bytesField);
+  final _bytesField_handle = Blob_toFfi(value.bytesField);
   final _pointField_handle = smoke_Structs_Point_toFfi(value.pointField);
   final _result = _smoke_Structs_AllTypesStruct_create_handle(_int8Field_handle, _uint8Field_handle, _int16Field_handle, _uint16Field_handle, _int32Field_handle, _uint32Field_handle, _int64Field_handle, _uint64Field_handle, _floatField_handle, _doubleField_handle, _stringField_handle, _booleanField_handle, _bytesField_handle, _pointField_handle);
   (_int8Field_handle);
@@ -279,7 +279,7 @@ Pointer<Void> smoke_Structs_AllTypesStruct_toFfi(Structs_AllTypesStruct value) {
   (_doubleField_handle);
   String_releaseFfiHandle(_stringField_handle);
   Boolean_releaseFfiHandle(_booleanField_handle);
-  (_bytesField_handle);
+  Blob_releaseFfiHandle(_bytesField_handle);
   smoke_Structs_Point_releaseFfiHandle(_pointField_handle);
   return _result;
 }
@@ -311,7 +311,7 @@ Structs_AllTypesStruct smoke_Structs_AllTypesStruct_fromFfi(Pointer<Void> handle
     (_doubleField_handle),
     String_fromFfi(_stringField_handle),
     Boolean_fromFfi(_booleanField_handle),
-    (_bytesField_handle),
+    Blob_fromFfi(_bytesField_handle),
     smoke_Structs_Point_fromFfi(_pointField_handle)
   );
   (_int8Field_handle);
@@ -326,7 +326,7 @@ Structs_AllTypesStruct smoke_Structs_AllTypesStruct_fromFfi(Pointer<Void> handle
   (_doubleField_handle);
   String_releaseFfiHandle(_stringField_handle);
   Boolean_releaseFfiHandle(_booleanField_handle);
-  (_bytesField_handle);
+  Blob_releaseFfiHandle(_bytesField_handle);
   smoke_Structs_Point_releaseFfiHandle(_pointField_handle);
   return _result;
 }


### PR DESCRIPTION
Added Dart and FFI templates for Blob type conversion. Fixed types and
indentation in Dart template for Generic types conversion.

Added/updated smoke and functional tests as appropriate.

Resolves: #57
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
