### PR TITLE
Add support for struct field initializers to Dart generator

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -255,7 +255,7 @@ feature(Errors cpp android swift dart SOURCES
     lime/test/ErrorsInInterface.lime
 )
 
-feature(Defaults cpp android swift SOURCES
+feature(Defaults cpp android swift dart SOURCES
     src/hello/HelloWorldDefaults.cpp
     src/test/Defaults.cpp
 

--- a/examples/libhello/lime/test/Defaults.lime
+++ b/examples/libhello/lime/test/Defaults.lime
@@ -27,14 +27,6 @@ class Defaults {
         stringField: String = "some string"
         enumField: SomeEnum = SomeEnum.BarValue
     }
-    struct NullableStructWithDefaults {
-        intField: Int? = null
-        uintField: UInt? = null
-        floatField: Float? = null
-        boolField: Boolean? = null
-        stringField: String? = null
-        enumField: SomeEnum? = null
-    }
     struct StructWithExternalDefaults {
         enumField: ExternalEnum = ExternalEnum.Another_Value
     }
@@ -55,15 +47,11 @@ class Defaults {
         doubleInfinityField: Double = Infinity
         doubleNegativeInfinityField: Double = -Infinity
     }
-    struct StructWithSingleNullableField {
-        nullableField: Int? = null
-    }
     struct StructWithEmptyDefaults {
         intsField: List<Int> = {}
         floatsField: FloatArray = {}
         mapField: IdToStringMap = {}
         structField: StructWithDefaults = {}
-        otherStructField: StructWithSingleNullableField = {}
         setTypeField: StringSet = {}
     }
     struct StructWithTypedefDefaults {
@@ -106,20 +94,23 @@ class Defaults {
     ): Boolean
     // Get a default-initialized ImmutableStructWithDefaults object.
     static fun getImmutableDefault(): ImmutableStructWithDefaults
+    @Dart("floatIsNan")
     static fun isNan(
         value: Float
     ): Boolean
+    @Dart("doubleIsNan")
     static fun isNan(
         value: Double
     ): Boolean
+    @Dart("floatIsInfinity")
     static fun isInfinity(
         value: Float
     ): Boolean
+    @Dart("doubleIsInfinity")
     static fun isInfinity(
         value: Double
     ): Boolean
     static fun createSpecial(): StructWithSpecialDefaults
-    static fun getNullableDefaults(): NullableStructWithDefaults
     static fun getEmptyDefaults(): StructWithEmptyDefaults
     static fun getInitializerDefaults(): StructWithInitializerDefaults
 }

--- a/examples/libhello/lime/test/NullableInterface.lime
+++ b/examples/libhello/lime/test/NullableInterface.lime
@@ -43,6 +43,12 @@ class NullableInterface {
         uint32Field: UInt? = null
         uint64Field: ULong? = null
     }
+    struct StructWithSingleNullableField {
+        nullableField: Int? = null
+    }
+    struct StructWithNestedNullableDefault {
+        otherStructField: StructWithSingleNullableField = {}
+    }
     enum SomeEnum {
         OFF,
         ON

--- a/examples/libhello/src/test/Defaults.cpp
+++ b/examples/libhello/src/test/Defaults.cpp
@@ -77,12 +77,6 @@ Defaults::create_special( )
     return {};
 }
 
-Defaults::NullableStructWithDefaults
-Defaults::get_nullable_defaults( )
-{
-    return {};
-}
-
 Defaults::StructWithEmptyDefaults
 Defaults::get_empty_defaults( )
 {

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/DefaultsTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/DefaultsTest.java
@@ -19,7 +19,6 @@
 package com.here.android.test;
 
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 
 import android.os.Build;
@@ -128,30 +127,6 @@ public final class DefaultsTest {
     assertTrue(Double.isInfinite(special.doubleInfinityField));
     assertTrue(Double.isInfinite(special.doubleNegativeInfinityField));
     assertTrue(special.doubleNegativeInfinityField < 0);
-  }
-
-  @Test
-  public void checkJavaNullableDefaults() {
-    Defaults.NullableStructWithDefaults result = new Defaults.NullableStructWithDefaults();
-
-    assertNull(result.intField);
-    assertNull(result.uintField);
-    assertNull(result.floatField);
-    assertNull(result.boolField);
-    assertNull(result.stringField);
-    assertNull(result.enumField);
-  }
-
-  @Test
-  public void checkCppNullableDefaults() {
-    Defaults.NullableStructWithDefaults result = Defaults.getNullableDefaults();
-
-    assertNull(result.intField);
-    assertNull(result.uintField);
-    assertNull(result.floatField);
-    assertNull(result.boolField);
-    assertNull(result.stringField);
-    assertNull(result.enumField);
   }
 
   @Test

--- a/examples/platforms/dart/main.dart
+++ b/examples/platforms/dart/main.dart
@@ -22,6 +22,7 @@ import "test/Blobs_test.dart" as BlobsTests;
 import "test/Classes_test.dart" as ClassesTests;
 import "test/Constants_test.dart" as ConstantsTests;
 import "test/Dates_test.dart" as DatesTests;
+import "test/Defaults_test.dart" as DefaultsTests;
 import "test/Enums_test.dart" as EnumsTests;
 import "test/Exceptions_test.dart" as Exceptions;
 import "test/ExternalTypes_test.dart" as ExternalTypes;
@@ -46,6 +47,7 @@ final _allTests = [
   ClassesTests.main,
   ConstantsTests.main,
   DatesTests.main,
+  DefaultsTests.main,
   EnumsTests.main,
   Exceptions.main,
   ExternalTypes.main,

--- a/examples/platforms/dart/test/Defaults_test.dart
+++ b/examples/platforms/dart/test/Defaults_test.dart
@@ -1,0 +1,77 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:hello/hello.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("Defaults");
+
+void main() {
+  _testSuite.test("Check defaults", () {
+    final result = new Defaults_StructWithDefaults.withDefaults();
+
+    expect(result.intField, 42);
+    expect(result.uintField, 4294967295);
+    expect(result.floatField, 3.14);
+    expect(result.boolField, true);
+    expect(result.stringField, "some string");
+    expect(result.enumField, Defaults_SomeEnum.barValue);
+  });
+  _testSuite.test("Check defaults immutable", () {
+    final result =
+        new Defaults_ImmutableStructWithDefaults.withDefaults(77, true);
+
+    expect(result.intField, 42);
+    expect(result.uintField, 77);
+    expect(result.floatField, 3.14);
+    expect(result.boolField, true);
+    expect(result.stringField, "some string");
+    expect(result.enumField, Defaults_SomeEnum.barValue);
+  });
+  _testSuite.test("Check special defaults", () {
+    final result = new Defaults_StructWithSpecialDefaults.withDefaults();
+
+    expect(result.floatNanField, isNaN);
+    expect(result.floatInfinityField, double.infinity);
+    expect(result.floatNegativeInfinityField, double.negativeInfinity);
+    expect(result.doubleNanField, isNaN);
+    expect(result.doubleInfinityField, double.infinity);
+    expect(result.doubleNegativeInfinityField, double.negativeInfinity);
+  });
+  _testSuite.test("Check empty defaults", () {
+    final result = new Defaults_StructWithEmptyDefaults.withDefaults();
+
+    expect(result.intsField, isEmpty);
+    expect(result.floatsField, isEmpty);
+    expect(result.mapField, isEmpty);
+    expect(result.structField.stringField, "some string");
+    expect(result.setTypeField, isEmpty);
+  });
+  _testSuite.test("Check initializer defaults", () {
+    final result = new Defaults_StructWithInitializerDefaults.withDefaults();
+
+    expect(result.intsField, [4, -2, 42]);
+    expect(result.floatsField, [3.14, double.negativeInfinity]);
+    expect(result.mapField, {1: "foo", 42: "bar"});
+    expect(result.structField.enumField, Defaults_ExternalEnum.oneValue);
+    expect(result.setTypeField, {"foo", "bar"});
+  });
+}

--- a/examples/platforms/ios/Tests/testTests/DefaultsTests.swift
+++ b/examples/platforms/ios/Tests/testTests/DefaultsTests.swift
@@ -97,28 +97,6 @@ class DefaultsTests: XCTestCase {
       XCTAssertTrue(special.doubleNegativeInfinityField < 0)
     }
 
-    func testSwiftNullableDefaults() {
-      let result = Defaults.NullableStructWithDefaults()
-
-      XCTAssertNil(result.intField)
-      XCTAssertNil(result.uintField)
-      XCTAssertNil(result.floatField)
-      XCTAssertNil(result.boolField)
-      XCTAssertNil(result.stringField)
-      XCTAssertNil(result.enumField)
-    }
-
-    func testCppNullableDefaults() {
-      let result = Defaults.getNullableDefaults()
-
-      XCTAssertNil(result.intField)
-      XCTAssertNil(result.uintField)
-      XCTAssertNil(result.floatField)
-      XCTAssertNil(result.boolField)
-      XCTAssertNil(result.stringField)
-      XCTAssertNil(result.enumField)
-    }
-
     func testSwiftEmptyDefaults() {
       let result = Defaults.StructWithEmptyDefaults()
 
@@ -167,8 +145,6 @@ class DefaultsTests: XCTestCase {
         ("testGetImmutableDefault", testGetImmutableDefault),
         ("testSwiftSpecialDefaults", testSwiftSpecialDefaults),
         ("testCppSpecialDefaults", testCppSpecialDefaults),
-        ("testSwiftNullableDefaults", testSwiftNullableDefaults),
-        ("testCppNullableDefaults", testCppNullableDefaults),
         ("testSwiftEmptyDefaults", testSwiftEmptyDefaults),
         ("testCppEmptyDefaults", testCppEmptyDefaults),
         ("testSwiftInitializerDefaults", testSwiftInitializerDefaults),

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -100,7 +100,10 @@ internal class DartNameResolver(
                 val postfix: String
                 when (actualType) {
                     is LimeStruct -> {
-                        prefix = "${resolveName(actualType)}("
+                        val useDefaultsConstructor =
+                            actualType.fields.isNotEmpty() && limeValue.values.isEmpty()
+                        val constructorName = if (useDefaultsConstructor) ".withDefaults" else ""
+                        prefix = "${resolveName(actualType)}$constructorName("
                         postfix = ")"
                     }
                     is LimeList -> {

--- a/gluecodium/src/main/resources/templates/dart/DartField.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartField.mustache
@@ -20,4 +20,4 @@
   !}}
 {{>dart/DartDocumentation}}
 {{#ifHasAttribute parent "Immutable"}}final {{/ifHasAttribute}}{{!!
-}}{{resolveName typeRef}} {{resolveName visibility}}{{resolveName}}{{#defaultValue}} = {{resolveName}}{{/defaultValue}};
+}}{{resolveName typeRef}} {{resolveName visibility}}{{resolveName}};

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -30,7 +30,11 @@ class {{resolveName visibility}}{{resolveName}} {
 {{#if fields}}  {{resolveName}}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{#if constructors}}  {{resolveName}}{{#if constructors}}._copy{{/if}}({{resolveName}} _other) : {{!!
 }}this._({{#fields}}_other.{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
-{{/if}}{{/if}}
+{{/if}}{{#unless constructors}}{{#if initializedFields}}
+  {{resolveName}}.withDefaults({{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}})
+    : {{#fields}}{{resolveName}} = {{#if defaultValue}}{{resolveName defaultValue}}{{/if}}{{!!
+    }}{{#unless defaultValue}}{{resolveName}}{{/unless}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
+{{/if}}{{/unless}}{{/if}}
 {{#set isInClass=true}}{{#constants}}{{prefixPartial "dart/DartConstant" "  "}}
 {{/constants}}{{/set}}
 {{#set parent=this isStruct=true}}{{#constructors}}

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/DefaultValues.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/DefaultValues.dart
@@ -1,0 +1,454 @@
+import 'package:library/src/Boolean__conversion.dart';
+import 'package:library/src/GenericTypes__conversion.dart';
+import 'package:library/src/String__conversion.dart';
+import 'package:library/src/smoke/DefaultValues_ExternalEnum__conversion.dart';
+import 'package:library/src/smoke/DefaultValues_SomeEnum__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final __release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_DefaultValues_release_handle');
+class DefaultValues {
+  final Pointer<Void> _handle;
+  DefaultValues._(this._handle);
+  void release() => __release_handle(_handle);
+  static DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) {
+    final _processStructWithDefaults_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_DefaultValues_processStructWithDefaults__StructWithDefaults');
+    final _input_handle = smoke_DefaultValues_StructWithDefaults_toFfi(input);
+    final __result_handle = _processStructWithDefaults_ffi(_input_handle);
+    smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_input_handle);
+    final _result = smoke_DefaultValues_StructWithDefaults_fromFfi(__result_handle);
+    smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_DefaultValues_toFfi(DefaultValues value) =>
+  value != null ? value._handle : Pointer<Void>.fromAddress(0);
+DefaultValues smoke_DefaultValues_fromFfi(Pointer<Void> handle) =>
+  handle.address != 0 ? DefaultValues._(handle) : null;
+void smoke_DefaultValues_releaseFfiHandle(Pointer<Void> handle) {}
+enum DefaultValues_SomeEnum {
+    fooValue,
+    barValue
+}
+enum DefaultValues_ExternalEnum {
+    oneValue,
+    anotherValue
+}
+class DefaultValues_StructWithDefaults {
+  int intField;
+  int uintField;
+  double floatField;
+  double doubleField;
+  bool boolField;
+  String stringField;
+  DefaultValues_SomeEnum enumField;
+  DefaultValues_ExternalEnum externalEnumField;
+  DefaultValues_StructWithDefaults(this.intField, this.uintField, this.floatField, this.doubleField, this.boolField, this.stringField, this.enumField, this.externalEnumField);
+  DefaultValues_StructWithDefaults.withDefaults()
+    : intField = 42, uintField = 4294967295, floatField = 3.14, doubleField = -1.4142, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n", enumField = DefaultValues_SomeEnum.barValue, externalEnumField = DefaultValues_ExternalEnum.anotherValue;
+}
+// DefaultValues_StructWithDefaults "private" section, not exported.
+final _smoke_DefaultValues_StructWithDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int32, Uint32, Float, Double, Uint8, Pointer<Void>, Uint32, Uint32),
+    Pointer<Void> Function(int, int, double, double, int, Pointer<Void>, int, int)
+  >('smoke_DefaultValues_StructWithDefaults_create_handle');
+final _smoke_DefaultValues_StructWithDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithDefaults_release_handle');
+final _smoke_DefaultValues_StructWithDefaults_get_field_intField = __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithDefaults_get_field_intField');
+final _smoke_DefaultValues_StructWithDefaults_get_field_uintField = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithDefaults_get_field_uintField');
+final _smoke_DefaultValues_StructWithDefaults_get_field_floatField = __lib.nativeLibrary.lookupFunction<
+    Float Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithDefaults_get_field_floatField');
+final _smoke_DefaultValues_StructWithDefaults_get_field_doubleField = __lib.nativeLibrary.lookupFunction<
+    Double Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithDefaults_get_field_doubleField');
+final _smoke_DefaultValues_StructWithDefaults_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithDefaults_get_field_boolField');
+final _smoke_DefaultValues_StructWithDefaults_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithDefaults_get_field_stringField');
+final _smoke_DefaultValues_StructWithDefaults_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithDefaults_get_field_enumField');
+final _smoke_DefaultValues_StructWithDefaults_get_field_externalEnumField = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithDefaults_get_field_externalEnumField');
+Pointer<Void> smoke_DefaultValues_StructWithDefaults_toFfi(DefaultValues_StructWithDefaults value) {
+  final _intField_handle = (value.intField);
+  final _uintField_handle = (value.uintField);
+  final _floatField_handle = (value.floatField);
+  final _doubleField_handle = (value.doubleField);
+  final _boolField_handle = Boolean_toFfi(value.boolField);
+  final _stringField_handle = String_toFfi(value.stringField);
+  final _enumField_handle = smoke_DefaultValues_SomeEnum_toFfi(value.enumField);
+  final _externalEnumField_handle = smoke_DefaultValues_ExternalEnum_toFfi(value.externalEnumField);
+  final _result = _smoke_DefaultValues_StructWithDefaults_create_handle(_intField_handle, _uintField_handle, _floatField_handle, _doubleField_handle, _boolField_handle, _stringField_handle, _enumField_handle, _externalEnumField_handle);
+  (_intField_handle);
+  (_uintField_handle);
+  (_floatField_handle);
+  (_doubleField_handle);
+  Boolean_releaseFfiHandle(_boolField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
+  smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumField_handle);
+  return _result;
+}
+DefaultValues_StructWithDefaults smoke_DefaultValues_StructWithDefaults_fromFfi(Pointer<Void> handle) {
+  final _intField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_intField(handle);
+  final _uintField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_uintField(handle);
+  final _floatField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_floatField(handle);
+  final _doubleField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_doubleField(handle);
+  final _boolField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_boolField(handle);
+  final _stringField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_stringField(handle);
+  final _enumField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_enumField(handle);
+  final _externalEnumField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_externalEnumField(handle);
+  final _result = DefaultValues_StructWithDefaults(
+    (_intField_handle),
+    (_uintField_handle),
+    (_floatField_handle),
+    (_doubleField_handle),
+    Boolean_fromFfi(_boolField_handle),
+    String_fromFfi(_stringField_handle),
+    smoke_DefaultValues_SomeEnum_fromFfi(_enumField_handle),
+    smoke_DefaultValues_ExternalEnum_fromFfi(_externalEnumField_handle)
+  );
+  (_intField_handle);
+  (_uintField_handle);
+  (_floatField_handle);
+  (_doubleField_handle);
+  Boolean_releaseFfiHandle(_boolField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
+  smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumField_handle);
+  return _result;
+}
+void smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithDefaults_release_handle(handle);
+// End of DefaultValues_StructWithDefaults "private" section.
+class DefaultValues_NullableStructWithDefaults {
+  int intField;
+  int uintField;
+  double floatField;
+  bool boolField;
+  String stringField;
+  DefaultValues_SomeEnum enumField;
+  DefaultValues_NullableStructWithDefaults(this.intField, this.uintField, this.floatField, this.boolField, this.stringField, this.enumField);
+  DefaultValues_NullableStructWithDefaults.withDefaults()
+    : intField = null, uintField = null, floatField = null, boolField = null, stringField = null, enumField = null;
+}
+// DefaultValues_NullableStructWithDefaults "private" section, not exported.
+final _smoke_DefaultValues_NullableStructWithDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int32, Uint32, Float, Uint8, Pointer<Void>, Uint32),
+    Pointer<Void> Function(int, int, double, int, Pointer<Void>, int)
+  >('smoke_DefaultValues_NullableStructWithDefaults_create_handle');
+final _smoke_DefaultValues_NullableStructWithDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_DefaultValues_NullableStructWithDefaults_release_handle');
+final _smoke_DefaultValues_NullableStructWithDefaults_get_field_intField = __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_DefaultValues_NullableStructWithDefaults_get_field_intField');
+final _smoke_DefaultValues_NullableStructWithDefaults_get_field_uintField = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_DefaultValues_NullableStructWithDefaults_get_field_uintField');
+final _smoke_DefaultValues_NullableStructWithDefaults_get_field_floatField = __lib.nativeLibrary.lookupFunction<
+    Float Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_DefaultValues_NullableStructWithDefaults_get_field_floatField');
+final _smoke_DefaultValues_NullableStructWithDefaults_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_DefaultValues_NullableStructWithDefaults_get_field_boolField');
+final _smoke_DefaultValues_NullableStructWithDefaults_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_DefaultValues_NullableStructWithDefaults_get_field_stringField');
+final _smoke_DefaultValues_NullableStructWithDefaults_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_DefaultValues_NullableStructWithDefaults_get_field_enumField');
+Pointer<Void> smoke_DefaultValues_NullableStructWithDefaults_toFfi(DefaultValues_NullableStructWithDefaults value) {
+  final _intField_handle = (value.intField);
+  final _uintField_handle = (value.uintField);
+  final _floatField_handle = (value.floatField);
+  final _boolField_handle = Boolean_toFfi(value.boolField);
+  final _stringField_handle = String_toFfi(value.stringField);
+  final _enumField_handle = smoke_DefaultValues_SomeEnum_toFfi(value.enumField);
+  final _result = _smoke_DefaultValues_NullableStructWithDefaults_create_handle(_intField_handle, _uintField_handle, _floatField_handle, _boolField_handle, _stringField_handle, _enumField_handle);
+  (_intField_handle);
+  (_uintField_handle);
+  (_floatField_handle);
+  Boolean_releaseFfiHandle(_boolField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
+  return _result;
+}
+DefaultValues_NullableStructWithDefaults smoke_DefaultValues_NullableStructWithDefaults_fromFfi(Pointer<Void> handle) {
+  final _intField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_intField(handle);
+  final _uintField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_uintField(handle);
+  final _floatField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_floatField(handle);
+  final _boolField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_boolField(handle);
+  final _stringField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_stringField(handle);
+  final _enumField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_enumField(handle);
+  final _result = DefaultValues_NullableStructWithDefaults(
+    (_intField_handle),
+    (_uintField_handle),
+    (_floatField_handle),
+    Boolean_fromFfi(_boolField_handle),
+    String_fromFfi(_stringField_handle),
+    smoke_DefaultValues_SomeEnum_fromFfi(_enumField_handle)
+  );
+  (_intField_handle);
+  (_uintField_handle);
+  (_floatField_handle);
+  Boolean_releaseFfiHandle(_boolField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
+  return _result;
+}
+void smoke_DefaultValues_NullableStructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_NullableStructWithDefaults_release_handle(handle);
+// End of DefaultValues_NullableStructWithDefaults "private" section.
+class DefaultValues_StructWithSpecialDefaults {
+  double floatNanField;
+  double floatInfinityField;
+  double floatNegativeInfinityField;
+  double doubleNanField;
+  double doubleInfinityField;
+  double doubleNegativeInfinityField;
+  DefaultValues_StructWithSpecialDefaults(this.floatNanField, this.floatInfinityField, this.floatNegativeInfinityField, this.doubleNanField, this.doubleInfinityField, this.doubleNegativeInfinityField);
+  DefaultValues_StructWithSpecialDefaults.withDefaults()
+    : floatNanField = double.nan, floatInfinityField = double.infinity, floatNegativeInfinityField = double.negativeInfinity, doubleNanField = double.nan, doubleInfinityField = double.infinity, doubleNegativeInfinityField = double.negativeInfinity;
+}
+// DefaultValues_StructWithSpecialDefaults "private" section, not exported.
+final _smoke_DefaultValues_StructWithSpecialDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Float, Float, Float, Double, Double, Double),
+    Pointer<Void> Function(double, double, double, double, double, double)
+  >('smoke_DefaultValues_StructWithSpecialDefaults_create_handle');
+final _smoke_DefaultValues_StructWithSpecialDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithSpecialDefaults_release_handle');
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNanField = __lib.nativeLibrary.lookupFunction<
+    Float Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNanField');
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatInfinityField = __lib.nativeLibrary.lookupFunction<
+    Float Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatInfinityField');
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNegativeInfinityField = __lib.nativeLibrary.lookupFunction<
+    Float Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNegativeInfinityField');
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNanField = __lib.nativeLibrary.lookupFunction<
+    Double Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNanField');
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleInfinityField = __lib.nativeLibrary.lookupFunction<
+    Double Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleInfinityField');
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNegativeInfinityField = __lib.nativeLibrary.lookupFunction<
+    Double Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNegativeInfinityField');
+Pointer<Void> smoke_DefaultValues_StructWithSpecialDefaults_toFfi(DefaultValues_StructWithSpecialDefaults value) {
+  final _floatNanField_handle = (value.floatNanField);
+  final _floatInfinityField_handle = (value.floatInfinityField);
+  final _floatNegativeInfinityField_handle = (value.floatNegativeInfinityField);
+  final _doubleNanField_handle = (value.doubleNanField);
+  final _doubleInfinityField_handle = (value.doubleInfinityField);
+  final _doubleNegativeInfinityField_handle = (value.doubleNegativeInfinityField);
+  final _result = _smoke_DefaultValues_StructWithSpecialDefaults_create_handle(_floatNanField_handle, _floatInfinityField_handle, _floatNegativeInfinityField_handle, _doubleNanField_handle, _doubleInfinityField_handle, _doubleNegativeInfinityField_handle);
+  (_floatNanField_handle);
+  (_floatInfinityField_handle);
+  (_floatNegativeInfinityField_handle);
+  (_doubleNanField_handle);
+  (_doubleInfinityField_handle);
+  (_doubleNegativeInfinityField_handle);
+  return _result;
+}
+DefaultValues_StructWithSpecialDefaults smoke_DefaultValues_StructWithSpecialDefaults_fromFfi(Pointer<Void> handle) {
+  final _floatNanField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNanField(handle);
+  final _floatInfinityField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatInfinityField(handle);
+  final _floatNegativeInfinityField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNegativeInfinityField(handle);
+  final _doubleNanField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNanField(handle);
+  final _doubleInfinityField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleInfinityField(handle);
+  final _doubleNegativeInfinityField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNegativeInfinityField(handle);
+  final _result = DefaultValues_StructWithSpecialDefaults(
+    (_floatNanField_handle),
+    (_floatInfinityField_handle),
+    (_floatNegativeInfinityField_handle),
+    (_doubleNanField_handle),
+    (_doubleInfinityField_handle),
+    (_doubleNegativeInfinityField_handle)
+  );
+  (_floatNanField_handle);
+  (_floatInfinityField_handle);
+  (_floatNegativeInfinityField_handle);
+  (_doubleNanField_handle);
+  (_doubleInfinityField_handle);
+  (_doubleNegativeInfinityField_handle);
+  return _result;
+}
+void smoke_DefaultValues_StructWithSpecialDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithSpecialDefaults_release_handle(handle);
+// End of DefaultValues_StructWithSpecialDefaults "private" section.
+class DefaultValues_StructWithEmptyDefaults {
+  List<int> intsField;
+  List<double> floatsField;
+  Map<int, String> mapField;
+  DefaultValues_StructWithDefaults structField;
+  Set<String> setTypeField;
+  DefaultValues_StructWithEmptyDefaults(this.intsField, this.floatsField, this.mapField, this.structField, this.setTypeField);
+  DefaultValues_StructWithEmptyDefaults.withDefaults()
+    : intsField = [], floatsField = [], mapField = {}, structField = DefaultValues_StructWithDefaults.withDefaults(), setTypeField = {};
+}
+// DefaultValues_StructWithEmptyDefaults "private" section, not exported.
+final _smoke_DefaultValues_StructWithEmptyDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
+  >('smoke_DefaultValues_StructWithEmptyDefaults_create_handle');
+final _smoke_DefaultValues_StructWithEmptyDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithEmptyDefaults_release_handle');
+final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_intsField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithEmptyDefaults_get_field_intsField');
+final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_floatsField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithEmptyDefaults_get_field_floatsField');
+final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_mapField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithEmptyDefaults_get_field_mapField');
+final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_structField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithEmptyDefaults_get_field_structField');
+final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField');
+Pointer<Void> smoke_DefaultValues_StructWithEmptyDefaults_toFfi(DefaultValues_StructWithEmptyDefaults value) {
+  final _intsField_handle = ListOf_Int_toFfi(value.intsField);
+  final _floatsField_handle = ListOf_Float_toFfi(value.floatsField);
+  final _mapField_handle = MapOf_UInt_to_String_toFfi(value.mapField);
+  final _structField_handle = smoke_DefaultValues_StructWithDefaults_toFfi(value.structField);
+  final _setTypeField_handle = SetOf_String_toFfi(value.setTypeField);
+  final _result = _smoke_DefaultValues_StructWithEmptyDefaults_create_handle(_intsField_handle, _floatsField_handle, _mapField_handle, _structField_handle, _setTypeField_handle);
+  ListOf_Int_releaseFfiHandle(_intsField_handle);
+  ListOf_Float_releaseFfiHandle(_floatsField_handle);
+  MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
+  smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_structField_handle);
+  SetOf_String_releaseFfiHandle(_setTypeField_handle);
+  return _result;
+}
+DefaultValues_StructWithEmptyDefaults smoke_DefaultValues_StructWithEmptyDefaults_fromFfi(Pointer<Void> handle) {
+  final _intsField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_intsField(handle);
+  final _floatsField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_floatsField(handle);
+  final _mapField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_mapField(handle);
+  final _structField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_structField(handle);
+  final _setTypeField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField(handle);
+  final _result = DefaultValues_StructWithEmptyDefaults(
+    ListOf_Int_fromFfi(_intsField_handle),
+    ListOf_Float_fromFfi(_floatsField_handle),
+    MapOf_UInt_to_String_fromFfi(_mapField_handle),
+    smoke_DefaultValues_StructWithDefaults_fromFfi(_structField_handle),
+    SetOf_String_fromFfi(_setTypeField_handle)
+  );
+  ListOf_Int_releaseFfiHandle(_intsField_handle);
+  ListOf_Float_releaseFfiHandle(_floatsField_handle);
+  MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
+  smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_structField_handle);
+  SetOf_String_releaseFfiHandle(_setTypeField_handle);
+  return _result;
+}
+void smoke_DefaultValues_StructWithEmptyDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithEmptyDefaults_release_handle(handle);
+// End of DefaultValues_StructWithEmptyDefaults "private" section.
+class DefaultValues_StructWithTypedefDefaults {
+  int longField;
+  bool boolField;
+  String stringField;
+  DefaultValues_SomeEnum enumField;
+  DefaultValues_StructWithTypedefDefaults(this.longField, this.boolField, this.stringField, this.enumField);
+  DefaultValues_StructWithTypedefDefaults.withDefaults()
+    : longField = 42, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n", enumField = DefaultValues_SomeEnum.barValue;
+}
+// DefaultValues_StructWithTypedefDefaults "private" section, not exported.
+final _smoke_DefaultValues_StructWithTypedefDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int64, Uint8, Pointer<Void>, Uint32),
+    Pointer<Void> Function(int, int, Pointer<Void>, int)
+  >('smoke_DefaultValues_StructWithTypedefDefaults_create_handle');
+final _smoke_DefaultValues_StructWithTypedefDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithTypedefDefaults_release_handle');
+final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_longField = __lib.nativeLibrary.lookupFunction<
+    Int64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithTypedefDefaults_get_field_longField');
+final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithTypedefDefaults_get_field_boolField');
+final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithTypedefDefaults_get_field_stringField');
+final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_DefaultValues_StructWithTypedefDefaults_get_field_enumField');
+Pointer<Void> smoke_DefaultValues_StructWithTypedefDefaults_toFfi(DefaultValues_StructWithTypedefDefaults value) {
+  final _longField_handle = (value.longField);
+  final _boolField_handle = Boolean_toFfi(value.boolField);
+  final _stringField_handle = String_toFfi(value.stringField);
+  final _enumField_handle = smoke_DefaultValues_SomeEnum_toFfi(value.enumField);
+  final _result = _smoke_DefaultValues_StructWithTypedefDefaults_create_handle(_longField_handle, _boolField_handle, _stringField_handle, _enumField_handle);
+  (_longField_handle);
+  Boolean_releaseFfiHandle(_boolField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
+  return _result;
+}
+DefaultValues_StructWithTypedefDefaults smoke_DefaultValues_StructWithTypedefDefaults_fromFfi(Pointer<Void> handle) {
+  final _longField_handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_field_longField(handle);
+  final _boolField_handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_field_boolField(handle);
+  final _stringField_handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_field_stringField(handle);
+  final _enumField_handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_field_enumField(handle);
+  final _result = DefaultValues_StructWithTypedefDefaults(
+    (_longField_handle),
+    Boolean_fromFfi(_boolField_handle),
+    String_fromFfi(_stringField_handle),
+    smoke_DefaultValues_SomeEnum_fromFfi(_enumField_handle)
+  );
+  (_longField_handle);
+  Boolean_releaseFfiHandle(_boolField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
+  return _result;
+}
+void smoke_DefaultValues_StructWithTypedefDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithTypedefDefaults_release_handle(handle);
+// End of DefaultValues_StructWithTypedefDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/StructWithInitializerDefaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/StructWithInitializerDefaults.dart
@@ -1,0 +1,81 @@
+import 'package:library/src/GenericTypes__conversion.dart';
+import 'package:library/src/String__conversion.dart';
+import 'package:library/src/smoke/TypesWithDefaults.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+class StructWithInitializerDefaults {
+  List<int> intsField;
+  List<double> floatsField;
+  StructWithAnEnum structField;
+  Set<String> setTypeField;
+  Map<int, String> mapField;
+  StructWithInitializerDefaults(this.intsField, this.floatsField, this.structField, this.setTypeField, this.mapField);
+  StructWithInitializerDefaults.withDefaults()
+    : intsField = [4, -2, 42], floatsField = [3.14, double.negativeInfinity], structField = StructWithAnEnum(AnEnum.disabled), setTypeField = {"foo", "bar"}, mapField = {1: "foo", 42: "bar"};
+}
+// StructWithInitializerDefaults "private" section, not exported.
+final _smoke_StructWithInitializerDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
+  >('smoke_StructWithInitializerDefaults_create_handle');
+final _smoke_StructWithInitializerDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_StructWithInitializerDefaults_release_handle');
+final _smoke_StructWithInitializerDefaults_get_field_intsField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_StructWithInitializerDefaults_get_field_intsField');
+final _smoke_StructWithInitializerDefaults_get_field_floatsField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_StructWithInitializerDefaults_get_field_floatsField');
+final _smoke_StructWithInitializerDefaults_get_field_structField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_StructWithInitializerDefaults_get_field_structField');
+final _smoke_StructWithInitializerDefaults_get_field_setTypeField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_StructWithInitializerDefaults_get_field_setTypeField');
+final _smoke_StructWithInitializerDefaults_get_field_mapField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_StructWithInitializerDefaults_get_field_mapField');
+Pointer<Void> smoke_StructWithInitializerDefaults_toFfi(StructWithInitializerDefaults value) {
+  final _intsField_handle = ListOf_Int_toFfi(value.intsField);
+  final _floatsField_handle = ListOf_Float_toFfi(value.floatsField);
+  final _structField_handle = smoke_TypesWithDefaults_StructWithAnEnum_toFfi(value.structField);
+  final _setTypeField_handle = SetOf_String_toFfi(value.setTypeField);
+  final _mapField_handle = MapOf_UInt_to_String_toFfi(value.mapField);
+  final _result = _smoke_StructWithInitializerDefaults_create_handle(_intsField_handle, _floatsField_handle, _structField_handle, _setTypeField_handle, _mapField_handle);
+  ListOf_Int_releaseFfiHandle(_intsField_handle);
+  ListOf_Float_releaseFfiHandle(_floatsField_handle);
+  smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_structField_handle);
+  SetOf_String_releaseFfiHandle(_setTypeField_handle);
+  MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
+  return _result;
+}
+StructWithInitializerDefaults smoke_StructWithInitializerDefaults_fromFfi(Pointer<Void> handle) {
+  final _intsField_handle = _smoke_StructWithInitializerDefaults_get_field_intsField(handle);
+  final _floatsField_handle = _smoke_StructWithInitializerDefaults_get_field_floatsField(handle);
+  final _structField_handle = _smoke_StructWithInitializerDefaults_get_field_structField(handle);
+  final _setTypeField_handle = _smoke_StructWithInitializerDefaults_get_field_setTypeField(handle);
+  final _mapField_handle = _smoke_StructWithInitializerDefaults_get_field_mapField(handle);
+  final _result = StructWithInitializerDefaults(
+    ListOf_Int_fromFfi(_intsField_handle),
+    ListOf_Float_fromFfi(_floatsField_handle),
+    smoke_TypesWithDefaults_StructWithAnEnum_fromFfi(_structField_handle),
+    SetOf_String_fromFfi(_setTypeField_handle),
+    MapOf_UInt_to_String_fromFfi(_mapField_handle)
+  );
+  ListOf_Int_releaseFfiHandle(_intsField_handle);
+  ListOf_Float_releaseFfiHandle(_floatsField_handle);
+  smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_structField_handle);
+  SetOf_String_releaseFfiHandle(_setTypeField_handle);
+  MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
+  return _result;
+}
+void smoke_StructWithInitializerDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithInitializerDefaults_release_handle(handle);
+// End of StructWithInitializerDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/TypesWithDefaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/TypesWithDefaults.dart
@@ -1,0 +1,249 @@
+import 'package:library/src/Boolean__conversion.dart';
+import 'package:library/src/String__conversion.dart';
+import 'package:library/src/smoke/AnEnum.dart';
+import 'package:library/src/smoke/AnEnum__conversion.dart';
+import 'package:library/src/smoke/DefaultValues.dart';
+import 'package:library/src/smoke/DefaultValues_ExternalEnum__conversion.dart';
+import 'package:library/src/smoke/SomeEnum__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+enum SomeEnum {
+    fooValue,
+    barValue
+}
+class StructWithDefaults {
+  int intField;
+  int uintField;
+  double floatField;
+  double doubleField;
+  bool boolField;
+  String stringField;
+  SomeEnum enumField;
+  StructWithDefaults(this.intField, this.uintField, this.floatField, this.doubleField, this.boolField, this.stringField, this.enumField);
+  StructWithDefaults.withDefaults()
+    : intField = 42, uintField = 4294967295, floatField = 3.14, doubleField = -1.4142, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n", enumField = SomeEnum.barValue;
+}
+// StructWithDefaults "private" section, not exported.
+final _smoke_TypesWithDefaults_StructWithDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int32, Uint32, Float, Double, Uint8, Pointer<Void>, Uint32),
+    Pointer<Void> Function(int, int, double, double, int, Pointer<Void>, int)
+  >('smoke_TypesWithDefaults_StructWithDefaults_create_handle');
+final _smoke_TypesWithDefaults_StructWithDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_StructWithDefaults_release_handle');
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_intField = __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_StructWithDefaults_get_field_intField');
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_uintField = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_StructWithDefaults_get_field_uintField');
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_floatField = __lib.nativeLibrary.lookupFunction<
+    Float Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_StructWithDefaults_get_field_floatField');
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_doubleField = __lib.nativeLibrary.lookupFunction<
+    Double Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_StructWithDefaults_get_field_doubleField');
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_StructWithDefaults_get_field_boolField');
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_StructWithDefaults_get_field_stringField');
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_StructWithDefaults_get_field_enumField');
+Pointer<Void> smoke_TypesWithDefaults_StructWithDefaults_toFfi(StructWithDefaults value) {
+  final _intField_handle = (value.intField);
+  final _uintField_handle = (value.uintField);
+  final _floatField_handle = (value.floatField);
+  final _doubleField_handle = (value.doubleField);
+  final _boolField_handle = Boolean_toFfi(value.boolField);
+  final _stringField_handle = String_toFfi(value.stringField);
+  final _enumField_handle = smoke_TypesWithDefaults_SomeEnum_toFfi(value.enumField);
+  final _result = _smoke_TypesWithDefaults_StructWithDefaults_create_handle(_intField_handle, _uintField_handle, _floatField_handle, _doubleField_handle, _boolField_handle, _stringField_handle, _enumField_handle);
+  (_intField_handle);
+  (_uintField_handle);
+  (_floatField_handle);
+  (_doubleField_handle);
+  Boolean_releaseFfiHandle(_boolField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumField_handle);
+  return _result;
+}
+StructWithDefaults smoke_TypesWithDefaults_StructWithDefaults_fromFfi(Pointer<Void> handle) {
+  final _intField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_intField(handle);
+  final _uintField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_uintField(handle);
+  final _floatField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_floatField(handle);
+  final _doubleField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_doubleField(handle);
+  final _boolField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_boolField(handle);
+  final _stringField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_stringField(handle);
+  final _enumField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_enumField(handle);
+  final _result = StructWithDefaults(
+    (_intField_handle),
+    (_uintField_handle),
+    (_floatField_handle),
+    (_doubleField_handle),
+    Boolean_fromFfi(_boolField_handle),
+    String_fromFfi(_stringField_handle),
+    smoke_TypesWithDefaults_SomeEnum_fromFfi(_enumField_handle)
+  );
+  (_intField_handle);
+  (_uintField_handle);
+  (_floatField_handle);
+  (_doubleField_handle);
+  Boolean_releaseFfiHandle(_boolField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumField_handle);
+  return _result;
+}
+void smoke_TypesWithDefaults_StructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypesWithDefaults_StructWithDefaults_release_handle(handle);
+// End of StructWithDefaults "private" section.
+class ImmutableStructWithDefaults {
+  final int intField;
+  final int uintField;
+  final double floatField;
+  final double doubleField;
+  final bool boolField;
+  final String stringField;
+  final SomeEnum enumField;
+  final DefaultValues_ExternalEnum externalEnumField;
+  ImmutableStructWithDefaults(this.intField, this.uintField, this.floatField, this.doubleField, this.boolField, this.stringField, this.enumField, this.externalEnumField);
+  ImmutableStructWithDefaults.withDefaults(int uintField, bool boolField)
+    : intField = 42, uintField = uintField, floatField = 3.14, doubleField = -1.4142, boolField = boolField, stringField = "\\Jonny \"Magic\" Smith\n", enumField = SomeEnum.barValue, externalEnumField = DefaultValues_ExternalEnum.anotherValue;
+}
+// ImmutableStructWithDefaults "private" section, not exported.
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int32, Uint32, Float, Double, Uint8, Pointer<Void>, Uint32, Uint32),
+    Pointer<Void> Function(int, int, double, double, int, Pointer<Void>, int, int)
+  >('smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle');
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle');
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_intField = __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_intField');
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_uintField = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_uintField');
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_floatField = __lib.nativeLibrary.lookupFunction<
+    Float Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_floatField');
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_doubleField = __lib.nativeLibrary.lookupFunction<
+    Double Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_doubleField');
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_boolField');
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_stringField');
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_enumField');
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_externalEnumField = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_externalEnumField');
+Pointer<Void> smoke_TypesWithDefaults_ImmutableStructWithDefaults_toFfi(ImmutableStructWithDefaults value) {
+  final _intField_handle = (value.intField);
+  final _uintField_handle = (value.uintField);
+  final _floatField_handle = (value.floatField);
+  final _doubleField_handle = (value.doubleField);
+  final _boolField_handle = Boolean_toFfi(value.boolField);
+  final _stringField_handle = String_toFfi(value.stringField);
+  final _enumField_handle = smoke_TypesWithDefaults_SomeEnum_toFfi(value.enumField);
+  final _externalEnumField_handle = smoke_DefaultValues_ExternalEnum_toFfi(value.externalEnumField);
+  final _result = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle(_intField_handle, _uintField_handle, _floatField_handle, _doubleField_handle, _boolField_handle, _stringField_handle, _enumField_handle, _externalEnumField_handle);
+  (_intField_handle);
+  (_uintField_handle);
+  (_floatField_handle);
+  (_doubleField_handle);
+  Boolean_releaseFfiHandle(_boolField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumField_handle);
+  smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumField_handle);
+  return _result;
+}
+ImmutableStructWithDefaults smoke_TypesWithDefaults_ImmutableStructWithDefaults_fromFfi(Pointer<Void> handle) {
+  final _intField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_intField(handle);
+  final _uintField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_uintField(handle);
+  final _floatField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_floatField(handle);
+  final _doubleField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_doubleField(handle);
+  final _boolField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_boolField(handle);
+  final _stringField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_stringField(handle);
+  final _enumField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_enumField(handle);
+  final _externalEnumField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_externalEnumField(handle);
+  final _result = ImmutableStructWithDefaults(
+    (_intField_handle),
+    (_uintField_handle),
+    (_floatField_handle),
+    (_doubleField_handle),
+    Boolean_fromFfi(_boolField_handle),
+    String_fromFfi(_stringField_handle),
+    smoke_TypesWithDefaults_SomeEnum_fromFfi(_enumField_handle),
+    smoke_DefaultValues_ExternalEnum_fromFfi(_externalEnumField_handle)
+  );
+  (_intField_handle);
+  (_uintField_handle);
+  (_floatField_handle);
+  (_doubleField_handle);
+  Boolean_releaseFfiHandle(_boolField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumField_handle);
+  smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumField_handle);
+  return _result;
+}
+void smoke_TypesWithDefaults_ImmutableStructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle(handle);
+// End of ImmutableStructWithDefaults "private" section.
+class StructWithAnEnum {
+  AnEnum config;
+  StructWithAnEnum(this.config);
+  StructWithAnEnum.withDefaults()
+    : config = AnEnum.enabled;
+}
+// StructWithAnEnum "private" section, not exported.
+final _smoke_TypesWithDefaults_StructWithAnEnum_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('smoke_TypesWithDefaults_StructWithAnEnum_create_handle');
+final _smoke_TypesWithDefaults_StructWithAnEnum_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_StructWithAnEnum_release_handle');
+final _smoke_TypesWithDefaults_StructWithAnEnum_get_field_config = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_TypesWithDefaults_StructWithAnEnum_get_field_config');
+Pointer<Void> smoke_TypesWithDefaults_StructWithAnEnum_toFfi(StructWithAnEnum value) {
+  final _config_handle = smoke_AnEnum_AnEnum_toFfi(value.config);
+  final _result = _smoke_TypesWithDefaults_StructWithAnEnum_create_handle(_config_handle);
+  smoke_AnEnum_AnEnum_releaseFfiHandle(_config_handle);
+  return _result;
+}
+StructWithAnEnum smoke_TypesWithDefaults_StructWithAnEnum_fromFfi(Pointer<Void> handle) {
+  final _config_handle = _smoke_TypesWithDefaults_StructWithAnEnum_get_field_config(handle);
+  final _result = StructWithAnEnum(
+    smoke_AnEnum_AnEnum_fromFfi(_config_handle)
+  );
+  smoke_AnEnum_AnEnum_releaseFfiHandle(_config_handle);
+  return _result;
+}
+void smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypesWithDefaults_StructWithAnEnum_release_handle(handle);
+// End of StructWithAnEnum "private" section.

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
@@ -38,4 +38,12 @@ class LimeStruct(
 ) {
     override val childTypes
         get() = fields.map { it.typeRef }
+
+    @Suppress("unused")
+    val initializedFields
+        get() = fields.filter { it.defaultValue != null }
+
+    @Suppress("unused")
+    val uninitializedFields
+        get() = fields.filter { it.defaultValue == null }
 }


### PR DESCRIPTION
Removed "nullable" use case from "Defaults" functional test as it was a
duplicate of what is already tested in "Nullable" functional test.

Added smoke and functional tests as appropriate.

Resolves: #93
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>