### PR TITLE
Add support for "internal" visibility to Dart generator

### DIFF
--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -28,7 +28,7 @@ final _{{resolveName "Ffi"}}_release_handle = __lib.nativeLibrary.lookupFunction
 
 {{/functions}}{{!!
 }}{{>dart/DartDocumentation}}
-class {{resolveName visibility}}{{resolveName}} {{!!
+class {{resolveName}} {{!!
 }}{{#if parent}}{{#isEq type parent.type.type}}extends{{/isEq}}{{!!
 }}{{#isNoEq type parent.type.type}}implements{{/isNoEq}} {{resolveName parent}} {{/if}}{
   final Pointer<Void> _handle;
@@ -82,7 +82,7 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) {}
 {{>dart/DartInterface}}
 {{/interfaces}}{{!!
 
-}}{{+dartConstructor}}{{resolveName visibility}}{{resolveName parent}}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}({{!!
+}}{{+dartConstructor}}{{resolveName parent}}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}({{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) : {{!!
 }}this._(_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}));
 {{/dartConstructor}}

--- a/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>dart/DartDocumentation}}
-enum {{resolveName visibility}}{{resolveName}} {
+enum {{resolveName}} {
 {{#enumerators}}
 {{prefixPartial "dart/DartEnumerator" "    "}}
 {{/enumerators}}

--- a/gluecodium/src/main/resources/templates/dart/DartException.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartException.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>dart/DartDocumentation}}
-class {{resolveName visibility}}{{resolveName}} implements Exception {
+class {{resolveName}} implements Exception {
   final {{resolveName errorType}} error;
   {{resolveName}}(this.error);
 }

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>dart/DartDocumentation}}
-abstract class {{resolveName visibility}}{{resolveName}} {{!!
+abstract class {{resolveName}} {{!!
 }}{{#if parent}}implements {{resolveName parent}} {{/if}}{
   void release();
 

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -24,7 +24,7 @@
 {{/functions}}{{!!
 }}{{#unless comment.isEmpty}}{{prefix comment "/// "}}
 {{/unless}}
-class {{resolveName visibility}}{{resolveName}} {
+class {{resolveName}} {
 {{#set parent=this}}{{#fields}}{{prefixPartial "dart/DartField" "  "}}
 {{/fields}}{{/set}}
 {{#if fields}}  {{resolveName}}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
@@ -96,7 +96,7 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveN
 
 // End of {{resolveName}} "private" section.{{!!
 
-}}{{+dartConstructor}}{{resolveName visibility}}{{resolveName parent}}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}({{!!
+}}{{+dartConstructor}}{{resolveName parent}}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}({{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) : {{!!
 }}this._copy(_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}));
 {{/dartConstructor}}

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/library.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/library.dart
@@ -1,0 +1,5 @@
+export 'src/smoke/InternalInterface.dart';
+export 'src/smoke/InternalClass.dart';
+export 'src/smoke/PublicInterface.dart' show PublicInterface;
+export 'src/smoke/PublicClass.dart' show PublicClass, PublicClass_PublicStruct, PublicClass_PublicStructWithInternalDefaults;
+export 'src/smoke/PublicTypeCollection.dart' show PublicTypeCollection;

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalClass.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalClass.dart
@@ -1,0 +1,20 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_InternalClass_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_InternalClass_release_handle');
+class InternalClass {
+  final Pointer<Void> _handle;
+  InternalClass._(this._handle);
+  void release() => _smoke_InternalClass_release_handle(_handle);
+}
+Pointer<Void> smoke_InternalClass_toFfi(InternalClass value) => value._handle;
+InternalClass smoke_InternalClass_fromFfi(Pointer<Void> handle) => InternalClass._(handle);
+void smoke_InternalClass_releaseFfiHandle(Pointer<Void> handle) {}
+Pointer<Void> smoke_InternalClass_toFfi_nullable(InternalClass value) =>
+  value != null ? value._handle : Pointer<Void>.fromAddress(0);
+InternalClass smoke_InternalClass_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? InternalClass._(handle) : null;
+void smoke_InternalClass_releaseFfiHandle_nullable(Pointer<Void> handle) {}

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalInterface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalInterface.dart
@@ -1,0 +1,27 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+abstract class InternalInterface {
+  void release();
+}
+// InternalInterface "private" section, not exported.
+final _smoke_InternalInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_InternalInterface_release_handle');
+class InternalInterface__Impl implements InternalInterface{
+  final Pointer<Void> _handle;
+  InternalInterface__Impl._(this._handle);
+  @override
+  void release() => _smoke_InternalInterface_release_handle(_handle);
+}
+Pointer<Void> smoke_InternalInterface_toFfi(InternalInterface__Impl value) => value._handle;
+InternalInterface smoke_InternalInterface_fromFfi(Pointer<Void> handle) =>
+  InternalInterface__Impl._(handle);
+void smoke_InternalInterface_releaseFfiHandle(Pointer<Void> handle) {}
+Pointer<Void> smoke_InternalInterface_toFfi_nullable(InternalInterface__Impl value) =>
+  value != null ? value._handle : Pointer<Void>.fromAddress(0);
+InternalInterface smoke_InternalInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? InternalInterface__Impl._(handle) : null;
+void smoke_InternalInterface_releaseFfiHandle_nullable(Pointer<Void> handle) {}
+// End of InternalInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicClass.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicClass.dart
@@ -1,0 +1,319 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_PublicClass_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicClass_release_handle');
+class PublicClass {
+  final Pointer<Void> _handle;
+  PublicClass._(this._handle);
+  void release() => _smoke_PublicClass_release_handle(_handle);
+  PublicClass_InternalStruct _internalMethod(PublicClass_InternalStruct input) {
+    final _internalMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_PublicClass_internalMethod__InternalStruct');
+    final _input_handle = smoke_PublicClass_InternalStruct_toFfi(input);
+    final __result_handle = _internalMethod_ffi(_handle, _input_handle);
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(_input_handle);
+    final _result = smoke_PublicClass_InternalStruct_fromFfi(__result_handle);
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  PublicClass_InternalStruct get _internalStructProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_PublicClass_internalStructProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = smoke_PublicClass_InternalStruct_fromFfi(__result_handle);
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set _internalStructProperty(PublicClass_InternalStruct value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_PublicClass_internalStructProperty_set__InternalStruct');
+    final _value_handle = smoke_PublicClass_InternalStruct_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  String get internalSetterProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_PublicClass_internalSetterProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set _internalSetterProperty(String value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_PublicClass_internalSetterProperty_set__String');
+    final _value_handle = String_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    String_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_PublicClass_toFfi(PublicClass value) => value._handle;
+PublicClass smoke_PublicClass_fromFfi(Pointer<Void> handle) => PublicClass._(handle);
+void smoke_PublicClass_releaseFfiHandle(Pointer<Void> handle) {}
+Pointer<Void> smoke_PublicClass_toFfi_nullable(PublicClass value) =>
+  value != null ? value._handle : Pointer<Void>.fromAddress(0);
+PublicClass smoke_PublicClass_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? PublicClass._(handle) : null;
+void smoke_PublicClass_releaseFfiHandle_nullable(Pointer<Void> handle) {}
+enum PublicClass_InternalEnum {
+    foo,
+    bar
+}
+// PublicClass_InternalEnum "private" section, not exported.
+int smoke_PublicClass_InternalEnum_toFfi(PublicClass_InternalEnum value) {
+  switch (value) {
+  case PublicClass_InternalEnum.foo:
+    return 0;
+  break;
+  case PublicClass_InternalEnum.bar:
+    return 1;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for PublicClass_InternalEnum enum.");
+  }
+}
+PublicClass_InternalEnum smoke_PublicClass_InternalEnum_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return PublicClass_InternalEnum.foo;
+  break;
+  case 1:
+    return PublicClass_InternalEnum.bar;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for PublicClass_InternalEnum enum.");
+  }
+}
+void smoke_PublicClass_InternalEnum_releaseFfiHandle(int handle) {}
+final _smoke_PublicClass_InternalEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('smoke_PublicClass_InternalEnum_create_handle_nullable');
+final _smoke_PublicClass_InternalEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicClass_InternalEnum_release_handle_nullable');
+final _smoke_PublicClass_InternalEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_PublicClass_InternalEnum_get_value_nullable');
+Pointer<Void> smoke_PublicClass_InternalEnum_toFfi_nullable(PublicClass_InternalEnum value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_PublicClass_InternalEnum_toFfi(value);
+  final result = _smoke_PublicClass_InternalEnum_create_handle_nullable(_handle);
+  smoke_PublicClass_InternalEnum_releaseFfiHandle(_handle);
+  return result;
+}
+PublicClass_InternalEnum smoke_PublicClass_InternalEnum_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_PublicClass_InternalEnum_get_value_nullable(handle);
+  final result = smoke_PublicClass_InternalEnum_fromFfi(_handle);
+  smoke_PublicClass_InternalEnum_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_PublicClass_InternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PublicClass_InternalEnum_release_handle_nullable(handle);
+// End of PublicClass_InternalEnum "private" section.
+class PublicClass_InternalStruct {
+  String _stringField;
+  PublicClass_InternalStruct(this.stringField);
+}
+// PublicClass_InternalStruct "private" section, not exported.
+final _smoke_PublicClass_InternalStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicClass_InternalStruct_create_handle');
+final _smoke_PublicClass_InternalStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicClass_InternalStruct_release_handle');
+final _smoke_PublicClass_InternalStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicClass_InternalStruct_get_field_stringField');
+Pointer<Void> smoke_PublicClass_InternalStruct_toFfi(PublicClass_InternalStruct value) {
+  final _stringField_handle = String_toFfi(value.stringField);
+  final _result = _smoke_PublicClass_InternalStruct_create_handle(_stringField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  return _result;
+}
+PublicClass_InternalStruct smoke_PublicClass_InternalStruct_fromFfi(Pointer<Void> handle) {
+  final _stringField_handle = _smoke_PublicClass_InternalStruct_get_field_stringField(handle);
+  final _result = PublicClass_InternalStruct(
+    String_fromFfi(_stringField_handle)
+  );
+  String_releaseFfiHandle(_stringField_handle);
+  return _result;
+}
+void smoke_PublicClass_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicClass_InternalStruct_release_handle(handle);
+// Nullable PublicClass_InternalStruct
+final _smoke_PublicClass_InternalStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicClass_InternalStruct_create_handle_nullable');
+final _smoke_PublicClass_InternalStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicClass_InternalStruct_release_handle_nullable');
+final _smoke_PublicClass_InternalStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicClass_InternalStruct_get_value_nullable');
+Pointer<Void> smoke_PublicClass_InternalStruct_toFfi_nullable(PublicClass_InternalStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_PublicClass_InternalStruct_toFfi(value);
+  final result = _smoke_PublicClass_InternalStruct_create_handle_nullable(_handle);
+  smoke_PublicClass_InternalStruct_releaseFfiHandle(_handle);
+  return result;
+}
+PublicClass_InternalStruct smoke_PublicClass_InternalStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_PublicClass_InternalStruct_get_value_nullable(handle);
+  final result = smoke_PublicClass_InternalStruct_fromFfi(_handle);
+  smoke_PublicClass_InternalStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_PublicClass_InternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PublicClass_InternalStruct_release_handle_nullable(handle);
+// End of PublicClass_InternalStruct "private" section.
+class PublicClass_PublicStruct {
+  PublicClass_InternalStruct _internalField;
+  PublicClass_PublicStruct(this.internalField);
+}
+// PublicClass_PublicStruct "private" section, not exported.
+final _smoke_PublicClass_PublicStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicClass_PublicStruct_create_handle');
+final _smoke_PublicClass_PublicStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicClass_PublicStruct_release_handle');
+final _smoke_PublicClass_PublicStruct_get_field_internalField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicClass_PublicStruct_get_field_internalField');
+Pointer<Void> smoke_PublicClass_PublicStruct_toFfi(PublicClass_PublicStruct value) {
+  final _internalField_handle = smoke_PublicClass_InternalStruct_toFfi(value.internalField);
+  final _result = _smoke_PublicClass_PublicStruct_create_handle(_internalField_handle);
+  smoke_PublicClass_InternalStruct_releaseFfiHandle(_internalField_handle);
+  return _result;
+}
+PublicClass_PublicStruct smoke_PublicClass_PublicStruct_fromFfi(Pointer<Void> handle) {
+  final _internalField_handle = _smoke_PublicClass_PublicStruct_get_field_internalField(handle);
+  final _result = PublicClass_PublicStruct(
+    smoke_PublicClass_InternalStruct_fromFfi(_internalField_handle)
+  );
+  smoke_PublicClass_InternalStruct_releaseFfiHandle(_internalField_handle);
+  return _result;
+}
+void smoke_PublicClass_PublicStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicClass_PublicStruct_release_handle(handle);
+// Nullable PublicClass_PublicStruct
+final _smoke_PublicClass_PublicStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicClass_PublicStruct_create_handle_nullable');
+final _smoke_PublicClass_PublicStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicClass_PublicStruct_release_handle_nullable');
+final _smoke_PublicClass_PublicStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicClass_PublicStruct_get_value_nullable');
+Pointer<Void> smoke_PublicClass_PublicStruct_toFfi_nullable(PublicClass_PublicStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_PublicClass_PublicStruct_toFfi(value);
+  final result = _smoke_PublicClass_PublicStruct_create_handle_nullable(_handle);
+  smoke_PublicClass_PublicStruct_releaseFfiHandle(_handle);
+  return result;
+}
+PublicClass_PublicStruct smoke_PublicClass_PublicStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_PublicClass_PublicStruct_get_value_nullable(handle);
+  final result = smoke_PublicClass_PublicStruct_fromFfi(_handle);
+  smoke_PublicClass_PublicStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_PublicClass_PublicStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PublicClass_PublicStruct_release_handle_nullable(handle);
+// End of PublicClass_PublicStruct "private" section.
+class PublicClass_PublicStructWithInternalDefaults {
+  String _internalField;
+  double publicField;
+  PublicClass_PublicStructWithInternalDefaults(this.internalField, this.publicField);
+  PublicClass_PublicStructWithInternalDefaults.withDefaults(double publicField)
+    : internalField = "foo", publicField = publicField;
+}
+// PublicClass_PublicStructWithInternalDefaults "private" section, not exported.
+final _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Float),
+    Pointer<Void> Function(Pointer<Void>, double)
+  >('smoke_PublicClass_PublicStructWithInternalDefaults_create_handle');
+final _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicClass_PublicStructWithInternalDefaults_release_handle');
+final _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_internalField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicClass_PublicStructWithInternalDefaults_get_field_internalField');
+final _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField = __lib.nativeLibrary.lookupFunction<
+    Float Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField');
+Pointer<Void> smoke_PublicClass_PublicStructWithInternalDefaults_toFfi(PublicClass_PublicStructWithInternalDefaults value) {
+  final _internalField_handle = String_toFfi(value.internalField);
+  final _publicField_handle = (value.publicField);
+  final _result = _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle(_internalField_handle, _publicField_handle);
+  String_releaseFfiHandle(_internalField_handle);
+  (_publicField_handle);
+  return _result;
+}
+PublicClass_PublicStructWithInternalDefaults smoke_PublicClass_PublicStructWithInternalDefaults_fromFfi(Pointer<Void> handle) {
+  final _internalField_handle = _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_internalField(handle);
+  final _publicField_handle = _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField(handle);
+  final _result = PublicClass_PublicStructWithInternalDefaults(
+    String_fromFfi(_internalField_handle),
+    (_publicField_handle)
+  );
+  String_releaseFfiHandle(_internalField_handle);
+  (_publicField_handle);
+  return _result;
+}
+void smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle(handle);
+// Nullable PublicClass_PublicStructWithInternalDefaults
+final _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicClass_PublicStructWithInternalDefaults_create_handle_nullable');
+final _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicClass_PublicStructWithInternalDefaults_release_handle_nullable');
+final _smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable');
+Pointer<Void> smoke_PublicClass_PublicStructWithInternalDefaults_toFfi_nullable(PublicClass_PublicStructWithInternalDefaults value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_PublicClass_PublicStructWithInternalDefaults_toFfi(value);
+  final result = _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle_nullable(_handle);
+  smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle(_handle);
+  return result;
+}
+PublicClass_PublicStructWithInternalDefaults smoke_PublicClass_PublicStructWithInternalDefaults_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable(handle);
+  final result = smoke_PublicClass_PublicStructWithInternalDefaults_fromFfi(_handle);
+  smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle_nullable(handle);
+// End of PublicClass_PublicStructWithInternalDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicInterface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicInterface.dart
@@ -1,0 +1,90 @@
+import 'package:library/src/smoke/PublicClass.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+abstract class PublicInterface {
+  void release();
+}
+class PublicInterface_InternalStruct {
+  PublicClass_InternalStruct _fieldOfInternalType;
+  PublicInterface_InternalStruct(this.fieldOfInternalType);
+}
+// PublicInterface_InternalStruct "private" section, not exported.
+final _smoke_PublicInterface_InternalStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicInterface_InternalStruct_create_handle');
+final _smoke_PublicInterface_InternalStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicInterface_InternalStruct_release_handle');
+final _smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType');
+Pointer<Void> smoke_PublicInterface_InternalStruct_toFfi(PublicInterface_InternalStruct value) {
+  final _fieldOfInternalType_handle = smoke_PublicClass_InternalStruct_toFfi(value.fieldOfInternalType);
+  final _result = _smoke_PublicInterface_InternalStruct_create_handle(_fieldOfInternalType_handle);
+  smoke_PublicClass_InternalStruct_releaseFfiHandle(_fieldOfInternalType_handle);
+  return _result;
+}
+PublicInterface_InternalStruct smoke_PublicInterface_InternalStruct_fromFfi(Pointer<Void> handle) {
+  final _fieldOfInternalType_handle = _smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType(handle);
+  final _result = PublicInterface_InternalStruct(
+    smoke_PublicClass_InternalStruct_fromFfi(_fieldOfInternalType_handle)
+  );
+  smoke_PublicClass_InternalStruct_releaseFfiHandle(_fieldOfInternalType_handle);
+  return _result;
+}
+void smoke_PublicInterface_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicInterface_InternalStruct_release_handle(handle);
+// Nullable PublicInterface_InternalStruct
+final _smoke_PublicInterface_InternalStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicInterface_InternalStruct_create_handle_nullable');
+final _smoke_PublicInterface_InternalStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicInterface_InternalStruct_release_handle_nullable');
+final _smoke_PublicInterface_InternalStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicInterface_InternalStruct_get_value_nullable');
+Pointer<Void> smoke_PublicInterface_InternalStruct_toFfi_nullable(PublicInterface_InternalStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_PublicInterface_InternalStruct_toFfi(value);
+  final result = _smoke_PublicInterface_InternalStruct_create_handle_nullable(_handle);
+  smoke_PublicInterface_InternalStruct_releaseFfiHandle(_handle);
+  return result;
+}
+PublicInterface_InternalStruct smoke_PublicInterface_InternalStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_PublicInterface_InternalStruct_get_value_nullable(handle);
+  final result = smoke_PublicInterface_InternalStruct_fromFfi(_handle);
+  smoke_PublicInterface_InternalStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_PublicInterface_InternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PublicInterface_InternalStruct_release_handle_nullable(handle);
+// End of PublicInterface_InternalStruct "private" section.
+// PublicInterface "private" section, not exported.
+final _smoke_PublicInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicInterface_release_handle');
+class PublicInterface__Impl implements PublicInterface{
+  final Pointer<Void> _handle;
+  PublicInterface__Impl._(this._handle);
+  @override
+  void release() => _smoke_PublicInterface_release_handle(_handle);
+}
+Pointer<Void> smoke_PublicInterface_toFfi(PublicInterface__Impl value) => value._handle;
+PublicInterface smoke_PublicInterface_fromFfi(Pointer<Void> handle) =>
+  PublicInterface__Impl._(handle);
+void smoke_PublicInterface_releaseFfiHandle(Pointer<Void> handle) {}
+Pointer<Void> smoke_PublicInterface_toFfi_nullable(PublicInterface__Impl value) =>
+  value != null ? value._handle : Pointer<Void>.fromAddress(0);
+PublicInterface smoke_PublicInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? PublicInterface__Impl._(handle) : null;
+void smoke_PublicInterface_releaseFfiHandle_nullable(Pointer<Void> handle) {}
+// End of PublicInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicTypeCollection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicTypeCollection.dart
@@ -1,0 +1,66 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+class InternalStruct {
+  String _stringField;
+  InternalStruct(this.stringField);
+}
+// InternalStruct "private" section, not exported.
+final _smoke_PublicTypeCollection_InternalStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicTypeCollection_InternalStruct_create_handle');
+final _smoke_PublicTypeCollection_InternalStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicTypeCollection_InternalStruct_release_handle');
+final _smoke_PublicTypeCollection_InternalStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicTypeCollection_InternalStruct_get_field_stringField');
+Pointer<Void> smoke_PublicTypeCollection_InternalStruct_toFfi(InternalStruct value) {
+  final _stringField_handle = String_toFfi(value.stringField);
+  final _result = _smoke_PublicTypeCollection_InternalStruct_create_handle(_stringField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  return _result;
+}
+InternalStruct smoke_PublicTypeCollection_InternalStruct_fromFfi(Pointer<Void> handle) {
+  final _stringField_handle = _smoke_PublicTypeCollection_InternalStruct_get_field_stringField(handle);
+  final _result = InternalStruct(
+    String_fromFfi(_stringField_handle)
+  );
+  String_releaseFfiHandle(_stringField_handle);
+  return _result;
+}
+void smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicTypeCollection_InternalStruct_release_handle(handle);
+// Nullable InternalStruct
+final _smoke_PublicTypeCollection_InternalStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicTypeCollection_InternalStruct_create_handle_nullable');
+final _smoke_PublicTypeCollection_InternalStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PublicTypeCollection_InternalStruct_release_handle_nullable');
+final _smoke_PublicTypeCollection_InternalStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PublicTypeCollection_InternalStruct_get_value_nullable');
+Pointer<Void> smoke_PublicTypeCollection_InternalStruct_toFfi_nullable(InternalStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_PublicTypeCollection_InternalStruct_toFfi(value);
+  final result = _smoke_PublicTypeCollection_InternalStruct_create_handle_nullable(_handle);
+  smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle(_handle);
+  return result;
+}
+InternalStruct smoke_PublicTypeCollection_InternalStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_PublicTypeCollection_InternalStruct_get_value_nullable(handle);
+  final result = smoke_PublicTypeCollection_InternalStruct_fromFfi(_handle);
+  smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PublicTypeCollection_InternalStruct_release_handle_nullable(handle);
+// End of InternalStruct "private" section.


### PR DESCRIPTION
There is no "internal" visibility concept in Dart. The solution is to
mark "internal" members (functions, properties, constants, fields) as
"private" with "_" prefix; and to mark "internal" types as "public", but
then to omit those types from the list of library exports.

"_" members marking was already in place. Updated Dart templates to not
to apply this marking to types. Implemented exports omission by
filtering the exportsCollector list in DartGeneratorSuite.

Added appropriate smoke tests.

Resolves: #130
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>