### PR TITLE
Add support for class/interface inheritance to Dart generator

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -263,7 +263,7 @@ feature(Defaults cpp android swift dart SOURCES
     lime/test/Defaults.lime
 )
 
-feature(Inheritance cpp android swift SOURCES
+feature(Inheritance cpp android swift dart SOURCES
     src/hello/HelloWorldInheritance.cpp
     src/test/ChildClassImpl.cpp
     src/test/ChildClassImpl.h

--- a/examples/libhello/lime/test/Inheritance.lime
+++ b/examples/libhello/lime/test/Inheritance.lime
@@ -107,8 +107,10 @@ class InheritanceTestHelper {
 }
 
 class ChildConstructorOverloads : ConstructorOverloads {
+    @Dart("createNoParametersChild")
     @Java("createNoParametersChild")
     constructor create()
+    @Dart("createWithErrorChild")
     @Java("createWithErrorChild")
     constructor create(
         input: Double

--- a/examples/platforms/dart/main.dart
+++ b/examples/platforms/dart/main.dart
@@ -28,6 +28,7 @@ import "test/EquatableStructs_test.dart" as EquatableStructsTests;
 import "test/Enums_test.dart" as EnumsTests;
 import "test/Exceptions_test.dart" as Exceptions;
 import "test/ExternalTypes_test.dart" as ExternalTypes;
+import "test/Inheritance_test.dart" as InheritanceTests;
 import "test/Interfaces_test.dart" as InterfacesTests;
 import "test/Lists_test.dart" as ListsTests;
 import "test/Maps_test.dart" as MapsTests;
@@ -56,6 +57,7 @@ final _allTests = [
   EnumsTests.main,
   Exceptions.main,
   ExternalTypes.main,
+  InheritanceTests.main,
   InterfacesTests.main,
   ListsTests.main,
   MapsTests.main,

--- a/examples/platforms/dart/test/Inheritance_test.dart
+++ b/examples/platforms/dart/test/Inheritance_test.dart
@@ -1,0 +1,61 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:hello/hello.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("Inheritance");
+
+void main() {
+  _testSuite.test("Create child class instance", () {
+    final ChildClass result = ChildClass.createChildClass();
+
+    expect(result.getName(), "Johnny");
+    expect(result.luckyNumber, 7);
+
+    result.release();
+  });
+  _testSuite.test("Cast child class instance to parent", () {
+    final ParentInterface result = ChildClass.createChildClass();
+
+    expect(result.getName(), "Johnny");
+    expect(result.luckyNumber, 7);
+
+    result.release();
+  });
+  _testSuite.test("Create grandchild class instance", () {
+    final GrandchildClass result = GrandchildClass.createGrandchildClass();
+
+    expect(result.getName(), "John F. Kimberly");
+    expect(result.luckyNumber, 42);
+
+    result.release();
+  });
+  _testSuite.test("Cast grandchild class instance to grandparent", () {
+    final ParentInterface result = GrandchildClass.createGrandchildClass();
+
+    expect(result.getName(), "John F. Kimberly");
+    expect(result.luckyNumber, 42);
+
+    result.release();
+  });
+  // TODO: #131 add tests for preserving type information
+}

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -31,34 +31,50 @@ final _{{resolveName "Ffi"}}_release_handle = __lib.nativeLibrary.lookupFunction
 {{/functions}}{{!!
 }}{{>dart/DartDocumentation}}
 class {{resolveName}} {{!!
-}}{{#if parent}}{{#isEq type parent.type.type}}extends{{/isEq}}{{!!
-}}{{#isNoEq type parent.type.type}}implements{{/isNoEq}} {{resolveName parent}} {{/if}}{
-  final Pointer<Void> _handle;
-  {{resolveName}}._(this._handle);
+}}{{#if parent}}{{#if hasClassParent}}extends{{/if}}{{!!
+}}{{#unless hasClassParent}}implements{{/unless}} {{resolveName parent}} {{/if}}{
+  {{#if hasClassParent}}Pointer<Void> get _handle => handle;{{/if}}{{!!
+  }}{{#unless hasClassParent}}{{#if visibility.isOpen}}@protected
+  final Pointer<Void> handle;
+  Pointer<Void> get _handle => handle;{{/if}}{{!!
+  }}{{#unless visibility.isOpen}}final Pointer<Void> _handle;{{/unless}}{{/unless}}
+  {{#if visibility.isOpen}}@protected
+  {{resolveName}}{{/if}}{{#unless visibility.isOpen}}{{resolveName}}._{{/unless}}{{!!
+  }}{{#unless hasClassParent}}(this.{{#unless visibility.isOpen}}_{{/unless}}handle){{/unless}}{{!!
+  }}{{#if hasClassParent}}(Pointer<Void> handle) : super(handle){{/if}};
 
   void release() => _{{resolveName "Ffi"}}_release_handle(_handle);
 
 {{#set isInClass=true}}{{#constants}}
 {{prefixPartial "dart/DartConstant" "  "}}
 {{/constants}}{{/set}}
-{{#set parent=this}}{{#constructors}}
+{{#set inheritanceParent=parent parent=this}}{{#constructors}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
 {{prefixPartial "dartConstructor" "  "}}
 {{/constructors}}
 {{#functions}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
 {{prefixPartial "dart/DartFunction" "  "}}
-{{/functions}}{{/set}}
+{{/functions}}{{#if inheritanceParent}}{{#instanceOf inheritanceParent.type "LimeInterface"}}
+{{#inheritedFunctions}}
+{{prefixPartial "dart/DartFunctionDocs" "  "}}
+  @override
+{{prefixPartial "dart/DartFunction" "  "}}
+{{/inheritedFunctions}}{{/instanceOf}}{{/if}}{{/set}}
 {{#properties}}
 {{prefixPartial "dart/DartProperty" "  "}}
 {{/properties}}
+{{#inheritedProperties}}
+  @override
+{{prefixPartial "dart/DartProperty" "  "}}
+{{/inheritedProperties}}
 {{#ifHasAttribute "Equatable"}}{{>dartFfiEqualityOperator}}{{/ifHasAttribute}}{{!!
 }}{{#ifHasAttribute "PointerEquatable"}}{{>dartFfiEqualityOperator}}{{/ifHasAttribute}}
 }
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) => value._handle;
 
-{{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) => {{resolveName}}._(handle);
+{{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) => {{resolveName}}{{#unless visibility.isOpen}}._{{/unless}}(handle);
 
 void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) {}
 
@@ -66,7 +82,7 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}} value) =>
   value != null ? value._handle : Pointer<Void>.fromAddress(0);
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? {{resolveName}}._(handle) : null;
+  handle.address != 0 ? {{resolveName}}{{#unless visibility.isOpen}}._{{/unless}}(handle) : null;
 
 void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) {}
 
@@ -88,7 +104,7 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) {}
 
 }}{{+dartConstructor}}{{resolveName parent}}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}({{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) : {{!!
-}}this._(_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}));
+}}this{{#unless parent.visibility.isOpen}}._{{/unless}}(_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}));
 {{/dartConstructor}}{{!!
 
 }}{{+dartFfiEqualityFunction}}

--- a/gluecodium/src/main/resources/templates/dart/DartFile.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFile.mustache
@@ -26,6 +26,7 @@
 
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 
 import 'package:{{libraryName}}/src/_library_init.dart' as __lib;
 

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -62,12 +62,14 @@ final _{{resolveName "Ffi"}}_release_handle = __lib.nativeLibrary.lookupFunction
 {{>dart/DartFunctionException}}
 
 {{/functions}}{{!!
-}}class {{resolveName}}__Impl implements {{resolveName}}{
-  final Pointer<Void> _handle;
-  {{resolveName}}__Impl._(this._handle);
+}}class {{resolveName}}__Impl {{#if parent}}extends {{resolveName parent}}__Impl {{/if}}implements {{resolveName}} {
+  Pointer<Void> get _handle => handle;
+  {{#if parent}}{{resolveName}}__Impl(Pointer<Void> handle) : super(handle);{{/if}}{{!!
+  }}{{#unless parent}}final Pointer<Void> handle;
+  {{resolveName}}__Impl(this.handle);{{/unless}}
 
   @override
-  void release() => _{{resolveName "Ffi"}}_release_handle(_handle);
+  void release() => _{{resolveName "Ffi"}}_release_handle(handle);
 
 {{#set parent=this}}{{#functions}}
   @override
@@ -78,10 +80,11 @@ final _{{resolveName "Ffi"}}_release_handle = __lib.nativeLibrary.lookupFunction
 {{/properties}}
 }
 
-Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}}__Impl value) => value._handle;
+Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}}__Impl value) =>
+  value != null ? value.handle : Pointer<Void>.fromAddress(0);
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) =>
-  {{resolveName}}__Impl._(handle);
+  handle.address != 0 ? {{resolveName}}__Impl(handle) : null;
 
 void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) {}
 
@@ -89,7 +92,7 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}}__Impl value) 
   value != null ? value._handle : Pointer<Void>.fromAddress(0);
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? {{resolveName}}__Impl._(handle) : null;
+  handle.address != 0 ? {{resolveName}}__Impl(handle) : null;
 
 void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) {}
 

--- a/gluecodium/src/main/resources/templates/dart/DartPubspec.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartPubspec.mustache
@@ -23,3 +23,4 @@ environment:
   sdk: '>=2.5.0 <3.0.0'
 dependencies:
   ffi:
+  meta:

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/BasicTypes.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/BasicTypes.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_BasicTypes_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/Constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/Constants.dart
@@ -1,5 +1,6 @@
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 enum StateEnum {
     off,

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/ConstantsInterface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/ConstantsInterface.dart
@@ -1,5 +1,6 @@
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_ConstantsInterface_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/StructConstants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/StructConstants.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_StructConstants_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/Constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/Constructors.dart
@@ -2,6 +2,7 @@ import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_Constructors_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
@@ -24,14 +25,17 @@ final _createFromString_return_has_error = __lib.nativeLibrary.lookupFunction<
     int Function(Pointer<Void>)
   >('smoke_Constructors_create__String_return_has_error');
 class Constructors {
-  final Pointer<Void> _handle;
-  Constructors._(this._handle);
+  @protected
+  final Pointer<Void> handle;
+  Pointer<Void> get _handle => handle;
+  @protected
+  Constructors(this.handle);
   void release() => _smoke_Constructors_release_handle(_handle);
-  Constructors.create() : this._(_create());
-  Constructors.createFromOther(Constructors other) : this._(_createFromOther(other));
-  Constructors.createFromMulti(String foo, int bar) : this._(_createFromMulti(foo, bar));
-  Constructors.createFromString(String input) : this._(_createFromString(input));
-  Constructors.createFromList(List<double> input) : this._(_createFromList(input));
+  Constructors.create() : this(_create());
+  Constructors.createFromOther(Constructors other) : this(_createFromOther(other));
+  Constructors.createFromMulti(String foo, int bar) : this(_createFromMulti(foo, bar));
+  Constructors.createFromString(String input) : this(_createFromString(input));
+  Constructors.createFromList(List<double> input) : this(_createFromList(input));
   static Pointer<Void> _create() {
     final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('smoke_Constructors_create');
     final __result_handle = _create_ffi();
@@ -78,12 +82,12 @@ class Constructors {
   }
 }
 Pointer<Void> smoke_Constructors_toFfi(Constructors value) => value._handle;
-Constructors smoke_Constructors_fromFfi(Pointer<Void> handle) => Constructors._(handle);
+Constructors smoke_Constructors_fromFfi(Pointer<Void> handle) => Constructors(handle);
 void smoke_Constructors_releaseFfiHandle(Pointer<Void> handle) {}
 Pointer<Void> smoke_Constructors_toFfi_nullable(Constructors value) =>
   value != null ? value._handle : Pointer<Void>.fromAddress(0);
 Constructors smoke_Constructors_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? Constructors._(handle) : null;
+  handle.address != 0 ? Constructors(handle) : null;
 void smoke_Constructors_releaseFfiHandle_nullable(Pointer<Void> handle) {}
 enum Constructors_ErrorEnum {
     none,

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/DefaultValues.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/DefaultValues.dart
@@ -2,6 +2,7 @@ import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_DefaultValues_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/StructWithInitializerDefaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/StructWithInitializerDefaults.dart
@@ -3,6 +3,7 @@ import 'package:library/src/GenericTypes__conversion.dart';
 import 'package:library/src/smoke/TypesWithDefaults.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 class StructWithInitializerDefaults {
   List<int> intsField;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/TypesWithDefaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/TypesWithDefaults.dart
@@ -3,6 +3,7 @@ import 'package:library/src/smoke/AnEnum.dart';
 import 'package:library/src/smoke/DefaultValues.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 enum SomeEnum {
     fooValue,

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/Enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/Enums.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_Enums_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/Equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/Equatable.dart
@@ -4,6 +4,7 @@ import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 enum SomeEnum {
     foo,

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/Errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/Errors.dart
@@ -3,6 +3,7 @@ import 'package:library/src/smoke/Payload.dart';
 import 'package:library/src/smoke/WithPayloadException.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_Errors_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithBasicTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithBasicTypes.dart
@@ -2,6 +2,7 @@ import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_GenericTypesWithBasicTypes_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithCompoundTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithCompoundTypes.dart
@@ -4,6 +4,7 @@ import 'package:library/src/smoke/DummyClass.dart';
 import 'package:library/src/smoke/DummyInterface.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_GenericTypesWithCompoundTypes_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithGenericTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithGenericTypes.dart
@@ -2,6 +2,7 @@ import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_GenericTypesWithGenericTypes_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalClass.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalClass.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_ExternalClass_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalInterface.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 abstract class ExternalInterface {
   void release();
@@ -126,11 +127,12 @@ final _smoke_ExternalInterface_release_handle = __lib.nativeLibrary.lookupFuncti
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('smoke_ExternalInterface_release_handle');
-class ExternalInterface__Impl implements ExternalInterface{
-  final Pointer<Void> _handle;
-  ExternalInterface__Impl._(this._handle);
+class ExternalInterface__Impl implements ExternalInterface {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  ExternalInterface__Impl(this.handle);
   @override
-  void release() => _smoke_ExternalInterface_release_handle(_handle);
+  void release() => _smoke_ExternalInterface_release_handle(handle);
   @override
   someMethod(int someParameter) {
     final _someMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int8), void Function(Pointer<Void>, int)>('smoke_ExternalInterface_someMethod__Byte');
@@ -149,13 +151,14 @@ class ExternalInterface__Impl implements ExternalInterface{
     return _result;
   }
 }
-Pointer<Void> smoke_ExternalInterface_toFfi(ExternalInterface__Impl value) => value._handle;
+Pointer<Void> smoke_ExternalInterface_toFfi(ExternalInterface__Impl value) =>
+  value != null ? value.handle : Pointer<Void>.fromAddress(0);
 ExternalInterface smoke_ExternalInterface_fromFfi(Pointer<Void> handle) =>
-  ExternalInterface__Impl._(handle);
+  handle.address != 0 ? ExternalInterface__Impl(handle) : null;
 void smoke_ExternalInterface_releaseFfiHandle(Pointer<Void> handle) {}
 Pointer<Void> smoke_ExternalInterface_toFfi_nullable(ExternalInterface__Impl value) =>
   value != null ? value._handle : Pointer<Void>.fromAddress(0);
 ExternalInterface smoke_ExternalInterface_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? ExternalInterface__Impl._(handle) : null;
+  handle.address != 0 ? ExternalInterface__Impl(handle) : null;
 void smoke_ExternalInterface_releaseFfiHandle_nullable(Pointer<Void> handle) {}
 // End of ExternalInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleClass.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleClass.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_SimpleClass_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleInterface.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 abstract class SimpleInterface {
   void release();
@@ -12,11 +13,12 @@ final _smoke_SimpleInterface_release_handle = __lib.nativeLibrary.lookupFunction
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('smoke_SimpleInterface_release_handle');
-class SimpleInterface__Impl implements SimpleInterface{
-  final Pointer<Void> _handle;
-  SimpleInterface__Impl._(this._handle);
+class SimpleInterface__Impl implements SimpleInterface {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  SimpleInterface__Impl(this.handle);
   @override
-  void release() => _smoke_SimpleInterface_release_handle(_handle);
+  void release() => _smoke_SimpleInterface_release_handle(handle);
   @override
   String getStringValue() {
     final _getStringValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_SimpleInterface_getStringValue');
@@ -36,13 +38,14 @@ class SimpleInterface__Impl implements SimpleInterface{
     return _result;
   }
 }
-Pointer<Void> smoke_SimpleInterface_toFfi(SimpleInterface__Impl value) => value._handle;
+Pointer<Void> smoke_SimpleInterface_toFfi(SimpleInterface__Impl value) =>
+  value != null ? value.handle : Pointer<Void>.fromAddress(0);
 SimpleInterface smoke_SimpleInterface_fromFfi(Pointer<Void> handle) =>
-  SimpleInterface__Impl._(handle);
+  handle.address != 0 ? SimpleInterface__Impl(handle) : null;
 void smoke_SimpleInterface_releaseFfiHandle(Pointer<Void> handle) {}
 Pointer<Void> smoke_SimpleInterface_toFfi_nullable(SimpleInterface__Impl value) =>
   value != null ? value._handle : Pointer<Void>.fromAddress(0);
 SimpleInterface smoke_SimpleInterface_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? SimpleInterface__Impl._(handle) : null;
+  handle.address != 0 ? SimpleInterface__Impl(handle) : null;
 void smoke_SimpleInterface_releaseFfiHandle_nullable(Pointer<Void> handle) {}
 // End of SimpleInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/StructWithClass.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/StructWithClass.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/smoke/SimpleClass.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 class StructWithClass {
   SimpleClass classInstance;

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/StructWithInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/StructWithInterface.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/smoke/SimpleInterface.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 class StructWithInterface {
   SimpleInterface interfaceInstance;

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/MethodOverloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/MethodOverloads.dart
@@ -2,6 +2,7 @@ import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_MethodOverloads_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/SpecialNames.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/SpecialNames.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_SpecialNames_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/Nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/Nullable.dart
@@ -3,6 +3,7 @@ import 'package:library/src/GenericTypes__conversion.dart';
 import 'package:library/src/smoke/SomeInterface.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_Nullable_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/NestedPackages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/NestedPackages.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_off_NestedPackages_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
@@ -4,6 +4,7 @@ import 'package:library/src/GenericTypes__conversion.dart';
 import 'package:library/src/smoke/PropertiesInterface.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_Properties_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/PropertiesInterface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/PropertiesInterface.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 abstract class PropertiesInterface {
   void release();
@@ -74,11 +75,12 @@ final _smoke_PropertiesInterface_release_handle = __lib.nativeLibrary.lookupFunc
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('smoke_PropertiesInterface_release_handle');
-class PropertiesInterface__Impl implements PropertiesInterface{
-  final Pointer<Void> _handle;
-  PropertiesInterface__Impl._(this._handle);
+class PropertiesInterface__Impl implements PropertiesInterface {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  PropertiesInterface__Impl(this.handle);
   @override
-  void release() => _smoke_PropertiesInterface_release_handle(_handle);
+  void release() => _smoke_PropertiesInterface_release_handle(handle);
   PropertiesInterface_ExampleStruct get structProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_PropertiesInterface_structProperty_get');
     final __result_handle = _get_ffi(_handle);
@@ -96,13 +98,14 @@ class PropertiesInterface__Impl implements PropertiesInterface{
     return _result;
   }
 }
-Pointer<Void> smoke_PropertiesInterface_toFfi(PropertiesInterface__Impl value) => value._handle;
+Pointer<Void> smoke_PropertiesInterface_toFfi(PropertiesInterface__Impl value) =>
+  value != null ? value.handle : Pointer<Void>.fromAddress(0);
 PropertiesInterface smoke_PropertiesInterface_fromFfi(Pointer<Void> handle) =>
-  PropertiesInterface__Impl._(handle);
+  handle.address != 0 ? PropertiesInterface__Impl(handle) : null;
 void smoke_PropertiesInterface_releaseFfiHandle(Pointer<Void> handle) {}
 Pointer<Void> smoke_PropertiesInterface_toFfi_nullable(PropertiesInterface__Impl value) =>
   value != null ? value._handle : Pointer<Void>.fromAddress(0);
 PropertiesInterface smoke_PropertiesInterface_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? PropertiesInterface__Impl._(handle) : null;
+  handle.address != 0 ? PropertiesInterface__Impl(handle) : null;
 void smoke_PropertiesInterface_releaseFfiHandle_nullable(Pointer<Void> handle) {}
 // End of PropertiesInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
@@ -4,6 +4,7 @@ import 'package:library/src/GenericTypes__conversion.dart';
 import 'package:library/src/smoke/TypeCollection.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_Structs_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/StructsWithConstants.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/StructsWithConstants.dart
@@ -2,6 +2,7 @@ import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/smoke/RouteUtils.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 class Route {
   String description;

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/StructsWithMethods.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/StructsWithMethods.dart
@@ -2,6 +2,7 @@ import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/smoke/ValidationUtils.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _create_return_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/TypeDefs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/TypeDefs.dart
@@ -3,6 +3,7 @@ import 'package:library/src/GenericTypes__conversion.dart';
 import 'package:library/src/smoke/TypeCollection.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_TypeDefs_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalClass.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalClass.dart
@@ -1,5 +1,6 @@
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_InternalClass_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalInterface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalInterface.dart
@@ -1,5 +1,6 @@
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 abstract class InternalInterface {
   void release();
@@ -9,19 +10,21 @@ final _smoke_InternalInterface_release_handle = __lib.nativeLibrary.lookupFuncti
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('smoke_InternalInterface_release_handle');
-class InternalInterface__Impl implements InternalInterface{
-  final Pointer<Void> _handle;
-  InternalInterface__Impl._(this._handle);
+class InternalInterface__Impl implements InternalInterface {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  InternalInterface__Impl(this.handle);
   @override
-  void release() => _smoke_InternalInterface_release_handle(_handle);
+  void release() => _smoke_InternalInterface_release_handle(handle);
 }
-Pointer<Void> smoke_InternalInterface_toFfi(InternalInterface__Impl value) => value._handle;
+Pointer<Void> smoke_InternalInterface_toFfi(InternalInterface__Impl value) =>
+  value != null ? value.handle : Pointer<Void>.fromAddress(0);
 InternalInterface smoke_InternalInterface_fromFfi(Pointer<Void> handle) =>
-  InternalInterface__Impl._(handle);
+  handle.address != 0 ? InternalInterface__Impl(handle) : null;
 void smoke_InternalInterface_releaseFfiHandle(Pointer<Void> handle) {}
 Pointer<Void> smoke_InternalInterface_toFfi_nullable(InternalInterface__Impl value) =>
   value != null ? value._handle : Pointer<Void>.fromAddress(0);
 InternalInterface smoke_InternalInterface_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? InternalInterface__Impl._(handle) : null;
+  handle.address != 0 ? InternalInterface__Impl(handle) : null;
 void smoke_InternalInterface_releaseFfiHandle_nullable(Pointer<Void> handle) {}
 // End of InternalInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicClass.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicClass.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 final _smoke_PublicClass_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicInterface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicInterface.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/smoke/PublicClass.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 abstract class PublicInterface {
   void release();
@@ -72,19 +73,21 @@ final _smoke_PublicInterface_release_handle = __lib.nativeLibrary.lookupFunction
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('smoke_PublicInterface_release_handle');
-class PublicInterface__Impl implements PublicInterface{
-  final Pointer<Void> _handle;
-  PublicInterface__Impl._(this._handle);
+class PublicInterface__Impl implements PublicInterface {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  PublicInterface__Impl(this.handle);
   @override
-  void release() => _smoke_PublicInterface_release_handle(_handle);
+  void release() => _smoke_PublicInterface_release_handle(handle);
 }
-Pointer<Void> smoke_PublicInterface_toFfi(PublicInterface__Impl value) => value._handle;
+Pointer<Void> smoke_PublicInterface_toFfi(PublicInterface__Impl value) =>
+  value != null ? value.handle : Pointer<Void>.fromAddress(0);
 PublicInterface smoke_PublicInterface_fromFfi(Pointer<Void> handle) =>
-  PublicInterface__Impl._(handle);
+  handle.address != 0 ? PublicInterface__Impl(handle) : null;
 void smoke_PublicInterface_releaseFfiHandle(Pointer<Void> handle) {}
 Pointer<Void> smoke_PublicInterface_toFfi_nullable(PublicInterface__Impl value) =>
   value != null ? value._handle : Pointer<Void>.fromAddress(0);
 PublicInterface smoke_PublicInterface_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? PublicInterface__Impl._(handle) : null;
+  handle.address != 0 ? PublicInterface__Impl(handle) : null;
 void smoke_PublicInterface_releaseFfiHandle_nullable(Pointer<Void> handle) {}
 // End of PublicInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicTypeCollection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicTypeCollection.dart
@@ -1,6 +1,7 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 class InternalStruct {
   String _stringField;

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeClass.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeClass.kt
@@ -51,4 +51,8 @@ class LimeClass(
     interfaces = interfaces,
     lambdas = lambdas,
     parent = parent
-)
+) {
+    @Suppress("unused")
+    val hasClassParent
+        get() = parent?.type?.actualType is LimeClass
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeContainerWithInheritance.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeContainerWithInheritance.kt
@@ -47,4 +47,14 @@ abstract class LimeContainerWithInheritance(
     functions = functions,
     properties = properties,
     exceptions = exceptions
-)
+) {
+    @Suppress("unused")
+    val inheritedFunctions: List<LimeFunction>
+        get() = (parent?.type?.actualType as? LimeContainerWithInheritance)
+            ?.let { it.functions + it.inheritedFunctions } ?: emptyList()
+
+    @Suppress("unused")
+    val inheritedProperties: List<LimeProperty>
+        get() = (parent?.type?.actualType as? LimeContainerWithInheritance)
+            ?.let { it.properties + it.inheritedProperties } ?: emptyList()
+}


### PR DESCRIPTION
Updated Dart templates to support class/interface inheritance. This does
not include preserving type information (see #131 for details on that).

Added/updated smoke and functional tests.

Resolves: #61
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>