### PR TITLE
Add error handling to calling Dart callbacks from C++

### DIFF
--- a/examples/platforms/dart/main.dart
+++ b/examples/platforms/dart/main.dart
@@ -33,6 +33,7 @@ import "test/Interfaces_test.dart" as InterfacesTests;
 import "test/Lists_test.dart" as ListsTests;
 import "test/Listeners_test.dart" as ListenersTests;
 import "test/ListenersWithAttributes_test.dart" as ListenersWithAttributesTests;
+import "test/ListenersWithErrors_test.dart" as ListenersWithErrorsTests;
 import "test/ListenersWithReturnValues_test.dart" as ListenersWithReturnValuesTests;
 import "test/Maps_test.dart" as MapsTests;
 import "test/MethodOverloads_test.dart" as MethodOverloadsTests;
@@ -65,6 +66,7 @@ final _allTests = [
   ListsTests.main,
   ListenersTests.main,
   ListenersWithAttributesTests.main,
+  ListenersWithErrorsTests.main,
   ListenersWithReturnValuesTests.main,
   MapsTests.main,
   MethodOverloadsTests.main,

--- a/examples/platforms/dart/test/ListenersWithErrors_test.dart
+++ b/examples/platforms/dart/test/ListenersWithErrors_test.dart
@@ -1,0 +1,125 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:hello/hello.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("ListenersWithErrors");
+
+class TestListener implements ErrorsInInterface {
+  String _message = "Doesn't work";
+
+  @override
+  String getMessage() => _message;
+
+  @override
+  void setMessage(String value) {
+    _message = value;
+  }
+
+  @override
+  String getMessageWithPayload() => _message;
+
+  @override
+  void setMessageWithPayload(String value) {
+    _message = value;
+  }
+
+  @override
+  void release() {}
+}
+
+class ThrowingListener implements ErrorsInInterface {
+  String _message = "Doesn't work";
+
+  @override
+  String getMessage() {
+    throw AdditionalErrors_ExternalException(AdditionalErrors_ExternalErrorCode.failed);
+  }
+
+  @override
+  void setMessage(String value) {
+    throw AdditionalErrors_ExternalException(AdditionalErrors_ExternalErrorCode.failed);
+  }
+
+  @override
+  String getMessageWithPayload() {
+    return ""; // TODO: #140 throw with payload
+  }
+
+  @override
+  void setMessageWithPayload(String value) {
+    // TODO: #140 throw with payload
+  }
+
+  @override
+  void release() {}
+}
+
+void main() {
+  ErrorMessenger messenger;
+  setUp(() {
+    messenger = ErrorMessenger();
+  });
+  tearDown(() {
+    messenger.release();
+  });
+
+  _testSuite.test("String round trip works", () {
+    final ErrorsInInterface listener = TestListener();
+
+    messenger.setMessage(listener, "Works");
+    final result = messenger.getMessage(listener);
+
+    expect(result, "Works");
+  });
+  _testSuite.test("getMessage() error rethrown", () {
+    AdditionalErrors_ExternalException exception = null;
+    final ErrorsInInterface listener = ThrowingListener();
+
+    try {
+      messenger.getMessage(listener);
+    } on AdditionalErrors_ExternalException catch(e) {
+      exception = e;
+    }
+
+    expect(exception, isNotNull);
+    expect(exception.error, AdditionalErrors_ExternalErrorCode.failed);
+
+    listener.release();
+  });
+  _testSuite.test("setMessage() error rethrown", () {
+    AdditionalErrors_ExternalException exception = null;
+    final ErrorsInInterface listener = ThrowingListener();
+
+    try {
+      messenger.setMessage(listener, "Foo");
+    } on AdditionalErrors_ExternalException catch(e) {
+      exception = e;
+    }
+
+    expect(exception, isNotNull);
+    expect(exception.error, AdditionalErrors_ExternalErrorCode.failed);
+
+    listener.release();
+  });
+  // TODO: #140 test throwing with payload
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppReturnTypeNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppReturnTypeNameResolver.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2016-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.ffi
+
+import com.here.gluecodium.cli.GluecodiumExecutionException
+import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.model.lime.LimeBasicType
+import com.here.gluecodium.model.lime.LimeBasicType.TypeId
+import com.here.gluecodium.model.lime.LimeEnumeration
+import com.here.gluecodium.model.lime.LimeFunction
+
+internal class FfiCppReturnTypeNameResolver(
+    private val internalNamespace: List<String>,
+    private val ffiCppNameResolver: FfiCppNameResolver
+) : NameResolver {
+
+    override fun resolveName(element: Any): String =
+        when (element) {
+            is LimeFunction -> resolveReturnTypeName(element)
+            else -> throw GluecodiumExecutionException("Unsupported element type ${element.javaClass.name}")
+        }
+
+    private fun resolveReturnTypeName(limeFunction: LimeFunction): String {
+        val returnTypeName = ffiCppNameResolver.resolveName(limeFunction.returnType.typeRef)
+        val exceptionPayload = limeFunction.exception?.errorType?.type ?: return returnTypeName
+
+        val returnPrefix = (internalNamespace + "Return").joinToString("::")
+        if (exceptionPayload.actualType !is LimeEnumeration) {
+            return "$returnPrefix<$returnTypeName, ${ffiCppNameResolver.resolveName(exceptionPayload)}>"
+        }
+
+        val actualReturnType = limeFunction.returnType.typeRef.type.actualType
+        return if ((actualReturnType as? LimeBasicType)?.typeId == TypeId.VOID) {
+            STD_ERROR_CODE
+        } else {
+            "$returnPrefix<$returnTypeName, $STD_ERROR_CODE>"
+        }
+    }
+
+    companion object {
+        private const val STD_ERROR_CODE = "std::error_code"
+    }
+}

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -101,19 +101,32 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 }}int _token{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
 }}{{#isNotEq returnType.typeRef.toString "Void"}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/isNotEq}}) {
+  {{#if thrownType}}
+  int _error = 0;
+  try {
+  {{/if}}
   {{#isNotEq returnType.typeRef.toString "Void"}}final _result_object = {{/isNotEq}}{{!!
   }}_{{resolveName parent}}_instance_cache[_token].{{resolveName visibility}}{{resolveName}}({{#parameters}}{{!!
   }}{{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}}){{#if iter.hasNext}}, {{/if}}{{!!
   }}{{/parameters}});{{#isNotEq returnType.typeRef.toString "Void"}}
   _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/isNotEq}}
-{{#parameters}}
+{{#if thrownType}}
+  } on {{resolveName exception}} catch(e) {
+{{#instanceOf exception.errorType.type.actualType "LimeEnumeration"}}{{!! TODO: #140 handle arbitrary payload}}{{!!
+}}    _error = {{#set typeRef=exception.errorType call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(e.error);{{/instanceOf}}
+  } finally {
+  {{/if}}{{!!
+}}{{#parameters}}
   {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
 {{/parameters}}{{#instanceOf returnType.typeRef.type.actualType "LimeClass"}}
   if (_result_object != null) _result_object.release();
 {{/instanceOf}}{{#instanceOf returnType.typeRef.type.actualType "LimeInterface"}}
   if (_result_object != null) _result_object.release();
-{{/instanceOf}}
-  return 0;{{!! TODO: #137 handle errors }}
+{{/instanceOf}}{{!!
+  }}{{#if thrownType}}
+  }
+  {{/if}}
+  return {{#if thrownType}}_error{{/if}}{{#unless thrownType}}0{{/unless}};
 }
 {{/each}}
 

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
@@ -32,7 +32,7 @@ public:
         }}{{#if setter}}, p{{iter.position}}s(p{{iter.position}}s){{/if}}{{#if iter.hasNext}}, {{/if}}{{/each}}{{/if}} { }
 
 {{#each inheritedFunctions functions}}
-    {{resolveName returnType.typeRef "C++"}}
+    {{resolveName "C++ return type"}}
     {{resolveName "C++"}}({{#parameters}}const {{resolveName typeRef "C++ parameter"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
     }}{{#ifHasAttribute this "Cpp" "Const"}} const{{/ifHasAttribute}} override {
         {{#isNotEq returnType.typeRef.toString "Void"}}{{resolveName returnType.typeRef}} _result_handle;{{/isNotEq}}
@@ -43,10 +43,17 @@ public:
             {{>ffi/FfiInternal}}::Conversion<{{resolveName typeRef "C++"}}>::toFfi({{resolveName}}){{#if iter.hasNext}},
 {{/if}}{{/parameters}}{{#isNotEq returnType.typeRef.toString "Void"}},
             &_result_handle{{/isNotEq}}
-        );{{!! TODO: #137 handle errors }}{{#isNotEq returnType.typeRef.toString "Void"}}
-        auto _result = {{>ffi/FfiInternal}}::Conversion<{{resolveName returnType.typeRef "C++"}}>::toCpp(_result_handle);
-        {{#returnType}}{{>ffiReleaseHandle}}{{/returnType}};
-        return _result;{{/isNotEq}}
+        );{{#if thrownType}}{{#instanceOf exception.errorType.type.actualType "LimeEnumeration"}}{{#isEq returnType.typeRef.toString "Void"}}
+{{prefixPartial "proxyReturnError" "        "}}{{/isEq}}{{!!
+        }}{{#isNotEq returnType.typeRef.toString "Void"}}
+        if (_error == 0) {
+{{prefixPartial "proxyReturnResult" "            "}}
+        } else {
+{{prefixPartial "proxyReturnError" "            "}}
+        }{{/isNotEq}}{{/instanceOf}}{{!!
+        }}{{#notInstanceOf exception.errorType.type.actualType "LimeEnumeration"}}{{!! TODO: #140 handle arbitrary payload}}{{/notInstanceOf}}{{/if}}{{!!
+        }}{{#unless thrownType}}{{#isNotEq returnType.typeRef.toString "Void"}}
+{{prefixPartial "proxyReturnResult" "        "}}{{/isNotEq}}{{/unless}}
     }
 
 {{/each}}
@@ -93,4 +100,10 @@ private:
 }}{{#notInstanceOf this "LimeBasicType"}}{{#instanceOf this "LimeEnumeration"}}{{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeEnumeration"}}delete reinterpret_cast<{{resolveName typeRef "C++"}}*>(_result_handle){{/notInstanceOf}}{{!!
 }}{{/notInstanceOf}}{{!!
-}}{{/typeRef.type.actualType}}{{/unless}}{{/ffiReleaseHandle}}
+}}{{/typeRef.type.actualType}}{{/unless}}{{/ffiReleaseHandle}}{{!!
+
+}}{{+proxyReturnResult}}auto _result = {{>ffi/FfiInternal}}::Conversion<{{resolveName returnType.typeRef "C++"}}>::toCpp(_result_handle);
+{{#returnType}}{{>ffiReleaseHandle}}{{/returnType}};
+return _result;{{/proxyReturnResult}}{{!!
+
+}}{{+proxyReturnError}}return make_error_code({{>ffi/FfiInternal}}::Conversion<{{resolveName exception.errorType "C++"}}>::toCpp((uint32_t)_error));{{/proxyReturnError}}

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
@@ -1,0 +1,264 @@
+#include "ffi_smoke_ErrorsInterface.h"
+#include "ConversionBase.h"
+#include "smoke/ErrorsInterface.h"
+#include "smoke/Payload.h"
+#include <memory>
+#include <string>
+#include <system_error>
+#include <memory>
+#include <new>
+class smoke_ErrorsInterface_Proxy : public ::smoke::ErrorsInterface {
+public:
+    smoke_ErrorsInterface_Proxy(uint64_t token, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4)
+        : token(token), f0(f0), f1(f1), f2(f2), f3(f3), f4(f4) { }
+    std::error_code
+    method_with_errors() override {
+        int64_t _error = (*reinterpret_cast<int64_t (*)(uint64_t)>(f0))(token
+        );
+        return make_error_code(gluecodium::ffi::Conversion<::smoke::ErrorsInterface::InternalError>::toCpp((uint32_t)_error));
+    }
+    std::error_code
+    method_with_external_errors() override {
+        int64_t _error = (*reinterpret_cast<int64_t (*)(uint64_t)>(f1))(token
+        );
+        return make_error_code(gluecodium::ffi::Conversion<::smoke::ErrorsInterface::ExternalErrors>::toCpp((uint32_t)_error));
+    }
+    gluecodium::Return<std::string, std::error_code>
+    method_with_errors_and_return_value() override {
+        FfiOpaqueHandle _result_handle;
+        int64_t _error = (*reinterpret_cast<int64_t (*)(uint64_t, FfiOpaqueHandle*)>(f2))(token,
+            &_result_handle
+        );
+        if (_error == 0) {
+            auto _result = gluecodium::ffi::Conversion<std::string>::toCpp(_result_handle);
+            delete reinterpret_cast<std::string*>(_result_handle);
+            return _result;
+        } else {
+            return make_error_code(gluecodium::ffi::Conversion<::smoke::ErrorsInterface::InternalError>::toCpp((uint32_t)_error));
+        }
+    }
+    gluecodium::Return<void, ::smoke::Payload>
+    method_with_payload_error() override {
+        int64_t _error = (*reinterpret_cast<int64_t (*)(uint64_t)>(f3))(token
+        );
+    }
+    gluecodium::Return<std::string, ::smoke::Payload>
+    method_with_payload_error_and_return_value() override {
+        FfiOpaqueHandle _result_handle;
+        int64_t _error = (*reinterpret_cast<int64_t (*)(uint64_t, FfiOpaqueHandle*)>(f4))(token,
+            &_result_handle
+        );
+    }
+private:
+    uint64_t token;
+    FfiOpaqueHandle f0;
+    FfiOpaqueHandle f1;
+    FfiOpaqueHandle f2;
+    FfiOpaqueHandle f3;
+    FfiOpaqueHandle f4;
+};
+#ifdef __cplusplus
+extern "C" {
+#endif
+void
+smoke_ErrorsInterface_methodWithErrors_return_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<gluecodium::Return<void, ::smoke::ErrorsInterface::InternalError>*>(handle);
+}
+uint32_t
+smoke_ErrorsInterface_methodWithErrors_return_get_error(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<::smoke::ErrorsInterface::InternalError>::toFfi(
+        reinterpret_cast<gluecodium::Return<void, ::smoke::ErrorsInterface::InternalError>*>(handle)->error()
+    );
+}
+bool
+smoke_ErrorsInterface_methodWithErrors_return_has_error(FfiOpaqueHandle handle) {
+    return !reinterpret_cast<gluecodium::Return<void, ::smoke::ErrorsInterface::InternalError>*>(handle)->has_value();
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_methodWithErrors(FfiOpaqueHandle _self) {
+    auto&& _cpp_call_result =         (*gluecodium::ffi::Conversion<std::shared_ptr<::smoke::ErrorsInterface>>::toCpp(_self)).method_with_errors();
+    if (_cpp_call_result.value() == 0) {
+        return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<void, ::smoke::ErrorsInterface::InternalError>(true));
+    }
+    auto _error_code = _cpp_call_result;
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<void, ::smoke::ErrorsInterface::InternalError>(
+        static_cast<::smoke::ErrorsInterface::InternalError>(_error_code.value())
+    ));
+}
+void
+smoke_ErrorsInterface_methodWithExternalErrors_return_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<gluecodium::Return<void, ::smoke::ErrorsInterface::ExternalErrors>*>(handle);
+}
+uint32_t
+smoke_ErrorsInterface_methodWithExternalErrors_return_get_error(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<::smoke::ErrorsInterface::ExternalErrors>::toFfi(
+        reinterpret_cast<gluecodium::Return<void, ::smoke::ErrorsInterface::ExternalErrors>*>(handle)->error()
+    );
+}
+bool
+smoke_ErrorsInterface_methodWithExternalErrors_return_has_error(FfiOpaqueHandle handle) {
+    return !reinterpret_cast<gluecodium::Return<void, ::smoke::ErrorsInterface::ExternalErrors>*>(handle)->has_value();
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_methodWithExternalErrors(FfiOpaqueHandle _self) {
+    auto&& _cpp_call_result =         (*gluecodium::ffi::Conversion<std::shared_ptr<::smoke::ErrorsInterface>>::toCpp(_self)).method_with_external_errors();
+    if (_cpp_call_result.value() == 0) {
+        return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<void, ::smoke::ErrorsInterface::ExternalErrors>(true));
+    }
+    auto _error_code = _cpp_call_result;
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<void, ::smoke::ErrorsInterface::ExternalErrors>(
+        static_cast<::smoke::ErrorsInterface::ExternalErrors>(_error_code.value())
+    ));
+}
+void
+smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<gluecodium::Return<std::string, ::smoke::ErrorsInterface::InternalError>*>(handle);
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_get_result(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<std::string>::toFfi(
+        reinterpret_cast<gluecodium::Return<std::string, ::smoke::ErrorsInterface::InternalError>*>(handle)->unsafe_value()
+    );
+}
+uint32_t
+smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_get_error(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<::smoke::ErrorsInterface::InternalError>::toFfi(
+        reinterpret_cast<gluecodium::Return<std::string, ::smoke::ErrorsInterface::InternalError>*>(handle)->error()
+    );
+}
+bool
+smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_has_error(FfiOpaqueHandle handle) {
+    return !reinterpret_cast<gluecodium::Return<std::string, ::smoke::ErrorsInterface::InternalError>*>(handle)->has_value();
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_methodWithErrorsAndReturnValue(FfiOpaqueHandle _self) {
+    auto&& _cpp_call_result =         (*gluecodium::ffi::Conversion<std::shared_ptr<::smoke::ErrorsInterface>>::toCpp(_self)).method_with_errors_and_return_value();
+    if (_cpp_call_result.has_value()) {
+        return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<std::string, ::smoke::ErrorsInterface::InternalError>(
+            std::forward<std::string>(_cpp_call_result.unsafe_value())
+        ));
+    }
+    auto _error_code = _cpp_call_result.error();
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<std::string, ::smoke::ErrorsInterface::InternalError>(
+        static_cast<::smoke::ErrorsInterface::InternalError>(_error_code.value())
+    ));
+}
+void
+smoke_ErrorsInterface_methodWithPayloadError_return_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<gluecodium::Return<void, ::smoke::Payload>*>(handle);
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_methodWithPayloadError_return_get_error(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<::smoke::Payload>::toFfi(
+        reinterpret_cast<gluecodium::Return<void, ::smoke::Payload>*>(handle)->error()
+    );
+}
+bool
+smoke_ErrorsInterface_methodWithPayloadError_return_has_error(FfiOpaqueHandle handle) {
+    return !reinterpret_cast<gluecodium::Return<void, ::smoke::Payload>*>(handle)->has_value();
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_methodWithPayloadError() {
+    auto&& _cpp_call_result =         ::smoke::ErrorsInterface::method_with_payload_error();
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<void, ::smoke::Payload>(
+        std::forward<gluecodium::Return<void, ::smoke::Payload>>(_cpp_call_result)
+    ));
+}
+void
+smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<gluecodium::Return<std::string, ::smoke::Payload>*>(handle);
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_get_result(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<std::string>::toFfi(
+        reinterpret_cast<gluecodium::Return<std::string, ::smoke::Payload>*>(handle)->unsafe_value()
+    );
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_get_error(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<::smoke::Payload>::toFfi(
+        reinterpret_cast<gluecodium::Return<std::string, ::smoke::Payload>*>(handle)->error()
+    );
+}
+bool
+smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_has_error(FfiOpaqueHandle handle) {
+    return !reinterpret_cast<gluecodium::Return<std::string, ::smoke::Payload>*>(handle)->has_value();
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue() {
+    auto&& _cpp_call_result =         ::smoke::ErrorsInterface::method_with_payload_error_and_return_value();
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<std::string, ::smoke::Payload>(
+        std::forward<gluecodium::Return<std::string, ::smoke::Payload>>(_cpp_call_result)
+    ));
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::ErrorsInterface>(
+            *reinterpret_cast<std::shared_ptr<::smoke::ErrorsInterface>*>(handle)
+        )
+    );
+}
+void
+smoke_ErrorsInterface_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::ErrorsInterface>*>(handle);
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_create_proxy(uint64_t token, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::ErrorsInterface>(
+            new (std::nothrow) smoke_ErrorsInterface_Proxy(token, f0, f1, f2, f3, f4)
+        )
+    );
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_get_raw_pointer(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        reinterpret_cast<std::shared_ptr<::smoke::ErrorsInterface>*>(handle)->get()
+    );
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_InternalError_create_handle_nullable(uint32_t value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<::smoke::ErrorsInterface::InternalError>(
+            gluecodium::ffi::Conversion<::smoke::ErrorsInterface::InternalError>::toCpp(value)
+        )
+    );
+}
+void
+smoke_ErrorsInterface_InternalError_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<::smoke::ErrorsInterface::InternalError>*>(handle);
+}
+uint32_t
+smoke_ErrorsInterface_InternalError_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<::smoke::ErrorsInterface::InternalError>::toFfi(
+        **reinterpret_cast<gluecodium::optional<::smoke::ErrorsInterface::InternalError>*>(handle)
+    );
+}
+FfiOpaqueHandle
+smoke_ErrorsInterface_ExternalErrors_create_handle_nullable(uint32_t value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<::smoke::ErrorsInterface::ExternalErrors>(
+            gluecodium::ffi::Conversion<::smoke::ErrorsInterface::ExternalErrors>::toCpp(value)
+        )
+    );
+}
+void
+smoke_ErrorsInterface_ExternalErrors_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<::smoke::ErrorsInterface::ExternalErrors>*>(handle);
+}
+uint32_t
+smoke_ErrorsInterface_ExternalErrors_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<::smoke::ErrorsInterface::ExternalErrors>::toFfi(
+        **reinterpret_cast<gluecodium::optional<::smoke::ErrorsInterface::ExternalErrors>*>(handle)
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/ErrorsInterface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/ErrorsInterface.dart
@@ -1,0 +1,403 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/smoke/Payload.dart';
+import 'package:library/src/smoke/WithPayloadException.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+abstract class ErrorsInterface {
+  void release();
+  methodWithErrors();
+  methodWithExternalErrors();
+  String methodWithErrorsAndReturnValue();
+  static methodWithPayloadError();
+  static String methodWithPayloadErrorAndReturnValue();
+}
+enum ErrorsInterface_InternalError {
+    errorNone,
+    errorFatal
+}
+// ErrorsInterface_InternalError "private" section, not exported.
+int smoke_ErrorsInterface_InternalError_toFfi(ErrorsInterface_InternalError value) {
+  switch (value) {
+  case ErrorsInterface_InternalError.errorNone:
+    return 0;
+  break;
+  case ErrorsInterface_InternalError.errorFatal:
+    return 1;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for ErrorsInterface_InternalError enum.");
+  }
+}
+ErrorsInterface_InternalError smoke_ErrorsInterface_InternalError_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return ErrorsInterface_InternalError.errorNone;
+  break;
+  case 1:
+    return ErrorsInterface_InternalError.errorFatal;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for ErrorsInterface_InternalError enum.");
+  }
+}
+void smoke_ErrorsInterface_InternalError_releaseFfiHandle(int handle) {}
+final _smoke_ErrorsInterface_InternalError_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('smoke_ErrorsInterface_InternalError_create_handle_nullable');
+final _smoke_ErrorsInterface_InternalError_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_InternalError_release_handle_nullable');
+final _smoke_ErrorsInterface_InternalError_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_InternalError_get_value_nullable');
+Pointer<Void> smoke_ErrorsInterface_InternalError_toFfi_nullable(ErrorsInterface_InternalError value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_ErrorsInterface_InternalError_toFfi(value);
+  final result = _smoke_ErrorsInterface_InternalError_create_handle_nullable(_handle);
+  smoke_ErrorsInterface_InternalError_releaseFfiHandle(_handle);
+  return result;
+}
+ErrorsInterface_InternalError smoke_ErrorsInterface_InternalError_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_ErrorsInterface_InternalError_get_value_nullable(handle);
+  final result = smoke_ErrorsInterface_InternalError_fromFfi(_handle);
+  smoke_ErrorsInterface_InternalError_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_ErrorsInterface_InternalError_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_ErrorsInterface_InternalError_release_handle_nullable(handle);
+// End of ErrorsInterface_InternalError "private" section.
+enum ErrorsInterface_ExternalErrors {
+    none,
+    boom,
+    bust
+}
+// ErrorsInterface_ExternalErrors "private" section, not exported.
+int smoke_ErrorsInterface_ExternalErrors_toFfi(ErrorsInterface_ExternalErrors value) {
+  switch (value) {
+  case ErrorsInterface_ExternalErrors.none:
+    return 0;
+  break;
+  case ErrorsInterface_ExternalErrors.boom:
+    return 1;
+  break;
+  case ErrorsInterface_ExternalErrors.bust:
+    return 2;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for ErrorsInterface_ExternalErrors enum.");
+  }
+}
+ErrorsInterface_ExternalErrors smoke_ErrorsInterface_ExternalErrors_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return ErrorsInterface_ExternalErrors.none;
+  break;
+  case 1:
+    return ErrorsInterface_ExternalErrors.boom;
+  break;
+  case 2:
+    return ErrorsInterface_ExternalErrors.bust;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for ErrorsInterface_ExternalErrors enum.");
+  }
+}
+void smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(int handle) {}
+final _smoke_ErrorsInterface_ExternalErrors_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('smoke_ErrorsInterface_ExternalErrors_create_handle_nullable');
+final _smoke_ErrorsInterface_ExternalErrors_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_ExternalErrors_release_handle_nullable');
+final _smoke_ErrorsInterface_ExternalErrors_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_ExternalErrors_get_value_nullable');
+Pointer<Void> smoke_ErrorsInterface_ExternalErrors_toFfi_nullable(ErrorsInterface_ExternalErrors value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_ErrorsInterface_ExternalErrors_toFfi(value);
+  final result = _smoke_ErrorsInterface_ExternalErrors_create_handle_nullable(_handle);
+  smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(_handle);
+  return result;
+}
+ErrorsInterface_ExternalErrors smoke_ErrorsInterface_ExternalErrors_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_ErrorsInterface_ExternalErrors_get_value_nullable(handle);
+  final result = smoke_ErrorsInterface_ExternalErrors_fromFfi(_handle);
+  smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_ErrorsInterface_ExternalErrors_release_handle_nullable(handle);
+// End of ErrorsInterface_ExternalErrors "private" section.
+class ErrorsInterface_InternalException implements Exception {
+  final ErrorsInterface_InternalError error;
+  ErrorsInterface_InternalException(this.error);
+}
+class ErrorsInterface_ExternalException implements Exception {
+  final ErrorsInterface_ExternalErrors error;
+  ErrorsInterface_ExternalException(this.error);
+}
+// ErrorsInterface "private" section, not exported.
+final _smoke_ErrorsInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_copy_handle');
+final _smoke_ErrorsInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_release_handle');
+final _smoke_ErrorsInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Pointer, Pointer, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, Pointer, Pointer, Pointer, Pointer, Pointer)
+  >('smoke_ErrorsInterface_create_proxy');
+final _smoke_ErrorsInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('smoke_ErrorsInterface_get_raw_pointer');
+int _ErrorsInterface_instance_counter = 1024;
+final Map<int, ErrorsInterface> _ErrorsInterface_instance_cache = {};
+final Map<Pointer<Void>, ErrorsInterface> _ErrorsInterface_reverse_cache = {};
+final _methodWithErrors_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithErrors_return_release_handle');
+final _methodWithErrors_return_get_result = (Pointer) {};
+final _methodWithErrors_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithErrors_return_get_error');
+final _methodWithErrors_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithErrors_return_has_error');
+final _methodWithExternalErrors_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithExternalErrors_return_release_handle');
+final _methodWithExternalErrors_return_get_result = (Pointer) {};
+final _methodWithExternalErrors_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithExternalErrors_return_get_error');
+final _methodWithExternalErrors_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithExternalErrors_return_has_error');
+final _methodWithErrorsAndReturnValue_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_release_handle');
+final _methodWithErrorsAndReturnValue_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_get_result');
+final _methodWithErrorsAndReturnValue_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_get_error');
+final _methodWithErrorsAndReturnValue_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_has_error');
+final _methodWithPayloadError_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithPayloadError_return_release_handle');
+final _methodWithPayloadError_return_get_result = (Pointer) {};
+final _methodWithPayloadError_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithPayloadError_return_get_error');
+final _methodWithPayloadError_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithPayloadError_return_has_error');
+final _methodWithPayloadErrorAndReturnValue_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_release_handle');
+final _methodWithPayloadErrorAndReturnValue_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_get_result');
+final _methodWithPayloadErrorAndReturnValue_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_get_error');
+final _methodWithPayloadErrorAndReturnValue_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_has_error');
+class ErrorsInterface__Impl implements ErrorsInterface {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  ErrorsInterface__Impl(this.handle);
+  @override
+  void release() => _smoke_ErrorsInterface_release_handle(handle);
+  @override
+  methodWithErrors() {
+    final _methodWithErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_ErrorsInterface_methodWithErrors');
+    final __call_result_handle = _methodWithErrors_ffi(_handle);
+    if (_methodWithErrors_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _methodWithErrors_return_get_error(__call_result_handle);
+        _methodWithErrors_return_release_handle(__call_result_handle);
+        final _error_value = smoke_ErrorsInterface_InternalError_fromFfi(__error_handle);
+        smoke_ErrorsInterface_InternalError_releaseFfiHandle(__error_handle);
+        throw ErrorsInterface_InternalException(_error_value);
+    }
+    final __result_handle = _methodWithErrors_return_get_result(__call_result_handle);
+    _methodWithErrors_return_release_handle(__call_result_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  methodWithExternalErrors() {
+    final _methodWithExternalErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_ErrorsInterface_methodWithExternalErrors');
+    final __call_result_handle = _methodWithExternalErrors_ffi(_handle);
+    if (_methodWithExternalErrors_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _methodWithExternalErrors_return_get_error(__call_result_handle);
+        _methodWithExternalErrors_return_release_handle(__call_result_handle);
+        final _error_value = smoke_ErrorsInterface_ExternalErrors_fromFfi(__error_handle);
+        smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(__error_handle);
+        throw ErrorsInterface_ExternalException(_error_value);
+    }
+    final __result_handle = _methodWithExternalErrors_return_get_result(__call_result_handle);
+    _methodWithExternalErrors_return_release_handle(__call_result_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  String methodWithErrorsAndReturnValue() {
+    final _methodWithErrorsAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_ErrorsInterface_methodWithErrorsAndReturnValue');
+    final __call_result_handle = _methodWithErrorsAndReturnValue_ffi(_handle);
+    if (_methodWithErrorsAndReturnValue_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _methodWithErrorsAndReturnValue_return_get_error(__call_result_handle);
+        _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
+        final _error_value = smoke_ErrorsInterface_InternalError_fromFfi(__error_handle);
+        smoke_ErrorsInterface_InternalError_releaseFfiHandle(__error_handle);
+        throw ErrorsInterface_InternalException(_error_value);
+    }
+    final __result_handle = _methodWithErrorsAndReturnValue_return_get_result(__call_result_handle);
+    _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  static methodWithPayloadError() {
+    final _methodWithPayloadError_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('smoke_ErrorsInterface_methodWithPayloadError');
+    final __call_result_handle = _methodWithPayloadError_ffi();
+    if (_methodWithPayloadError_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _methodWithPayloadError_return_get_error(__call_result_handle);
+        _methodWithPayloadError_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Payload_fromFfi(__error_handle);
+        smoke_Payload_releaseFfiHandle(__error_handle);
+        throw WithPayloadException(_error_value);
+    }
+    final __result_handle = _methodWithPayloadError_return_get_result(__call_result_handle);
+    _methodWithPayloadError_return_release_handle(__call_result_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  static String methodWithPayloadErrorAndReturnValue() {
+    final _methodWithPayloadErrorAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue');
+    final __call_result_handle = _methodWithPayloadErrorAndReturnValue_ffi();
+    if (_methodWithPayloadErrorAndReturnValue_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _methodWithPayloadErrorAndReturnValue_return_get_error(__call_result_handle);
+        _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Payload_fromFfi(__error_handle);
+        smoke_Payload_releaseFfiHandle(__error_handle);
+        throw WithPayloadException(_error_value);
+    }
+    final __result_handle = _methodWithPayloadErrorAndReturnValue_return_get_result(__call_result_handle);
+    _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+int _ErrorsInterface_methodWithErrors_static(int _token) {
+  int _error = 0;
+  try {
+  _ErrorsInterface_instance_cache[_token].methodWithErrors();
+  } on ErrorsInterface_InternalException catch(e) {
+    _error = smoke_ErrorsInterface_InternalError_toFfi(e.error);
+  } finally {
+  }
+  return _error;
+}
+int _ErrorsInterface_methodWithExternalErrors_static(int _token) {
+  int _error = 0;
+  try {
+  _ErrorsInterface_instance_cache[_token].methodWithExternalErrors();
+  } on ErrorsInterface_ExternalException catch(e) {
+    _error = smoke_ErrorsInterface_ExternalErrors_toFfi(e.error);
+  } finally {
+  }
+  return _error;
+}
+int _ErrorsInterface_methodWithErrorsAndReturnValue_static(int _token, Pointer<Pointer<Void>> _result) {
+  int _error = 0;
+  try {
+  final _result_object = _ErrorsInterface_instance_cache[_token].methodWithErrorsAndReturnValue();
+  _result.value = String_toFfi(_result_object);
+  } on ErrorsInterface_InternalException catch(e) {
+    _error = smoke_ErrorsInterface_InternalError_toFfi(e.error);
+  } finally {
+  }
+  return _error;
+}
+int _ErrorsInterface_methodWithPayloadError_static(int _token) {
+  int _error = 0;
+  try {
+  _ErrorsInterface_instance_cache[_token].methodWithPayloadError();
+  } on WithPayloadException catch(e) {
+  } finally {
+  }
+  return _error;
+}
+int _ErrorsInterface_methodWithPayloadErrorAndReturnValue_static(int _token, Pointer<Pointer<Void>> _result) {
+  int _error = 0;
+  try {
+  final _result_object = _ErrorsInterface_instance_cache[_token].methodWithPayloadErrorAndReturnValue();
+  _result.value = String_toFfi(_result_object);
+  } on WithPayloadException catch(e) {
+  } finally {
+  }
+  return _error;
+}
+Pointer<Void> smoke_ErrorsInterface_toFfi(ErrorsInterface value) {
+  if (value is ErrorsInterface__Impl) return _smoke_ErrorsInterface_copy_handle(value.handle);
+  const UNKNOWN_ERROR = -1;
+  final token = _ErrorsInterface_instance_counter++;
+  _ErrorsInterface_instance_cache[token] = value;
+  final result = _smoke_ErrorsInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithErrors_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithExternalErrors_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ErrorsInterface_methodWithErrorsAndReturnValue_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithPayloadError_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ErrorsInterface_methodWithPayloadErrorAndReturnValue_static, UNKNOWN_ERROR));
+  _ErrorsInterface_reverse_cache[_smoke_ErrorsInterface_get_raw_pointer(result)] = value;
+  return result;
+}
+ErrorsInterface smoke_ErrorsInterface_fromFfi(Pointer<Void> handle) {
+  final instance = _ErrorsInterface_reverse_cache[_smoke_ErrorsInterface_get_raw_pointer(handle)];
+  return instance != null ? instance : ErrorsInterface__Impl(_smoke_ErrorsInterface_copy_handle(handle));
+}
+void smoke_ErrorsInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_ErrorsInterface_release_handle(handle);
+Pointer<Void> smoke_ErrorsInterface_toFfi_nullable(ErrorsInterface value) =>
+  value != null ? smoke_ErrorsInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+ErrorsInterface smoke_ErrorsInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_ErrorsInterface_fromFfi(handle) : null;
+void smoke_ErrorsInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_ErrorsInterface_release_handle(handle);
+// End of ErrorsInterface "private" section.


### PR DESCRIPTION
Updated Dart and FFI templates to propagate exceptions thrown in Dart
code to C++ as error code, when calling Dart callbacks from C++.

Added smoke and functional tests as appropriate.

Resolves: #137
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>