### PR TITLE
Fix redundant newlines in C++ structs and enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Move BuiltinOptionals.swift into correct source set
+  * Fixed redundant empty lines in C++ headers for enums and structs.
 
 ## 6.1.0
 Release date: 2020-01-21

--- a/gluecodium/src/main/resources/templates/cpp/CppEnum.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppEnum.mustache
@@ -26,9 +26,7 @@ enum class {{name}} {
 };
 {{/unless}}{{!!
 
-}}{{+enumItem}}
-{{#if comment.documentation}}
-{{prefixPartial "cpp/DocComment" "    "}}
-{{/if}}
-    {{name}}{{#value}} = {{name}}{{/value}}{{!!
+}}{{+enumItem}}{{!!
+}}{{#if comment.documentation}}{{prefixPartial "cpp/DocComment" "    "}}{{/if}}{{!!
+}}    {{name}}{{#value}} = {{name}}{{/value}}{{!!
 }}{{/enumItem}}

--- a/gluecodium/src/main/resources/templates/cpp/CppStruct.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppStruct.mustache
@@ -30,10 +30,8 @@ public:
 {{/if}}{{!!
 }}{{#unless hasAccessors}}
 {{#fields}}
-{{#if hasComment}}
-{{prefixPartial "cpp/CppFieldComment" "    "}}
-{{/if}}
-    {{#if isImmutable}}const {{/if}}{{type.name}} {{name}}{{#initializer}} = {{name}}{{/initializer}};
+{{#if hasComment}}{{prefixPartial "cpp/CppFieldComment" "    "}}{{/if}}{{!!
+}}    {{#if isImmutable}}const {{/if}}{{type.name}} {{name}}{{#initializer}} = {{name}}{{/initializer}};
 {{/fields}}
 {{/unless}}{{!!
 }}{{#if fields}}
@@ -44,7 +42,8 @@ public:
 {{prefix constructorComment "     * "}}
      */
 {{/if}}
-    {{name}}( );{{/if}}{{#if hasPartialDefaults}}
+    {{name}}( );{{/if}}{{!!
+}}{{#if hasPartialDefaults}}
 {{#if constructorComment}}
     /**
 {{prefix constructorComment "     * "}}
@@ -83,15 +82,16 @@ public:
     void {{setterName}}( {{>cpp/CppMethodParameterType}} value_ ) { {{name}} = value_; }{{/unless}}
 {{/fields}}
 
-{{/if}}{{!!}}{{#if methods}}
+{{/if}}{{!!
+}}{{#if methods}}
 {{#methods}}
-    {{>cpp/CppMethodSignature}};
+{{prefixPartial "cpp/CppMethodSignature" "    "}};
 {{/methods}}
 
 {{/if}}{{!!
 }}{{#if constants}}
 {{#constants}}
-    {{#set storageQualifier="static"}}{{>cpp/CppConstant}}{{/set}}
+{{#set storageQualifier="static"}}{{prefixPartial "cpp/CppConstant" "    "}}{{/set}}
 {{/constants}}
 
 {{/if}}{{!!


### PR DESCRIPTION
Updated C++ templates for C++ structs and enums to generate less useless
newlines.

Resolves: #128
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>