### PR TITLE
Adds CFBundleSupportedPlatforms with detected platform to plist for iOS

### DIFF
--- a/cmake/modules/gluecodium/swift/MacOSXFrameworkInfo.plist.in
+++ b/cmake/modules/gluecodium/swift/MacOSXFrameworkInfo.plist.in
@@ -24,5 +24,7 @@
 	<string>${MACOSX_FRAMEWORK_MINIMUM_OS_VERSION}</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
+	<key>CFBundleSupportedPlatforms</key>
+	<array><string>${APPLE_PLATFORM_NAME}</string></array>
 </dict>
 </plist>


### PR DESCRIPTION
Sometimes Xcode can't export archive because it's not sure about target
platform. The option CFBundleSupportedPlatforms should list suported
platforms to resolve this issue.

This patch adds the option and simple logic to detect platform based
on enabled architecture (see CMake option CMAKE_OSX_ARCHITECTURES)

Signed-off-by: Yauheni Khnykin <yauheni.khnykin@here.com>
