### PR TITLE
Dart tests catch up

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -188,6 +188,7 @@ feature(Properties cpp android swift dart SOURCES
     lime/test/AttributesInterfaceFactory.lime
 )
 
+# This feature is intended for Android only.
 feature(JavaBuilder android SOURCES
     lime/test/JavaBuilder.lime
 )
@@ -209,7 +210,7 @@ feature(Listeners cpp android swift dart SOURCES
     lime/test/ListenerNameClash.lime
 )
 
-feature(ComplexListeners cpp android swift SOURCES
+feature(ComplexListeners cpp android swift dart SOURCES
     src/test/ComplexListener.cpp
     src/test/ComplexListener.h
 
@@ -284,7 +285,7 @@ feature(Serialization android swift SOURCES
     lime/test/Serialization.lime
 )
 
-feature(CircularDependencies cpp android swift SOURCES
+feature(CircularDependencies cpp android swift dart SOURCES
     lime/test/Circular.lime
 )
 
@@ -297,7 +298,7 @@ feature(ExternalTypes cpp android swift dart SOURCES
     lime/test/UseExternalTypes.lime
 )
 
-feature(UnderscorePackage cpp android swift SOURCES
+feature(UnderscorePackage cpp android swift dart SOURCES
     src/test/UseUnderscorePackage.cpp
 
     lime/test/UnderscorePackage.lime
@@ -325,6 +326,7 @@ feature(Nullable cpp android swift dart SOURCES
     lime/test/NullableInterface.lime
 )
 
+#TODO: #138 enable for Dart
 feature(ListenersWithThreads cpp android SOURCES
     src/test/ListenersThreads.cpp
 
@@ -345,6 +347,7 @@ feature(StructsWithCompanion cpp android swift dart SOURCES
     lime/test/StructsWithConstants.lime
 )
 
+#TODO: #80 enable for Dart
 feature(Comments cpp android swift SOURCES
     src/test/Comments.cpp
 
@@ -352,13 +355,13 @@ feature(Comments cpp android swift SOURCES
     lime/test/CommentsInterface.lime
 )
 
-feature(PlatformNames cpp android swift SOURCES
+feature(PlatformNames cpp android swift dart SOURCES
     src/test/PlatformNames.cpp
 
     lime/test/PlatformNames.lime
 )
 
-feature(EscapedNames cpp android swift SOURCES
+feature(EscapedNames cpp android swift dart SOURCES
     lime/test/KeywordNames.lime
 )
 
@@ -376,7 +379,8 @@ feature(Lambdas cpp android swift dart SOURCES
     src/test/Lambdas.cpp
 )
 
-feature(Extensions cpp android swift SOURCES
+# This feature is intended for Swift only.
+feature(Extensions swift SOURCES
     lime/test/Extensions.lime
 )
 

--- a/examples/libhello/lime/test/KeywordNames.lime
+++ b/examples/libhello/lime/test/KeywordNames.lime
@@ -31,6 +31,7 @@ types `types` {
 
     typealias `ULong` = List<`struct`>
 
+    @Dart("Const")
     const `const`: `enum` = `enum`.`Blob`
 }
 

--- a/examples/libhello/lime/test/PlatformNames.lime
+++ b/examples/libhello/lime/test/PlatformNames.lime
@@ -23,26 +23,31 @@ types PlatformNames {
     @Cpp("fooStruct")
     @Java("barStruct")
     @Swift("bazStruct")
+    @Dart("weeStruct")
     struct BasicStruct {
         @Cpp("FOO_FIELD")
         @Java("BAR_FIELD")
         @Swift("BAZ_FIELD")
+        @Dart("WEE_FIELD")
         stringField: String
         @Cpp("create")
         constructor make(
             @Cpp("FooParameter")
             @Java("BarParameter")
             @Swift("BazParameter", Label = "_")
+            @Dart("WeeParameter")
             basicParameter: String
         )
     }
     @Cpp("fooEnum")
     @Java("barEnum")
     @Swift("bazEnum")
+    @Dart("weeEnum")
     enum BasicEnum {
         @Cpp("foo_item")
         @Java("bar_item")
         @Swift("BAZ_ITEM")
+        @Dart("WEE_ITEM")
         BASIC_ITEM
     }
     @Cpp("fooTypedef")
@@ -57,26 +62,32 @@ types PlatformNames {
 @Cpp("fooInterface")
 @Java("barInterface")
 @Swift("bazInterface")
+@Dart("wwInterface")
 class PlatformNamesInterface {
     @Cpp("FooMethod")
     @Java("BarMethod")
     @Swift("BazMethod")
+    @Dart("WeeMethod")
     static fun basicMethod(
         @Cpp("FooParameter")
         @Java("BarParameter")
         @Swift("BazParameter", Label = "_")
+        @Dart("WeeParameter")
         basicParameter: String
     ): PlatformNames.BasicStruct
     @Cpp("make")
     @Java("make")
     @Swift("make")
+    @Dart("make")
     constructor create(
         @Cpp("makeParameter")
         @Java("makeParameter")
         @Swift("makeParameter", Label = "_")
+        @Dart("makeParameter")
         basicParameter: String
     )
     @Swift("BAZ_ATTRIBUTE")
+    @Dart("WEE_ATTRIBUTE")
     property basicAttribute: UInt {
         @Cpp("GET_FOO_ATTRIBUTE")
         @Java("GET_BAR_ATTRIBUTE")
@@ -90,14 +101,17 @@ class PlatformNamesInterface {
 @Cpp("fooListener")
 @Java("barListener")
 @Swift("bazListener")
+@Dart("WeeListener")
 interface PlatformNamesListener {
     @Cpp("FooMethod")
     @Java("BarMethod")
     @Swift("BazMethod")
+    @Dart("WeeMethod")
     fun basicMethod(
         @Cpp("FooParameter")
         @Java("BarParameter")
         @Swift("BazParameter", Label = "_")
+        @Dart("WeeParameter")
         basicParameter: String
     )
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/ffi/ffi_smoke_Dates.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/ffi/ffi_smoke_Dates.cpp
@@ -1,0 +1,82 @@
+#include "ffi_smoke_Dates.h"
+#include "ConversionBase.h"
+#include "gluecodium/TimePointHash.h"
+#include "smoke/Dates.h"
+#include <chrono>
+#include <memory>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+uint64_t
+smoke_Dates_dateMethod__Date(FfiOpaqueHandle _self, uint64_t input) {
+    return gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<::smoke::Dates>>::toCpp(_self)).date_method(
+            gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toCpp(input)
+        )
+    );
+}
+uint64_t
+smoke_Dates_dateProperty_get(FfiOpaqueHandle _self) {
+    return gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<::smoke::Dates>>::toCpp(_self)).get_date_property()
+    );
+}
+void
+smoke_Dates_dateProperty_set__Date(FfiOpaqueHandle _self, uint64_t value) {
+            (*gluecodium::ffi::Conversion<std::shared_ptr<::smoke::Dates>>::toCpp(_self)).set_date_property(
+            gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toCpp(value)
+        );
+}
+FfiOpaqueHandle
+smoke_Dates_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::Dates>(
+            *reinterpret_cast<std::shared_ptr<::smoke::Dates>*>(handle)
+        )
+    );
+}
+void
+smoke_Dates_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::Dates>*>(handle);
+}
+FfiOpaqueHandle
+smoke_Dates_DateStruct_create_handle(uint64_t dateField) {
+    auto _result = new (std::nothrow) ::smoke::Dates::DateStruct(gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toCpp(dateField));
+    return reinterpret_cast<FfiOpaqueHandle>(_result);
+}
+void
+smoke_Dates_DateStruct_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<::smoke::Dates::DateStruct*>(handle);
+}
+uint64_t
+smoke_Dates_DateStruct_get_field_dateField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toFfi(
+        reinterpret_cast<::smoke::Dates::DateStruct*>(handle)->date_field
+    );
+}
+FfiOpaqueHandle
+smoke_Dates_DateStruct_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<::smoke::Dates::DateStruct>(
+            gluecodium::ffi::Conversion<::smoke::Dates::DateStruct>::toCpp(value)
+        )
+    );
+}
+void
+smoke_Dates_DateStruct_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<::smoke::Dates::DateStruct>*>(handle);
+}
+FfiOpaqueHandle
+smoke_Dates_DateStruct_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<::smoke::Dates::DateStruct>::toFfi(
+        **reinterpret_cast<gluecodium::optional<::smoke::Dates::DateStruct>*>(handle)
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/Dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/Dates.dart
@@ -1,0 +1,117 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_Dates_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_Dates_copy_handle');
+final _smoke_Dates_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_Dates_release_handle');
+class Dates {
+  final Pointer<Void> _handle;
+  Dates._(this._handle);
+  void release() => _smoke_Dates_release_handle(_handle);
+  DateTime dateMethod(DateTime input) {
+    final _dateMethod_ffi = __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Uint64), int Function(Pointer<Void>, int)>('smoke_Dates_dateMethod__Date');
+    final _input_handle = Date_toFfi(input);
+    final __result_handle = _dateMethod_ffi(_handle, _input_handle);
+    Date_releaseFfiHandle(_input_handle);
+    final _result = Date_fromFfi(__result_handle);
+    Date_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  DateTime get dateProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>), int Function(Pointer<Void>)>('smoke_Dates_dateProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = Date_fromFfi(__result_handle);
+    Date_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set dateProperty(DateTime value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint64), void Function(Pointer<Void>, int)>('smoke_Dates_dateProperty_set__Date');
+    final _value_handle = Date_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Date_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_Dates_toFfi(Dates value) =>
+  _smoke_Dates_copy_handle(value._handle);
+Dates smoke_Dates_fromFfi(Pointer<Void> handle) =>
+  Dates._(_smoke_Dates_copy_handle(handle));
+void smoke_Dates_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Dates_release_handle(handle);
+Pointer<Void> smoke_Dates_toFfi_nullable(Dates value) =>
+  value != null ? smoke_Dates_toFfi(value) : Pointer<Void>.fromAddress(0);
+Dates smoke_Dates_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_Dates_fromFfi(handle) : null;
+void smoke_Dates_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Dates_release_handle(handle);
+class Dates_DateStruct {
+  DateTime dateField;
+  Dates_DateStruct(this.dateField);
+}
+// Dates_DateStruct "private" section, not exported.
+final _smoke_Dates_DateStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64),
+    Pointer<Void> Function(int)
+  >('smoke_Dates_DateStruct_create_handle');
+final _smoke_Dates_DateStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_Dates_DateStruct_release_handle');
+final _smoke_Dates_DateStruct_get_field_dateField = __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_Dates_DateStruct_get_field_dateField');
+Pointer<Void> smoke_Dates_DateStruct_toFfi(Dates_DateStruct value) {
+  final _dateField_handle = Date_toFfi(value.dateField);
+  final _result = _smoke_Dates_DateStruct_create_handle(_dateField_handle);
+  Date_releaseFfiHandle(_dateField_handle);
+  return _result;
+}
+Dates_DateStruct smoke_Dates_DateStruct_fromFfi(Pointer<Void> handle) {
+  final _dateField_handle = _smoke_Dates_DateStruct_get_field_dateField(handle);
+  final _result = Dates_DateStruct(
+    Date_fromFfi(_dateField_handle)
+  );
+  Date_releaseFfiHandle(_dateField_handle);
+  return _result;
+}
+void smoke_Dates_DateStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Dates_DateStruct_release_handle(handle);
+// Nullable Dates_DateStruct
+final _smoke_Dates_DateStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_Dates_DateStruct_create_handle_nullable');
+final _smoke_Dates_DateStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_Dates_DateStruct_release_handle_nullable');
+final _smoke_Dates_DateStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_Dates_DateStruct_get_value_nullable');
+Pointer<Void> smoke_Dates_DateStruct_toFfi_nullable(Dates_DateStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_Dates_DateStruct_toFfi(value);
+  final result = _smoke_Dates_DateStruct_create_handle_nullable(_handle);
+  smoke_Dates_DateStruct_releaseFfiHandle(_handle);
+  return result;
+}
+Dates_DateStruct smoke_Dates_DateStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_Dates_DateStruct_get_value_nullable(handle);
+  final result = smoke_Dates_DateStruct_fromFfi(_handle);
+  smoke_Dates_DateStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_Dates_DateStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Dates_DateStruct_release_handle_nullable(handle);
+// End of Dates_DateStruct "private" section.

--- a/gluecodium/src/test/resources/smoke/escaped_names/input/KeywordNames.lime
+++ b/gluecodium/src/test/resources/smoke/escaped_names/input/KeywordNames.lime
@@ -31,6 +31,7 @@ types `types` {
 
     typealias `List` = List<`struct`>
 
+    @Dart("Const")
     const `const`: `enum` = `enum`.`NaN`
 }
 

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Class.dart
@@ -1,0 +1,88 @@
+import 'package:library/src/GenericTypes__conversion.dart';
+import 'package:library/src/package/Interface.dart';
+import 'package:library/src/package/Types.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _package_Class_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('package_Class_copy_handle');
+final _package_Class_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('package_Class_release_handle');
+final _fun_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('package_Class_fun__ListOf_1package_1Types_1Struct_return_release_handle');
+final _fun_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('package_Class_fun__ListOf_1package_1Types_1Struct_return_get_result');
+final _fun_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('package_Class_fun__ListOf_1package_1Types_1Struct_return_get_error');
+final _fun_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('package_Class_fun__ListOf_1package_1Types_1Struct_return_has_error');
+class Class implements Interface {
+  final Pointer<Void> _handle;
+  Class._(this._handle);
+  void release() => _package_Class_release_handle(_handle);
+  Class() : this._(_constructor());
+  static Pointer<Void> _constructor() {
+    final _constructor_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('package_Class_constructor');
+    final __result_handle = _constructor_ffi();
+    return __result_handle;
+  }
+  Struct fun(List<Struct> double) {
+    final _fun_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('package_Class_fun__ListOf_1package_1Types_1Struct');
+    final _double_handle = ListOf_package_Types_Struct_toFfi(double);
+    final __call_result_handle = _fun_ffi(_handle, _double_handle);
+    ListOf_package_Types_Struct_releaseFfiHandle(_double_handle);
+    if (_fun_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _fun_return_get_error(__call_result_handle);
+        _fun_return_release_handle(__call_result_handle);
+        final _error_value = package_Types_Enum_fromFfi(__error_handle);
+        package_Types_Enum_releaseFfiHandle(__error_handle);
+        throw ExceptionException(_error_value);
+    }
+    final __result_handle = _fun_return_get_result(__call_result_handle);
+    _fun_return_release_handle(__call_result_handle);
+    final _result = package_Types_Struct_fromFfi(__result_handle);
+    package_Types_Struct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  Enum get property {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('package_Class_property_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = package_Types_Enum_fromFfi(__result_handle);
+    package_Types_Enum_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set property(Enum value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint32), void Function(Pointer<Void>, int)>('package_Class_property_set__enum');
+    final _value_handle = package_Types_Enum_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    package_Types_Enum_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> package_Class_toFfi(Class value) =>
+  _package_Class_copy_handle(value._handle);
+Class package_Class_fromFfi(Pointer<Void> handle) =>
+  Class._(_package_Class_copy_handle(handle));
+void package_Class_releaseFfiHandle(Pointer<Void> handle) =>
+  _package_Class_release_handle(handle);
+Pointer<Void> package_Class_toFfi_nullable(Class value) =>
+  value != null ? package_Class_toFfi(value) : Pointer<Void>.fromAddress(0);
+Class package_Class_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? package_Class_fromFfi(handle) : null;
+void package_Class_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _package_Class_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Interface.dart
@@ -1,0 +1,56 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+abstract class Interface {
+  void release();
+}
+// Interface "private" section, not exported.
+final _package_Interface_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('package_Interface_copy_handle');
+final _package_Interface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('package_Interface_release_handle');
+final _package_Interface_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64),
+    Pointer<Void> Function(int)
+  >('package_Interface_create_proxy');
+final _package_Interface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('package_Interface_get_raw_pointer');
+int _Interface_instance_counter = 1024;
+final Map<int, Interface> _Interface_instance_cache = {};
+final Map<Pointer<Void>, Interface> _Interface_reverse_cache = {};
+class Interface__Impl implements Interface {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  Interface__Impl(this.handle);
+  @override
+  void release() => _package_Interface_release_handle(handle);
+}
+Pointer<Void> package_Interface_toFfi(Interface value) {
+  if (value is Interface__Impl) return _package_Interface_copy_handle(value.handle);
+  const UNKNOWN_ERROR = -1;
+  final token = _Interface_instance_counter++;
+  _Interface_instance_cache[token] = value;
+  final result = _package_Interface_create_proxy(token);
+  _Interface_reverse_cache[_package_Interface_get_raw_pointer(result)] = value;
+  return result;
+}
+Interface package_Interface_fromFfi(Pointer<Void> handle) {
+  final instance = _Interface_reverse_cache[_package_Interface_get_raw_pointer(handle)];
+  return instance != null ? instance : Interface__Impl(_package_Interface_copy_handle(handle));
+}
+void package_Interface_releaseFfiHandle(Pointer<Void> handle) =>
+  _package_Interface_release_handle(handle);
+Pointer<Void> package_Interface_toFfi_nullable(Interface value) =>
+  value != null ? package_Interface_toFfi(value) : Pointer<Void>.fromAddress(0);
+Interface package_Interface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? package_Interface_fromFfi(handle) : null;
+void package_Interface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _package_Interface_release_handle(handle);
+// End of Interface "private" section.

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Types.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Types.dart
@@ -1,0 +1,125 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+enum Enum {
+    naN
+}
+// Enum "private" section, not exported.
+int package_Types_Enum_toFfi(Enum value) {
+  switch (value) {
+  case Enum.naN:
+    return 0;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for Enum enum.");
+  }
+}
+Enum package_Types_Enum_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return Enum.naN;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for Enum enum.");
+  }
+}
+void package_Types_Enum_releaseFfiHandle(int handle) {}
+final _package_Types_Enum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('package_Types_Enum_create_handle_nullable');
+final _package_Types_Enum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('package_Types_Enum_release_handle_nullable');
+final _package_Types_Enum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('package_Types_Enum_get_value_nullable');
+Pointer<Void> package_Types_Enum_toFfi_nullable(Enum value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = package_Types_Enum_toFfi(value);
+  final result = _package_Types_Enum_create_handle_nullable(_handle);
+  package_Types_Enum_releaseFfiHandle(_handle);
+  return result;
+}
+Enum package_Types_Enum_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _package_Types_Enum_get_value_nullable(handle);
+  final result = package_Types_Enum_fromFfi(_handle);
+  package_Types_Enum_releaseFfiHandle(_handle);
+  return result;
+}
+void package_Types_Enum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _package_Types_Enum_release_handle_nullable(handle);
+// End of Enum "private" section.
+class ExceptionException implements Exception {
+  final Enum error;
+  ExceptionException(this.error);
+}
+class Struct {
+  Enum null;
+  Struct(this.null);
+  Struct.withDefaults()
+    : null = Enum.naN;
+}
+// Struct "private" section, not exported.
+final _package_Types_Struct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('package_Types_Struct_create_handle');
+final _package_Types_Struct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('package_Types_Struct_release_handle');
+final _package_Types_Struct_get_field_null = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('package_Types_Struct_get_field_null');
+Pointer<Void> package_Types_Struct_toFfi(Struct value) {
+  final _null_handle = package_Types_Enum_toFfi(value.null);
+  final _result = _package_Types_Struct_create_handle(_null_handle);
+  package_Types_Enum_releaseFfiHandle(_null_handle);
+  return _result;
+}
+Struct package_Types_Struct_fromFfi(Pointer<Void> handle) {
+  final _null_handle = _package_Types_Struct_get_field_null(handle);
+  final _result = Struct(
+    package_Types_Enum_fromFfi(_null_handle)
+  );
+  package_Types_Enum_releaseFfiHandle(_null_handle);
+  return _result;
+}
+void package_Types_Struct_releaseFfiHandle(Pointer<Void> handle) => _package_Types_Struct_release_handle(handle);
+// Nullable Struct
+final _package_Types_Struct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('package_Types_Struct_create_handle_nullable');
+final _package_Types_Struct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('package_Types_Struct_release_handle_nullable');
+final _package_Types_Struct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('package_Types_Struct_get_value_nullable');
+Pointer<Void> package_Types_Struct_toFfi_nullable(Struct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = package_Types_Struct_toFfi(value);
+  final result = _package_Types_Struct_create_handle_nullable(_handle);
+  package_Types_Struct_releaseFfiHandle(_handle);
+  return result;
+}
+Struct package_Types_Struct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _package_Types_Struct_get_value_nullable(handle);
+  final result = package_Types_Struct_fromFfi(_handle);
+  package_Types_Struct_releaseFfiHandle(_handle);
+  return result;
+}
+void package_Types_Struct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _package_Types_Struct_release_handle_nullable(handle);
+// End of Struct "private" section.
+final Enum Const = Enum.naN;

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/lime/package/types.lime
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/lime/package/types.lime
@@ -8,5 +8,6 @@ types `types` {
     struct `struct` {
         `null`: `enum` = `enum`.`NaN`
     }
+    @Dart("Const")
     const `const`: `enum` = `enum`.`NaN`
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/ffi/ffi_smoke_ChildClassFromClass.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/ffi/ffi_smoke_ChildClassFromClass.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "Export.h"
+#include "OpaqueHandle.h"
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+_GLUECODIUM_FFI_EXPORT void smoke_ChildClassFromClass_childClassMethod(FfiOpaqueHandle _self);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_ChildClassFromClass_copy_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void smoke_ChildClassFromClass_release_handle(FfiOpaqueHandle handle);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/ffi/ffi_smoke_ChildClassFromInterface.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/ffi/ffi_smoke_ChildClassFromInterface.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "Export.h"
+#include "OpaqueHandle.h"
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+_GLUECODIUM_FFI_EXPORT void smoke_ChildClassFromInterface_childClassMethod(FfiOpaqueHandle _self);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_ChildClassFromInterface_copy_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void smoke_ChildClassFromInterface_release_handle(FfiOpaqueHandle handle);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/ffi/ffi_smoke_ChildInterface.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/ffi/ffi_smoke_ChildInterface.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "Export.h"
+#include "OpaqueHandle.h"
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+_GLUECODIUM_FFI_EXPORT void smoke_ChildInterface_childMethod(FfiOpaqueHandle _self);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_ChildInterface_copy_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void smoke_ChildInterface_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_ChildInterface_create_proxy(uint64_t token, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_ChildInterface_get_raw_pointer(FfiOpaqueHandle handle);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildClassFromClass.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildClassFromClass.dart
@@ -1,0 +1,38 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/smoke/ParentClass.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_ChildClassFromClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_ChildClassFromClass_copy_handle');
+final _smoke_ChildClassFromClass_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ChildClassFromClass_release_handle');
+class ChildClassFromClass extends ParentClass {
+  Pointer<Void> get _handle => handle;
+  ChildClassFromClass._(Pointer<Void> handle) : super(handle);
+  void release() => _smoke_ChildClassFromClass_release_handle(_handle);
+  childClassMethod() {
+    final _childClassMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('smoke_ChildClassFromClass_childClassMethod');
+    final __result_handle = _childClassMethod_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_ChildClassFromClass_toFfi(ChildClassFromClass value) =>
+  _smoke_ChildClassFromClass_copy_handle(value._handle);
+ChildClassFromClass smoke_ChildClassFromClass_fromFfi(Pointer<Void> handle) =>
+  ChildClassFromClass._(_smoke_ChildClassFromClass_copy_handle(handle));
+void smoke_ChildClassFromClass_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_ChildClassFromClass_release_handle(handle);
+Pointer<Void> smoke_ChildClassFromClass_toFfi_nullable(ChildClassFromClass value) =>
+  value != null ? smoke_ChildClassFromClass_toFfi(value) : Pointer<Void>.fromAddress(0);
+ChildClassFromClass smoke_ChildClassFromClass_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_ChildClassFromClass_fromFfi(handle) : null;
+void smoke_ChildClassFromClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_ChildClassFromClass_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildClassFromInterface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildClassFromInterface.dart
@@ -1,0 +1,63 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/smoke/ParentInterface.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_ChildClassFromInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_ChildClassFromInterface_copy_handle');
+final _smoke_ChildClassFromInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ChildClassFromInterface_release_handle');
+class ChildClassFromInterface implements ParentInterface {
+  final Pointer<Void> _handle;
+  ChildClassFromInterface._(this._handle);
+  void release() => _smoke_ChildClassFromInterface_release_handle(_handle);
+  childClassMethod() {
+    final _childClassMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('smoke_ChildClassFromInterface_childClassMethod');
+    final __result_handle = _childClassMethod_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  rootMethod() {
+    final _rootMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('smoke_ParentInterface_rootMethod');
+    final __result_handle = _rootMethod_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  String get rootProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_ParentInterface_rootProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set rootProperty(String value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_ParentInterface_rootProperty_set__String');
+    final _value_handle = String_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    String_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_ChildClassFromInterface_toFfi(ChildClassFromInterface value) =>
+  _smoke_ChildClassFromInterface_copy_handle(value._handle);
+ChildClassFromInterface smoke_ChildClassFromInterface_fromFfi(Pointer<Void> handle) =>
+  ChildClassFromInterface._(_smoke_ChildClassFromInterface_copy_handle(handle));
+void smoke_ChildClassFromInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_ChildClassFromInterface_release_handle(handle);
+Pointer<Void> smoke_ChildClassFromInterface_toFfi_nullable(ChildClassFromInterface value) =>
+  value != null ? smoke_ChildClassFromInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+ChildClassFromInterface smoke_ChildClassFromInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_ChildClassFromInterface_fromFfi(handle) : null;
+void smoke_ChildClassFromInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_ChildClassFromInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildInterface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildInterface.dart
@@ -1,0 +1,83 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/smoke/ParentInterface.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+abstract class ChildInterface implements ParentInterface {
+  void release();
+  childMethod();
+}
+// ChildInterface "private" section, not exported.
+final _smoke_ChildInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_ChildInterface_copy_handle');
+final _smoke_ChildInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ChildInterface_release_handle');
+final _smoke_ChildInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Pointer, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, Pointer, Pointer, Pointer, Pointer)
+  >('smoke_ChildInterface_create_proxy');
+final _smoke_ChildInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('smoke_ChildInterface_get_raw_pointer');
+int _ChildInterface_instance_counter = 1024;
+final Map<int, ChildInterface> _ChildInterface_instance_cache = {};
+final Map<Pointer<Void>, ChildInterface> _ChildInterface_reverse_cache = {};
+class ChildInterface__Impl extends ParentInterface__Impl implements ChildInterface {
+  Pointer<Void> get _handle => handle;
+  ChildInterface__Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() => _smoke_ChildInterface_release_handle(handle);
+  @override
+  childMethod() {
+    final _childMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('smoke_ChildInterface_childMethod');
+    final __result_handle = _childMethod_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+int _ChildInterface_rootMethod_static(int _token) {
+  _ChildInterface_instance_cache[_token].rootMethod();
+  return 0;
+}
+int _ChildInterface_childMethod_static(int _token) {
+  _ChildInterface_instance_cache[_token].childMethod();
+  return 0;
+}
+int _ChildInterface_rootProperty_get_static(int _token, Pointer<Pointer<Void>> _result) {
+  _result.value = String_toFfi(_ChildInterface_instance_cache[_token].rootProperty);
+  return 0;
+}
+int _ChildInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
+  _ChildInterface_instance_cache[_token].rootProperty = String_fromFfi(_value);
+  String_releaseFfiHandle(_value);
+  return 0;
+}
+Pointer<Void> smoke_ChildInterface_toFfi(ChildInterface value) {
+  if (value is ChildInterface__Impl) return _smoke_ChildInterface_copy_handle(value.handle);
+  const UNKNOWN_ERROR = -1;
+  final token = _ChildInterface_instance_counter++;
+  _ChildInterface_instance_cache[token] = value;
+  final result = _smoke_ChildInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64)>(_ChildInterface_rootMethod_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64)>(_ChildInterface_childMethod_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ChildInterface_rootProperty_get_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ChildInterface_rootProperty_set_static, UNKNOWN_ERROR));
+  _ChildInterface_reverse_cache[_smoke_ChildInterface_get_raw_pointer(result)] = value;
+  return result;
+}
+ChildInterface smoke_ChildInterface_fromFfi(Pointer<Void> handle) {
+  final instance = _ChildInterface_reverse_cache[_smoke_ChildInterface_get_raw_pointer(handle)];
+  return instance != null ? instance : ChildInterface__Impl(_smoke_ChildInterface_copy_handle(handle));
+}
+void smoke_ChildInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_ChildInterface_release_handle(handle);
+Pointer<Void> smoke_ChildInterface_toFfi_nullable(ChildInterface value) =>
+  value != null ? smoke_ChildInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+ChildInterface smoke_ChildInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_ChildInterface_fromFfi(handle) : null;
+void smoke_ChildInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_ChildInterface_release_handle(handle);
+// End of ChildInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentClass.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentClass.dart
@@ -1,0 +1,40 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_ParentClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_ParentClass_copy_handle');
+final _smoke_ParentClass_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ParentClass_release_handle');
+class ParentClass {
+  @protected
+  final Pointer<Void> handle;
+  Pointer<Void> get _handle => handle;
+  @protected
+  ParentClass(this.handle);
+  void release() => _smoke_ParentClass_release_handle(_handle);
+  rootMethod() {
+    final _rootMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('smoke_ParentClass_rootMethod');
+    final __result_handle = _rootMethod_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_ParentClass_toFfi(ParentClass value) =>
+  _smoke_ParentClass_copy_handle(value._handle);
+ParentClass smoke_ParentClass_fromFfi(Pointer<Void> handle) =>
+  ParentClass(_smoke_ParentClass_copy_handle(handle));
+void smoke_ParentClass_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_ParentClass_release_handle(handle);
+Pointer<Void> smoke_ParentClass_toFfi_nullable(ParentClass value) =>
+  value != null ? smoke_ParentClass_toFfi(value) : Pointer<Void>.fromAddress(0);
+ParentClass smoke_ParentClass_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_ParentClass_fromFfi(handle) : null;
+void smoke_ParentClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_ParentClass_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentInterface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentInterface.dart
@@ -1,0 +1,97 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+abstract class ParentInterface {
+  void release();
+  rootMethod();
+  String get rootProperty;
+  set rootProperty(String value);
+}
+// ParentInterface "private" section, not exported.
+final _smoke_ParentInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_ParentInterface_copy_handle');
+final _smoke_ParentInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_ParentInterface_release_handle');
+final _smoke_ParentInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, Pointer, Pointer, Pointer)
+  >('smoke_ParentInterface_create_proxy');
+final _smoke_ParentInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('smoke_ParentInterface_get_raw_pointer');
+int _ParentInterface_instance_counter = 1024;
+final Map<int, ParentInterface> _ParentInterface_instance_cache = {};
+final Map<Pointer<Void>, ParentInterface> _ParentInterface_reverse_cache = {};
+class ParentInterface__Impl implements ParentInterface {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  ParentInterface__Impl(this.handle);
+  @override
+  void release() => _smoke_ParentInterface_release_handle(handle);
+  @override
+  rootMethod() {
+    final _rootMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('smoke_ParentInterface_rootMethod');
+    final __result_handle = _rootMethod_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  String get rootProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_ParentInterface_rootProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  set rootProperty(String value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_ParentInterface_rootProperty_set__String');
+    final _value_handle = String_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    String_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+int _ParentInterface_rootMethod_static(int _token) {
+  _ParentInterface_instance_cache[_token].rootMethod();
+  return 0;
+}
+int _ParentInterface_rootProperty_get_static(int _token, Pointer<Pointer<Void>> _result) {
+  _result.value = String_toFfi(_ParentInterface_instance_cache[_token].rootProperty);
+  return 0;
+}
+int _ParentInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
+  _ParentInterface_instance_cache[_token].rootProperty = String_fromFfi(_value);
+  String_releaseFfiHandle(_value);
+  return 0;
+}
+Pointer<Void> smoke_ParentInterface_toFfi(ParentInterface value) {
+  if (value is ParentInterface__Impl) return _smoke_ParentInterface_copy_handle(value.handle);
+  const UNKNOWN_ERROR = -1;
+  final token = _ParentInterface_instance_counter++;
+  _ParentInterface_instance_cache[token] = value;
+  final result = _smoke_ParentInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64)>(_ParentInterface_rootMethod_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ParentInterface_rootProperty_get_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ParentInterface_rootProperty_set_static, UNKNOWN_ERROR));
+  _ParentInterface_reverse_cache[_smoke_ParentInterface_get_raw_pointer(result)] = value;
+  return result;
+}
+ParentInterface smoke_ParentInterface_fromFfi(Pointer<Void> handle) {
+  final instance = _ParentInterface_reverse_cache[_smoke_ParentInterface_get_raw_pointer(handle)];
+  return instance != null ? instance : ParentInterface__Impl(_smoke_ParentInterface_copy_handle(handle));
+}
+void smoke_ParentInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_ParentInterface_release_handle(handle);
+Pointer<Void> smoke_ParentInterface_toFfi_nullable(ParentInterface value) =>
+  value != null ? smoke_ParentInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+ParentInterface smoke_ParentInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_ParentInterface_fromFfi(handle) : null;
+void smoke_ParentInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_ParentInterface_release_handle(handle);
+// End of ParentInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_FreePoint.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_FreePoint.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "Export.h"
+#include "OpaqueHandle.h"
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_FreePoint_flip(FfiOpaqueHandle _self);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_FreePoint_create_handle(double, double);
+_GLUECODIUM_FFI_EXPORT void smoke_FreePoint_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT double smoke_FreePoint_get_field_x(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT double smoke_FreePoint_get_field_y(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_FreePoint_create_handle_nullable(FfiOpaqueHandle value);
+_GLUECODIUM_FFI_EXPORT void smoke_FreePoint_release_handle_nullable(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle smoke_FreePoint_get_value_nullable(FfiOpaqueHandle handle);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_LevelOne.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_LevelOne.cpp
@@ -1,0 +1,108 @@
+#include "ffi_smoke_LevelOne.h"
+#include "ConversionBase.h"
+#include "smoke/LevelOne.h"
+#include "smoke/OuterClass.h"
+#include "smoke/OuterInterface.h"
+#include <memory>
+#include <string>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+smoke_LevelOne_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::LevelOne>(
+            *reinterpret_cast<std::shared_ptr<::smoke::LevelOne>*>(handle)
+        )
+    );
+}
+void
+smoke_LevelOne_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::LevelOne>*>(handle);
+}
+FfiOpaqueHandle
+smoke_LevelOne_LevelTwo_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::LevelOne::LevelTwo>(
+            *reinterpret_cast<std::shared_ptr<::smoke::LevelOne::LevelTwo>*>(handle)
+        )
+    );
+}
+void
+smoke_LevelOne_LevelTwo_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::LevelOne::LevelTwo>*>(handle);
+}
+FfiOpaqueHandle
+smoke_LevelOne_LevelTwo_LevelThree_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>(
+            *reinterpret_cast<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>*>(handle)
+        )
+    );
+}
+void
+smoke_LevelOne_LevelTwo_LevelThree_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>*>(handle);
+}
+FfiOpaqueHandle
+smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle(FfiOpaqueHandle stringField) {
+    auto _result = new (std::nothrow) ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour(gluecodium::ffi::Conversion<std::string>::toCpp(stringField));
+    return reinterpret_cast<FfiOpaqueHandle>(_result);
+}
+void
+smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour*>(handle);
+}
+FfiOpaqueHandle
+smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<std::string>::toFfi(
+        reinterpret_cast<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour*>(handle)->string_field
+    );
+}
+FfiOpaqueHandle
+smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>(
+            gluecodium::ffi::Conversion<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>::toCpp(value)
+        )
+    );
+}
+void
+smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>*>(handle);
+}
+FfiOpaqueHandle
+smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>::toFfi(
+        **reinterpret_cast<gluecodium::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>*>(handle)
+    );
+}
+FfiOpaqueHandle
+smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_create_handle_nullable(uint32_t value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>(
+            gluecodium::ffi::Conversion<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>::toCpp(value)
+        )
+    );
+}
+void
+smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>*>(handle);
+}
+uint32_t
+smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>::toFfi(
+        **reinterpret_cast<gluecodium::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>*>(handle)
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
@@ -1,0 +1,90 @@
+#include "ffi_smoke_OuterClass.h"
+#include "ConversionBase.h"
+#include "smoke/OuterClass.h"
+#include <memory>
+#include <string>
+#include <memory>
+#include <new>
+class smoke_OuterClass_InnerInterface_Proxy : public ::smoke::OuterClass::InnerInterface {
+public:
+    smoke_OuterClass_InnerInterface_Proxy(uint64_t token, FfiOpaqueHandle f0)
+        : token(token), f0(f0) { }
+    std::string
+    foo(const std::string& input) override {
+        FfiOpaqueHandle _result_handle;
+        int64_t _error = (*reinterpret_cast<int64_t (*)(uint64_t, FfiOpaqueHandle, FfiOpaqueHandle*)>(f0))(token,
+            gluecodium::ffi::Conversion<std::string>::toFfi(input),
+            &_result_handle
+        );
+        auto _result = gluecodium::ffi::Conversion<std::string>::toCpp(_result_handle);
+        delete reinterpret_cast<std::string*>(_result_handle);
+        return _result;
+    }
+private:
+    uint64_t token;
+    FfiOpaqueHandle f0;
+};
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+smoke_OuterClass_foo__String(FfiOpaqueHandle _self, FfiOpaqueHandle input) {
+    return gluecodium::ffi::Conversion<std::string>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<::smoke::OuterClass>>::toCpp(_self)).foo(
+            gluecodium::ffi::Conversion<std::string>::toCpp(input)
+        )
+    );
+}
+FfiOpaqueHandle
+smoke_OuterClass_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::OuterClass>(
+            *reinterpret_cast<std::shared_ptr<::smoke::OuterClass>*>(handle)
+        )
+    );
+}
+void
+smoke_OuterClass_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::OuterClass>*>(handle);
+}
+FfiOpaqueHandle
+smoke_OuterClass_InnerClass_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::OuterClass::InnerClass>(
+            *reinterpret_cast<std::shared_ptr<::smoke::OuterClass::InnerClass>*>(handle)
+        )
+    );
+}
+void
+smoke_OuterClass_InnerClass_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::OuterClass::InnerClass>*>(handle);
+}
+FfiOpaqueHandle
+smoke_OuterClass_InnerInterface_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::OuterClass::InnerInterface>(
+            *reinterpret_cast<std::shared_ptr<::smoke::OuterClass::InnerInterface>*>(handle)
+        )
+    );
+}
+void
+smoke_OuterClass_InnerInterface_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::OuterClass::InnerInterface>*>(handle);
+}
+FfiOpaqueHandle
+smoke_OuterClass_InnerInterface_create_proxy(uint64_t token, FfiOpaqueHandle f0) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::OuterClass::InnerInterface>(
+            new (std::nothrow) smoke_OuterClass_InnerInterface_Proxy(token, f0)
+        )
+    );
+}
+FfiOpaqueHandle
+smoke_OuterClass_InnerInterface_get_raw_pointer(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        reinterpret_cast<std::shared_ptr<::smoke::OuterClass::InnerInterface>*>(handle)->get()
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
@@ -1,0 +1,123 @@
+#include "ffi_smoke_OuterInterface.h"
+#include "ConversionBase.h"
+#include "smoke/OuterInterface.h"
+#include <memory>
+#include <string>
+#include <memory>
+#include <new>
+class smoke_OuterInterface_Proxy : public ::smoke::OuterInterface {
+public:
+    smoke_OuterInterface_Proxy(uint64_t token, FfiOpaqueHandle f0)
+        : token(token), f0(f0) { }
+    std::string
+    foo(const std::string& input) override {
+        FfiOpaqueHandle _result_handle;
+        int64_t _error = (*reinterpret_cast<int64_t (*)(uint64_t, FfiOpaqueHandle, FfiOpaqueHandle*)>(f0))(token,
+            gluecodium::ffi::Conversion<std::string>::toFfi(input),
+            &_result_handle
+        );
+        auto _result = gluecodium::ffi::Conversion<std::string>::toCpp(_result_handle);
+        delete reinterpret_cast<std::string*>(_result_handle);
+        return _result;
+    }
+private:
+    uint64_t token;
+    FfiOpaqueHandle f0;
+};
+class smoke_OuterInterface_InnerInterface_Proxy : public ::smoke::OuterInterface::InnerInterface {
+public:
+    smoke_OuterInterface_InnerInterface_Proxy(uint64_t token, FfiOpaqueHandle f0)
+        : token(token), f0(f0) { }
+    std::string
+    foo(const std::string& input) override {
+        FfiOpaqueHandle _result_handle;
+        int64_t _error = (*reinterpret_cast<int64_t (*)(uint64_t, FfiOpaqueHandle, FfiOpaqueHandle*)>(f0))(token,
+            gluecodium::ffi::Conversion<std::string>::toFfi(input),
+            &_result_handle
+        );
+        auto _result = gluecodium::ffi::Conversion<std::string>::toCpp(_result_handle);
+        delete reinterpret_cast<std::string*>(_result_handle);
+        return _result;
+    }
+private:
+    uint64_t token;
+    FfiOpaqueHandle f0;
+};
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+smoke_OuterInterface_foo__String(FfiOpaqueHandle _self, FfiOpaqueHandle input) {
+    return gluecodium::ffi::Conversion<std::string>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<::smoke::OuterInterface>>::toCpp(_self)).foo(
+            gluecodium::ffi::Conversion<std::string>::toCpp(input)
+        )
+    );
+}
+FfiOpaqueHandle
+smoke_OuterInterface_InnerClass_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::OuterInterface::InnerClass>(
+            *reinterpret_cast<std::shared_ptr<::smoke::OuterInterface::InnerClass>*>(handle)
+        )
+    );
+}
+void
+smoke_OuterInterface_InnerClass_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::OuterInterface::InnerClass>*>(handle);
+}
+FfiOpaqueHandle
+smoke_OuterInterface_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::OuterInterface>(
+            *reinterpret_cast<std::shared_ptr<::smoke::OuterInterface>*>(handle)
+        )
+    );
+}
+void
+smoke_OuterInterface_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::OuterInterface>*>(handle);
+}
+FfiOpaqueHandle
+smoke_OuterInterface_InnerInterface_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::OuterInterface::InnerInterface>(
+            *reinterpret_cast<std::shared_ptr<::smoke::OuterInterface::InnerInterface>*>(handle)
+        )
+    );
+}
+void
+smoke_OuterInterface_InnerInterface_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::OuterInterface::InnerInterface>*>(handle);
+}
+FfiOpaqueHandle
+smoke_OuterInterface_create_proxy(uint64_t token, FfiOpaqueHandle f0) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::OuterInterface>(
+            new (std::nothrow) smoke_OuterInterface_Proxy(token, f0)
+        )
+    );
+}
+FfiOpaqueHandle
+smoke_OuterInterface_get_raw_pointer(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        reinterpret_cast<std::shared_ptr<::smoke::OuterInterface>*>(handle)->get()
+    );
+}
+FfiOpaqueHandle
+smoke_OuterInterface_InnerInterface_create_proxy(uint64_t token, FfiOpaqueHandle f0) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::OuterInterface::InnerInterface>(
+            new (std::nothrow) smoke_OuterInterface_InnerInterface_Proxy(token, f0)
+        )
+    );
+}
+FfiOpaqueHandle
+smoke_OuterInterface_InnerInterface_get_raw_pointer(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        reinterpret_cast<std::shared_ptr<::smoke::OuterInterface::InnerInterface>*>(handle)->get()
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/FreeEnum.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/FreeEnum.dart
@@ -1,0 +1,63 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+enum FreeEnum {
+    foo,
+    bar
+}
+// FreeEnum "private" section, not exported.
+int smoke_FreeEnum_toFfi(FreeEnum value) {
+  switch (value) {
+  case FreeEnum.foo:
+    return 0;
+  break;
+  case FreeEnum.bar:
+    return 1;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for FreeEnum enum.");
+  }
+}
+FreeEnum smoke_FreeEnum_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return FreeEnum.foo;
+  break;
+  case 1:
+    return FreeEnum.bar;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for FreeEnum enum.");
+  }
+}
+void smoke_FreeEnum_releaseFfiHandle(int handle) {}
+final _smoke_FreeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('smoke_FreeEnum_create_handle_nullable');
+final _smoke_FreeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_FreeEnum_release_handle_nullable');
+final _smoke_FreeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_FreeEnum_get_value_nullable');
+Pointer<Void> smoke_FreeEnum_toFfi_nullable(FreeEnum value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_FreeEnum_toFfi(value);
+  final result = _smoke_FreeEnum_create_handle_nullable(_handle);
+  smoke_FreeEnum_releaseFfiHandle(_handle);
+  return result;
+}
+FreeEnum smoke_FreeEnum_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_FreeEnum_get_value_nullable(handle);
+  final result = smoke_FreeEnum_fromFfi(_handle);
+  smoke_FreeEnum_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_FreeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_FreeEnum_release_handle_nullable(handle);
+// End of FreeEnum "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/FreeException.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/FreeException.dart
@@ -1,0 +1,9 @@
+import 'package:library/src/smoke/FreeEnum.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+class FreeException implements Exception {
+  final FreeEnum error;
+  FreeException(this.error);
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/FreePoint.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/FreePoint.dart
@@ -1,0 +1,88 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/smoke/FreeEnum.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+class FreePoint {
+  double x;
+  double y;
+  FreePoint(this.x, this.y);
+  static final FreeEnum aBar = FreeEnum.bar;
+  FreePoint flip() {
+    final _flip_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_FreePoint_flip');
+    final _handle = smoke_FreePoint_toFfi(this);
+    final __result_handle = _flip_ffi(_handle);
+    smoke_FreePoint_releaseFfiHandle(_handle);
+    final _result = smoke_FreePoint_fromFfi(__result_handle);
+    smoke_FreePoint_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+// FreePoint "private" section, not exported.
+final _smoke_FreePoint_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Double, Double),
+    Pointer<Void> Function(double, double)
+  >('smoke_FreePoint_create_handle');
+final _smoke_FreePoint_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_FreePoint_release_handle');
+final _smoke_FreePoint_get_field_x = __lib.nativeLibrary.lookupFunction<
+    Double Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_FreePoint_get_field_x');
+final _smoke_FreePoint_get_field_y = __lib.nativeLibrary.lookupFunction<
+    Double Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('smoke_FreePoint_get_field_y');
+Pointer<Void> smoke_FreePoint_toFfi(FreePoint value) {
+  final _x_handle = (value.x);
+  final _y_handle = (value.y);
+  final _result = _smoke_FreePoint_create_handle(_x_handle, _y_handle);
+  (_x_handle);
+  (_y_handle);
+  return _result;
+}
+FreePoint smoke_FreePoint_fromFfi(Pointer<Void> handle) {
+  final _x_handle = _smoke_FreePoint_get_field_x(handle);
+  final _y_handle = _smoke_FreePoint_get_field_y(handle);
+  final _result = FreePoint(
+    (_x_handle),
+    (_y_handle)
+  );
+  (_x_handle);
+  (_y_handle);
+  return _result;
+}
+void smoke_FreePoint_releaseFfiHandle(Pointer<Void> handle) => _smoke_FreePoint_release_handle(handle);
+// Nullable FreePoint
+final _smoke_FreePoint_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_FreePoint_create_handle_nullable');
+final _smoke_FreePoint_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_FreePoint_release_handle_nullable');
+final _smoke_FreePoint_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_FreePoint_get_value_nullable');
+Pointer<Void> smoke_FreePoint_toFfi_nullable(FreePoint value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_FreePoint_toFfi(value);
+  final result = _smoke_FreePoint_create_handle_nullable(_handle);
+  smoke_FreePoint_releaseFfiHandle(_handle);
+  return result;
+}
+FreePoint smoke_FreePoint_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_FreePoint_get_value_nullable(handle);
+  final result = smoke_FreePoint_fromFfi(_handle);
+  smoke_FreePoint_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_FreePoint_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_FreePoint_release_handle_nullable(handle);
+// End of FreePoint "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/LevelOne.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/LevelOne.dart
@@ -1,0 +1,213 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/smoke/OuterClass.dart';
+import 'package:library/src/smoke/OuterInterface.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_LevelOne_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_LevelOne_copy_handle');
+final _smoke_LevelOne_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_LevelOne_release_handle');
+class LevelOne {
+  final Pointer<Void> _handle;
+  LevelOne._(this._handle);
+  void release() => _smoke_LevelOne_release_handle(_handle);
+}
+Pointer<Void> smoke_LevelOne_toFfi(LevelOne value) =>
+  _smoke_LevelOne_copy_handle(value._handle);
+LevelOne smoke_LevelOne_fromFfi(Pointer<Void> handle) =>
+  LevelOne._(_smoke_LevelOne_copy_handle(handle));
+void smoke_LevelOne_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_LevelOne_release_handle(handle);
+Pointer<Void> smoke_LevelOne_toFfi_nullable(LevelOne value) =>
+  value != null ? smoke_LevelOne_toFfi(value) : Pointer<Void>.fromAddress(0);
+LevelOne smoke_LevelOne_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_LevelOne_fromFfi(handle) : null;
+void smoke_LevelOne_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_LevelOne_release_handle(handle);
+final _smoke_LevelOne_LevelTwo_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_LevelOne_LevelTwo_copy_handle');
+final _smoke_LevelOne_LevelTwo_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_LevelOne_LevelTwo_release_handle');
+class LevelOne_LevelTwo {
+  final Pointer<Void> _handle;
+  LevelOne_LevelTwo._(this._handle);
+  void release() => _smoke_LevelOne_LevelTwo_release_handle(_handle);
+}
+Pointer<Void> smoke_LevelOne_LevelTwo_toFfi(LevelOne_LevelTwo value) =>
+  _smoke_LevelOne_LevelTwo_copy_handle(value._handle);
+LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi(Pointer<Void> handle) =>
+  LevelOne_LevelTwo._(_smoke_LevelOne_LevelTwo_copy_handle(handle));
+void smoke_LevelOne_LevelTwo_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_LevelOne_LevelTwo_release_handle(handle);
+Pointer<Void> smoke_LevelOne_LevelTwo_toFfi_nullable(LevelOne_LevelTwo value) =>
+  value != null ? smoke_LevelOne_LevelTwo_toFfi(value) : Pointer<Void>.fromAddress(0);
+LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_LevelOne_LevelTwo_fromFfi(handle) : null;
+void smoke_LevelOne_LevelTwo_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_LevelOne_LevelTwo_release_handle(handle);
+final _smoke_LevelOne_LevelTwo_LevelThree_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_LevelOne_LevelTwo_LevelThree_copy_handle');
+final _smoke_LevelOne_LevelTwo_LevelThree_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_LevelOne_LevelTwo_LevelThree_release_handle');
+class LevelOne_LevelTwo_LevelThree {
+  final Pointer<Void> _handle;
+  LevelOne_LevelTwo_LevelThree._(this._handle);
+  void release() => _smoke_LevelOne_LevelTwo_LevelThree_release_handle(_handle);
+  OuterInterface_InnerClass foo(OuterClass_InnerInterface input) {
+    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_LevelOne_LevelTwo_LevelThree_foo__InnerInterface');
+    final _input_handle = smoke_OuterClass_InnerInterface_toFfi(input);
+    final __result_handle = _foo_ffi(_handle, _input_handle);
+    smoke_OuterClass_InnerInterface_releaseFfiHandle(_input_handle);
+    final _result = smoke_OuterInterface_InnerClass_fromFfi(__result_handle);
+    smoke_OuterInterface_InnerClass_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi(LevelOne_LevelTwo_LevelThree value) =>
+  _smoke_LevelOne_LevelTwo_LevelThree_copy_handle(value._handle);
+LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi(Pointer<Void> handle) =>
+  LevelOne_LevelTwo_LevelThree._(_smoke_LevelOne_LevelTwo_LevelThree_copy_handle(handle));
+void smoke_LevelOne_LevelTwo_LevelThree_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
+Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi_nullable(LevelOne_LevelTwo_LevelThree value) =>
+  value != null ? smoke_LevelOne_LevelTwo_LevelThree_toFfi(value) : Pointer<Void>.fromAddress(0);
+LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_LevelOne_LevelTwo_LevelThree_fromFfi(handle) : null;
+void smoke_LevelOne_LevelTwo_LevelThree_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
+enum LevelOne_LevelTwo_LevelThree_LevelFourEnum {
+    none
+}
+// LevelOne_LevelTwo_LevelThree_LevelFourEnum "private" section, not exported.
+int smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_toFfi(LevelOne_LevelTwo_LevelThree_LevelFourEnum value) {
+  switch (value) {
+  case LevelOne_LevelTwo_LevelThree_LevelFourEnum.none:
+    return 0;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for LevelOne_LevelTwo_LevelThree_LevelFourEnum enum.");
+  }
+}
+LevelOne_LevelTwo_LevelThree_LevelFourEnum smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return LevelOne_LevelTwo_LevelThree_LevelFourEnum.none;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for LevelOne_LevelTwo_LevelThree_LevelFourEnum enum.");
+  }
+}
+void smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_releaseFfiHandle(int handle) {}
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_create_handle_nullable');
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_release_handle_nullable');
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable');
+Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_toFfi_nullable(LevelOne_LevelTwo_LevelThree_LevelFourEnum value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_toFfi(value);
+  final result = _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_create_handle_nullable(_handle);
+  smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_releaseFfiHandle(_handle);
+  return result;
+}
+LevelOne_LevelTwo_LevelThree_LevelFourEnum smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable(handle);
+  final result = smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_fromFfi(_handle);
+  smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_release_handle_nullable(handle);
+// End of LevelOne_LevelTwo_LevelThree_LevelFourEnum "private" section.
+class LevelOne_LevelTwo_LevelThree_LevelFour {
+  String stringField;
+  LevelOne_LevelTwo_LevelThree_LevelFour(this.stringField);
+  static final bool foo = false;
+  static LevelOne_LevelTwo_LevelThree_LevelFour fooFactory() {
+    final _fooFactory_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fooFactory');
+    final __result_handle = _fooFactory_ffi();
+    final _result = smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi(__result_handle);
+    smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+// LevelOne_LevelTwo_LevelThree_LevelFour "private" section, not exported.
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle');
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle');
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField');
+Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi(LevelOne_LevelTwo_LevelThree_LevelFour value) {
+  final _stringField_handle = String_toFfi(value.stringField);
+  final _result = _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle(_stringField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  return _result;
+}
+LevelOne_LevelTwo_LevelThree_LevelFour smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi(Pointer<Void> handle) {
+  final _stringField_handle = _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField(handle);
+  final _result = LevelOne_LevelTwo_LevelThree_LevelFour(
+    String_fromFfi(_stringField_handle)
+  );
+  String_releaseFfiHandle(_stringField_handle);
+  return _result;
+}
+void smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(Pointer<Void> handle) => _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle(handle);
+// Nullable LevelOne_LevelTwo_LevelThree_LevelFour
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle_nullable');
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable');
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable');
+Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi_nullable(LevelOne_LevelTwo_LevelThree_LevelFour value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi(value);
+  final result = _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle_nullable(_handle);
+  smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(_handle);
+  return result;
+}
+LevelOne_LevelTwo_LevelThree_LevelFour smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable(handle);
+  final result = smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi(_handle);
+  smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable(handle);
+// End of LevelOne_LevelTwo_LevelThree_LevelFour "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterClass.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterClass.dart
@@ -1,0 +1,142 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_OuterClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_OuterClass_copy_handle');
+final _smoke_OuterClass_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_OuterClass_release_handle');
+class OuterClass {
+  final Pointer<Void> _handle;
+  OuterClass._(this._handle);
+  void release() => _smoke_OuterClass_release_handle(_handle);
+  String foo(String input) {
+    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_OuterClass_foo__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _foo_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_OuterClass_toFfi(OuterClass value) =>
+  _smoke_OuterClass_copy_handle(value._handle);
+OuterClass smoke_OuterClass_fromFfi(Pointer<Void> handle) =>
+  OuterClass._(_smoke_OuterClass_copy_handle(handle));
+void smoke_OuterClass_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_OuterClass_release_handle(handle);
+Pointer<Void> smoke_OuterClass_toFfi_nullable(OuterClass value) =>
+  value != null ? smoke_OuterClass_toFfi(value) : Pointer<Void>.fromAddress(0);
+OuterClass smoke_OuterClass_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_OuterClass_fromFfi(handle) : null;
+void smoke_OuterClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_OuterClass_release_handle(handle);
+final _smoke_OuterClass_InnerClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_OuterClass_InnerClass_copy_handle');
+final _smoke_OuterClass_InnerClass_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_OuterClass_InnerClass_release_handle');
+class OuterClass_InnerClass {
+  final Pointer<Void> _handle;
+  OuterClass_InnerClass._(this._handle);
+  void release() => _smoke_OuterClass_InnerClass_release_handle(_handle);
+  String foo(String input) {
+    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_OuterClass_InnerClass_foo__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _foo_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_OuterClass_InnerClass_toFfi(OuterClass_InnerClass value) =>
+  _smoke_OuterClass_InnerClass_copy_handle(value._handle);
+OuterClass_InnerClass smoke_OuterClass_InnerClass_fromFfi(Pointer<Void> handle) =>
+  OuterClass_InnerClass._(_smoke_OuterClass_InnerClass_copy_handle(handle));
+void smoke_OuterClass_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_OuterClass_InnerClass_release_handle(handle);
+Pointer<Void> smoke_OuterClass_InnerClass_toFfi_nullable(OuterClass_InnerClass value) =>
+  value != null ? smoke_OuterClass_InnerClass_toFfi(value) : Pointer<Void>.fromAddress(0);
+OuterClass_InnerClass smoke_OuterClass_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_OuterClass_InnerClass_fromFfi(handle) : null;
+void smoke_OuterClass_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_OuterClass_InnerClass_release_handle(handle);
+abstract class OuterClass_InnerInterface {
+  void release();
+  String foo(String input);
+}
+// OuterClass_InnerInterface "private" section, not exported.
+final _smoke_OuterClass_InnerInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_OuterClass_InnerInterface_copy_handle');
+final _smoke_OuterClass_InnerInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_OuterClass_InnerInterface_release_handle');
+final _smoke_OuterClass_InnerInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Pointer),
+    Pointer<Void> Function(int, Pointer)
+  >('smoke_OuterClass_InnerInterface_create_proxy');
+final _smoke_OuterClass_InnerInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('smoke_OuterClass_InnerInterface_get_raw_pointer');
+int _OuterClass_InnerInterface_instance_counter = 1024;
+final Map<int, OuterClass_InnerInterface> _OuterClass_InnerInterface_instance_cache = {};
+final Map<Pointer<Void>, OuterClass_InnerInterface> _OuterClass_InnerInterface_reverse_cache = {};
+class OuterClass_InnerInterface__Impl implements OuterClass_InnerInterface {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  OuterClass_InnerInterface__Impl(this.handle);
+  @override
+  void release() => _smoke_OuterClass_InnerInterface_release_handle(handle);
+  @override
+  String foo(String input) {
+    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_OuterClass_InnerInterface_foo__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _foo_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+int _OuterClass_InnerInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
+  final _result_object = _OuterClass_InnerInterface_instance_cache[_token].foo(String_fromFfi(input));
+  _result.value = String_toFfi(_result_object);
+  String_releaseFfiHandle(input);
+  return 0;
+}
+Pointer<Void> smoke_OuterClass_InnerInterface_toFfi(OuterClass_InnerInterface value) {
+  if (value is OuterClass_InnerInterface__Impl) return _smoke_OuterClass_InnerInterface_copy_handle(value.handle);
+  const UNKNOWN_ERROR = -1;
+  final token = _OuterClass_InnerInterface_instance_counter++;
+  _OuterClass_InnerInterface_instance_cache[token] = value;
+  final result = _smoke_OuterClass_InnerInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterClass_InnerInterface_foo_static, UNKNOWN_ERROR));
+  _OuterClass_InnerInterface_reverse_cache[_smoke_OuterClass_InnerInterface_get_raw_pointer(result)] = value;
+  return result;
+}
+OuterClass_InnerInterface smoke_OuterClass_InnerInterface_fromFfi(Pointer<Void> handle) {
+  final instance = _OuterClass_InnerInterface_reverse_cache[_smoke_OuterClass_InnerInterface_get_raw_pointer(handle)];
+  return instance != null ? instance : OuterClass_InnerInterface__Impl(_smoke_OuterClass_InnerInterface_copy_handle(handle));
+}
+void smoke_OuterClass_InnerInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_OuterClass_InnerInterface_release_handle(handle);
+Pointer<Void> smoke_OuterClass_InnerInterface_toFfi_nullable(OuterClass_InnerInterface value) =>
+  value != null ? smoke_OuterClass_InnerInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+OuterClass_InnerInterface smoke_OuterClass_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_OuterClass_InnerInterface_fromFfi(handle) : null;
+void smoke_OuterClass_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_OuterClass_InnerInterface_release_handle(handle);
+// End of OuterClass_InnerInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterInterface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterInterface.dart
@@ -1,0 +1,177 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+abstract class OuterInterface {
+  void release();
+  String foo(String input);
+}
+final _smoke_OuterInterface_InnerClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_OuterInterface_InnerClass_copy_handle');
+final _smoke_OuterInterface_InnerClass_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_OuterInterface_InnerClass_release_handle');
+class OuterInterface_InnerClass {
+  final Pointer<Void> _handle;
+  OuterInterface_InnerClass._(this._handle);
+  void release() => _smoke_OuterInterface_InnerClass_release_handle(_handle);
+  String foo(String input) {
+    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_OuterInterface_InnerClass_foo__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _foo_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_OuterInterface_InnerClass_toFfi(OuterInterface_InnerClass value) =>
+  _smoke_OuterInterface_InnerClass_copy_handle(value._handle);
+OuterInterface_InnerClass smoke_OuterInterface_InnerClass_fromFfi(Pointer<Void> handle) =>
+  OuterInterface_InnerClass._(_smoke_OuterInterface_InnerClass_copy_handle(handle));
+void smoke_OuterInterface_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_OuterInterface_InnerClass_release_handle(handle);
+Pointer<Void> smoke_OuterInterface_InnerClass_toFfi_nullable(OuterInterface_InnerClass value) =>
+  value != null ? smoke_OuterInterface_InnerClass_toFfi(value) : Pointer<Void>.fromAddress(0);
+OuterInterface_InnerClass smoke_OuterInterface_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_OuterInterface_InnerClass_fromFfi(handle) : null;
+void smoke_OuterInterface_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_OuterInterface_InnerClass_release_handle(handle);
+abstract class OuterInterface_InnerInterface {
+  void release();
+  String foo(String input);
+}
+// OuterInterface_InnerInterface "private" section, not exported.
+final _smoke_OuterInterface_InnerInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_OuterInterface_InnerInterface_copy_handle');
+final _smoke_OuterInterface_InnerInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_OuterInterface_InnerInterface_release_handle');
+final _smoke_OuterInterface_InnerInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Pointer),
+    Pointer<Void> Function(int, Pointer)
+  >('smoke_OuterInterface_InnerInterface_create_proxy');
+final _smoke_OuterInterface_InnerInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('smoke_OuterInterface_InnerInterface_get_raw_pointer');
+int _OuterInterface_InnerInterface_instance_counter = 1024;
+final Map<int, OuterInterface_InnerInterface> _OuterInterface_InnerInterface_instance_cache = {};
+final Map<Pointer<Void>, OuterInterface_InnerInterface> _OuterInterface_InnerInterface_reverse_cache = {};
+class OuterInterface_InnerInterface__Impl implements OuterInterface_InnerInterface {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  OuterInterface_InnerInterface__Impl(this.handle);
+  @override
+  void release() => _smoke_OuterInterface_InnerInterface_release_handle(handle);
+  @override
+  String foo(String input) {
+    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_OuterInterface_InnerInterface_foo__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _foo_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+int _OuterInterface_InnerInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
+  final _result_object = _OuterInterface_InnerInterface_instance_cache[_token].foo(String_fromFfi(input));
+  _result.value = String_toFfi(_result_object);
+  String_releaseFfiHandle(input);
+  return 0;
+}
+Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi(OuterInterface_InnerInterface value) {
+  if (value is OuterInterface_InnerInterface__Impl) return _smoke_OuterInterface_InnerInterface_copy_handle(value.handle);
+  const UNKNOWN_ERROR = -1;
+  final token = _OuterInterface_InnerInterface_instance_counter++;
+  _OuterInterface_InnerInterface_instance_cache[token] = value;
+  final result = _smoke_OuterInterface_InnerInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterInterface_InnerInterface_foo_static, UNKNOWN_ERROR));
+  _OuterInterface_InnerInterface_reverse_cache[_smoke_OuterInterface_InnerInterface_get_raw_pointer(result)] = value;
+  return result;
+}
+OuterInterface_InnerInterface smoke_OuterInterface_InnerInterface_fromFfi(Pointer<Void> handle) {
+  final instance = _OuterInterface_InnerInterface_reverse_cache[_smoke_OuterInterface_InnerInterface_get_raw_pointer(handle)];
+  return instance != null ? instance : OuterInterface_InnerInterface__Impl(_smoke_OuterInterface_InnerInterface_copy_handle(handle));
+}
+void smoke_OuterInterface_InnerInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_OuterInterface_InnerInterface_release_handle(handle);
+Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi_nullable(OuterInterface_InnerInterface value) =>
+  value != null ? smoke_OuterInterface_InnerInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+OuterInterface_InnerInterface smoke_OuterInterface_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_OuterInterface_InnerInterface_fromFfi(handle) : null;
+void smoke_OuterInterface_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_OuterInterface_InnerInterface_release_handle(handle);
+// End of OuterInterface_InnerInterface "private" section.
+// OuterInterface "private" section, not exported.
+final _smoke_OuterInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_OuterInterface_copy_handle');
+final _smoke_OuterInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_OuterInterface_release_handle');
+final _smoke_OuterInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Pointer),
+    Pointer<Void> Function(int, Pointer)
+  >('smoke_OuterInterface_create_proxy');
+final _smoke_OuterInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('smoke_OuterInterface_get_raw_pointer');
+int _OuterInterface_instance_counter = 1024;
+final Map<int, OuterInterface> _OuterInterface_instance_cache = {};
+final Map<Pointer<Void>, OuterInterface> _OuterInterface_reverse_cache = {};
+class OuterInterface__Impl implements OuterInterface {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  OuterInterface__Impl(this.handle);
+  @override
+  void release() => _smoke_OuterInterface_release_handle(handle);
+  @override
+  String foo(String input) {
+    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_OuterInterface_foo__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _foo_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+int _OuterInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
+  final _result_object = _OuterInterface_instance_cache[_token].foo(String_fromFfi(input));
+  _result.value = String_toFfi(_result_object);
+  String_releaseFfiHandle(input);
+  return 0;
+}
+Pointer<Void> smoke_OuterInterface_toFfi(OuterInterface value) {
+  if (value is OuterInterface__Impl) return _smoke_OuterInterface_copy_handle(value.handle);
+  const UNKNOWN_ERROR = -1;
+  final token = _OuterInterface_instance_counter++;
+  _OuterInterface_instance_cache[token] = value;
+  final result = _smoke_OuterInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterInterface_foo_static, UNKNOWN_ERROR));
+  _OuterInterface_reverse_cache[_smoke_OuterInterface_get_raw_pointer(result)] = value;
+  return result;
+}
+OuterInterface smoke_OuterInterface_fromFfi(Pointer<Void> handle) {
+  final instance = _OuterInterface_reverse_cache[_smoke_OuterInterface_get_raw_pointer(handle)];
+  return instance != null ? instance : OuterInterface__Impl(_smoke_OuterInterface_copy_handle(handle));
+}
+void smoke_OuterInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_OuterInterface_release_handle(handle);
+Pointer<Void> smoke_OuterInterface_toFfi_nullable(OuterInterface value) =>
+  value != null ? smoke_OuterInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+OuterInterface smoke_OuterInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_OuterInterface_fromFfi(handle) : null;
+void smoke_OuterInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_OuterInterface_release_handle(handle);
+// End of OuterInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/UseFreeTypes.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/UseFreeTypes.dart
@@ -1,0 +1,69 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/smoke/FreeEnum.dart';
+import 'package:library/src/smoke/FreeException.dart';
+import 'package:library/src/smoke/FreePoint.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_UseFreeTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_UseFreeTypes_copy_handle');
+final _smoke_UseFreeTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_UseFreeTypes_release_handle');
+final _doStuff_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_release_handle');
+final _doStuff_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_get_result');
+final _doStuff_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_get_error');
+final _doStuff_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_has_error');
+class UseFreeTypes {
+  final Pointer<Void> _handle;
+  UseFreeTypes._(this._handle);
+  void release() => _smoke_UseFreeTypes_release_handle(_handle);
+  DateTime doStuff(FreePoint point, FreeEnum mode) {
+    final _doStuff_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, Pointer<Void>, int)>('smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum');
+    final _point_handle = smoke_FreePoint_toFfi(point);
+    final _mode_handle = smoke_FreeEnum_toFfi(mode);
+    final __call_result_handle = _doStuff_ffi(_handle, _point_handle, _mode_handle);
+    smoke_FreePoint_releaseFfiHandle(_point_handle);
+    smoke_FreeEnum_releaseFfiHandle(_mode_handle);
+    if (_doStuff_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _doStuff_return_get_error(__call_result_handle);
+        _doStuff_return_release_handle(__call_result_handle);
+        final _error_value = smoke_FreeEnum_fromFfi(__error_handle);
+        smoke_FreeEnum_releaseFfiHandle(__error_handle);
+        throw FreeException(_error_value);
+    }
+    final __result_handle = _doStuff_return_get_result(__call_result_handle);
+    _doStuff_return_release_handle(__call_result_handle);
+    final _result = Date_fromFfi(__result_handle);
+    Date_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_UseFreeTypes_toFfi(UseFreeTypes value) =>
+  _smoke_UseFreeTypes_copy_handle(value._handle);
+UseFreeTypes smoke_UseFreeTypes_fromFfi(Pointer<Void> handle) =>
+  UseFreeTypes._(_smoke_UseFreeTypes_copy_handle(handle));
+void smoke_UseFreeTypes_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_UseFreeTypes_release_handle(handle);
+Pointer<Void> smoke_UseFreeTypes_toFfi_nullable(UseFreeTypes value) =>
+  value != null ? smoke_UseFreeTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
+UseFreeTypes smoke_UseFreeTypes_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_UseFreeTypes_fromFfi(handle) : null;
+void smoke_UseFreeTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_UseFreeTypes_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/input/PlatformNames.lime
+++ b/gluecodium/src/test/resources/smoke/platform_names/input/PlatformNames.lime
@@ -19,26 +19,31 @@ package smoke
 
 @Cpp("fooTypes")
 @Swift("bazTypes")
+@Dart("weeTypes")
 types PlatformNames {
 
     @Cpp("fooStruct")
     @Java("barStruct")
     @Swift("bazStruct")
+    @Dart("weeStruct")
     struct BasicStruct {
 
         @Cpp("FOO_FIELD")
         @Java("BAR_FIELD")
         @Swift("BAZ_FIELD")
+        @Dart("WEE_FIELD")
         stringField: String
 
         @Cpp("FooCreate")
         @Java("BarCreate")
         @Swift("BazCreate")
+        @Dart("WeeCreate")
         constructor make(
 
             @Cpp("FooParameter")
             @Java("BarParameter")
             @Swift(Name = "BazParameter", Label = "_")
+            @Dart("WeeParameter")
             basicParameter: String
         )
     }
@@ -46,11 +51,13 @@ types PlatformNames {
     @Cpp("fooEnum")
     @Java("barEnum")
     @Swift("bazEnum")
+    @Dart("werrEnum")
     enum BasicEnum {
 
         @Cpp("foo_item")
         @Java("bar_item")
         @Swift("BAZ_ITEM")
+        @Dart("WEE_ITEM")
         BASIC_ITEM
     }
 
@@ -62,31 +69,37 @@ types PlatformNames {
 @Cpp("fooInterface")
 @Java("barInterface")
 @Swift("bazInterface")
+@Dart("weeInterface")
 class PlatformNamesInterface {
 
     @Cpp("FooMethod")
     @Java("BarMethod")
     @Swift("BazMethod")
+    @Dart("WeeMethod")
     fun basicMethod(
 
         @Cpp("FooParameter")
         @Java("BarParameter")
         @Swift(Name = "BazParameter", Label = "_")
+        @Dart("WeeParameter")
         basicParameter: String
     ): PlatformNames.BasicStruct
 
     @Cpp("make")
     @Java("make")
     @Swift("make")
+    @Dart("make")
     constructor create(
 
         @Cpp("makeParameter")
         @Java("makeParameter")
         @Swift(Name = "makeParameter", Label = "_")
+        @Dart("makeParameter")
         basicParameter: String
     )
 
     @Swift("BAZ_PROPERTY")
+    @Dart("WEE_PROPERTY")
     property basicProperty: UInt {
         @Cpp("GET_FOO_PROPERTY")
         @Java("GET_BAR_PROPERTY")
@@ -100,16 +113,19 @@ class PlatformNamesInterface {
 @Cpp("fooListener")
 @Java("barListener")
 @Swift("bazListener")
+@Dart("weeListener")
 interface PlatformNamesListener {
 
     @Cpp("FooMethod")
     @Java("BarMethod")
     @Swift("BazMethod")
+    @Dart("WeeMethod")
     fun basicMethod(
 
         @Cpp("FooParameter")
         @Java("BarParameter")
         @Swift(Name = "BazParameter", Label = "_")
+        @Dart("WeeParameter")
         basicParameter: String
     )
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeInterface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeInterface.dart
@@ -1,0 +1,64 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/smoke/weeTypes.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_PlatformNamesInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PlatformNamesInterface_copy_handle');
+final _smoke_PlatformNamesInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PlatformNamesInterface_release_handle');
+class weeInterface {
+  final Pointer<Void> _handle;
+  weeInterface._(this._handle);
+  void release() => _smoke_PlatformNamesInterface_release_handle(_handle);
+  weeInterface(String makeParameter) : this._(_make(makeParameter));
+  weeStruct WeeMethod(String WeeParameter) {
+    final _WeeMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_PlatformNamesInterface_basicMethod__String');
+    final _WeeParameter_handle = String_toFfi(WeeParameter);
+    final __result_handle = _WeeMethod_ffi(_handle, _WeeParameter_handle);
+    String_releaseFfiHandle(_WeeParameter_handle);
+    final _result = smoke_PlatformNames_BasicStruct_fromFfi(__result_handle);
+    smoke_PlatformNames_BasicStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static Pointer<Void> _make(String makeParameter) {
+    final _make_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_PlatformNamesInterface_create__String');
+    final _makeParameter_handle = String_toFfi(makeParameter);
+    final __result_handle = _make_ffi(_makeParameter_handle);
+    String_releaseFfiHandle(_makeParameter_handle);
+    return __result_handle;
+  }
+  int get WEE_PROPERTY {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('smoke_PlatformNamesInterface_basicProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  set WEE_PROPERTY(int value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint32), void Function(Pointer<Void>, int)>('smoke_PlatformNamesInterface_basicProperty_set__UInt');
+    final _value_handle = (value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    (_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_PlatformNamesInterface_toFfi(weeInterface value) =>
+  _smoke_PlatformNamesInterface_copy_handle(value._handle);
+weeInterface smoke_PlatformNamesInterface_fromFfi(Pointer<Void> handle) =>
+  weeInterface._(_smoke_PlatformNamesInterface_copy_handle(handle));
+void smoke_PlatformNamesInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_PlatformNamesInterface_release_handle(handle);
+Pointer<Void> smoke_PlatformNamesInterface_toFfi_nullable(weeInterface value) =>
+  value != null ? smoke_PlatformNamesInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+weeInterface smoke_PlatformNamesInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_PlatformNamesInterface_fromFfi(handle) : null;
+void smoke_PlatformNamesInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PlatformNamesInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeListener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeListener.dart
@@ -1,0 +1,73 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+abstract class weeListener {
+  void release();
+  WeeMethod(String WeeParameter);
+}
+// weeListener "private" section, not exported.
+final _smoke_PlatformNamesListener_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PlatformNamesListener_copy_handle');
+final _smoke_PlatformNamesListener_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PlatformNamesListener_release_handle');
+final _smoke_PlatformNamesListener_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Pointer),
+    Pointer<Void> Function(int, Pointer)
+  >('smoke_PlatformNamesListener_create_proxy');
+final _smoke_PlatformNamesListener_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('smoke_PlatformNamesListener_get_raw_pointer');
+int _weeListener_instance_counter = 1024;
+final Map<int, weeListener> _weeListener_instance_cache = {};
+final Map<Pointer<Void>, weeListener> _weeListener_reverse_cache = {};
+class weeListener__Impl implements weeListener {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  weeListener__Impl(this.handle);
+  @override
+  void release() => _smoke_PlatformNamesListener_release_handle(handle);
+  @override
+  WeeMethod(String WeeParameter) {
+    final _WeeMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_PlatformNamesListener_basicMethod__String');
+    final _WeeParameter_handle = String_toFfi(WeeParameter);
+    final __result_handle = _WeeMethod_ffi(_handle, _WeeParameter_handle);
+    String_releaseFfiHandle(_WeeParameter_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+int _weeListener_WeeMethod_static(int _token, Pointer<Void> WeeParameter) {
+  _weeListener_instance_cache[_token].WeeMethod(String_fromFfi(WeeParameter));
+  String_releaseFfiHandle(WeeParameter);
+  return 0;
+}
+Pointer<Void> smoke_PlatformNamesListener_toFfi(weeListener value) {
+  if (value is weeListener__Impl) return _smoke_PlatformNamesListener_copy_handle(value.handle);
+  const UNKNOWN_ERROR = -1;
+  final token = _weeListener_instance_counter++;
+  _weeListener_instance_cache[token] = value;
+  final result = _smoke_PlatformNamesListener_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_weeListener_WeeMethod_static, UNKNOWN_ERROR));
+  _weeListener_reverse_cache[_smoke_PlatformNamesListener_get_raw_pointer(result)] = value;
+  return result;
+}
+weeListener smoke_PlatformNamesListener_fromFfi(Pointer<Void> handle) {
+  final instance = _weeListener_reverse_cache[_smoke_PlatformNamesListener_get_raw_pointer(handle)];
+  return instance != null ? instance : weeListener__Impl(_smoke_PlatformNamesListener_copy_handle(handle));
+}
+void smoke_PlatformNamesListener_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_PlatformNamesListener_release_handle(handle);
+Pointer<Void> smoke_PlatformNamesListener_toFfi_nullable(weeListener value) =>
+  value != null ? smoke_PlatformNamesListener_toFfi(value) : Pointer<Void>.fromAddress(0);
+weeListener smoke_PlatformNamesListener_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_PlatformNamesListener_fromFfi(handle) : null;
+void smoke_PlatformNamesListener_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PlatformNamesListener_release_handle(handle);
+// End of weeListener "private" section.

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeTypes.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeTypes.dart
@@ -1,0 +1,130 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+enum werrEnum {
+    WEE_ITEM
+}
+// werrEnum "private" section, not exported.
+int smoke_PlatformNames_BasicEnum_toFfi(werrEnum value) {
+  switch (value) {
+  case werrEnum.WEE_ITEM:
+    return 0;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for werrEnum enum.");
+  }
+}
+werrEnum smoke_PlatformNames_BasicEnum_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return werrEnum.WEE_ITEM;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for werrEnum enum.");
+  }
+}
+void smoke_PlatformNames_BasicEnum_releaseFfiHandle(int handle) {}
+final _smoke_PlatformNames_BasicEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('smoke_PlatformNames_BasicEnum_create_handle_nullable');
+final _smoke_PlatformNames_BasicEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PlatformNames_BasicEnum_release_handle_nullable');
+final _smoke_PlatformNames_BasicEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('smoke_PlatformNames_BasicEnum_get_value_nullable');
+Pointer<Void> smoke_PlatformNames_BasicEnum_toFfi_nullable(werrEnum value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_PlatformNames_BasicEnum_toFfi(value);
+  final result = _smoke_PlatformNames_BasicEnum_create_handle_nullable(_handle);
+  smoke_PlatformNames_BasicEnum_releaseFfiHandle(_handle);
+  return result;
+}
+werrEnum smoke_PlatformNames_BasicEnum_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_PlatformNames_BasicEnum_get_value_nullable(handle);
+  final result = smoke_PlatformNames_BasicEnum_fromFfi(_handle);
+  smoke_PlatformNames_BasicEnum_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_PlatformNames_BasicEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PlatformNames_BasicEnum_release_handle_nullable(handle);
+// End of werrEnum "private" section.
+class weeStruct {
+  String WEE_FIELD;
+  weeStruct._(this.WEE_FIELD);
+  weeStruct._copy(weeStruct _other) : this._(_other.WEE_FIELD);
+  weeStruct(String WeeParameter) : this._copy(_WeeCreate(WeeParameter));
+  static weeStruct _WeeCreate(String WeeParameter) {
+    final _WeeCreate_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_PlatformNames_BasicStruct_make__String');
+    final _WeeParameter_handle = String_toFfi(WeeParameter);
+    final __result_handle = _WeeCreate_ffi(_WeeParameter_handle);
+    String_releaseFfiHandle(_WeeParameter_handle);
+    final _result = smoke_PlatformNames_BasicStruct_fromFfi(__result_handle);
+    smoke_PlatformNames_BasicStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+// weeStruct "private" section, not exported.
+final _smoke_PlatformNames_BasicStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PlatformNames_BasicStruct_create_handle');
+final _smoke_PlatformNames_BasicStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PlatformNames_BasicStruct_release_handle');
+final _smoke_PlatformNames_BasicStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PlatformNames_BasicStruct_get_field_stringField');
+Pointer<Void> smoke_PlatformNames_BasicStruct_toFfi(weeStruct value) {
+  final _WEE_FIELD_handle = String_toFfi(value.WEE_FIELD);
+  final _result = _smoke_PlatformNames_BasicStruct_create_handle(_WEE_FIELD_handle);
+  String_releaseFfiHandle(_WEE_FIELD_handle);
+  return _result;
+}
+weeStruct smoke_PlatformNames_BasicStruct_fromFfi(Pointer<Void> handle) {
+  final _WEE_FIELD_handle = _smoke_PlatformNames_BasicStruct_get_field_stringField(handle);
+  final _result = weeStruct._(
+    String_fromFfi(_WEE_FIELD_handle)
+  );
+  String_releaseFfiHandle(_WEE_FIELD_handle);
+  return _result;
+}
+void smoke_PlatformNames_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PlatformNames_BasicStruct_release_handle(handle);
+// Nullable weeStruct
+final _smoke_PlatformNames_BasicStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PlatformNames_BasicStruct_create_handle_nullable');
+final _smoke_PlatformNames_BasicStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('smoke_PlatformNames_BasicStruct_release_handle_nullable');
+final _smoke_PlatformNames_BasicStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('smoke_PlatformNames_BasicStruct_get_value_nullable');
+Pointer<Void> smoke_PlatformNames_BasicStruct_toFfi_nullable(weeStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_PlatformNames_BasicStruct_toFfi(value);
+  final result = _smoke_PlatformNames_BasicStruct_create_handle_nullable(_handle);
+  smoke_PlatformNames_BasicStruct_releaseFfiHandle(_handle);
+  return result;
+}
+weeStruct smoke_PlatformNames_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_PlatformNames_BasicStruct_get_value_nullable(handle);
+  final result = smoke_PlatformNames_BasicStruct_fromFfi(_handle);
+  smoke_PlatformNames_BasicStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_PlatformNames_BasicStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PlatformNames_BasicStruct_release_handle_nullable(handle);
+// End of weeStruct "private" section.

--- a/gluecodium/src/test/resources/smoke/platform_names/output/lime/smoke/PlatformNames.lime
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/lime/smoke/PlatformNames.lime
@@ -1,38 +1,41 @@
 package smoke
-
 @Cpp("fooTypes")
 @Swift("bazTypes")
+@Dart("weeTypes")
 types PlatformNames {
     @Cpp("fooTypedef")
     @Swift("bazTypedef")
     typealias BasicTypedef = Double
-
     @Cpp("fooEnum")
     @Java("barEnum")
     @Swift("bazEnum")
+    @Dart("werrEnum")
     enum BasicEnum {
         @Cpp("foo_item")
         @Java("bar_item")
         @Swift("BAZ_ITEM")
+        @Dart("WEE_ITEM")
         BASIC_ITEM
     }
-
     @Cpp("fooStruct")
     @Java("barStruct")
     @Swift("bazStruct")
+    @Dart("weeStruct")
     struct BasicStruct {
         @Cpp("FOO_FIELD")
         @Java("BAR_FIELD")
         @Swift("BAZ_FIELD")
+        @Dart("WEE_FIELD")
         stringField: String
-
         @Cpp("FooCreate")
         @Java("BarCreate")
         @Swift("BazCreate")
+        @Dart("WeeCreate")
         constructor make(
             @Cpp("FooParameter")
             @Java("BarParameter")
             @Swift("BazParameter", Label = "_")
+            @Dart("WeeParameter")
             basicParameter: String
         )
     }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/lime/smoke/PlatformNamesInterface.lime
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/lime/smoke/PlatformNamesInterface.lime
@@ -1,31 +1,34 @@
 package smoke
-
 import smoke.PlatformNames.BasicStruct
 @Cpp("fooInterface")
 @Java("barInterface")
 @Swift("bazInterface")
+@Dart("weeInterface")
 class PlatformNamesInterface {
     @Cpp("FooMethod")
     @Java("BarMethod")
     @Swift("BazMethod")
+    @Dart("WeeMethod")
     fun basicMethod(
         @Cpp("FooParameter")
         @Java("BarParameter")
         @Swift("BazParameter", Label = "_")
+        @Dart("WeeParameter")
         basicParameter: String
     ): BasicStruct
-
     @Cpp("make")
     @Java("make")
     @Swift("make")
+    @Dart("make")
     constructor create(
         @Cpp("makeParameter")
         @Java("makeParameter")
         @Swift("makeParameter", Label = "_")
+        @Dart("makeParameter")
         basicParameter: String
     )
-
     @Swift("BAZ_PROPERTY")
+    @Dart("WEE_PROPERTY")
     property basicProperty: UInt {
         @Cpp("GET_FOO_PROPERTY")
         @Java("GET_BAR_PROPERTY")

--- a/gluecodium/src/test/resources/smoke/platform_names/output/lime/smoke/PlatformNamesListener.lime
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/lime/smoke/PlatformNamesListener.lime
@@ -1,16 +1,18 @@
 package smoke
-
 @Cpp("fooListener")
 @Java("barListener")
 @Swift("bazListener")
+@Dart("weeListener")
 interface PlatformNamesListener {
     @Cpp("FooMethod")
     @Java("BarMethod")
     @Swift("BazMethod")
+    @Dart("WeeMethod")
     fun basicMethod(
         @Cpp("FooParameter")
         @Java("BarParameter")
         @Swift("BazParameter", Label = "_")
+        @Dart("WeeParameter")
         basicParameter: String
     )
 }


### PR DESCRIPTION
Enabled remaining functional tests that were not enabled for Dart yet.
Marked tests for features that are not implemented in Dart yet with TODO
comments referencing the appropriate issue number.

Added missing Dart smoke tests for "Dates", "Escaped Names",
"Inheritance", "Nesting", and "Platform Names" features.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>