### PR TITLE
Add support for doc comments to Dart generator

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -347,8 +347,7 @@ feature(StructsWithCompanion cpp android swift dart SOURCES
     lime/test/StructsWithConstants.lime
 )
 
-#TODO: #80 enable for Dart
-feature(Comments cpp android swift SOURCES
+feature(Comments cpp android swift dart SOURCES
     src/test/Comments.cpp
 
     lime/test/Comments.lime

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/GetAttributeHelper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/GetAttributeHelper.kt
@@ -22,21 +22,18 @@ package com.here.gluecodium.generator.common.templates
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeNamedElement
-import org.trimou.handlebars.BasicSectionHelper
+import org.trimou.handlebars.BasicHelper
 import org.trimou.handlebars.Options
 
 /**
- * ifHasAttribute: Check the presence of the attribute with given type and given value type (if present) on the
- * given LIME element and execute the section if it is there. If LIME element is omitted, `this` is
- * taken instead.<br/>
- * Usage: {{#ifHasAttribute \[limeElement\] "attributeType" \["attributeValueType"\]}}...{{/ifHasAttribute}}<br/>
- * Example: {{#ifHasAttribute "equatable"}}...{{/ifHasAttribute}}<br/>
- * Example: {{#ifHasAttribute type "equatable"}}...{{/ifHasAttribute}}<br/>
- * Example: {{#ifHasAttribute type "cpp" "accessors"}}...{{/ifHasAttribute}}<br/>
- * unlessHasAttribute: same as above, except the the section is executed only if the attribute is
- * not there.
+ * getAttribute: Get the value of the attribute with given type and given value type (if present) on the
+ * given LIME element.<br/>
+ * Usage: {{getAttribute \[limeElement\] "attributeType" \["attributeValueType"\]}}<br/>
+ * Example: {{getAttribute "equatable"}}<br/>
+ * Example: {{getAttribute type "equatable"}}<br/>
+ * Example: {{getAttribute type "cpp" "accessors"}}
  */
-internal class IfHasAttributeHelper(private val equality: Boolean) : BasicSectionHelper() {
+internal class GetAttributeHelper : BasicHelper() {
     override fun execute(options: Options) {
         val limeElement: LimeNamedElement
         val attributeTypeName: String
@@ -55,16 +52,10 @@ internal class IfHasAttributeHelper(private val equality: Boolean) : BasicSectio
         }
 
         val attributeType = resolveAttributeType(attributeTypeName) ?: return
-        if (attributeValueTypeName == null) {
-            if (limeElement.attributes.have(attributeType) == equality) {
-                options.fn()
-            }
-        } else {
-            val attributeValueType = resolveAttributeValueType(attributeValueTypeName) ?: return
-            if (limeElement.attributes.have(attributeType, attributeValueType) == equality) {
-                options.fn()
-            }
-        }
+        val attributeValueType = attributeValueTypeName?.let { resolveAttributeValueType(it) }
+            ?: attributeType.defaultValueType
+            ?: return
+        limeElement.attributes.get(attributeType, attributeValueType)?.let { options.append(it) }
     }
 
     private fun resolveAttributeType(attributeTypeName: String) =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/NameResolverHelper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/NameResolverHelper.kt
@@ -35,7 +35,9 @@ import org.trimou.handlebars.Options
  * Example: {{resolveName visibility}}<br/>
  * Example: {{resolveName "C++"}}<br/>
  * Example: {{resolveName returnType.typeRef "C++"}}<br/>
- * Example: {{resolveName field "C++" "getter"}}
+ * Example: {{resolveName field "C++" "getter"}}<br/>
+ * <br/>
+ * Also can be used as a section helper, e.g. {{#resolveName visibility}}...{{/resolveName}}
  */
 internal class NameResolverHelper : BasicHelper() {
     val nameResolvers = mutableMapOf<String, NameResolver>()
@@ -72,7 +74,14 @@ internal class NameResolverHelper : BasicHelper() {
             "setter" -> resolver.resolveSetterName(element)
             else -> resolver.resolveName(element)
         }
-        options.append(name)
+
+        if (isSection(options)) {
+            options.push(name)
+            options.fn()
+            options.pop()
+        } else {
+            options.append(name)
+        }
     }
 
     override fun numberOfRequiredParameters() = 0

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/TemplateEngine.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/TemplateEngine.kt
@@ -50,6 +50,7 @@ object TemplateEngine {
             .registerHelper("resolveName", nameResolverHelper)
             .registerHelper("ifHasAttribute", IfHasAttributeHelper(true))
             .registerHelper("unlessHasAttribute", IfHasAttributeHelper(false))
+            .registerHelper("getAttribute", GetAttributeHelper())
             .registerHelpers(
                 HelpersBuilder.empty()
                     .addIsEqual()

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartCommentsProcessor.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.dart
+
+import com.here.gluecodium.platform.common.CommentsProcessor
+import com.vladsch.flexmark.ast.LinkRef
+import com.vladsch.flexmark.formatter.Formatter
+import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
+
+internal class DartCommentsProcessor : CommentsProcessor(Formatter.builder().build()) {
+    override fun processLink(linkNode: LinkRef, linkReference: String) {
+        linkNode.reference = BasedSequenceImpl.of(linkReference)
+        linkNode.referenceOpeningMarker = BasedSequenceImpl.of("[")
+        linkNode.referenceClosingMarker = BasedSequenceImpl.of("]")
+        linkNode.firstChild.unlink()
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -21,6 +21,7 @@ package com.here.gluecodium.generator.dart
 
 import com.here.gluecodium.Gluecodium
 import com.here.gluecodium.cli.GluecodiumExecutionException
+import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.common.LimeTypeRefsVisitor
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.NameResolver
@@ -59,6 +60,7 @@ import com.here.gluecodium.model.lime.LimeTypeHelper
 import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeTypesCollection
 import com.here.gluecodium.platform.common.GeneratorSuite
+import java.util.logging.Logger
 
 class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
 
@@ -70,7 +72,11 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
     private val internalNamespace = options.cppInternalNamespace
 
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
-        val dartNameResolver = DartNameResolver(limeModel.referenceMap, nameRules)
+        val dartNameResolver = DartNameResolver(
+            limeModel.referenceMap,
+            nameRules,
+            LimeLogger(logger, limeModel.fileNameMap)
+        )
         val ffiNameResolver = FfiNameResolver(limeModel.referenceMap, nameRules)
 
         val dartResolvers = mapOf(
@@ -414,6 +420,8 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
 
     companion object {
         const val GENERATOR_NAME = "dart"
+
+        private val logger = Logger.getLogger(DartGeneratorSuite::class.java.name)
         private const val ROOT_DIR = GENERATOR_NAME
         private const val LIB_DIR = "$ROOT_DIR/lib"
         private const val SRC_DIR_SUFFIX = "src"

--- a/gluecodium/src/main/resources/templates/dart/DartDocumentation.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartDocumentation.mustache
@@ -18,5 +18,8 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless comment.isEmpty}}{{prefix comment "/// "}}
-{{/unless}}
+{{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "/// "}}
+{{/unless}}{{/resolveName}}{{!!
+}}{{#ifHasAttribute "Deprecated"}}
+@Deprecated("{{getAttribute "Deprecated"}}")
+{{/ifHasAttribute}}

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
@@ -18,11 +18,14 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless comment.isEmpty}}{{prefix comment "/// "}}
-{{/unless}}{{!!
-}}{{#parameters}}{{#unless comment.isEmpty}}/// @param[{{name}}] {{prefix comment "/// " skipFirstLine=true}}
-{{/unless}}{{/parameters}}{{!!
-}}{{#unless returnType.comment.isEmpty}}/// @return {{prefix returnType.comment "/// " skipFirstLine=true}}
-{{/unless}}{{!!
-}}{{#if thrownType}}{{#unless thrownType.comment.isEmpty}}/// @throws {{prefix thrownType.comment "/// " skipFirstLine=true}}
-{{/unless}}{{/if}}
+{{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "/// "}}
+{{/unless}}{{/resolveName}}{{!!
+}}{{#parameters}}{{#resolveName comment}}{{#unless this.isEmpty}}/// @param[{{name}}] {{prefix this "/// " skipFirstLine=true}}
+{{/unless}}{{/resolveName}}{{/parameters}}{{!!
+}}{{#resolveName returnType.comment}}{{#unless this.isEmpty}}/// @return {{prefix this "/// " skipFirstLine=true}}
+{{/unless}}{{/resolveName}}{{!!
+}}{{#if thrownType}}{{#resolveName thrownType.comment}}{{#unless this.isEmpty}}/// @throws {{prefix this "/// " skipFirstLine=true}}
+{{/unless}}{{/resolveName}}{{/if}}{{!!
+}}{{#ifHasAttribute "Deprecated"}}
+@Deprecated("{{getAttribute "Deprecated"}}")
+{{/ifHasAttribute}}

--- a/gluecodium/src/main/resources/templates/dart/DartProperty.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartProperty.mustache
@@ -20,14 +20,12 @@
   !}}
 {{#set property=this}}
 {{#getter}}
-{{#unless comment.isEmpty}}{{prefix comment "/// "}}
-{{/unless}}
+{{>dart/DartDocumentation}}
 {{#if isStatic}}static {{/if}}{{resolveName property.typeRef}} get {{resolveName visibility}}{{resolveName property}}{{!!
 }}{{#unless skipBody}}{{>dart/DartFunctionBody}}{{/unless}}{{#if skipBody}};{{/if}}
 {{/getter}}
 {{#setter}}
-{{#unless comment.isEmpty}}{{prefix comment "/// "}}
-{{/unless}}
+{{>dart/DartDocumentation}}
 {{#if isStatic}}static {{/if}}set {{resolveName visibility}}{{resolveName property}}({{resolveName property.typeRef}} value){{!!
 }}{{#unless skipBody}}{{>dart/DartFunctionBody}}{{/unless}}{{#if skipBody}};{{/if}}
 {{/setter}}

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -22,8 +22,7 @@
 {{>dart/DartFunctionException}}
 
 {{/functions}}{{!!
-}}{{#unless comment.isEmpty}}{{prefix comment "/// "}}
-{{/unless}}
+}}{{>dart/DartDocumentation}}
 class {{resolveName}} {
 {{#set parent=this}}{{#fields}}{{prefixPartial "dart/DartField" "  "}}
 {{/fields}}{{/set}}

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/GetAttributeHelperTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/GetAttributeHelperTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2016-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.common.templates
+
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeAttributes
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimePath
+import io.mockk.every
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.trimou.handlebars.Options
+
+@RunWith(JUnit4::class)
+class GetAttributeHelperTest {
+    private val parameters = mutableListOf<Any>()
+    private val options = spyk<Options>()
+    private val limeElement = object : LimeNamedElement(LimePath.EMPTY_PATH) {}
+    private val limeElementWithAttribute = object : LimeNamedElement(
+        LimePath.EMPTY_PATH,
+        attributes = LimeAttributes.Builder()
+            .addAttribute(LimeAttributeType.DEPRECATED, LimeAttributeValueType.MESSAGE, "foobar")
+            .build()
+    ) {}
+
+    private val helper = GetAttributeHelper()
+
+    @Before
+    fun beforeMocks() {
+        every { options.parameters } returns parameters
+    }
+
+    @Test
+    fun executeInvalidContext() {
+        every { options.peek() } returns ""
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.append(any()) }
+    }
+
+    @Test
+    fun executeNoParameters() {
+        every { options.peek() } returns limeElement
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.append(any()) }
+    }
+
+    @Test
+    fun executeOneParameterInvalidAttributeName() {
+        every { options.peek() } returns limeElement
+        parameters.add("foobar")
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.append(any()) }
+    }
+
+    @Test
+    fun executeOneParameterNoAttribute() {
+        every { options.peek() } returns limeElement
+        parameters.add("deprecated")
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.append(any()) }
+    }
+
+    @Test
+    fun executeOneParameterWithAttribute() {
+        every { options.peek() } returns limeElementWithAttribute
+        parameters.add("deprecated")
+
+        helper.execute(options)
+
+        verify(exactly = 1) { options.append("foobar") }
+    }
+
+    @Test
+    fun executeTwoParametersInvalidElement() {
+        parameters.add(2)
+        parameters.add("deprecated")
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.append(any()) }
+    }
+
+    @Test
+    fun executeTwoParametersNoAttribute() {
+        parameters.add(limeElement)
+        parameters.add("deprecated")
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.append(any()) }
+    }
+
+    @Test
+    fun executeTwoParametersWithAttribute() {
+        parameters.add(limeElementWithAttribute)
+        parameters.add("deprecated")
+
+        helper.execute(options)
+
+        verify(exactly = 1) { options.append("foobar") }
+    }
+
+    @Test
+    fun executeTwoParametersValueTypeNoAttribute() {
+        every { options.peek() } returns limeElement
+        parameters.add("cpp")
+        parameters.add("name")
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.append(any()) }
+    }
+
+    @Test
+    fun executeTwoParametersValueTypeWithAttribute() {
+        every { options.peek() } returns limeElementWithAttribute
+        parameters.add("deprecated")
+        parameters.add("message")
+
+        helper.execute(options)
+
+        verify(exactly = 1) { options.append("foobar") }
+    }
+
+    @Test
+    fun executeThreeParametersNoAttribute() {
+        parameters.add(limeElement)
+        parameters.add("cpp")
+        parameters.add("name")
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.append(any()) }
+    }
+
+    @Test
+    fun executeThreeParametersWithAttribute() {
+        parameters.add(limeElementWithAttribute)
+        parameters.add("deprecated")
+        parameters.add("message")
+
+        helper.execute(options)
+
+        verify(exactly = 1) { options.append("foobar") }
+    }
+}

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/NameResolverHelperTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/NameResolverHelperTest.kt
@@ -27,6 +27,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.trimou.engine.MustacheTagType
 import org.trimou.handlebars.Options
 
 @RunWith(JUnit4::class)
@@ -44,6 +45,7 @@ class NameResolverHelperTest {
                 if (element === genericElement) "foo" else "bar"
         }
         every { options.parameters } returns parameters
+        every { options.tagInfo.type } returns MustacheTagType.VARIABLE
     }
 
     @Test

--- a/gluecodium/src/test/resources/smoke/comments/input/PlatformComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/PlatformComments.lime
@@ -24,18 +24,18 @@ class PlatformComments {
         Useful
     }
 
-    // An {@Java exception}{@Swift error} when something goes wrong.
+    // An {@Java @Dart exception}{@Swift error} when something goes wrong.
     exception SomethingWrong(SomeEnum)
 
-    // This is some very useless method that {@Cpp does nothing}{@Java makes some coffee}{@Swift is very swift}.
+    // This is some very useless method that {@Cpp does nothing}{@Java makes some coffee}{@Swift is very swift}{@Dart cannot have overloads}.
     fun doNothing()
 
-    // {@Cpp Cooks very special C++ sauce.}{@Java Makes some coffee.}{@Swift Eats a hip bruschetta.}
+    // {@Cpp Cooks very special C++ sauce.}{@Java Makes some coffee.}{@Swift Eats a hip bruschetta.}{@Dart Colors everything in fuchsia.}
     fun doMagic()
 
     // This is some very useful method that measures the usefulness of its input or \\esc\@pe\{s\}.
     // @param[input] Very useful {@Cpp input [PlatformComments] }parameter that \\esc\@pe\{s\}
-    // @return {@Cpp Usefulness}{@Java Uselessness [SomeEnum]}{@Swift Usefulness} of the input
+    // @return {@Cpp Usefulness}{@Java Uselessness [SomeEnum]}{@Swift Usefulness}{@Dart Uselessness [SomeEnum]} of the input
     // @throws Sometimes it happens{@Swift  but not on iOS [SomethingWrong] \\esc\@pe\{s\} }.
     fun someMethodWithAllComments(input: String): Boolean throws SomethingWrong
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/Comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/Comments.dart
@@ -1,0 +1,339 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_Comments_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Comments_copy_handle');
+final _smoke_Comments_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Comments_release_handle');
+final _someMethodWithAllComments_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Comments_someMethodWithAllComments__String_return_release_handle');
+final _someMethodWithAllComments_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Comments_someMethodWithAllComments__String_return_get_result');
+final _someMethodWithAllComments_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Comments_someMethodWithAllComments__String_return_get_error');
+final _someMethodWithAllComments_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Comments_someMethodWithAllComments__String_return_has_error');
+/// This is some very useful interface.
+class Comments {
+  final Pointer<Void> _handle;
+  Comments._(this._handle);
+  void release() => _smoke_Comments_release_handle(_handle);
+  /// This is some very useful constant.
+  static final bool veryUseful = true;
+  /// This is some very useful method that measures the usefulness of its input.
+  /// @param[input] Very useful input parameter
+  /// @return Usefulness of the input
+  /// @throws Sometimes it happens.
+  bool someMethodWithAllComments(String input) {
+    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithAllComments__String');
+    final _input_handle = String_toFfi(input);
+    final __call_result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
+        _someMethodWithAllComments_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Comments_SomeEnum_fromFfi(__error_handle);
+        smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
+        throw Comments_SomethingWrongException(_error_value);
+    }
+    final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
+    _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  /// This is some very useful method that measures the usefulness of its input.
+  /// @param[input] Very useful input parameter
+  bool someMethodWithInputComments(String input) {
+    final _someMethodWithInputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithInputComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithInputComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  /// This is some very useful method that measures the usefulness of its input.
+  /// @return Usefulness of the input
+  bool someMethodWithOutputComments(String input) {
+    final _someMethodWithOutputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithOutputComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithOutputComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  /// This is some very useful method that measures the usefulness of its input.
+  bool someMethodWithNoComments(String input) {
+    final _someMethodWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithNoComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithNoComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  /// This is some very useful method that does not measure the usefulness of its input.
+  /// @param[input] Very useful input parameter
+  someMethodWithoutReturnTypeWithAllComments(String input) {
+    final _someMethodWithoutReturnTypeWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithAllComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithoutReturnTypeWithAllComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  /// This is some very useful method that does not measure the usefulness of its input.
+  someMethodWithoutReturnTypeWithNoComments(String input) {
+    final _someMethodWithoutReturnTypeWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithNoComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithoutReturnTypeWithNoComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  /// This is some very useful method that measures the usefulness of something.
+  /// @return Usefulness of the input
+  bool someMethodWithoutInputParametersWithAllComments() {
+    final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Comments_someMethodWithoutInputParametersWithAllComments');
+    final __result_handle = _someMethodWithoutInputParametersWithAllComments_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  /// This is some very useful method that measures the usefulness of something.
+  bool someMethodWithoutInputParametersWithNoComments() {
+    final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Comments_someMethodWithoutInputParametersWithNoComments');
+    final __result_handle = _someMethodWithoutInputParametersWithNoComments_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  someMethodWithNothing() {
+    final _someMethodWithNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_Comments_someMethodWithNothing');
+    final __result_handle = _someMethodWithNothing_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  /// This is some very useful method that does nothing.
+  someMethodWithoutReturnTypeOrInputParameters() {
+    final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeOrInputParameters');
+    final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  /// @param[documented] nicely documented
+  String oneParameterCommentOnly(String undocumented, String documented) {
+    final _oneParameterCommentOnly_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_oneParameterCommentOnly__String_String');
+    final _undocumented_handle = String_toFfi(undocumented);
+    final _documented_handle = String_toFfi(documented);
+    final __result_handle = _oneParameterCommentOnly_ffi(_handle, _undocumented_handle, _documented_handle);
+    String_releaseFfiHandle(_undocumented_handle);
+    String_releaseFfiHandle(_documented_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  /// @return nicely documented
+  String returnCommentOnly(String undocumented) {
+    final _returnCommentOnly_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_returnCommentOnly__String');
+    final _undocumented_handle = String_toFfi(undocumented);
+    final __result_handle = _returnCommentOnly_ffi(_handle, _undocumented_handle);
+    String_releaseFfiHandle(_undocumented_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  /// Gets some very useful property.
+  bool get isSomeProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Comments_isSomeProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  /// Sets some very useful property.
+  set isSomeProperty(bool value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint8), void Function(Pointer<Void>, int)>('library_smoke_Comments_isSomeProperty_set__Boolean');
+    final _value_handle = Boolean_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Boolean_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_Comments_toFfi(Comments value) =>
+  _smoke_Comments_copy_handle(value._handle);
+Comments smoke_Comments_fromFfi(Pointer<Void> handle) =>
+  Comments._(_smoke_Comments_copy_handle(handle));
+void smoke_Comments_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Comments_release_handle(handle);
+Pointer<Void> smoke_Comments_toFfi_nullable(Comments value) =>
+  value != null ? smoke_Comments_toFfi(value) : Pointer<Void>.fromAddress(0);
+Comments smoke_Comments_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_Comments_fromFfi(handle) : null;
+void smoke_Comments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Comments_release_handle(handle);
+/// This is some very useful enum.
+enum Comments_SomeEnum {
+    /// Not quite useful
+    useless,
+    /// Somewhat useful
+    useful
+}
+// Comments_SomeEnum "private" section, not exported.
+int smoke_Comments_SomeEnum_toFfi(Comments_SomeEnum value) {
+  switch (value) {
+  case Comments_SomeEnum.useless:
+    return 0;
+  break;
+  case Comments_SomeEnum.useful:
+    return 1;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for Comments_SomeEnum enum.");
+  }
+}
+Comments_SomeEnum smoke_Comments_SomeEnum_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return Comments_SomeEnum.useless;
+  break;
+  case 1:
+    return Comments_SomeEnum.useful;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for Comments_SomeEnum enum.");
+  }
+}
+void smoke_Comments_SomeEnum_releaseFfiHandle(int handle) {}
+final _smoke_Comments_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_Comments_SomeEnum_create_handle_nullable');
+final _smoke_Comments_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeEnum_release_handle_nullable');
+final _smoke_Comments_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeEnum_get_value_nullable');
+Pointer<Void> smoke_Comments_SomeEnum_toFfi_nullable(Comments_SomeEnum value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_Comments_SomeEnum_toFfi(value);
+  final result = _smoke_Comments_SomeEnum_create_handle_nullable(_handle);
+  smoke_Comments_SomeEnum_releaseFfiHandle(_handle);
+  return result;
+}
+Comments_SomeEnum smoke_Comments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_Comments_SomeEnum_get_value_nullable(handle);
+  final result = smoke_Comments_SomeEnum_fromFfi(_handle);
+  smoke_Comments_SomeEnum_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_Comments_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Comments_SomeEnum_release_handle_nullable(handle);
+// End of Comments_SomeEnum "private" section.
+/// This is some very useful exception.
+class Comments_SomethingWrongException implements Exception {
+  final Comments_SomeEnum error;
+  Comments_SomethingWrongException(this.error);
+}
+/// This is some very useful struct.
+class Comments_SomeStruct {
+  /// How useful this struct is
+  /// remains to be seen
+  bool someField;
+  /// Can be `null`
+  String nullableField;
+  Comments_SomeStruct(this.someField, this.nullableField);
+}
+// Comments_SomeStruct "private" section, not exported.
+final _smoke_Comments_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint8, Pointer<Void>),
+    Pointer<Void> Function(int, Pointer<Void>)
+  >('library_smoke_Comments_SomeStruct_create_handle');
+final _smoke_Comments_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeStruct_release_handle');
+final _smoke_Comments_SomeStruct_get_field_someField = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeStruct_get_field_someField');
+final _smoke_Comments_SomeStruct_get_field_nullableField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeStruct_get_field_nullableField');
+Pointer<Void> smoke_Comments_SomeStruct_toFfi(Comments_SomeStruct value) {
+  final _someField_handle = Boolean_toFfi(value.someField);
+  final _nullableField_handle = String_toFfi_nullable(value.nullableField);
+  final _result = _smoke_Comments_SomeStruct_create_handle(_someField_handle, _nullableField_handle);
+  Boolean_releaseFfiHandle(_someField_handle);
+  String_releaseFfiHandle_nullable(_nullableField_handle);
+  return _result;
+}
+Comments_SomeStruct smoke_Comments_SomeStruct_fromFfi(Pointer<Void> handle) {
+  final _someField_handle = _smoke_Comments_SomeStruct_get_field_someField(handle);
+  final _nullableField_handle = _smoke_Comments_SomeStruct_get_field_nullableField(handle);
+  final _result = Comments_SomeStruct(
+    Boolean_fromFfi(_someField_handle),
+    String_fromFfi_nullable(_nullableField_handle)
+  );
+  Boolean_releaseFfiHandle(_someField_handle);
+  String_releaseFfiHandle_nullable(_nullableField_handle);
+  return _result;
+}
+void smoke_Comments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Comments_SomeStruct_release_handle(handle);
+// Nullable Comments_SomeStruct
+final _smoke_Comments_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeStruct_create_handle_nullable');
+final _smoke_Comments_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeStruct_release_handle_nullable');
+final _smoke_Comments_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeStruct_get_value_nullable');
+Pointer<Void> smoke_Comments_SomeStruct_toFfi_nullable(Comments_SomeStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_Comments_SomeStruct_toFfi(value);
+  final result = _smoke_Comments_SomeStruct_create_handle_nullable(_handle);
+  smoke_Comments_SomeStruct_releaseFfiHandle(_handle);
+  return result;
+}
+Comments_SomeStruct smoke_Comments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_Comments_SomeStruct_get_value_nullable(handle);
+  final result = smoke_Comments_SomeStruct_fromFfi(_handle);
+  smoke_Comments_SomeStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_Comments_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Comments_SomeStruct_release_handle_nullable(handle);
+// End of Comments_SomeStruct "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsInterface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsInterface.dart
@@ -1,0 +1,409 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+/// This is some very useful interface.
+abstract class CommentsInterface {
+  void release();
+  /// This is some very useful constant.
+  static final bool veryUseful = true;
+  /// This is some very useful method that measures the usefulness of its input.
+  /// @param[input] Very useful input parameter
+  /// @return Usefulness of the input
+  bool someMethodWithAllComments(String input);
+  /// This is some very useful method that measures the usefulness of its input.
+  /// @param[input] Very useful input parameter
+  bool someMethodWithInputComments(String input);
+  /// This is some very useful method that measures the usefulness of its input.
+  /// @return Usefulness of the input
+  bool someMethodWithOutputComments(String input);
+  /// This is some very useful method that measures the usefulness of its input.
+  bool someMethodWithNoComments(String input);
+  /// This is some very useful method that does not measure the usefulness of its input.
+  /// @param[input] Very useful input parameter
+  someMethodWithoutReturnTypeWithAllComments(String input);
+  /// This is some very useful method that does not measure the usefulness of its input.
+  someMethodWithoutReturnTypeWithNoComments(String input);
+  /// This is some very useful method that measures the usefulness of something.
+  /// @return Usefulness of the input
+  bool someMethodWithoutInputParametersWithAllComments();
+  /// This is some very useful method that measures the usefulness of something.
+  bool someMethodWithoutInputParametersWithNoComments();
+  someMethodWithNothing();
+  /// This is some very useful method that does nothing.
+  someMethodWithoutReturnTypeOrInputParameters();
+  /// Gets some very useful property.
+  bool get isSomeProperty;
+  /// Sets some very useful property.
+  set isSomeProperty(bool value);
+}
+/// This is some very useful enum.
+enum CommentsInterface_SomeEnum {
+    /// Not quite useful
+    useless,
+    /// Somewhat useful
+    useful
+}
+// CommentsInterface_SomeEnum "private" section, not exported.
+int smoke_CommentsInterface_SomeEnum_toFfi(CommentsInterface_SomeEnum value) {
+  switch (value) {
+  case CommentsInterface_SomeEnum.useless:
+    return 0;
+  break;
+  case CommentsInterface_SomeEnum.useful:
+    return 1;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for CommentsInterface_SomeEnum enum.");
+  }
+}
+CommentsInterface_SomeEnum smoke_CommentsInterface_SomeEnum_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return CommentsInterface_SomeEnum.useless;
+  break;
+  case 1:
+    return CommentsInterface_SomeEnum.useful;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for CommentsInterface_SomeEnum enum.");
+  }
+}
+void smoke_CommentsInterface_SomeEnum_releaseFfiHandle(int handle) {}
+final _smoke_CommentsInterface_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_CommentsInterface_SomeEnum_create_handle_nullable');
+final _smoke_CommentsInterface_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_CommentsInterface_SomeEnum_release_handle_nullable');
+final _smoke_CommentsInterface_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_CommentsInterface_SomeEnum_get_value_nullable');
+Pointer<Void> smoke_CommentsInterface_SomeEnum_toFfi_nullable(CommentsInterface_SomeEnum value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_CommentsInterface_SomeEnum_toFfi(value);
+  final result = _smoke_CommentsInterface_SomeEnum_create_handle_nullable(_handle);
+  smoke_CommentsInterface_SomeEnum_releaseFfiHandle(_handle);
+  return result;
+}
+CommentsInterface_SomeEnum smoke_CommentsInterface_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_CommentsInterface_SomeEnum_get_value_nullable(handle);
+  final result = smoke_CommentsInterface_SomeEnum_fromFfi(_handle);
+  smoke_CommentsInterface_SomeEnum_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_CommentsInterface_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_CommentsInterface_SomeEnum_release_handle_nullable(handle);
+// End of CommentsInterface_SomeEnum "private" section.
+/// This is some very useful struct.
+class CommentsInterface_SomeStruct {
+  /// How useful this struct is
+  bool someField;
+  CommentsInterface_SomeStruct(this.someField);
+}
+// CommentsInterface_SomeStruct "private" section, not exported.
+final _smoke_CommentsInterface_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint8),
+    Pointer<Void> Function(int)
+  >('library_smoke_CommentsInterface_SomeStruct_create_handle');
+final _smoke_CommentsInterface_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_CommentsInterface_SomeStruct_release_handle');
+final _smoke_CommentsInterface_SomeStruct_get_field_someField = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_CommentsInterface_SomeStruct_get_field_someField');
+Pointer<Void> smoke_CommentsInterface_SomeStruct_toFfi(CommentsInterface_SomeStruct value) {
+  final _someField_handle = Boolean_toFfi(value.someField);
+  final _result = _smoke_CommentsInterface_SomeStruct_create_handle(_someField_handle);
+  Boolean_releaseFfiHandle(_someField_handle);
+  return _result;
+}
+CommentsInterface_SomeStruct smoke_CommentsInterface_SomeStruct_fromFfi(Pointer<Void> handle) {
+  final _someField_handle = _smoke_CommentsInterface_SomeStruct_get_field_someField(handle);
+  final _result = CommentsInterface_SomeStruct(
+    Boolean_fromFfi(_someField_handle)
+  );
+  Boolean_releaseFfiHandle(_someField_handle);
+  return _result;
+}
+void smoke_CommentsInterface_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_CommentsInterface_SomeStruct_release_handle(handle);
+// Nullable CommentsInterface_SomeStruct
+final _smoke_CommentsInterface_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_CommentsInterface_SomeStruct_create_handle_nullable');
+final _smoke_CommentsInterface_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_CommentsInterface_SomeStruct_release_handle_nullable');
+final _smoke_CommentsInterface_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_CommentsInterface_SomeStruct_get_value_nullable');
+Pointer<Void> smoke_CommentsInterface_SomeStruct_toFfi_nullable(CommentsInterface_SomeStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_CommentsInterface_SomeStruct_toFfi(value);
+  final result = _smoke_CommentsInterface_SomeStruct_create_handle_nullable(_handle);
+  smoke_CommentsInterface_SomeStruct_releaseFfiHandle(_handle);
+  return result;
+}
+CommentsInterface_SomeStruct smoke_CommentsInterface_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_CommentsInterface_SomeStruct_get_value_nullable(handle);
+  final result = smoke_CommentsInterface_SomeStruct_fromFfi(_handle);
+  smoke_CommentsInterface_SomeStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_CommentsInterface_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_CommentsInterface_SomeStruct_release_handle_nullable(handle);
+// End of CommentsInterface_SomeStruct "private" section.
+// CommentsInterface "private" section, not exported.
+final _smoke_CommentsInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_CommentsInterface_copy_handle');
+final _smoke_CommentsInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_CommentsInterface_release_handle');
+final _smoke_CommentsInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
+  >('library_smoke_CommentsInterface_create_proxy');
+final _smoke_CommentsInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_CommentsInterface_get_raw_pointer');
+final _smoke_CommentsInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_CommentsInterface_get_type_id');
+class CommentsInterface__Impl implements CommentsInterface {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  CommentsInterface__Impl(this.handle);
+  @override
+  void release() => _smoke_CommentsInterface_release_handle(handle);
+  @override
+  bool someMethodWithAllComments(String input) {
+    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithAllComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool someMethodWithInputComments(String input) {
+    final _someMethodWithInputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithInputComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithInputComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool someMethodWithOutputComments(String input) {
+    final _someMethodWithOutputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithOutputComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithOutputComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool someMethodWithNoComments(String input) {
+    final _someMethodWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithNoComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithNoComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  someMethodWithoutReturnTypeWithAllComments(String input) {
+    final _someMethodWithoutReturnTypeWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithAllComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithoutReturnTypeWithAllComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  someMethodWithoutReturnTypeWithNoComments(String input) {
+    final _someMethodWithoutReturnTypeWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithNoComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithoutReturnTypeWithNoComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  bool someMethodWithoutInputParametersWithAllComments() {
+    final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithAllComments');
+    final __result_handle = _someMethodWithoutInputParametersWithAllComments_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool someMethodWithoutInputParametersWithNoComments() {
+    final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithNoComments');
+    final __result_handle = _someMethodWithoutInputParametersWithNoComments_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  someMethodWithNothing() {
+    final _someMethodWithNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithNothing');
+    final __result_handle = _someMethodWithNothing_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  someMethodWithoutReturnTypeOrInputParameters() {
+    final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeOrInputParameters');
+    final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  /// Gets some very useful property.
+  bool get isSomeProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_CommentsInterface_isSomeProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  /// Sets some very useful property.
+  set isSomeProperty(bool value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint8), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_isSomeProperty_set__Boolean');
+    final _value_handle = Boolean_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Boolean_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+int _CommentsInterface_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
+  final _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithAllComments(String_fromFfi(input));
+  _result.value = Boolean_toFfi(_result_object);
+  String_releaseFfiHandle(input);
+  return 0;
+}
+int _CommentsInterface_someMethodWithInputComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
+  final _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithInputComments(String_fromFfi(input));
+  _result.value = Boolean_toFfi(_result_object);
+  String_releaseFfiHandle(input);
+  return 0;
+}
+int _CommentsInterface_someMethodWithOutputComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
+  final _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithOutputComments(String_fromFfi(input));
+  _result.value = Boolean_toFfi(_result_object);
+  String_releaseFfiHandle(input);
+  return 0;
+}
+int _CommentsInterface_someMethodWithNoComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
+  final _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithNoComments(String_fromFfi(input));
+  _result.value = Boolean_toFfi(_result_object);
+  String_releaseFfiHandle(input);
+  return 0;
+}
+int _CommentsInterface_someMethodWithoutReturnTypeWithAllComments_static(int _token, Pointer<Void> input) {
+  (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutReturnTypeWithAllComments(String_fromFfi(input));
+  String_releaseFfiHandle(input);
+  return 0;
+}
+int _CommentsInterface_someMethodWithoutReturnTypeWithNoComments_static(int _token, Pointer<Void> input) {
+  (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutReturnTypeWithNoComments(String_fromFfi(input));
+  String_releaseFfiHandle(input);
+  return 0;
+}
+int _CommentsInterface_someMethodWithoutInputParametersWithAllComments_static(int _token, Pointer<Uint8> _result) {
+  final _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithAllComments();
+  _result.value = Boolean_toFfi(_result_object);
+  return 0;
+}
+int _CommentsInterface_someMethodWithoutInputParametersWithNoComments_static(int _token, Pointer<Uint8> _result) {
+  final _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithNoComments();
+  _result.value = Boolean_toFfi(_result_object);
+  return 0;
+}
+int _CommentsInterface_someMethodWithNothing_static(int _token) {
+  (__lib.instanceCache[_token] as CommentsInterface).someMethodWithNothing();
+  return 0;
+}
+int _CommentsInterface_someMethodWithoutReturnTypeOrInputParameters_static(int _token) {
+  (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutReturnTypeOrInputParameters();
+  return 0;
+}
+int _CommentsInterface_isSomeProperty_get_static(int _token, Pointer<Uint8> _result) {
+  _result.value = Boolean_toFfi((__lib.instanceCache[_token] as CommentsInterface).isSomeProperty);
+  return 0;
+}
+int _CommentsInterface_isSomeProperty_set_static(int _token, int _value) {
+  (__lib.instanceCache[_token] as CommentsInterface).isSomeProperty = Boolean_fromFfi(_value);
+  Boolean_releaseFfiHandle(_value);
+  return 0;
+}
+Pointer<Void> smoke_CommentsInterface_toFfi(CommentsInterface value) {
+  if (value is CommentsInterface__Impl) return _smoke_CommentsInterface_copy_handle(value.handle);
+  final result = _smoke_CommentsInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_CommentsInterface_someMethodWithAllComments_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_CommentsInterface_someMethodWithInputComments_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_CommentsInterface_someMethodWithOutputComments_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_CommentsInterface_someMethodWithNoComments_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CommentsInterface_someMethodWithoutReturnTypeWithAllComments_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CommentsInterface_someMethodWithoutReturnTypeWithNoComments_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint8>)>(_CommentsInterface_someMethodWithoutInputParametersWithAllComments_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint8>)>(_CommentsInterface_someMethodWithoutInputParametersWithNoComments_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64)>(_CommentsInterface_someMethodWithNothing_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64)>(_CommentsInterface_someMethodWithoutReturnTypeOrInputParameters_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint8>)>(_CommentsInterface_isSomeProperty_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Uint8)>(_CommentsInterface_isSomeProperty_set_static, __lib.unknownError)
+  );
+  __lib.reverseCache[_smoke_CommentsInterface_get_raw_pointer(result)] = value;
+  return result;
+}
+CommentsInterface smoke_CommentsInterface_fromFfi(Pointer<Void> handle) {
+  final instance = __lib.reverseCache[_smoke_CommentsInterface_get_raw_pointer(handle)] as CommentsInterface;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_CommentsInterface_copy_handle(handle);
+  final _type_id_handle = _smoke_CommentsInterface_get_type_id(handle);
+  final _type_id = String_fromFfi(_type_id_handle);
+  final result = _type_id.isEmpty
+    ? CommentsInterface__Impl(_copied_handle)
+    : __lib.typeRepository[_type_id](_copied_handle);
+  String_releaseFfiHandle(_type_id_handle);
+  return result;
+}
+void smoke_CommentsInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_CommentsInterface_release_handle(handle);
+Pointer<Void> smoke_CommentsInterface_toFfi_nullable(CommentsInterface value) =>
+  value != null ? smoke_CommentsInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+CommentsInterface smoke_CommentsInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_CommentsInterface_fromFfi(handle) : null;
+void smoke_CommentsInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_CommentsInterface_release_handle(handle);
+// End of CommentsInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
@@ -1,0 +1,162 @@
+import 'package:library/src/smoke/Comments.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_CommentsLinks_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_copy_handle');
+final _smoke_CommentsLinks_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_release_handle');
+final _randomMethod_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_release_handle');
+final _randomMethod_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_result');
+final _randomMethod_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_error');
+final _randomMethod_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_has_error');
+/// The nested types like [random_method] don't need full name prefix, but it's
+/// possible to references other interfaces like [CommentsInterface] or other members
+/// [comments.someMethodWithAllComments].
+///
+/// Weblinks are not modified like this [example] or [www.example.com].
+///
+/// [example]: http://example.com
+class CommentsLinks {
+  final Pointer<Void> _handle;
+  CommentsLinks._(this._handle);
+  void release() => _smoke_CommentsLinks_release_handle(_handle);
+  /// Link types:
+  /// * constant: [veryUseful]
+  /// * struct: [Comments_SomeStruct]
+  /// * struct field: [someField]
+  /// * enum: [Comments_SomeEnum]
+  /// * enum item: [useful]
+  /// * property: [isSomeProperty]
+  /// * property setter: [isSomeProperty]
+  /// * property getter: [isSomeProperty]
+  /// * method: [comments.someMethodWithAllComments]
+  /// * parameter: [inputParameter]
+  /// * top level constant: [typeCollectionConstant]
+  /// * top level struct: [TypeCollectionStruct]
+  /// * top level struct field: [field]
+  /// * top level enum: [TypeCollectionEnum]
+  /// * top level enum item: [item]
+  /// * error: [Comments_SomethingWrongException]
+  ///
+  /// Not working for Java:
+  /// * typedef: [bool]
+  /// * top level typedef: [bool]
+  ///
+  /// Not working for Swift:
+  /// * named comment: [][veryUseful]
+  /// @param[inputParameter] Sometimes takes [useful]
+  /// @return Sometimes returns [useful]
+  /// @throws May or may not throw [Comments_SomethingWrongException]
+  Comments_SomeEnum randomMethod(Comments_SomeEnum inputParameter) {
+    final _randomMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_CommentsLinks_randomMethod__SomeEnum');
+    final _inputParameter_handle = smoke_Comments_SomeEnum_toFfi(inputParameter);
+    final __call_result_handle = _randomMethod_ffi(_handle, _inputParameter_handle);
+    smoke_Comments_SomeEnum_releaseFfiHandle(_inputParameter_handle);
+    if (_randomMethod_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _randomMethod_return_get_error(__call_result_handle);
+        _randomMethod_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Comments_SomeEnum_fromFfi(__error_handle);
+        smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
+        throw Comments_SomethingWrongException(_error_value);
+    }
+    final __result_handle = _randomMethod_return_get_result(__call_result_handle);
+    _randomMethod_return_release_handle(__call_result_handle);
+    final _result = smoke_Comments_SomeEnum_fromFfi(__result_handle);
+    smoke_Comments_SomeEnum_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_CommentsLinks_toFfi(CommentsLinks value) =>
+  _smoke_CommentsLinks_copy_handle(value._handle);
+CommentsLinks smoke_CommentsLinks_fromFfi(Pointer<Void> handle) =>
+  CommentsLinks._(_smoke_CommentsLinks_copy_handle(handle));
+void smoke_CommentsLinks_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_CommentsLinks_release_handle(handle);
+Pointer<Void> smoke_CommentsLinks_toFfi_nullable(CommentsLinks value) =>
+  value != null ? smoke_CommentsLinks_toFfi(value) : Pointer<Void>.fromAddress(0);
+CommentsLinks smoke_CommentsLinks_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_CommentsLinks_fromFfi(handle) : null;
+void smoke_CommentsLinks_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_CommentsLinks_release_handle(handle);
+/// Links also work in:
+class CommentsLinks_RandomStruct {
+  /// Some random field [Comments_SomeStruct]
+  Comments_SomeStruct randomField;
+  CommentsLinks_RandomStruct(this.randomField);
+}
+// CommentsLinks_RandomStruct "private" section, not exported.
+final _smoke_CommentsLinks_RandomStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_RandomStruct_create_handle');
+final _smoke_CommentsLinks_RandomStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_RandomStruct_release_handle');
+final _smoke_CommentsLinks_RandomStruct_get_field_randomField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_RandomStruct_get_field_randomField');
+Pointer<Void> smoke_CommentsLinks_RandomStruct_toFfi(CommentsLinks_RandomStruct value) {
+  final _randomField_handle = smoke_Comments_SomeStruct_toFfi(value.randomField);
+  final _result = _smoke_CommentsLinks_RandomStruct_create_handle(_randomField_handle);
+  smoke_Comments_SomeStruct_releaseFfiHandle(_randomField_handle);
+  return _result;
+}
+CommentsLinks_RandomStruct smoke_CommentsLinks_RandomStruct_fromFfi(Pointer<Void> handle) {
+  final _randomField_handle = _smoke_CommentsLinks_RandomStruct_get_field_randomField(handle);
+  final _result = CommentsLinks_RandomStruct(
+    smoke_Comments_SomeStruct_fromFfi(_randomField_handle)
+  );
+  smoke_Comments_SomeStruct_releaseFfiHandle(_randomField_handle);
+  return _result;
+}
+void smoke_CommentsLinks_RandomStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_CommentsLinks_RandomStruct_release_handle(handle);
+// Nullable CommentsLinks_RandomStruct
+final _smoke_CommentsLinks_RandomStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_RandomStruct_create_handle_nullable');
+final _smoke_CommentsLinks_RandomStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_RandomStruct_release_handle_nullable');
+final _smoke_CommentsLinks_RandomStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_RandomStruct_get_value_nullable');
+Pointer<Void> smoke_CommentsLinks_RandomStruct_toFfi_nullable(CommentsLinks_RandomStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_CommentsLinks_RandomStruct_toFfi(value);
+  final result = _smoke_CommentsLinks_RandomStruct_create_handle_nullable(_handle);
+  smoke_CommentsLinks_RandomStruct_releaseFfiHandle(_handle);
+  return result;
+}
+CommentsLinks_RandomStruct smoke_CommentsLinks_RandomStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_CommentsLinks_RandomStruct_get_value_nullable(handle);
+  final result = smoke_CommentsLinks_RandomStruct_fromFfi(_handle);
+  smoke_CommentsLinks_RandomStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_CommentsLinks_RandomStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_CommentsLinks_RandomStruct_release_handle_nullable(handle);
+// End of CommentsLinks_RandomStruct "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationComments.dart
@@ -1,0 +1,266 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+/// This is some very useful interface.
+@Deprecated("Unfortunately, this interface is deprecated. Use [comments] instead.")
+abstract class DeprecationComments {
+  void release();
+  /// This is some very useful constant.
+  @Deprecated("Unfortunately, this constant is deprecated. Use [comments.VeryUseful] instead.")
+  static final bool veryUseful = true;
+  /// This is some very useful method that measures the usefulness of its input.
+  /// @param[input] Very useful input parameter
+  /// @return Usefulness of the input
+  @Deprecated("Unfortunately, this method is deprecated.
+  Use [comments.someMethodWithAllComments] instead.")
+  bool someMethodWithAllComments(String input);
+  /// Gets some very useful property.
+  @Deprecated("Unfortunately, this property's getter is deprecated.
+  Use [comments.SomeProperty.get] instead.")
+  bool get isSomeProperty;
+  /// Sets some very useful property.
+  @Deprecated("Unfortunately, this property's setter is deprecated.
+  Use [comments.SomeProperty.set] instead.")
+  set isSomeProperty(bool value);
+}
+/// This is some very useful enum.
+@Deprecated("Unfortunately, this enum is deprecated. Use [comments.SomeEnum] instead.")
+enum DeprecationComments_SomeEnum {
+    /// Not quite useful
+    @Deprecated("Unfortunately, this item is deprecated.
+    Use [comments.SomeEnum.Useless] instead.")
+    useless
+}
+// DeprecationComments_SomeEnum "private" section, not exported.
+int smoke_DeprecationComments_SomeEnum_toFfi(DeprecationComments_SomeEnum value) {
+  switch (value) {
+  case DeprecationComments_SomeEnum.useless:
+    return 0;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for DeprecationComments_SomeEnum enum.");
+  }
+}
+DeprecationComments_SomeEnum smoke_DeprecationComments_SomeEnum_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return DeprecationComments_SomeEnum.useless;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for DeprecationComments_SomeEnum enum.");
+  }
+}
+void smoke_DeprecationComments_SomeEnum_releaseFfiHandle(int handle) {}
+final _smoke_DeprecationComments_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_DeprecationComments_SomeEnum_create_handle_nullable');
+final _smoke_DeprecationComments_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecationComments_SomeEnum_release_handle_nullable');
+final _smoke_DeprecationComments_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DeprecationComments_SomeEnum_get_value_nullable');
+Pointer<Void> smoke_DeprecationComments_SomeEnum_toFfi_nullable(DeprecationComments_SomeEnum value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_DeprecationComments_SomeEnum_toFfi(value);
+  final result = _smoke_DeprecationComments_SomeEnum_create_handle_nullable(_handle);
+  smoke_DeprecationComments_SomeEnum_releaseFfiHandle(_handle);
+  return result;
+}
+DeprecationComments_SomeEnum smoke_DeprecationComments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_DeprecationComments_SomeEnum_get_value_nullable(handle);
+  final result = smoke_DeprecationComments_SomeEnum_fromFfi(_handle);
+  smoke_DeprecationComments_SomeEnum_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_DeprecationComments_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_DeprecationComments_SomeEnum_release_handle_nullable(handle);
+// End of DeprecationComments_SomeEnum "private" section.
+@Deprecated("Unfortunately, this exception is deprecated, please use [comments.SomethingWrong] instead.")
+class DeprecationComments_SomethingWrongException implements Exception {
+  final DeprecationComments_SomeEnum error;
+  DeprecationComments_SomethingWrongException(this.error);
+}
+/// This is some very useful struct.
+@Deprecated("Unfortunately, this struct is deprecated. Use [comments.SomeStruct] instead.")
+class DeprecationComments_SomeStruct {
+  /// How useful this struct is.
+  @Deprecated("Unfortunately, this field is deprecated.
+  Use [comments.SomeStruct.someField] instead.")
+  bool someField;
+  DeprecationComments_SomeStruct(this.someField);
+}
+// DeprecationComments_SomeStruct "private" section, not exported.
+final _smoke_DeprecationComments_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint8),
+    Pointer<Void> Function(int)
+  >('library_smoke_DeprecationComments_SomeStruct_create_handle');
+final _smoke_DeprecationComments_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecationComments_SomeStruct_release_handle');
+final _smoke_DeprecationComments_SomeStruct_get_field_someField = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DeprecationComments_SomeStruct_get_field_someField');
+Pointer<Void> smoke_DeprecationComments_SomeStruct_toFfi(DeprecationComments_SomeStruct value) {
+  final _someField_handle = Boolean_toFfi(value.someField);
+  final _result = _smoke_DeprecationComments_SomeStruct_create_handle(_someField_handle);
+  Boolean_releaseFfiHandle(_someField_handle);
+  return _result;
+}
+DeprecationComments_SomeStruct smoke_DeprecationComments_SomeStruct_fromFfi(Pointer<Void> handle) {
+  final _someField_handle = _smoke_DeprecationComments_SomeStruct_get_field_someField(handle);
+  final _result = DeprecationComments_SomeStruct(
+    Boolean_fromFfi(_someField_handle)
+  );
+  Boolean_releaseFfiHandle(_someField_handle);
+  return _result;
+}
+void smoke_DeprecationComments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_DeprecationComments_SomeStruct_release_handle(handle);
+// Nullable DeprecationComments_SomeStruct
+final _smoke_DeprecationComments_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecationComments_SomeStruct_create_handle_nullable');
+final _smoke_DeprecationComments_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecationComments_SomeStruct_release_handle_nullable');
+final _smoke_DeprecationComments_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecationComments_SomeStruct_get_value_nullable');
+Pointer<Void> smoke_DeprecationComments_SomeStruct_toFfi_nullable(DeprecationComments_SomeStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_DeprecationComments_SomeStruct_toFfi(value);
+  final result = _smoke_DeprecationComments_SomeStruct_create_handle_nullable(_handle);
+  smoke_DeprecationComments_SomeStruct_releaseFfiHandle(_handle);
+  return result;
+}
+DeprecationComments_SomeStruct smoke_DeprecationComments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_DeprecationComments_SomeStruct_get_value_nullable(handle);
+  final result = smoke_DeprecationComments_SomeStruct_fromFfi(_handle);
+  smoke_DeprecationComments_SomeStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_DeprecationComments_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_DeprecationComments_SomeStruct_release_handle_nullable(handle);
+// End of DeprecationComments_SomeStruct "private" section.
+// DeprecationComments "private" section, not exported.
+final _smoke_DeprecationComments_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecationComments_copy_handle');
+final _smoke_DeprecationComments_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecationComments_release_handle');
+final _smoke_DeprecationComments_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Pointer, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, Pointer, Pointer, Pointer, Pointer)
+  >('library_smoke_DeprecationComments_create_proxy');
+final _smoke_DeprecationComments_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_DeprecationComments_get_raw_pointer');
+final _smoke_DeprecationComments_get_type_id = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecationComments_get_type_id');
+class DeprecationComments__Impl implements DeprecationComments {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  DeprecationComments__Impl(this.handle);
+  @override
+  void release() => _smoke_DeprecationComments_release_handle(handle);
+  @override
+  bool someMethodWithAllComments(String input) {
+    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_DeprecationComments_someMethodWithAllComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  /// Gets some very useful property.
+  @Deprecated("Unfortunately, this property's getter is deprecated.
+  Use [comments.SomeProperty.get] instead.")
+  bool get isSomeProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_DeprecationComments_isSomeProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  /// Sets some very useful property.
+  @Deprecated("Unfortunately, this property's setter is deprecated.
+  Use [comments.SomeProperty.set] instead.")
+  set isSomeProperty(bool value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint8), void Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_isSomeProperty_set__Boolean');
+    final _value_handle = Boolean_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Boolean_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+int _DeprecationComments_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
+  final _result_object = (__lib.instanceCache[_token] as DeprecationComments).someMethodWithAllComments(String_fromFfi(input));
+  _result.value = Boolean_toFfi(_result_object);
+  String_releaseFfiHandle(input);
+  return 0;
+}
+int _DeprecationComments_isSomeProperty_get_static(int _token, Pointer<Uint8> _result) {
+  _result.value = Boolean_toFfi((__lib.instanceCache[_token] as DeprecationComments).isSomeProperty);
+  return 0;
+}
+int _DeprecationComments_isSomeProperty_set_static(int _token, int _value) {
+  (__lib.instanceCache[_token] as DeprecationComments).isSomeProperty = Boolean_fromFfi(_value);
+  Boolean_releaseFfiHandle(_value);
+  return 0;
+}
+Pointer<Void> smoke_DeprecationComments_toFfi(DeprecationComments value) {
+  if (value is DeprecationComments__Impl) return _smoke_DeprecationComments_copy_handle(value.handle);
+  final result = _smoke_DeprecationComments_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_DeprecationComments_someMethodWithAllComments_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint8>)>(_DeprecationComments_isSomeProperty_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Uint8)>(_DeprecationComments_isSomeProperty_set_static, __lib.unknownError)
+  );
+  __lib.reverseCache[_smoke_DeprecationComments_get_raw_pointer(result)] = value;
+  return result;
+}
+DeprecationComments smoke_DeprecationComments_fromFfi(Pointer<Void> handle) {
+  final instance = __lib.reverseCache[_smoke_DeprecationComments_get_raw_pointer(handle)] as DeprecationComments;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_DeprecationComments_copy_handle(handle);
+  final _type_id_handle = _smoke_DeprecationComments_get_type_id(handle);
+  final _type_id = String_fromFfi(_type_id_handle);
+  final result = _type_id.isEmpty
+    ? DeprecationComments__Impl(_copied_handle)
+    : __lib.typeRepository[_type_id](_copied_handle);
+  String_releaseFfiHandle(_type_id_handle);
+  return result;
+}
+void smoke_DeprecationComments_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_DeprecationComments_release_handle(handle);
+Pointer<Void> smoke_DeprecationComments_toFfi_nullable(DeprecationComments value) =>
+  value != null ? smoke_DeprecationComments_toFfi(value) : Pointer<Void>.fromAddress(0);
+DeprecationComments smoke_DeprecationComments_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_DeprecationComments_fromFfi(handle) : null;
+void smoke_DeprecationComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_DeprecationComments_release_handle(handle);
+// End of DeprecationComments "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationCommentsOnly.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationCommentsOnly.dart
@@ -1,0 +1,243 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+@Deprecated("Unfortunately, this interface is deprecated.")
+abstract class DeprecationCommentsOnly {
+  void release();
+  @Deprecated("Unfortunately, this constant is deprecated.")
+  static final bool veryUseful = true;
+  /// @param[input] Very useful input parameter
+  /// @return Usefulness of the input
+  @Deprecated("Unfortunately, this method is deprecated.")
+  bool someMethodWithAllComments(String input);
+  @Deprecated("Unfortunately, this property's getter is deprecated.")
+  bool get isSomeProperty;
+  @Deprecated("Unfortunately, this property's setter is deprecated.")
+  set isSomeProperty(bool value);
+}
+@Deprecated("Unfortunately, this enum is deprecated.")
+enum DeprecationCommentsOnly_SomeEnum {
+    @Deprecated("Unfortunately, this item is deprecated.")
+    useless
+}
+// DeprecationCommentsOnly_SomeEnum "private" section, not exported.
+int smoke_DeprecationCommentsOnly_SomeEnum_toFfi(DeprecationCommentsOnly_SomeEnum value) {
+  switch (value) {
+  case DeprecationCommentsOnly_SomeEnum.useless:
+    return 0;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for DeprecationCommentsOnly_SomeEnum enum.");
+  }
+}
+DeprecationCommentsOnly_SomeEnum smoke_DeprecationCommentsOnly_SomeEnum_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return DeprecationCommentsOnly_SomeEnum.useless;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for DeprecationCommentsOnly_SomeEnum enum.");
+  }
+}
+void smoke_DeprecationCommentsOnly_SomeEnum_releaseFfiHandle(int handle) {}
+final _smoke_DeprecationCommentsOnly_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_DeprecationCommentsOnly_SomeEnum_create_handle_nullable');
+final _smoke_DeprecationCommentsOnly_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecationCommentsOnly_SomeEnum_release_handle_nullable');
+final _smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable');
+Pointer<Void> smoke_DeprecationCommentsOnly_SomeEnum_toFfi_nullable(DeprecationCommentsOnly_SomeEnum value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_DeprecationCommentsOnly_SomeEnum_toFfi(value);
+  final result = _smoke_DeprecationCommentsOnly_SomeEnum_create_handle_nullable(_handle);
+  smoke_DeprecationCommentsOnly_SomeEnum_releaseFfiHandle(_handle);
+  return result;
+}
+DeprecationCommentsOnly_SomeEnum smoke_DeprecationCommentsOnly_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable(handle);
+  final result = smoke_DeprecationCommentsOnly_SomeEnum_fromFfi(_handle);
+  smoke_DeprecationCommentsOnly_SomeEnum_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_DeprecationCommentsOnly_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_DeprecationCommentsOnly_SomeEnum_release_handle_nullable(handle);
+// End of DeprecationCommentsOnly_SomeEnum "private" section.
+@Deprecated("Unfortunately, this struct is deprecated.")
+class DeprecationCommentsOnly_SomeStruct {
+  @Deprecated("Unfortunately, this field is deprecated.")
+  bool someField;
+  DeprecationCommentsOnly_SomeStruct(this.someField);
+}
+// DeprecationCommentsOnly_SomeStruct "private" section, not exported.
+final _smoke_DeprecationCommentsOnly_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint8),
+    Pointer<Void> Function(int)
+  >('library_smoke_DeprecationCommentsOnly_SomeStruct_create_handle');
+final _smoke_DeprecationCommentsOnly_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecationCommentsOnly_SomeStruct_release_handle');
+final _smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField');
+Pointer<Void> smoke_DeprecationCommentsOnly_SomeStruct_toFfi(DeprecationCommentsOnly_SomeStruct value) {
+  final _someField_handle = Boolean_toFfi(value.someField);
+  final _result = _smoke_DeprecationCommentsOnly_SomeStruct_create_handle(_someField_handle);
+  Boolean_releaseFfiHandle(_someField_handle);
+  return _result;
+}
+DeprecationCommentsOnly_SomeStruct smoke_DeprecationCommentsOnly_SomeStruct_fromFfi(Pointer<Void> handle) {
+  final _someField_handle = _smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField(handle);
+  final _result = DeprecationCommentsOnly_SomeStruct(
+    Boolean_fromFfi(_someField_handle)
+  );
+  Boolean_releaseFfiHandle(_someField_handle);
+  return _result;
+}
+void smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_DeprecationCommentsOnly_SomeStruct_release_handle(handle);
+// Nullable DeprecationCommentsOnly_SomeStruct
+final _smoke_DeprecationCommentsOnly_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecationCommentsOnly_SomeStruct_create_handle_nullable');
+final _smoke_DeprecationCommentsOnly_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecationCommentsOnly_SomeStruct_release_handle_nullable');
+final _smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable');
+Pointer<Void> smoke_DeprecationCommentsOnly_SomeStruct_toFfi_nullable(DeprecationCommentsOnly_SomeStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_DeprecationCommentsOnly_SomeStruct_toFfi(value);
+  final result = _smoke_DeprecationCommentsOnly_SomeStruct_create_handle_nullable(_handle);
+  smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle(_handle);
+  return result;
+}
+DeprecationCommentsOnly_SomeStruct smoke_DeprecationCommentsOnly_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable(handle);
+  final result = smoke_DeprecationCommentsOnly_SomeStruct_fromFfi(_handle);
+  smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_DeprecationCommentsOnly_SomeStruct_release_handle_nullable(handle);
+// End of DeprecationCommentsOnly_SomeStruct "private" section.
+// DeprecationCommentsOnly "private" section, not exported.
+final _smoke_DeprecationCommentsOnly_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecationCommentsOnly_copy_handle');
+final _smoke_DeprecationCommentsOnly_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecationCommentsOnly_release_handle');
+final _smoke_DeprecationCommentsOnly_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Pointer, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, Pointer, Pointer, Pointer, Pointer)
+  >('library_smoke_DeprecationCommentsOnly_create_proxy');
+final _smoke_DeprecationCommentsOnly_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_DeprecationCommentsOnly_get_raw_pointer');
+final _smoke_DeprecationCommentsOnly_get_type_id = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecationCommentsOnly_get_type_id');
+class DeprecationCommentsOnly__Impl implements DeprecationCommentsOnly {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  DeprecationCommentsOnly__Impl(this.handle);
+  @override
+  void release() => _smoke_DeprecationCommentsOnly_release_handle(handle);
+  @override
+  bool someMethodWithAllComments(String input) {
+    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_DeprecationCommentsOnly_someMethodWithAllComments__String');
+    final _input_handle = String_toFfi(input);
+    final __result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @Deprecated("Unfortunately, this property's getter is deprecated.")
+  bool get isSomeProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_get');
+    final __result_handle = _get_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @Deprecated("Unfortunately, this property's setter is deprecated.")
+  set isSomeProperty(bool value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint8), void Function(Pointer<Void>, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_set__Boolean');
+    final _value_handle = Boolean_toFfi(value);
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Boolean_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+int _DeprecationCommentsOnly_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
+  final _result_object = (__lib.instanceCache[_token] as DeprecationCommentsOnly).someMethodWithAllComments(String_fromFfi(input));
+  _result.value = Boolean_toFfi(_result_object);
+  String_releaseFfiHandle(input);
+  return 0;
+}
+int _DeprecationCommentsOnly_isSomeProperty_get_static(int _token, Pointer<Uint8> _result) {
+  _result.value = Boolean_toFfi((__lib.instanceCache[_token] as DeprecationCommentsOnly).isSomeProperty);
+  return 0;
+}
+int _DeprecationCommentsOnly_isSomeProperty_set_static(int _token, int _value) {
+  (__lib.instanceCache[_token] as DeprecationCommentsOnly).isSomeProperty = Boolean_fromFfi(_value);
+  Boolean_releaseFfiHandle(_value);
+  return 0;
+}
+Pointer<Void> smoke_DeprecationCommentsOnly_toFfi(DeprecationCommentsOnly value) {
+  if (value is DeprecationCommentsOnly__Impl) return _smoke_DeprecationCommentsOnly_copy_handle(value.handle);
+  final result = _smoke_DeprecationCommentsOnly_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_DeprecationCommentsOnly_someMethodWithAllComments_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint8>)>(_DeprecationCommentsOnly_isSomeProperty_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Uint8)>(_DeprecationCommentsOnly_isSomeProperty_set_static, __lib.unknownError)
+  );
+  __lib.reverseCache[_smoke_DeprecationCommentsOnly_get_raw_pointer(result)] = value;
+  return result;
+}
+DeprecationCommentsOnly smoke_DeprecationCommentsOnly_fromFfi(Pointer<Void> handle) {
+  final instance = __lib.reverseCache[_smoke_DeprecationCommentsOnly_get_raw_pointer(handle)] as DeprecationCommentsOnly;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_DeprecationCommentsOnly_copy_handle(handle);
+  final _type_id_handle = _smoke_DeprecationCommentsOnly_get_type_id(handle);
+  final _type_id = String_fromFfi(_type_id_handle);
+  final result = _type_id.isEmpty
+    ? DeprecationCommentsOnly__Impl(_copied_handle)
+    : __lib.typeRepository[_type_id](_copied_handle);
+  String_releaseFfiHandle(_type_id_handle);
+  return result;
+}
+void smoke_DeprecationCommentsOnly_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_DeprecationCommentsOnly_release_handle(handle);
+Pointer<Void> smoke_DeprecationCommentsOnly_toFfi_nullable(DeprecationCommentsOnly value) =>
+  value != null ? smoke_DeprecationCommentsOnly_toFfi(value) : Pointer<Void>.fromAddress(0);
+DeprecationCommentsOnly smoke_DeprecationCommentsOnly_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_DeprecationCommentsOnly_fromFfi(handle) : null;
+void smoke_DeprecationCommentsOnly_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_DeprecationCommentsOnly_release_handle(handle);
+// End of DeprecationCommentsOnly "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/MultiLineComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/MultiLineComments.dart
@@ -1,0 +1,67 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_MultiLineComments_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MultiLineComments_copy_handle');
+final _smoke_MultiLineComments_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MultiLineComments_release_handle');
+/// This is some very useful interface.
+/// There is a lot to say about this interface.
+/// at least it has multiline comments.
+///
+/// I am a heading
+/// --------------
+///
+/// And now comes a list:
+/// * asterisk
+/// * needs
+/// * escaping
+///
+/// ```Some example code;```
+class MultiLineComments {
+  final Pointer<Void> _handle;
+  MultiLineComments._(this._handle);
+  void release() => _smoke_MultiLineComments_release_handle(_handle);
+  /// This is very important method.
+  /// It has very important parameters.
+  /// It has side effects.
+  /// @param[input] Very useful input parameter.
+  /// You must not confuse it with the second parameter.
+  /// But they are similar.
+  /// @param[ratio] Not as useful as the first parameter.
+  /// But still useful.
+  /// use a positive value for more happiness.
+  /// @return If you provide a useful input,
+  /// and a useful ratio you can expect a useful output.
+  /// Just kidding do not expect anything from a method until
+  /// you see its body.
+  double someMethodWithLongComment(String input, double ratio) {
+    final _someMethodWithLongComment_ffi = __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Pointer<Void>, Double), double Function(Pointer<Void>, Pointer<Void>, double)>('library_smoke_MultiLineComments_someMethodWithLongComment__String_Double');
+    final _input_handle = String_toFfi(input);
+    final _ratio_handle = (ratio);
+    final __result_handle = _someMethodWithLongComment_ffi(_handle, _input_handle, _ratio_handle);
+    String_releaseFfiHandle(_input_handle);
+    (_ratio_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_MultiLineComments_toFfi(MultiLineComments value) =>
+  _smoke_MultiLineComments_copy_handle(value._handle);
+MultiLineComments smoke_MultiLineComments_fromFfi(Pointer<Void> handle) =>
+  MultiLineComments._(_smoke_MultiLineComments_copy_handle(handle));
+void smoke_MultiLineComments_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_MultiLineComments_release_handle(handle);
+Pointer<Void> smoke_MultiLineComments_toFfi_nullable(MultiLineComments value) =>
+  value != null ? smoke_MultiLineComments_toFfi(value) : Pointer<Void>.fromAddress(0);
+MultiLineComments smoke_MultiLineComments_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_MultiLineComments_fromFfi(handle) : null;
+void smoke_MultiLineComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_MultiLineComments_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/PlatformComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/PlatformComments.dart
@@ -1,0 +1,211 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_PlatformComments_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_copy_handle');
+final _smoke_PlatformComments_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_release_handle');
+final _someMethodWithAllComments_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_release_handle');
+final _someMethodWithAllComments_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_result');
+final _someMethodWithAllComments_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_error');
+final _someMethodWithAllComments_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_has_error');
+class PlatformComments {
+  final Pointer<Void> _handle;
+  PlatformComments._(this._handle);
+  void release() => _smoke_PlatformComments_release_handle(_handle);
+  /// This is some very useless method that cannot have overloads.
+  doNothing() {
+    final _doNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_PlatformComments_doNothing');
+    final __result_handle = _doNothing_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  /// Colors everything in fuchsia.
+  doMagic() {
+    final _doMagic_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_PlatformComments_doMagic');
+    final __result_handle = _doMagic_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  /// This is some very useful method that measures the usefulness of its input or \esc@pe{s}.
+  /// @param[input] Very useful parameter that \esc@pe{s}
+  /// @return Uselessness [PlatformComments_SomeEnum] of the input
+  /// @throws Sometimes it happens.
+  bool someMethodWithAllComments(String input) {
+    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_PlatformComments_someMethodWithAllComments__String');
+    final _input_handle = String_toFfi(input);
+    final __call_result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
+        _someMethodWithAllComments_return_release_handle(__call_result_handle);
+        final _error_value = smoke_PlatformComments_SomeEnum_fromFfi(__error_handle);
+        smoke_PlatformComments_SomeEnum_releaseFfiHandle(__error_handle);
+        throw PlatformComments_SomethingWrongException(_error_value);
+    }
+    final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
+    _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_PlatformComments_toFfi(PlatformComments value) =>
+  _smoke_PlatformComments_copy_handle(value._handle);
+PlatformComments smoke_PlatformComments_fromFfi(Pointer<Void> handle) =>
+  PlatformComments._(_smoke_PlatformComments_copy_handle(handle));
+void smoke_PlatformComments_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_PlatformComments_release_handle(handle);
+Pointer<Void> smoke_PlatformComments_toFfi_nullable(PlatformComments value) =>
+  value != null ? smoke_PlatformComments_toFfi(value) : Pointer<Void>.fromAddress(0);
+PlatformComments smoke_PlatformComments_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_PlatformComments_fromFfi(handle) : null;
+void smoke_PlatformComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PlatformComments_release_handle(handle);
+enum PlatformComments_SomeEnum {
+    useless,
+    useful
+}
+// PlatformComments_SomeEnum "private" section, not exported.
+int smoke_PlatformComments_SomeEnum_toFfi(PlatformComments_SomeEnum value) {
+  switch (value) {
+  case PlatformComments_SomeEnum.useless:
+    return 0;
+  break;
+  case PlatformComments_SomeEnum.useful:
+    return 1;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for PlatformComments_SomeEnum enum.");
+  }
+}
+PlatformComments_SomeEnum smoke_PlatformComments_SomeEnum_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return PlatformComments_SomeEnum.useless;
+  break;
+  case 1:
+    return PlatformComments_SomeEnum.useful;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for PlatformComments_SomeEnum enum.");
+  }
+}
+void smoke_PlatformComments_SomeEnum_releaseFfiHandle(int handle) {}
+final _smoke_PlatformComments_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_PlatformComments_SomeEnum_create_handle_nullable');
+final _smoke_PlatformComments_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_SomeEnum_release_handle_nullable');
+final _smoke_PlatformComments_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_SomeEnum_get_value_nullable');
+Pointer<Void> smoke_PlatformComments_SomeEnum_toFfi_nullable(PlatformComments_SomeEnum value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_PlatformComments_SomeEnum_toFfi(value);
+  final result = _smoke_PlatformComments_SomeEnum_create_handle_nullable(_handle);
+  smoke_PlatformComments_SomeEnum_releaseFfiHandle(_handle);
+  return result;
+}
+PlatformComments_SomeEnum smoke_PlatformComments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_PlatformComments_SomeEnum_get_value_nullable(handle);
+  final result = smoke_PlatformComments_SomeEnum_fromFfi(_handle);
+  smoke_PlatformComments_SomeEnum_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_PlatformComments_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PlatformComments_SomeEnum_release_handle_nullable(handle);
+// End of PlatformComments_SomeEnum "private" section.
+/// An exception when something goes wrong.
+class PlatformComments_SomethingWrongException implements Exception {
+  final PlatformComments_SomeEnum error;
+  PlatformComments_SomethingWrongException(this.error);
+}
+/// This is a.
+class PlatformComments_Something {
+  String nothing;
+  PlatformComments_Something(this.nothing);
+}
+// PlatformComments_Something "private" section, not exported.
+final _smoke_PlatformComments_Something_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_Something_create_handle');
+final _smoke_PlatformComments_Something_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_Something_release_handle');
+final _smoke_PlatformComments_Something_get_field_nothing = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_Something_get_field_nothing');
+Pointer<Void> smoke_PlatformComments_Something_toFfi(PlatformComments_Something value) {
+  final _nothing_handle = String_toFfi(value.nothing);
+  final _result = _smoke_PlatformComments_Something_create_handle(_nothing_handle);
+  String_releaseFfiHandle(_nothing_handle);
+  return _result;
+}
+PlatformComments_Something smoke_PlatformComments_Something_fromFfi(Pointer<Void> handle) {
+  final _nothing_handle = _smoke_PlatformComments_Something_get_field_nothing(handle);
+  final _result = PlatformComments_Something(
+    String_fromFfi(_nothing_handle)
+  );
+  String_releaseFfiHandle(_nothing_handle);
+  return _result;
+}
+void smoke_PlatformComments_Something_releaseFfiHandle(Pointer<Void> handle) => _smoke_PlatformComments_Something_release_handle(handle);
+// Nullable PlatformComments_Something
+final _smoke_PlatformComments_Something_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_Something_create_handle_nullable');
+final _smoke_PlatformComments_Something_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_Something_release_handle_nullable');
+final _smoke_PlatformComments_Something_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_Something_get_value_nullable');
+Pointer<Void> smoke_PlatformComments_Something_toFfi_nullable(PlatformComments_Something value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_PlatformComments_Something_toFfi(value);
+  final result = _smoke_PlatformComments_Something_create_handle_nullable(_handle);
+  smoke_PlatformComments_Something_releaseFfiHandle(_handle);
+  return result;
+}
+PlatformComments_Something smoke_PlatformComments_Something_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_PlatformComments_Something_get_value_nullable(handle);
+  final result = smoke_PlatformComments_Something_fromFfi(_handle);
+  smoke_PlatformComments_Something_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_PlatformComments_Something_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PlatformComments_Something_release_handle_nullable(handle);
+// End of PlatformComments_Something "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/UnicodeComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/UnicodeComments.dart
@@ -1,0 +1,69 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/smoke/Comments.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_init.dart' as __lib;
+final _smoke_UnicodeComments_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_UnicodeComments_copy_handle');
+final _smoke_UnicodeComments_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_UnicodeComments_release_handle');
+final _someMethodWithAllComments_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_release_handle');
+final _someMethodWithAllComments_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_get_result');
+final _someMethodWithAllComments_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_get_error');
+final _someMethodWithAllComments_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_has_error');
+class UnicodeComments {
+  final Pointer<Void> _handle;
+  UnicodeComments._(this._handle);
+  void release() => _smoke_UnicodeComments_release_handle(_handle);
+  /// Süßölgefäß
+  /// @param[input] שלום
+  /// @return товарищ
+  /// @throws ネコ
+  bool someMethodWithAllComments(String input) {
+    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_UnicodeComments_someMethodWithAllComments__String');
+    final _input_handle = String_toFfi(input);
+    final __call_result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
+        _someMethodWithAllComments_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Comments_SomeEnum_fromFfi(__error_handle);
+        smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
+        throw Comments_SomethingWrongException(_error_value);
+    }
+    final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
+    _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_UnicodeComments_toFfi(UnicodeComments value) =>
+  _smoke_UnicodeComments_copy_handle(value._handle);
+UnicodeComments smoke_UnicodeComments_fromFfi(Pointer<Void> handle) =>
+  UnicodeComments._(_smoke_UnicodeComments_copy_handle(handle));
+void smoke_UnicodeComments_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_UnicodeComments_release_handle(handle);
+Pointer<Void> smoke_UnicodeComments_toFfi_nullable(UnicodeComments value) =>
+  value != null ? smoke_UnicodeComments_toFfi(value) : Pointer<Void>.fromAddress(0);
+UnicodeComments smoke_UnicodeComments_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_UnicodeComments_fromFfi(handle) : null;
+void smoke_UnicodeComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_UnicodeComments_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/PlatformComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/PlatformComments.lime
@@ -5,19 +5,19 @@ class PlatformComments {
         Useless,
         Useful
     }
-    // An {@Java exception}{@Swift error} when something goes wrong.
+    // An {@Java exception}{@Dart exception}{@Swift error} when something goes wrong.
     exception SomethingWrong(SomeEnum)
     // This is a{@Cpp  very}{@Java  very}{@Java  super}{@Swift  super}{@Swift  useful}{@Cpp  useful}{@Cpp  struct}{@Java  struct}{@Swift  struct}.
     struct something {
         nothing: String
     }
-    // This is some very useless method that {@Cpp does nothing}{@Java makes some coffee}{@Swift is very swift}.
+    // This is some very useless method that {@Cpp does nothing}{@Java makes some coffee}{@Swift is very swift}{@Dart cannot have overloads}.
     fun doNothing()
-    // {@Cpp Cooks very special C++ sauce.}{@Java Makes some coffee.}{@Swift Eats a hip bruschetta.}
+    // {@Cpp Cooks very special C++ sauce.}{@Java Makes some coffee.}{@Swift Eats a hip bruschetta.}{@Dart Colors everything in fuchsia.}
     fun doMagic()
     // This is some very useful method that measures the usefulness of its input or \\esc\@pe\{s\}.
     // @param[input] Very useful {@Cpp input [PlatformComments] }parameter that \\esc\@pe\{s\}
-    // @return {@Cpp Usefulness}{@Java Uselessness [SomeEnum]}{@Swift Usefulness} of the input
+    // @return {@Cpp Usefulness}{@Java Uselessness [SomeEnum]}{@Swift Usefulness}{@Dart Uselessness [SomeEnum]} of the input
     // @throws Sometimes it happens{@Swift  but not on iOS [SomethingWrong] \\esc\@pe\{s\} }.
     fun someMethodWithAllComments(
         input: String

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -740,7 +740,7 @@ internal class AntlrLimeModelBuilder(
         parser.removeErrorListeners()
         parser.addErrorListener(ThrowingErrorListener(ctx.getStart().line - 1))
 
-        val builder = AntlrLimedocBuilder()
+        val builder = AntlrLimedocBuilder(currentPath)
         ParseTreeWalker.DEFAULT.walk(builder, parser.documentation())
 
         return builder.result

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimedocBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimedocBuilder.kt
@@ -22,8 +22,9 @@ package com.here.gluecodium.loader
 import com.here.gluecodium.antlr.LimedocParser
 import com.here.gluecodium.antlr.LimedocParserBaseListener
 import com.here.gluecodium.model.lime.LimeComment
+import com.here.gluecodium.model.lime.LimePath
 
-internal class AntlrLimedocBuilder : LimedocParserBaseListener() {
+internal class AntlrLimedocBuilder(private val currentPath: LimePath) : LimedocParserBaseListener() {
 
     private val commentsCollector = mutableMapOf<Pair<String, String>, LimeComment>()
     private val contentCollector = mutableListOf<Pair<String, String>>()
@@ -37,7 +38,7 @@ internal class AntlrLimedocBuilder : LimedocParserBaseListener() {
     // Overrides
 
     override fun exitDescription(ctx: LimedocParser.DescriptionContext) {
-        commentsCollector[Pair("", "")] = LimeComment(contentCollector.toList())
+        commentsCollector[Pair("", "")] = LimeComment(currentPath, contentCollector.toList())
         contentCollector.clear()
     }
 
@@ -62,7 +63,8 @@ internal class AntlrLimedocBuilder : LimedocParserBaseListener() {
     override fun exitBlockTag(ctx: LimedocParser.BlockTagContext) {
         val tagName = ctx.tagName().text
         val tagParameter = ctx.blockTagParameter()?.text ?: ""
-        commentsCollector[Pair(tagName, tagParameter)] = LimeComment(contentCollector.toList())
+        commentsCollector[Pair(tagName, tagParameter)] =
+            LimeComment(currentPath, contentCollector.toList())
         contentCollector.clear()
     }
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeComment.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeComment.kt
@@ -25,9 +25,13 @@ package com.here.gluecodium.model.lime
  * only applies to the platform represented by the tag (and thus should be skipped for all other
  * platforms).
  */
-class LimeComment(private val taggedSections: List<Pair<String, String>> = emptyList()) {
+class LimeComment(
+    val path: LimePath = LimePath.EMPTY_PATH,
+    private val taggedSections: List<Pair<String, String>> = emptyList()
+) {
 
-    constructor(comment: String) : this(listOf("" to comment))
+    constructor(comment: String, path: LimePath = LimePath.EMPTY_PATH) :
+            this(path, listOf("" to comment))
 
     fun isEmpty() = taggedSections.all { it.second.isEmpty() }
 


### PR DESCRIPTION
Added {{getAttribute}} helper to retrieve values of LIME attributes in
Mustache templates. Added unit tests for it.

Updated DartNameResolver to resolve Dart-specific platform comments and
to process comment links (replacing IDL element names with Dart element
names).

Utilizing both of the above, updated Dart templates to generate
documentation comments and @Deprecated annotations.

Added appropriate smoke tests.

Resolves: #80
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>