### PR TITLE
Add optional prefix to collection conversion functions in Dart

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -71,7 +71,7 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
 
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
         val dartNameResolver = DartNameResolver(limeModel.referenceMap, nameRules)
-        val ffiNameResolver = FfiNameResolver(limeModel.referenceMap, nameRules)
+        val ffiNameResolver = FfiNameResolver(limeModel.referenceMap, nameRules, libraryName)
 
         val dartResolvers = mapOf(
             "" to dartNameResolver,

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/Constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/Constructors.dart
@@ -84,9 +84,9 @@ class Constructors {
   }
   static Pointer<Void> _createFromList(List<double> input) {
     final _createFromList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Constructors_create__ListOf_1Double');
-    final _input_handle = ListOf_Double_toFfi(input);
+    final _input_handle = library_ListOf_Double_toFfi(input);
     final __result_handle = _createFromList_ffi(_input_handle);
-    ListOf_Double_releaseFfiHandle(_input_handle);
+    library_ListOf_Double_releaseFfiHandle(_input_handle);
     return __result_handle;
   }
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/DefaultValues.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/DefaultValues.dart
@@ -558,17 +558,17 @@ final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField = __li
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField');
 Pointer<Void> smoke_DefaultValues_StructWithEmptyDefaults_toFfi(DefaultValues_StructWithEmptyDefaults value) {
-  final _intsField_handle = ListOf_Int_toFfi(value.intsField);
-  final _floatsField_handle = ListOf_Float_toFfi(value.floatsField);
-  final _mapField_handle = MapOf_UInt_to_String_toFfi(value.mapField);
+  final _intsField_handle = library_ListOf_Int_toFfi(value.intsField);
+  final _floatsField_handle = library_ListOf_Float_toFfi(value.floatsField);
+  final _mapField_handle = library_MapOf_UInt_to_String_toFfi(value.mapField);
   final _structField_handle = smoke_DefaultValues_StructWithDefaults_toFfi(value.structField);
-  final _setTypeField_handle = SetOf_String_toFfi(value.setTypeField);
+  final _setTypeField_handle = library_SetOf_String_toFfi(value.setTypeField);
   final _result = _smoke_DefaultValues_StructWithEmptyDefaults_create_handle(_intsField_handle, _floatsField_handle, _mapField_handle, _structField_handle, _setTypeField_handle);
-  ListOf_Int_releaseFfiHandle(_intsField_handle);
-  ListOf_Float_releaseFfiHandle(_floatsField_handle);
-  MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
+  library_ListOf_Int_releaseFfiHandle(_intsField_handle);
+  library_ListOf_Float_releaseFfiHandle(_floatsField_handle);
+  library_MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
   smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_structField_handle);
-  SetOf_String_releaseFfiHandle(_setTypeField_handle);
+  library_SetOf_String_releaseFfiHandle(_setTypeField_handle);
   return _result;
 }
 DefaultValues_StructWithEmptyDefaults smoke_DefaultValues_StructWithEmptyDefaults_fromFfi(Pointer<Void> handle) {
@@ -578,17 +578,17 @@ DefaultValues_StructWithEmptyDefaults smoke_DefaultValues_StructWithEmptyDefault
   final _structField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_structField(handle);
   final _setTypeField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField(handle);
   final _result = DefaultValues_StructWithEmptyDefaults(
-    ListOf_Int_fromFfi(_intsField_handle),
-    ListOf_Float_fromFfi(_floatsField_handle),
-    MapOf_UInt_to_String_fromFfi(_mapField_handle),
+    library_ListOf_Int_fromFfi(_intsField_handle),
+    library_ListOf_Float_fromFfi(_floatsField_handle),
+    library_MapOf_UInt_to_String_fromFfi(_mapField_handle),
     smoke_DefaultValues_StructWithDefaults_fromFfi(_structField_handle),
-    SetOf_String_fromFfi(_setTypeField_handle)
+    library_SetOf_String_fromFfi(_setTypeField_handle)
   );
-  ListOf_Int_releaseFfiHandle(_intsField_handle);
-  ListOf_Float_releaseFfiHandle(_floatsField_handle);
-  MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
+  library_ListOf_Int_releaseFfiHandle(_intsField_handle);
+  library_ListOf_Float_releaseFfiHandle(_floatsField_handle);
+  library_MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
   smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_structField_handle);
-  SetOf_String_releaseFfiHandle(_setTypeField_handle);
+  library_SetOf_String_releaseFfiHandle(_setTypeField_handle);
   return _result;
 }
 void smoke_DefaultValues_StructWithEmptyDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithEmptyDefaults_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/StructWithInitializerDefaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/StructWithInitializerDefaults.dart
@@ -45,17 +45,17 @@ final _smoke_StructWithInitializerDefaults_get_field_mapField = __lib.nativeLibr
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_StructWithInitializerDefaults_get_field_mapField');
 Pointer<Void> smoke_StructWithInitializerDefaults_toFfi(StructWithInitializerDefaults value) {
-  final _intsField_handle = ListOf_Int_toFfi(value.intsField);
-  final _floatsField_handle = ListOf_Float_toFfi(value.floatsField);
+  final _intsField_handle = library_ListOf_Int_toFfi(value.intsField);
+  final _floatsField_handle = library_ListOf_Float_toFfi(value.floatsField);
   final _structField_handle = smoke_TypesWithDefaults_StructWithAnEnum_toFfi(value.structField);
-  final _setTypeField_handle = SetOf_String_toFfi(value.setTypeField);
-  final _mapField_handle = MapOf_UInt_to_String_toFfi(value.mapField);
+  final _setTypeField_handle = library_SetOf_String_toFfi(value.setTypeField);
+  final _mapField_handle = library_MapOf_UInt_to_String_toFfi(value.mapField);
   final _result = _smoke_StructWithInitializerDefaults_create_handle(_intsField_handle, _floatsField_handle, _structField_handle, _setTypeField_handle, _mapField_handle);
-  ListOf_Int_releaseFfiHandle(_intsField_handle);
-  ListOf_Float_releaseFfiHandle(_floatsField_handle);
+  library_ListOf_Int_releaseFfiHandle(_intsField_handle);
+  library_ListOf_Float_releaseFfiHandle(_floatsField_handle);
   smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_structField_handle);
-  SetOf_String_releaseFfiHandle(_setTypeField_handle);
-  MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
+  library_SetOf_String_releaseFfiHandle(_setTypeField_handle);
+  library_MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
   return _result;
 }
 StructWithInitializerDefaults smoke_StructWithInitializerDefaults_fromFfi(Pointer<Void> handle) {
@@ -65,17 +65,17 @@ StructWithInitializerDefaults smoke_StructWithInitializerDefaults_fromFfi(Pointe
   final _setTypeField_handle = _smoke_StructWithInitializerDefaults_get_field_setTypeField(handle);
   final _mapField_handle = _smoke_StructWithInitializerDefaults_get_field_mapField(handle);
   final _result = StructWithInitializerDefaults(
-    ListOf_Int_fromFfi(_intsField_handle),
-    ListOf_Float_fromFfi(_floatsField_handle),
+    library_ListOf_Int_fromFfi(_intsField_handle),
+    library_ListOf_Float_fromFfi(_floatsField_handle),
     smoke_TypesWithDefaults_StructWithAnEnum_fromFfi(_structField_handle),
-    SetOf_String_fromFfi(_setTypeField_handle),
-    MapOf_UInt_to_String_fromFfi(_mapField_handle)
+    library_SetOf_String_fromFfi(_setTypeField_handle),
+    library_MapOf_UInt_to_String_fromFfi(_mapField_handle)
   );
-  ListOf_Int_releaseFfiHandle(_intsField_handle);
-  ListOf_Float_releaseFfiHandle(_floatsField_handle);
+  library_ListOf_Int_releaseFfiHandle(_intsField_handle);
+  library_ListOf_Float_releaseFfiHandle(_floatsField_handle);
   smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_structField_handle);
-  SetOf_String_releaseFfiHandle(_setTypeField_handle);
-  MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
+  library_SetOf_String_releaseFfiHandle(_setTypeField_handle);
+  library_MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
   return _result;
 }
 void smoke_StructWithInitializerDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithInitializerDefaults_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/Equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/Equatable.dart
@@ -167,8 +167,8 @@ Pointer<Void> smoke_Equatable_EquatableStruct_toFfi(EquatableStruct value) {
   final _stringField_handle = String_toFfi(value.stringField);
   final _structField_handle = smoke_Equatable_NestedEquatableStruct_toFfi(value.structField);
   final _enumField_handle = smoke_Equatable_SomeEnum_toFfi(value.enumField);
-  final _arrayField_handle = ListOf_String_toFfi(value.arrayField);
-  final _mapField_handle = MapOf_Int_to_String_toFfi(value.mapField);
+  final _arrayField_handle = library_ListOf_String_toFfi(value.arrayField);
+  final _mapField_handle = library_MapOf_Int_to_String_toFfi(value.mapField);
   final _result = _smoke_Equatable_EquatableStruct_create_handle(_boolField_handle, _intField_handle, _longField_handle, _floatField_handle, _doubleField_handle, _stringField_handle, _structField_handle, _enumField_handle, _arrayField_handle, _mapField_handle);
   Boolean_releaseFfiHandle(_boolField_handle);
   (_intField_handle);
@@ -178,8 +178,8 @@ Pointer<Void> smoke_Equatable_EquatableStruct_toFfi(EquatableStruct value) {
   String_releaseFfiHandle(_stringField_handle);
   smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(_structField_handle);
   smoke_Equatable_SomeEnum_releaseFfiHandle(_enumField_handle);
-  ListOf_String_releaseFfiHandle(_arrayField_handle);
-  MapOf_Int_to_String_releaseFfiHandle(_mapField_handle);
+  library_ListOf_String_releaseFfiHandle(_arrayField_handle);
+  library_MapOf_Int_to_String_releaseFfiHandle(_mapField_handle);
   return _result;
 }
 EquatableStruct smoke_Equatable_EquatableStruct_fromFfi(Pointer<Void> handle) {
@@ -202,8 +202,8 @@ EquatableStruct smoke_Equatable_EquatableStruct_fromFfi(Pointer<Void> handle) {
     String_fromFfi(_stringField_handle),
     smoke_Equatable_NestedEquatableStruct_fromFfi(_structField_handle),
     smoke_Equatable_SomeEnum_fromFfi(_enumField_handle),
-    ListOf_String_fromFfi(_arrayField_handle),
-    MapOf_Int_to_String_fromFfi(_mapField_handle)
+    library_ListOf_String_fromFfi(_arrayField_handle),
+    library_MapOf_Int_to_String_fromFfi(_mapField_handle)
   );
   Boolean_releaseFfiHandle(_boolField_handle);
   (_intField_handle);
@@ -213,8 +213,8 @@ EquatableStruct smoke_Equatable_EquatableStruct_fromFfi(Pointer<Void> handle) {
   String_releaseFfiHandle(_stringField_handle);
   smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(_structField_handle);
   smoke_Equatable_SomeEnum_releaseFfiHandle(_enumField_handle);
-  ListOf_String_releaseFfiHandle(_arrayField_handle);
-  MapOf_Int_to_String_releaseFfiHandle(_mapField_handle);
+  library_ListOf_String_releaseFfiHandle(_arrayField_handle);
+  library_MapOf_Int_to_String_releaseFfiHandle(_mapField_handle);
   return _result;
 }
 void smoke_Equatable_EquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Equatable_EquatableStruct_release_handle(handle);
@@ -342,8 +342,8 @@ Pointer<Void> smoke_Equatable_EquatableNullableStruct_toFfi(EquatableNullableStr
   final _stringField_handle = String_toFfi_nullable(value.stringField);
   final _structField_handle = smoke_Equatable_NestedEquatableStruct_toFfi_nullable(value.structField);
   final _enumField_handle = smoke_Equatable_SomeEnum_toFfi_nullable(value.enumField);
-  final _arrayField_handle = ListOf_String_toFfi_nullable(value.arrayField);
-  final _mapField_handle = MapOf_Int_to_String_toFfi_nullable(value.mapField);
+  final _arrayField_handle = library_ListOf_String_toFfi_nullable(value.arrayField);
+  final _mapField_handle = library_MapOf_Int_to_String_toFfi_nullable(value.mapField);
   final _result = _smoke_Equatable_EquatableNullableStruct_create_handle(_boolField_handle, _intField_handle, _uintField_handle, _floatField_handle, _stringField_handle, _structField_handle, _enumField_handle, _arrayField_handle, _mapField_handle);
   Boolean_releaseFfiHandle_nullable(_boolField_handle);
   Int_releaseFfiHandle_nullable(_intField_handle);
@@ -352,8 +352,8 @@ Pointer<Void> smoke_Equatable_EquatableNullableStruct_toFfi(EquatableNullableStr
   String_releaseFfiHandle_nullable(_stringField_handle);
   smoke_Equatable_NestedEquatableStruct_releaseFfiHandle_nullable(_structField_handle);
   smoke_Equatable_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
-  ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
-  MapOf_Int_to_String_releaseFfiHandle_nullable(_mapField_handle);
+  library_ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
+  library_MapOf_Int_to_String_releaseFfiHandle_nullable(_mapField_handle);
   return _result;
 }
 EquatableNullableStruct smoke_Equatable_EquatableNullableStruct_fromFfi(Pointer<Void> handle) {
@@ -374,8 +374,8 @@ EquatableNullableStruct smoke_Equatable_EquatableNullableStruct_fromFfi(Pointer<
     String_fromFfi_nullable(_stringField_handle),
     smoke_Equatable_NestedEquatableStruct_fromFfi_nullable(_structField_handle),
     smoke_Equatable_SomeEnum_fromFfi_nullable(_enumField_handle),
-    ListOf_String_fromFfi_nullable(_arrayField_handle),
-    MapOf_Int_to_String_fromFfi_nullable(_mapField_handle)
+    library_ListOf_String_fromFfi_nullable(_arrayField_handle),
+    library_MapOf_Int_to_String_fromFfi_nullable(_mapField_handle)
   );
   Boolean_releaseFfiHandle_nullable(_boolField_handle);
   Int_releaseFfiHandle_nullable(_intField_handle);
@@ -384,8 +384,8 @@ EquatableNullableStruct smoke_Equatable_EquatableNullableStruct_fromFfi(Pointer<
   String_releaseFfiHandle_nullable(_stringField_handle);
   smoke_Equatable_NestedEquatableStruct_releaseFfiHandle_nullable(_structField_handle);
   smoke_Equatable_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
-  ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
-  MapOf_Int_to_String_releaseFfiHandle_nullable(_mapField_handle);
+  library_ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
+  library_MapOf_Int_to_String_releaseFfiHandle_nullable(_mapField_handle);
   return _result;
 }
 void smoke_Equatable_EquatableNullableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Equatable_EquatableNullableStruct_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Class.dart
@@ -47,9 +47,9 @@ class Class implements Interface {
   }
   Struct fun(List<Struct> double) {
     final _fun_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('package_Class_fun__ListOf_1package_1Types_1Struct');
-    final _double_handle = ListOf_package_Types_Struct_toFfi(double);
+    final _double_handle = library_ListOf_package_Types_Struct_toFfi(double);
     final __call_result_handle = _fun_ffi(_handle, _double_handle);
-    ListOf_package_Types_Struct_releaseFfiHandle(_double_handle);
+    library_ListOf_package_Types_Struct_releaseFfiHandle(_double_handle);
     if (_fun_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _fun_return_get_error(__call_result_handle);
         _fun_return_release_handle(__call_result_handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/ffi/GenericTypesConversion.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/ffi/GenericTypesConversion.cpp
@@ -20,46 +20,46 @@
 extern "C" {
 #endif
 FfiOpaqueHandle
-ListOf_Float_create_handle() {
+library_ListOf_Float_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<float>());
 }
 void
-ListOf_Float_release_handle(FfiOpaqueHandle handle) {
+library_ListOf_Float_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::vector<float>*>(handle);
 }
 void
-ListOf_Float_insert(FfiOpaqueHandle handle, float value) {
+library_ListOf_Float_insert(FfiOpaqueHandle handle, float value) {
     reinterpret_cast<std::vector<float>*>(handle)->push_back(
         gluecodium::ffi::Conversion<float>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-ListOf_Float_iterator(FfiOpaqueHandle handle) {
+library_ListOf_Float_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<float>::iterator(
         reinterpret_cast<std::vector<float>*>(handle)->begin()
     ));
 }
 void
-ListOf_Float_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_ListOf_Float_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::vector<float>::iterator*>(iterator_handle);
 }
 bool
-ListOf_Float_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_ListOf_Float_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::vector<float>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::vector<float>*>(handle)->end();
 }
 void
-ListOf_Float_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_ListOf_Float_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::vector<float>::iterator*>(iterator_handle);
 }
 float
-ListOf_Float_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_ListOf_Float_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<float>::toFfi(
         **reinterpret_cast<std::vector<float>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-ListOf_Float_create_handle_nullable(FfiOpaqueHandle value)
+library_ListOf_Float_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::vector<float>>(
@@ -68,58 +68,58 @@ ListOf_Float_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-ListOf_Float_release_handle_nullable(FfiOpaqueHandle handle)
+library_ListOf_Float_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::vector<float>>*>(handle);
 }
 FfiOpaqueHandle
-ListOf_Float_get_value_nullable(FfiOpaqueHandle handle)
+library_ListOf_Float_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::vector<float>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::vector<float>>*>(handle)
     );
 }
 FfiOpaqueHandle
-ListOf_Int_create_handle() {
+library_ListOf_Int_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<int32_t>());
 }
 void
-ListOf_Int_release_handle(FfiOpaqueHandle handle) {
+library_ListOf_Int_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::vector<int32_t>*>(handle);
 }
 void
-ListOf_Int_insert(FfiOpaqueHandle handle, int32_t value) {
+library_ListOf_Int_insert(FfiOpaqueHandle handle, int32_t value) {
     reinterpret_cast<std::vector<int32_t>*>(handle)->push_back(
         gluecodium::ffi::Conversion<int32_t>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-ListOf_Int_iterator(FfiOpaqueHandle handle) {
+library_ListOf_Int_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<int32_t>::iterator(
         reinterpret_cast<std::vector<int32_t>*>(handle)->begin()
     ));
 }
 void
-ListOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_ListOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::vector<int32_t>::iterator*>(iterator_handle);
 }
 bool
-ListOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_ListOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::vector<int32_t>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::vector<int32_t>*>(handle)->end();
 }
 void
-ListOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_ListOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::vector<int32_t>::iterator*>(iterator_handle);
 }
 int32_t
-ListOf_Int_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_ListOf_Int_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<int32_t>::toFfi(
         **reinterpret_cast<std::vector<int32_t>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-ListOf_Int_create_handle_nullable(FfiOpaqueHandle value)
+library_ListOf_Int_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::vector<int32_t>>(
@@ -128,238 +128,58 @@ ListOf_Int_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-ListOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
+library_ListOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::vector<int32_t>>*>(handle);
 }
 FfiOpaqueHandle
-ListOf_Int_get_value_nullable(FfiOpaqueHandle handle)
+library_ListOf_Int_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::vector<int32_t>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::vector<int32_t>>*>(handle)
     );
 }
 FfiOpaqueHandle
-ListOf_ListOf_Int_create_handle() {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::vector<int32_t>>());
-}
-void
-ListOf_ListOf_Int_release_handle(FfiOpaqueHandle handle) {
-    delete reinterpret_cast<std::vector<std::vector<int32_t>>*>(handle);
-}
-void
-ListOf_ListOf_Int_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
-    reinterpret_cast<std::vector<std::vector<int32_t>>*>(handle)->push_back(
-        gluecodium::ffi::Conversion<std::vector<int32_t>>::toCpp(value)
-    );
-}
-FfiOpaqueHandle
-ListOf_ListOf_Int_iterator(FfiOpaqueHandle handle) {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::vector<int32_t>>::iterator(
-        reinterpret_cast<std::vector<std::vector<int32_t>>*>(handle)->begin()
-    ));
-}
-void
-ListOf_ListOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
-    delete reinterpret_cast<std::vector<std::vector<int32_t>>::iterator*>(iterator_handle);
-}
-bool
-ListOf_ListOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
-    return *reinterpret_cast<std::vector<std::vector<int32_t>>::iterator*>(iterator_handle) !=
-        reinterpret_cast<std::vector<std::vector<int32_t>>*>(handle)->end();
-}
-void
-ListOf_ListOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
-    ++*reinterpret_cast<std::vector<std::vector<int32_t>>::iterator*>(iterator_handle);
-}
-FfiOpaqueHandle
-ListOf_ListOf_Int_iterator_get(FfiOpaqueHandle iterator_handle) {
-    return gluecodium::ffi::Conversion<std::vector<int32_t>>::toFfi(
-        **reinterpret_cast<std::vector<std::vector<int32_t>>::iterator*>(iterator_handle)
-    );
-}
-FfiOpaqueHandle
-ListOf_ListOf_Int_create_handle_nullable(FfiOpaqueHandle value)
-{
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) gluecodium::optional<std::vector<std::vector<int32_t>>>(
-            gluecodium::ffi::Conversion<std::vector<std::vector<int32_t>>>::toCpp(value)
-        )
-    );
-}
-void
-ListOf_ListOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
-{
-    delete reinterpret_cast<gluecodium::optional<std::vector<std::vector<int32_t>>>*>(handle);
-}
-FfiOpaqueHandle
-ListOf_ListOf_Int_get_value_nullable(FfiOpaqueHandle handle)
-{
-    return gluecodium::ffi::Conversion<std::vector<std::vector<int32_t>>>::toFfi(
-        **reinterpret_cast<gluecodium::optional<std::vector<std::vector<int32_t>>>*>(handle)
-    );
-}
-FfiOpaqueHandle
-ListOf_MapOf_Int_to_Boolean_create_handle() {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::unordered_map<int32_t, bool>>());
-}
-void
-ListOf_MapOf_Int_to_Boolean_release_handle(FfiOpaqueHandle handle) {
-    delete reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>*>(handle);
-}
-void
-ListOf_MapOf_Int_to_Boolean_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
-    reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>*>(handle)->push_back(
-        gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toCpp(value)
-    );
-}
-FfiOpaqueHandle
-ListOf_MapOf_Int_to_Boolean_iterator(FfiOpaqueHandle handle) {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::unordered_map<int32_t, bool>>::iterator(
-        reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>*>(handle)->begin()
-    ));
-}
-void
-ListOf_MapOf_Int_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
-    delete reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle);
-}
-bool
-ListOf_MapOf_Int_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
-    return *reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle) !=
-        reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>*>(handle)->end();
-}
-void
-ListOf_MapOf_Int_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
-    ++*reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle);
-}
-FfiOpaqueHandle
-ListOf_MapOf_Int_to_Boolean_iterator_get(FfiOpaqueHandle iterator_handle) {
-    return gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toFfi(
-        **reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle)
-    );
-}
-FfiOpaqueHandle
-ListOf_MapOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
-{
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) gluecodium::optional<std::vector<std::unordered_map<int32_t, bool>>>(
-            gluecodium::ffi::Conversion<std::vector<std::unordered_map<int32_t, bool>>>::toCpp(value)
-        )
-    );
-}
-void
-ListOf_MapOf_Int_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
-{
-    delete reinterpret_cast<gluecodium::optional<std::vector<std::unordered_map<int32_t, bool>>>*>(handle);
-}
-FfiOpaqueHandle
-ListOf_MapOf_Int_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
-{
-    return gluecodium::ffi::Conversion<std::vector<std::unordered_map<int32_t, bool>>>::toFfi(
-        **reinterpret_cast<gluecodium::optional<std::vector<std::unordered_map<int32_t, bool>>>*>(handle)
-    );
-}
-FfiOpaqueHandle
-ListOf_SetOf_Int_create_handle() {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::unordered_set<int32_t>>());
-}
-void
-ListOf_SetOf_Int_release_handle(FfiOpaqueHandle handle) {
-    delete reinterpret_cast<std::vector<std::unordered_set<int32_t>>*>(handle);
-}
-void
-ListOf_SetOf_Int_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
-    reinterpret_cast<std::vector<std::unordered_set<int32_t>>*>(handle)->push_back(
-        gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toCpp(value)
-    );
-}
-FfiOpaqueHandle
-ListOf_SetOf_Int_iterator(FfiOpaqueHandle handle) {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::unordered_set<int32_t>>::iterator(
-        reinterpret_cast<std::vector<std::unordered_set<int32_t>>*>(handle)->begin()
-    ));
-}
-void
-ListOf_SetOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
-    delete reinterpret_cast<std::vector<std::unordered_set<int32_t>>::iterator*>(iterator_handle);
-}
-bool
-ListOf_SetOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
-    return *reinterpret_cast<std::vector<std::unordered_set<int32_t>>::iterator*>(iterator_handle) !=
-        reinterpret_cast<std::vector<std::unordered_set<int32_t>>*>(handle)->end();
-}
-void
-ListOf_SetOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
-    ++*reinterpret_cast<std::vector<std::unordered_set<int32_t>>::iterator*>(iterator_handle);
-}
-FfiOpaqueHandle
-ListOf_SetOf_Int_iterator_get(FfiOpaqueHandle iterator_handle) {
-    return gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toFfi(
-        **reinterpret_cast<std::vector<std::unordered_set<int32_t>>::iterator*>(iterator_handle)
-    );
-}
-FfiOpaqueHandle
-ListOf_SetOf_Int_create_handle_nullable(FfiOpaqueHandle value)
-{
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) gluecodium::optional<std::vector<std::unordered_set<int32_t>>>(
-            gluecodium::ffi::Conversion<std::vector<std::unordered_set<int32_t>>>::toCpp(value)
-        )
-    );
-}
-void
-ListOf_SetOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
-{
-    delete reinterpret_cast<gluecodium::optional<std::vector<std::unordered_set<int32_t>>>*>(handle);
-}
-FfiOpaqueHandle
-ListOf_SetOf_Int_get_value_nullable(FfiOpaqueHandle handle)
-{
-    return gluecodium::ffi::Conversion<std::vector<std::unordered_set<int32_t>>>::toFfi(
-        **reinterpret_cast<gluecodium::optional<std::vector<std::unordered_set<int32_t>>>*>(handle)
-    );
-}
-FfiOpaqueHandle
-ListOf_String_create_handle() {
+library_ListOf_String_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::string>());
 }
 void
-ListOf_String_release_handle(FfiOpaqueHandle handle) {
+library_ListOf_String_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::vector<std::string>*>(handle);
 }
 void
-ListOf_String_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+library_ListOf_String_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
     reinterpret_cast<std::vector<std::string>*>(handle)->push_back(
         gluecodium::ffi::Conversion<std::string>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-ListOf_String_iterator(FfiOpaqueHandle handle) {
+library_ListOf_String_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::string>::iterator(
         reinterpret_cast<std::vector<std::string>*>(handle)->begin()
     ));
 }
 void
-ListOf_String_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_ListOf_String_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::vector<std::string>::iterator*>(iterator_handle);
 }
 bool
-ListOf_String_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_ListOf_String_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::vector<std::string>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::vector<std::string>*>(handle)->end();
 }
 void
-ListOf_String_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_ListOf_String_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::vector<std::string>::iterator*>(iterator_handle);
 }
 FfiOpaqueHandle
-ListOf_String_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_ListOf_String_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::string>::toFfi(
         **reinterpret_cast<std::vector<std::string>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-ListOf_String_create_handle_nullable(FfiOpaqueHandle value)
+library_ListOf_String_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::vector<std::string>>(
@@ -368,58 +188,58 @@ ListOf_String_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-ListOf_String_release_handle_nullable(FfiOpaqueHandle handle)
+library_ListOf_String_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::vector<std::string>>*>(handle);
 }
 FfiOpaqueHandle
-ListOf_String_get_value_nullable(FfiOpaqueHandle handle)
+library_ListOf_String_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::vector<std::string>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::vector<std::string>>*>(handle)
     );
 }
 FfiOpaqueHandle
-ListOf_UByte_create_handle() {
+library_ListOf_UByte_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<uint8_t>());
 }
 void
-ListOf_UByte_release_handle(FfiOpaqueHandle handle) {
+library_ListOf_UByte_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::vector<uint8_t>*>(handle);
 }
 void
-ListOf_UByte_insert(FfiOpaqueHandle handle, uint8_t value) {
+library_ListOf_UByte_insert(FfiOpaqueHandle handle, uint8_t value) {
     reinterpret_cast<std::vector<uint8_t>*>(handle)->push_back(
         gluecodium::ffi::Conversion<uint8_t>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-ListOf_UByte_iterator(FfiOpaqueHandle handle) {
+library_ListOf_UByte_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<uint8_t>::iterator(
         reinterpret_cast<std::vector<uint8_t>*>(handle)->begin()
     ));
 }
 void
-ListOf_UByte_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_ListOf_UByte_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::vector<uint8_t>::iterator*>(iterator_handle);
 }
 bool
-ListOf_UByte_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_ListOf_UByte_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::vector<uint8_t>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::vector<uint8_t>*>(handle)->end();
 }
 void
-ListOf_UByte_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_ListOf_UByte_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::vector<uint8_t>::iterator*>(iterator_handle);
 }
 uint8_t
-ListOf_UByte_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_ListOf_UByte_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<uint8_t>::toFfi(
         **reinterpret_cast<std::vector<uint8_t>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-ListOf_UByte_create_handle_nullable(FfiOpaqueHandle value)
+library_ListOf_UByte_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::vector<uint8_t>>(
@@ -428,58 +248,238 @@ ListOf_UByte_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-ListOf_UByte_release_handle_nullable(FfiOpaqueHandle handle)
+library_ListOf_UByte_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::vector<uint8_t>>*>(handle);
 }
 FfiOpaqueHandle
-ListOf_UByte_get_value_nullable(FfiOpaqueHandle handle)
+library_ListOf_UByte_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::vector<uint8_t>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::vector<uint8_t>>*>(handle)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_DummyClass_create_handle() {
+library_ListOf_library_ListOf_Int_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::vector<int32_t>>());
+}
+void
+library_ListOf_library_ListOf_Int_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::vector<std::vector<int32_t>>*>(handle);
+}
+void
+library_ListOf_library_ListOf_Int_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+    reinterpret_cast<std::vector<std::vector<int32_t>>*>(handle)->push_back(
+        gluecodium::ffi::Conversion<std::vector<int32_t>>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_ListOf_library_ListOf_Int_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::vector<int32_t>>::iterator(
+        reinterpret_cast<std::vector<std::vector<int32_t>>*>(handle)->begin()
+    ));
+}
+void
+library_ListOf_library_ListOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::vector<std::vector<int32_t>>::iterator*>(iterator_handle);
+}
+bool
+library_ListOf_library_ListOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::vector<std::vector<int32_t>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::vector<std::vector<int32_t>>*>(handle)->end();
+}
+void
+library_ListOf_library_ListOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::vector<std::vector<int32_t>>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_ListOf_library_ListOf_Int_iterator_get(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::vector<int32_t>>::toFfi(
+        **reinterpret_cast<std::vector<std::vector<int32_t>>::iterator*>(iterator_handle)
+    );
+}
+FfiOpaqueHandle
+library_ListOf_library_ListOf_Int_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::vector<std::vector<int32_t>>>(
+            gluecodium::ffi::Conversion<std::vector<std::vector<int32_t>>>::toCpp(value)
+        )
+    );
+}
+void
+library_ListOf_library_ListOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::vector<std::vector<int32_t>>>*>(handle);
+}
+FfiOpaqueHandle
+library_ListOf_library_ListOf_Int_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::vector<std::vector<int32_t>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::vector<std::vector<int32_t>>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_ListOf_library_MapOf_Int_to_Boolean_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::unordered_map<int32_t, bool>>());
+}
+void
+library_ListOf_library_MapOf_Int_to_Boolean_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>*>(handle);
+}
+void
+library_ListOf_library_MapOf_Int_to_Boolean_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+    reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>*>(handle)->push_back(
+        gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_ListOf_library_MapOf_Int_to_Boolean_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::unordered_map<int32_t, bool>>::iterator(
+        reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>*>(handle)->begin()
+    ));
+}
+void
+library_ListOf_library_MapOf_Int_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle);
+}
+bool
+library_ListOf_library_MapOf_Int_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>*>(handle)->end();
+}
+void
+library_ListOf_library_MapOf_Int_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_ListOf_library_MapOf_Int_to_Boolean_iterator_get(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toFfi(
+        **reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle)
+    );
+}
+FfiOpaqueHandle
+library_ListOf_library_MapOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::vector<std::unordered_map<int32_t, bool>>>(
+            gluecodium::ffi::Conversion<std::vector<std::unordered_map<int32_t, bool>>>::toCpp(value)
+        )
+    );
+}
+void
+library_ListOf_library_MapOf_Int_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::vector<std::unordered_map<int32_t, bool>>>*>(handle);
+}
+FfiOpaqueHandle
+library_ListOf_library_MapOf_Int_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::vector<std::unordered_map<int32_t, bool>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::vector<std::unordered_map<int32_t, bool>>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_ListOf_library_SetOf_Int_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::unordered_set<int32_t>>());
+}
+void
+library_ListOf_library_SetOf_Int_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::vector<std::unordered_set<int32_t>>*>(handle);
+}
+void
+library_ListOf_library_SetOf_Int_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+    reinterpret_cast<std::vector<std::unordered_set<int32_t>>*>(handle)->push_back(
+        gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_ListOf_library_SetOf_Int_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::unordered_set<int32_t>>::iterator(
+        reinterpret_cast<std::vector<std::unordered_set<int32_t>>*>(handle)->begin()
+    ));
+}
+void
+library_ListOf_library_SetOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::vector<std::unordered_set<int32_t>>::iterator*>(iterator_handle);
+}
+bool
+library_ListOf_library_SetOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::vector<std::unordered_set<int32_t>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::vector<std::unordered_set<int32_t>>*>(handle)->end();
+}
+void
+library_ListOf_library_SetOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::vector<std::unordered_set<int32_t>>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_ListOf_library_SetOf_Int_iterator_get(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toFfi(
+        **reinterpret_cast<std::vector<std::unordered_set<int32_t>>::iterator*>(iterator_handle)
+    );
+}
+FfiOpaqueHandle
+library_ListOf_library_SetOf_Int_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::vector<std::unordered_set<int32_t>>>(
+            gluecodium::ffi::Conversion<std::vector<std::unordered_set<int32_t>>>::toCpp(value)
+        )
+    );
+}
+void
+library_ListOf_library_SetOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::vector<std::unordered_set<int32_t>>>*>(handle);
+}
+FfiOpaqueHandle
+library_ListOf_library_SetOf_Int_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::vector<std::unordered_set<int32_t>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::vector<std::unordered_set<int32_t>>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_ListOf_smoke_DummyClass_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::shared_ptr<::smoke::DummyClass>>());
 }
 void
-ListOf_smoke_DummyClass_release_handle(FfiOpaqueHandle handle) {
+library_ListOf_smoke_DummyClass_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyClass>>*>(handle);
 }
 void
-ListOf_smoke_DummyClass_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+library_ListOf_smoke_DummyClass_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
     reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyClass>>*>(handle)->push_back(
         gluecodium::ffi::Conversion<std::shared_ptr<::smoke::DummyClass>>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_DummyClass_iterator(FfiOpaqueHandle handle) {
+library_ListOf_smoke_DummyClass_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::shared_ptr<::smoke::DummyClass>>::iterator(
         reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyClass>>*>(handle)->begin()
     ));
 }
 void
-ListOf_smoke_DummyClass_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_DummyClass_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyClass>>::iterator*>(iterator_handle);
 }
 bool
-ListOf_smoke_DummyClass_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_DummyClass_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyClass>>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyClass>>*>(handle)->end();
 }
 void
-ListOf_smoke_DummyClass_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_DummyClass_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyClass>>::iterator*>(iterator_handle);
 }
 FfiOpaqueHandle
-ListOf_smoke_DummyClass_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_DummyClass_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::shared_ptr<::smoke::DummyClass>>::toFfi(
         **reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyClass>>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_DummyClass_create_handle_nullable(FfiOpaqueHandle value)
+library_ListOf_smoke_DummyClass_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::vector<std::shared_ptr<::smoke::DummyClass>>>(
@@ -488,58 +488,58 @@ ListOf_smoke_DummyClass_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-ListOf_smoke_DummyClass_release_handle_nullable(FfiOpaqueHandle handle)
+library_ListOf_smoke_DummyClass_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::vector<std::shared_ptr<::smoke::DummyClass>>>*>(handle);
 }
 FfiOpaqueHandle
-ListOf_smoke_DummyClass_get_value_nullable(FfiOpaqueHandle handle)
+library_ListOf_smoke_DummyClass_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::vector<std::shared_ptr<::smoke::DummyClass>>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::vector<std::shared_ptr<::smoke::DummyClass>>>*>(handle)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_DummyInterface_create_handle() {
+library_ListOf_smoke_DummyInterface_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::shared_ptr<::smoke::DummyInterface>>());
 }
 void
-ListOf_smoke_DummyInterface_release_handle(FfiOpaqueHandle handle) {
+library_ListOf_smoke_DummyInterface_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyInterface>>*>(handle);
 }
 void
-ListOf_smoke_DummyInterface_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+library_ListOf_smoke_DummyInterface_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
     reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyInterface>>*>(handle)->push_back(
         gluecodium::ffi::Conversion<std::shared_ptr<::smoke::DummyInterface>>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_DummyInterface_iterator(FfiOpaqueHandle handle) {
+library_ListOf_smoke_DummyInterface_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::shared_ptr<::smoke::DummyInterface>>::iterator(
         reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyInterface>>*>(handle)->begin()
     ));
 }
 void
-ListOf_smoke_DummyInterface_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_DummyInterface_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyInterface>>::iterator*>(iterator_handle);
 }
 bool
-ListOf_smoke_DummyInterface_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_DummyInterface_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyInterface>>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyInterface>>*>(handle)->end();
 }
 void
-ListOf_smoke_DummyInterface_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_DummyInterface_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyInterface>>::iterator*>(iterator_handle);
 }
 FfiOpaqueHandle
-ListOf_smoke_DummyInterface_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_DummyInterface_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::shared_ptr<::smoke::DummyInterface>>::toFfi(
         **reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyInterface>>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_DummyInterface_create_handle_nullable(FfiOpaqueHandle value)
+library_ListOf_smoke_DummyInterface_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::vector<std::shared_ptr<::smoke::DummyInterface>>>(
@@ -548,58 +548,58 @@ ListOf_smoke_DummyInterface_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-ListOf_smoke_DummyInterface_release_handle_nullable(FfiOpaqueHandle handle)
+library_ListOf_smoke_DummyInterface_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::vector<std::shared_ptr<::smoke::DummyInterface>>>*>(handle);
 }
 FfiOpaqueHandle
-ListOf_smoke_DummyInterface_get_value_nullable(FfiOpaqueHandle handle)
+library_ListOf_smoke_DummyInterface_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::vector<std::shared_ptr<::smoke::DummyInterface>>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::vector<std::shared_ptr<::smoke::DummyInterface>>>*>(handle)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle() {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>());
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(FfiOpaqueHandle handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>*>(handle);
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
     reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>*>(handle)->push_back(
         gluecodium::ffi::Conversion<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator(FfiOpaqueHandle handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator(
         reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>*>(handle)->begin()
     ));
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>(iterator_handle);
 }
 bool
-ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>*>(handle)->end();
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>(iterator_handle);
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::toFfi(
         **reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable(FfiOpaqueHandle value)
+library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>(
@@ -608,58 +608,58 @@ ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable(Ff
     );
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable(FfiOpaqueHandle handle)
+library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>*>(handle);
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable(FfiOpaqueHandle handle)
+library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>*>(handle)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle() {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<::alien::FooEnum>());
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(FfiOpaqueHandle handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::vector<::alien::FooEnum>*>(handle);
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(FfiOpaqueHandle handle, uint32_t value) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(FfiOpaqueHandle handle, uint32_t value) {
     reinterpret_cast<std::vector<::alien::FooEnum>*>(handle)->push_back(
         gluecodium::ffi::Conversion<::alien::FooEnum>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(FfiOpaqueHandle handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<::alien::FooEnum>::iterator(
         reinterpret_cast<std::vector<::alien::FooEnum>*>(handle)->begin()
     ));
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::vector<::alien::FooEnum>::iterator*>(iterator_handle);
 }
 bool
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::vector<::alien::FooEnum>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::vector<::alien::FooEnum>*>(handle)->end();
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::vector<::alien::FooEnum>::iterator*>(iterator_handle);
 }
 uint32_t
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<::alien::FooEnum>::toFfi(
         **reinterpret_cast<std::vector<::alien::FooEnum>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(FfiOpaqueHandle value)
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::vector<::alien::FooEnum>>(
@@ -668,58 +668,58 @@ ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(F
     );
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(FfiOpaqueHandle handle)
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::vector<::alien::FooEnum>>*>(handle);
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(FfiOpaqueHandle handle)
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::vector<::alien::FooEnum>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::vector<::alien::FooEnum>>*>(handle)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle() {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<::alien::FooStruct>());
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(FfiOpaqueHandle handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::vector<::alien::FooStruct>*>(handle);
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
     reinterpret_cast<std::vector<::alien::FooStruct>*>(handle)->push_back(
         gluecodium::ffi::Conversion<::alien::FooStruct>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator(FfiOpaqueHandle handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<::alien::FooStruct>::iterator(
         reinterpret_cast<std::vector<::alien::FooStruct>*>(handle)->begin()
     ));
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::vector<::alien::FooStruct>::iterator*>(iterator_handle);
 }
 bool
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::vector<::alien::FooStruct>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::vector<::alien::FooStruct>*>(handle)->end();
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::vector<::alien::FooStruct>::iterator*>(iterator_handle);
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<::alien::FooStruct>::toFfi(
         **reinterpret_cast<std::vector<::alien::FooStruct>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable(FfiOpaqueHandle value)
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::vector<::alien::FooStruct>>(
@@ -728,58 +728,58 @@ ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable
     );
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable(FfiOpaqueHandle handle)
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::vector<::alien::FooStruct>>*>(handle);
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable(FfiOpaqueHandle handle)
+library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::vector<::alien::FooStruct>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::vector<::alien::FooStruct>>*>(handle)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle() {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>());
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(FfiOpaqueHandle handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>*>(handle);
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(FfiOpaqueHandle handle, uint32_t value) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(FfiOpaqueHandle handle, uint32_t value) {
     reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>*>(handle)->push_back(
         gluecodium::ffi::Conversion<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(FfiOpaqueHandle handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator(
         reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>*>(handle)->begin()
     ));
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>(iterator_handle);
 }
 bool
-ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>*>(handle)->end();
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>(iterator_handle);
 }
 uint32_t
-ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::toFfi(
         **reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(FfiOpaqueHandle value)
+library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>(
@@ -788,65 +788,65 @@ ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(FfiOp
     );
 }
 void
-ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable(FfiOpaqueHandle handle)
+library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>(handle);
 }
 FfiOpaqueHandle
-ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(FfiOpaqueHandle handle)
+library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_Float_to_Double_create_handle() {
+library_MapOf_Float_to_Double_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<float, double>());
 }
 void
-MapOf_Float_to_Double_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_Float_to_Double_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<float, double>*>(handle);
 }
 void
-MapOf_Float_to_Double_put(FfiOpaqueHandle handle, float key, double value) {
+library_MapOf_Float_to_Double_put(FfiOpaqueHandle handle, float key, double value) {
     reinterpret_cast<std::unordered_map<float, double>*>(handle)->emplace(
         gluecodium::ffi::Conversion<float>::toCpp(key),
         gluecodium::ffi::Conversion<double>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_Float_to_Double_iterator(FfiOpaqueHandle handle) {
+library_MapOf_Float_to_Double_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<float, double>::iterator(
         reinterpret_cast<std::unordered_map<float, double>*>(handle)->begin()
     ));
 }
 void
-MapOf_Float_to_Double_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Float_to_Double_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<float, double>::iterator*>(iterator_handle);
 }
 bool
-MapOf_Float_to_Double_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_Float_to_Double_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<float, double>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<float, double>*>(handle)->end();
 }
 void
-MapOf_Float_to_Double_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Float_to_Double_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<float, double>::iterator*>(iterator_handle);
 }
 float
-MapOf_Float_to_Double_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Float_to_Double_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<float>::toFfi(
         (*reinterpret_cast<std::unordered_map<float, double>::iterator*>(iterator_handle))->first
     );
 }
 double
-MapOf_Float_to_Double_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Float_to_Double_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<double>::toFfi(
         (*reinterpret_cast<std::unordered_map<float, double>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_Float_to_Double_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_Float_to_Double_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<float, double>>(
@@ -855,65 +855,65 @@ MapOf_Float_to_Double_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-MapOf_Float_to_Double_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_Float_to_Double_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<float, double>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_Float_to_Double_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_Float_to_Double_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<float, double>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<float, double>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_Boolean_create_handle() {
+library_MapOf_Int_to_Boolean_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, bool>());
 }
 void
-MapOf_Int_to_Boolean_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_Boolean_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, bool>*>(handle);
 }
 void
-MapOf_Int_to_Boolean_put(FfiOpaqueHandle handle, int32_t key, bool value) {
+library_MapOf_Int_to_Boolean_put(FfiOpaqueHandle handle, int32_t key, bool value) {
     reinterpret_cast<std::unordered_map<int32_t, bool>*>(handle)->emplace(
         gluecodium::ffi::Conversion<int32_t>::toCpp(key),
         gluecodium::ffi::Conversion<bool>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_Boolean_iterator(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_Boolean_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, bool>::iterator(
         reinterpret_cast<std::unordered_map<int32_t, bool>*>(handle)->begin()
     ));
 }
 void
-MapOf_Int_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, bool>::iterator*>(iterator_handle);
 }
 bool
-MapOf_Int_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<int32_t, bool>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<int32_t, bool>*>(handle)->end();
 }
 void
-MapOf_Int_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<int32_t, bool>::iterator*>(iterator_handle);
 }
 int32_t
-MapOf_Int_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<int32_t>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, bool>::iterator*>(iterator_handle))->first
     );
 }
 bool
-MapOf_Int_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<bool>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, bool>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<int32_t, bool>>(
@@ -922,65 +922,65 @@ MapOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-MapOf_Int_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, bool>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_Int_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, bool>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_ListOf_Int_create_handle() {
+library_MapOf_Int_to_library_ListOf_Int_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, std::vector<int32_t>>());
 }
 void
-MapOf_Int_to_ListOf_Int_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_library_ListOf_Int_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>*>(handle);
 }
 void
-MapOf_Int_to_ListOf_Int_put(FfiOpaqueHandle handle, int32_t key, FfiOpaqueHandle value) {
+library_MapOf_Int_to_library_ListOf_Int_put(FfiOpaqueHandle handle, int32_t key, FfiOpaqueHandle value) {
     reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>*>(handle)->emplace(
         gluecodium::ffi::Conversion<int32_t>::toCpp(key),
         gluecodium::ffi::Conversion<std::vector<int32_t>>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_ListOf_Int_iterator(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_library_ListOf_Int_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, std::vector<int32_t>>::iterator(
         reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>*>(handle)->begin()
     ));
 }
 void
-MapOf_Int_to_ListOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_ListOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>::iterator*>(iterator_handle);
 }
 bool
-MapOf_Int_to_ListOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_ListOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>*>(handle)->end();
 }
 void
-MapOf_Int_to_ListOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_ListOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>::iterator*>(iterator_handle);
 }
 int32_t
-MapOf_Int_to_ListOf_Int_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_ListOf_Int_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<int32_t>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>::iterator*>(iterator_handle))->first
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_ListOf_Int_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_ListOf_Int_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::vector<int32_t>>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_ListOf_Int_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_Int_to_library_ListOf_Int_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<int32_t, std::vector<int32_t>>>(
@@ -989,65 +989,65 @@ MapOf_Int_to_ListOf_Int_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-MapOf_Int_to_ListOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_library_ListOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, std::vector<int32_t>>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_Int_to_ListOf_Int_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_library_ListOf_Int_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<int32_t, std::vector<int32_t>>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, std::vector<int32_t>>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_MapOf_Int_to_Boolean_create_handle() {
+library_MapOf_Int_to_library_MapOf_Int_to_Boolean_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>());
 }
 void
-MapOf_Int_to_MapOf_Int_to_Boolean_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_library_MapOf_Int_to_Boolean_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>*>(handle);
 }
 void
-MapOf_Int_to_MapOf_Int_to_Boolean_put(FfiOpaqueHandle handle, int32_t key, FfiOpaqueHandle value) {
+library_MapOf_Int_to_library_MapOf_Int_to_Boolean_put(FfiOpaqueHandle handle, int32_t key, FfiOpaqueHandle value) {
     reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>*>(handle)->emplace(
         gluecodium::ffi::Conversion<int32_t>::toCpp(key),
         gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_MapOf_Int_to_Boolean_iterator(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_library_MapOf_Int_to_Boolean_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>::iterator(
         reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>*>(handle)->begin()
     ));
 }
 void
-MapOf_Int_to_MapOf_Int_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_MapOf_Int_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle);
 }
 bool
-MapOf_Int_to_MapOf_Int_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_MapOf_Int_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>*>(handle)->end();
 }
 void
-MapOf_Int_to_MapOf_Int_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_MapOf_Int_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle);
 }
 int32_t
-MapOf_Int_to_MapOf_Int_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_MapOf_Int_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<int32_t>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle))->first
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_MapOf_Int_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_MapOf_Int_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_MapOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_Int_to_library_MapOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>>(
@@ -1056,65 +1056,65 @@ MapOf_Int_to_MapOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-MapOf_Int_to_MapOf_Int_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_library_MapOf_Int_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_Int_to_MapOf_Int_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_library_MapOf_Int_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_SetOf_Int_create_handle() {
+library_MapOf_Int_to_library_SetOf_Int_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, std::unordered_set<int32_t>>());
 }
 void
-MapOf_Int_to_SetOf_Int_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_library_SetOf_Int_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>*>(handle);
 }
 void
-MapOf_Int_to_SetOf_Int_put(FfiOpaqueHandle handle, int32_t key, FfiOpaqueHandle value) {
+library_MapOf_Int_to_library_SetOf_Int_put(FfiOpaqueHandle handle, int32_t key, FfiOpaqueHandle value) {
     reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>*>(handle)->emplace(
         gluecodium::ffi::Conversion<int32_t>::toCpp(key),
         gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_SetOf_Int_iterator(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_library_SetOf_Int_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, std::unordered_set<int32_t>>::iterator(
         reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>*>(handle)->begin()
     ));
 }
 void
-MapOf_Int_to_SetOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_SetOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>::iterator*>(iterator_handle);
 }
 bool
-MapOf_Int_to_SetOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_SetOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>*>(handle)->end();
 }
 void
-MapOf_Int_to_SetOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_SetOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>::iterator*>(iterator_handle);
 }
 int32_t
-MapOf_Int_to_SetOf_Int_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_SetOf_Int_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<int32_t>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>::iterator*>(iterator_handle))->first
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_SetOf_Int_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_library_SetOf_Int_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_SetOf_Int_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_Int_to_library_SetOf_Int_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<int32_t, std::unordered_set<int32_t>>>(
@@ -1123,65 +1123,65 @@ MapOf_Int_to_SetOf_Int_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-MapOf_Int_to_SetOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_library_SetOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, std::unordered_set<int32_t>>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_Int_to_SetOf_Int_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_library_SetOf_Int_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<int32_t, std::unordered_set<int32_t>>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, std::unordered_set<int32_t>>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_DummyClass_create_handle() {
+library_MapOf_Int_to_smoke_DummyClass_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>());
 }
 void
-MapOf_Int_to_smoke_DummyClass_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_smoke_DummyClass_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>*>(handle);
 }
 void
-MapOf_Int_to_smoke_DummyClass_put(FfiOpaqueHandle handle, int32_t key, FfiOpaqueHandle value) {
+library_MapOf_Int_to_smoke_DummyClass_put(FfiOpaqueHandle handle, int32_t key, FfiOpaqueHandle value) {
     reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>*>(handle)->emplace(
         gluecodium::ffi::Conversion<int32_t>::toCpp(key),
         gluecodium::ffi::Conversion<std::shared_ptr<::smoke::DummyClass>>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_DummyClass_iterator(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_smoke_DummyClass_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>::iterator(
         reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>*>(handle)->begin()
     ));
 }
 void
-MapOf_Int_to_smoke_DummyClass_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_DummyClass_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>::iterator*>(iterator_handle);
 }
 bool
-MapOf_Int_to_smoke_DummyClass_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_DummyClass_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>*>(handle)->end();
 }
 void
-MapOf_Int_to_smoke_DummyClass_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_DummyClass_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>::iterator*>(iterator_handle);
 }
 int32_t
-MapOf_Int_to_smoke_DummyClass_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_DummyClass_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<int32_t>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>::iterator*>(iterator_handle))->first
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_DummyClass_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_DummyClass_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::shared_ptr<::smoke::DummyClass>>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_DummyClass_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_Int_to_smoke_DummyClass_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>>(
@@ -1190,65 +1190,65 @@ MapOf_Int_to_smoke_DummyClass_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-MapOf_Int_to_smoke_DummyClass_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_smoke_DummyClass_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_DummyClass_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_smoke_DummyClass_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_DummyInterface_create_handle() {
+library_MapOf_Int_to_smoke_DummyInterface_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>());
 }
 void
-MapOf_Int_to_smoke_DummyInterface_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_smoke_DummyInterface_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>*>(handle);
 }
 void
-MapOf_Int_to_smoke_DummyInterface_put(FfiOpaqueHandle handle, int32_t key, FfiOpaqueHandle value) {
+library_MapOf_Int_to_smoke_DummyInterface_put(FfiOpaqueHandle handle, int32_t key, FfiOpaqueHandle value) {
     reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>*>(handle)->emplace(
         gluecodium::ffi::Conversion<int32_t>::toCpp(key),
         gluecodium::ffi::Conversion<std::shared_ptr<::smoke::DummyInterface>>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_DummyInterface_iterator(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_smoke_DummyInterface_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>::iterator(
         reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>*>(handle)->begin()
     ));
 }
 void
-MapOf_Int_to_smoke_DummyInterface_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_DummyInterface_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>::iterator*>(iterator_handle);
 }
 bool
-MapOf_Int_to_smoke_DummyInterface_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_DummyInterface_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>*>(handle)->end();
 }
 void
-MapOf_Int_to_smoke_DummyInterface_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_DummyInterface_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>::iterator*>(iterator_handle);
 }
 int32_t
-MapOf_Int_to_smoke_DummyInterface_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_DummyInterface_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<int32_t>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>::iterator*>(iterator_handle))->first
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_DummyInterface_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_DummyInterface_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::shared_ptr<::smoke::DummyInterface>>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_DummyInterface_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_Int_to_smoke_DummyInterface_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>>(
@@ -1257,65 +1257,65 @@ MapOf_Int_to_smoke_DummyInterface_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-MapOf_Int_to_smoke_DummyInterface_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_smoke_DummyInterface_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_DummyInterface_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_smoke_DummyInterface_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle() {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, ::alien::FooEnum>());
 }
 void
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>*>(handle);
 }
 void
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_put(FfiOpaqueHandle handle, int32_t key, uint32_t value) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_put(FfiOpaqueHandle handle, int32_t key, uint32_t value) {
     reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>*>(handle)->emplace(
         gluecodium::ffi::Conversion<int32_t>::toCpp(key),
         gluecodium::ffi::Conversion<::alien::FooEnum>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, ::alien::FooEnum>::iterator(
         reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>*>(handle)->begin()
     ));
 }
 void
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>(iterator_handle);
 }
 bool
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>*>(handle)->end();
 }
 void
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>(iterator_handle);
 }
 int32_t
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<int32_t>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>(iterator_handle))->first
     );
 }
 uint32_t
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<::alien::FooEnum>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<int32_t, ::alien::FooEnum>>(
@@ -1324,65 +1324,65 @@ MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_null
     );
 }
 void
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, ::alien::FooEnum>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<int32_t, ::alien::FooEnum>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, ::alien::FooEnum>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle() {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>());
 }
 void
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>*>(handle);
 }
 void
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_put(FfiOpaqueHandle handle, int32_t key, uint32_t value) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_put(FfiOpaqueHandle handle, int32_t key, uint32_t value) {
     reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>*>(handle)->emplace(
         gluecodium::ffi::Conversion<int32_t>::toCpp(key),
         gluecodium::ffi::Conversion<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(FfiOpaqueHandle handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator(
         reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>*>(handle)->begin()
     ));
 }
 void
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>(iterator_handle);
 }
 bool
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>*>(handle)->end();
 }
 void
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>(iterator_handle);
 }
 int32_t
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<int32_t>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>(iterator_handle))->first
     );
 }
 uint32_t
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::toFfi(
         (*reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>(
@@ -1391,266 +1391,65 @@ MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable
     );
 }
 void
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_ListOf_Int_to_Boolean_create_handle() {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>());
-}
-void
-MapOf_ListOf_Int_to_Boolean_release_handle(FfiOpaqueHandle handle) {
-    delete reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>*>(handle);
-}
-void
-MapOf_ListOf_Int_to_Boolean_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, bool value) {
-    reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>*>(handle)->emplace(
-        gluecodium::ffi::Conversion<std::vector<int32_t>>::toCpp(key),
-        gluecodium::ffi::Conversion<bool>::toCpp(value)
-    );
-}
-FfiOpaqueHandle
-MapOf_ListOf_Int_to_Boolean_iterator(FfiOpaqueHandle handle) {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>::iterator(
-        reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>*>(handle)->begin()
-    ));
-}
-void
-MapOf_ListOf_Int_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle);
-}
-bool
-MapOf_ListOf_Int_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle) !=
-        reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>*>(handle)->end();
-}
-void
-MapOf_ListOf_Int_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle);
-}
-FfiOpaqueHandle
-MapOf_ListOf_Int_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
-    return gluecodium::ffi::Conversion<std::vector<int32_t>>::toFfi(
-        (*reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle))->first
-    );
-}
-bool
-MapOf_ListOf_Int_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
-    return gluecodium::ffi::Conversion<bool>::toFfi(
-        (*reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle))->second
-    );
-}
-FfiOpaqueHandle
-MapOf_ListOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
-{
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) gluecodium::optional<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>>(
-            gluecodium::ffi::Conversion<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>>::toCpp(value)
-        )
-    );
-}
-void
-MapOf_ListOf_Int_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
-{
-    delete reinterpret_cast<gluecodium::optional<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>>*>(handle);
-}
-FfiOpaqueHandle
-MapOf_ListOf_Int_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
-{
-    return gluecodium::ffi::Conversion<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>>::toFfi(
-        **reinterpret_cast<gluecodium::optional<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>>*>(handle)
-    );
-}
-FfiOpaqueHandle
-MapOf_MapOf_Int_to_Boolean_to_Boolean_create_handle() {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>());
-}
-void
-MapOf_MapOf_Int_to_Boolean_to_Boolean_release_handle(FfiOpaqueHandle handle) {
-    delete reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle);
-}
-void
-MapOf_MapOf_Int_to_Boolean_to_Boolean_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, bool value) {
-    reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle)->emplace(
-        gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toCpp(key),
-        gluecodium::ffi::Conversion<bool>::toCpp(value)
-    );
-}
-FfiOpaqueHandle
-MapOf_MapOf_Int_to_Boolean_to_Boolean_iterator(FfiOpaqueHandle handle) {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator(
-        reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle)->begin()
-    ));
-}
-void
-MapOf_MapOf_Int_to_Boolean_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle);
-}
-bool
-MapOf_MapOf_Int_to_Boolean_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle) !=
-        reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle)->end();
-}
-void
-MapOf_MapOf_Int_to_Boolean_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle);
-}
-FfiOpaqueHandle
-MapOf_MapOf_Int_to_Boolean_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
-    return gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toFfi(
-        (*reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle))->first
-    );
-}
-bool
-MapOf_MapOf_Int_to_Boolean_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
-    return gluecodium::ffi::Conversion<bool>::toFfi(
-        (*reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle))->second
-    );
-}
-FfiOpaqueHandle
-MapOf_MapOf_Int_to_Boolean_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
-{
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) gluecodium::optional<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>>(
-            gluecodium::ffi::Conversion<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>>::toCpp(value)
-        )
-    );
-}
-void
-MapOf_MapOf_Int_to_Boolean_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
-{
-    delete reinterpret_cast<gluecodium::optional<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>>*>(handle);
-}
-FfiOpaqueHandle
-MapOf_MapOf_Int_to_Boolean_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
-{
-    return gluecodium::ffi::Conversion<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>>::toFfi(
-        **reinterpret_cast<gluecodium::optional<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>>*>(handle)
-    );
-}
-FfiOpaqueHandle
-MapOf_SetOf_Int_to_Boolean_create_handle() {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>());
-}
-void
-MapOf_SetOf_Int_to_Boolean_release_handle(FfiOpaqueHandle handle) {
-    delete reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle);
-}
-void
-MapOf_SetOf_Int_to_Boolean_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, bool value) {
-    reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle)->emplace(
-        gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toCpp(key),
-        gluecodium::ffi::Conversion<bool>::toCpp(value)
-    );
-}
-FfiOpaqueHandle
-MapOf_SetOf_Int_to_Boolean_iterator(FfiOpaqueHandle handle) {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>::iterator(
-        reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle)->begin()
-    ));
-}
-void
-MapOf_SetOf_Int_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle);
-}
-bool
-MapOf_SetOf_Int_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle) !=
-        reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle)->end();
-}
-void
-MapOf_SetOf_Int_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle);
-}
-FfiOpaqueHandle
-MapOf_SetOf_Int_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
-    return gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toFfi(
-        (*reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle))->first
-    );
-}
-bool
-MapOf_SetOf_Int_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
-    return gluecodium::ffi::Conversion<bool>::toFfi(
-        (*reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle))->second
-    );
-}
-FfiOpaqueHandle
-MapOf_SetOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
-{
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) gluecodium::optional<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>>(
-            gluecodium::ffi::Conversion<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>>::toCpp(value)
-        )
-    );
-}
-void
-MapOf_SetOf_Int_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
-{
-    delete reinterpret_cast<gluecodium::optional<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>>*>(handle);
-}
-FfiOpaqueHandle
-MapOf_SetOf_Int_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
-{
-    return gluecodium::ffi::Conversion<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>>::toFfi(
-        **reinterpret_cast<gluecodium::optional<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>>*>(handle)
-    );
-}
-FfiOpaqueHandle
-MapOf_String_to_String_create_handle() {
+library_MapOf_String_to_String_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::string, std::string>());
 }
 void
-MapOf_String_to_String_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_String_to_String_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<std::string, std::string>*>(handle);
 }
 void
-MapOf_String_to_String_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, FfiOpaqueHandle value) {
+library_MapOf_String_to_String_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, FfiOpaqueHandle value) {
     reinterpret_cast<std::unordered_map<std::string, std::string>*>(handle)->emplace(
         gluecodium::ffi::Conversion<std::string>::toCpp(key),
         gluecodium::ffi::Conversion<std::string>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_String_to_String_iterator(FfiOpaqueHandle handle) {
+library_MapOf_String_to_String_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::string, std::string>::iterator(
         reinterpret_cast<std::unordered_map<std::string, std::string>*>(handle)->begin()
     ));
 }
 void
-MapOf_String_to_String_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_String_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<std::string, std::string>::iterator*>(iterator_handle);
 }
 bool
-MapOf_String_to_String_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_String_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<std::string, std::string>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<std::string, std::string>*>(handle)->end();
 }
 void
-MapOf_String_to_String_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_String_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<std::string, std::string>::iterator*>(iterator_handle);
 }
 FfiOpaqueHandle
-MapOf_String_to_String_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_String_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::string>::toFfi(
         (*reinterpret_cast<std::unordered_map<std::string, std::string>::iterator*>(iterator_handle))->first
     );
 }
 FfiOpaqueHandle
-MapOf_String_to_String_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_String_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::string>::toFfi(
         (*reinterpret_cast<std::unordered_map<std::string, std::string>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_String_to_String_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_String_to_String_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<std::string, std::string>>(
@@ -1659,65 +1458,65 @@ MapOf_String_to_String_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-MapOf_String_to_String_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_String_to_String_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<std::string, std::string>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_String_to_String_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_String_to_String_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<std::string, std::string>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<std::string, std::string>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle() {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>());
 }
 void
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>*>(handle);
 }
 void
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, FfiOpaqueHandle value) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, FfiOpaqueHandle value) {
     reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>*>(handle)->emplace(
         gluecodium::ffi::Conversion<std::string>::toCpp(key),
         gluecodium::ffi::Conversion<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator(FfiOpaqueHandle handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator(
         reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>*>(handle)->begin()
     ));
 }
 void
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>(iterator_handle);
 }
 bool
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>*>(handle)->end();
 }
 void
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>(iterator_handle);
 }
 FfiOpaqueHandle
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::string>::toFfi(
         (*reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>(iterator_handle))->first
     );
 }
 FfiOpaqueHandle
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::toFfi(
         (*reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>(
@@ -1726,65 +1525,65 @@ MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nu
     );
 }
 void
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle() {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::string, ::alien::FooStruct>());
 }
 void
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>*>(handle);
 }
 void
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, FfiOpaqueHandle value) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, FfiOpaqueHandle value) {
     reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>*>(handle)->emplace(
         gluecodium::ffi::Conversion<std::string>::toCpp(key),
         gluecodium::ffi::Conversion<::alien::FooStruct>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator(FfiOpaqueHandle handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::string, ::alien::FooStruct>::iterator(
         reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>*>(handle)->begin()
     ));
 }
 void
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>::iterator*>(iterator_handle);
 }
 bool
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>*>(handle)->end();
 }
 void
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>::iterator*>(iterator_handle);
 }
 FfiOpaqueHandle
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::string>::toFfi(
         (*reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>::iterator*>(iterator_handle))->first
     );
 }
 FfiOpaqueHandle
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<::alien::FooStruct>::toFfi(
         (*reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<std::string, ::alien::FooStruct>>(
@@ -1793,65 +1592,65 @@ MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle
     );
 }
 void
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<std::string, ::alien::FooStruct>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<std::string, ::alien::FooStruct>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<std::string, ::alien::FooStruct>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_UByte_to_String_create_handle() {
+library_MapOf_UByte_to_String_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<uint8_t, std::string>());
 }
 void
-MapOf_UByte_to_String_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_UByte_to_String_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<uint8_t, std::string>*>(handle);
 }
 void
-MapOf_UByte_to_String_put(FfiOpaqueHandle handle, uint8_t key, FfiOpaqueHandle value) {
+library_MapOf_UByte_to_String_put(FfiOpaqueHandle handle, uint8_t key, FfiOpaqueHandle value) {
     reinterpret_cast<std::unordered_map<uint8_t, std::string>*>(handle)->emplace(
         gluecodium::ffi::Conversion<uint8_t>::toCpp(key),
         gluecodium::ffi::Conversion<std::string>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_UByte_to_String_iterator(FfiOpaqueHandle handle) {
+library_MapOf_UByte_to_String_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<uint8_t, std::string>::iterator(
         reinterpret_cast<std::unordered_map<uint8_t, std::string>*>(handle)->begin()
     ));
 }
 void
-MapOf_UByte_to_String_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_UByte_to_String_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<uint8_t, std::string>::iterator*>(iterator_handle);
 }
 bool
-MapOf_UByte_to_String_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_UByte_to_String_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<uint8_t, std::string>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<uint8_t, std::string>*>(handle)->end();
 }
 void
-MapOf_UByte_to_String_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_UByte_to_String_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<uint8_t, std::string>::iterator*>(iterator_handle);
 }
 uint8_t
-MapOf_UByte_to_String_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_UByte_to_String_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<uint8_t>::toFfi(
         (*reinterpret_cast<std::unordered_map<uint8_t, std::string>::iterator*>(iterator_handle))->first
     );
 }
 FfiOpaqueHandle
-MapOf_UByte_to_String_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_UByte_to_String_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::string>::toFfi(
         (*reinterpret_cast<std::unordered_map<uint8_t, std::string>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_UByte_to_String_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_UByte_to_String_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<uint8_t, std::string>>(
@@ -1860,65 +1659,266 @@ MapOf_UByte_to_String_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-MapOf_UByte_to_String_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_UByte_to_String_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<uint8_t, std::string>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_UByte_to_String_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_UByte_to_String_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<uint8_t, std::string>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<uint8_t, std::string>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle() {
+library_MapOf_library_ListOf_Int_to_Boolean_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>());
+}
+void
+library_MapOf_library_ListOf_Int_to_Boolean_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>*>(handle);
+}
+void
+library_MapOf_library_ListOf_Int_to_Boolean_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, bool value) {
+    reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>*>(handle)->emplace(
+        gluecodium::ffi::Conversion<std::vector<int32_t>>::toCpp(key),
+        gluecodium::ffi::Conversion<bool>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_MapOf_library_ListOf_Int_to_Boolean_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>::iterator(
+        reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>*>(handle)->begin()
+    ));
+}
+void
+library_MapOf_library_ListOf_Int_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle);
+}
+bool
+library_MapOf_library_ListOf_Int_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>*>(handle)->end();
+}
+void
+library_MapOf_library_ListOf_Int_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_MapOf_library_ListOf_Int_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::vector<int32_t>>::toFfi(
+        (*reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle))->first
+    );
+}
+bool
+library_MapOf_library_ListOf_Int_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<bool>::toFfi(
+        (*reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle))->second
+    );
+}
+FfiOpaqueHandle
+library_MapOf_library_ListOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>>(
+            gluecodium::ffi::Conversion<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>>::toCpp(value)
+        )
+    );
+}
+void
+library_MapOf_library_ListOf_Int_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>>*>(handle);
+}
+FfiOpaqueHandle
+library_MapOf_library_ListOf_Int_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>());
+}
+void
+library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle);
+}
+void
+library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, bool value) {
+    reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle)->emplace(
+        gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toCpp(key),
+        gluecodium::ffi::Conversion<bool>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator(
+        reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle)->begin()
+    ));
+}
+void
+library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle);
+}
+bool
+library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle)->end();
+}
+void
+library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toFfi(
+        (*reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle))->first
+    );
+}
+bool
+library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<bool>::toFfi(
+        (*reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle))->second
+    );
+}
+FfiOpaqueHandle
+library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>>(
+            gluecodium::ffi::Conversion<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>>::toCpp(value)
+        )
+    );
+}
+void
+library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>>*>(handle);
+}
+FfiOpaqueHandle
+library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_MapOf_library_SetOf_Int_to_Boolean_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>());
+}
+void
+library_MapOf_library_SetOf_Int_to_Boolean_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle);
+}
+void
+library_MapOf_library_SetOf_Int_to_Boolean_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, bool value) {
+    reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle)->emplace(
+        gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toCpp(key),
+        gluecodium::ffi::Conversion<bool>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_MapOf_library_SetOf_Int_to_Boolean_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>::iterator(
+        reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle)->begin()
+    ));
+}
+void
+library_MapOf_library_SetOf_Int_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle);
+}
+bool
+library_MapOf_library_SetOf_Int_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle)->end();
+}
+void
+library_MapOf_library_SetOf_Int_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_MapOf_library_SetOf_Int_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toFfi(
+        (*reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle))->first
+    );
+}
+bool
+library_MapOf_library_SetOf_Int_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<bool>::toFfi(
+        (*reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle))->second
+    );
+}
+FfiOpaqueHandle
+library_MapOf_library_SetOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>>(
+            gluecodium::ffi::Conversion<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>>::toCpp(value)
+        )
+    );
+}
+void
+library_MapOf_library_SetOf_Int_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>>*>(handle);
+}
+FfiOpaqueHandle
+library_MapOf_library_SetOf_Int_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>());
 }
 void
-MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>*>(handle);
 }
 void
-MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_put(FfiOpaqueHandle handle, uint32_t key, bool value) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_put(FfiOpaqueHandle handle, uint32_t key, bool value) {
     reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>*>(handle)->emplace(
         gluecodium::ffi::Conversion<::alien::FooEnum>::toCpp(key),
         gluecodium::ffi::Conversion<bool>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator(FfiOpaqueHandle handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>::iterator(
         reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>*>(handle)->begin()
     ));
 }
 void
-MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>::iterator*>(iterator_handle);
 }
 bool
-MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>*>(handle)->end();
 }
 void
-MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>::iterator*>(iterator_handle);
 }
 uint32_t
-MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<::alien::FooEnum>::toFfi(
         (*reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>::iterator*>(iterator_handle))->first
     );
 }
 bool
-MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<bool>::toFfi(
         (*reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>>(
@@ -1927,65 +1927,65 @@ MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle_
     );
 }
 void
-MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>>*>(handle)
     );
 }
 FfiOpaqueHandle
-MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle() {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>());
 }
 void
-MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle(FfiOpaqueHandle handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>(handle);
 }
 void
-MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_put(FfiOpaqueHandle handle, uint32_t key, bool value) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_put(FfiOpaqueHandle handle, uint32_t key, bool value) {
     reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>(handle)->emplace(
         gluecodium::ffi::Conversion<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::toCpp(key),
         gluecodium::ffi::Conversion<bool>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator(FfiOpaqueHandle handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator(
         reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>(handle)->begin()
     ));
 }
 void
-MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>(iterator_handle);
 }
 bool
-MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>(handle)->end();
 }
 void
-MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>(iterator_handle);
 }
 uint32_t
-MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::toFfi(
         (*reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>(iterator_handle))->first
     );
 }
 bool
-MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<bool>::toFfi(
         (*reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>(iterator_handle))->second
     );
 }
 FfiOpaqueHandle
-MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
+library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(
@@ -1994,58 +1994,58 @@ MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle_null
     );
 }
 void
-MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
+library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>*>(handle);
 }
 FfiOpaqueHandle
-MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
+library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>*>(handle)
     );
 }
 FfiOpaqueHandle
-SetOf_Float_create_handle() {
+library_SetOf_Float_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<float>());
 }
 void
-SetOf_Float_release_handle(FfiOpaqueHandle handle) {
+library_SetOf_Float_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_set<float>*>(handle);
 }
 void
-SetOf_Float_insert(FfiOpaqueHandle handle, float value) {
+library_SetOf_Float_insert(FfiOpaqueHandle handle, float value) {
     reinterpret_cast<std::unordered_set<float>*>(handle)->insert(
         gluecodium::ffi::Conversion<float>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-SetOf_Float_iterator(FfiOpaqueHandle handle) {
+library_SetOf_Float_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<float>::iterator(
         reinterpret_cast<std::unordered_set<float>*>(handle)->begin()
     ));
 }
 void
-SetOf_Float_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_SetOf_Float_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_set<float>::iterator*>(iterator_handle);
 }
 bool
-SetOf_Float_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_SetOf_Float_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_set<float>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_set<float>*>(handle)->end();
 }
 void
-SetOf_Float_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_SetOf_Float_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_set<float>::iterator*>(iterator_handle);
 }
 float
-SetOf_Float_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_SetOf_Float_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<float>::toFfi(
         **reinterpret_cast<std::unordered_set<float>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-SetOf_Float_create_handle_nullable(FfiOpaqueHandle value)
+library_SetOf_Float_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_set<float>>(
@@ -2054,58 +2054,58 @@ SetOf_Float_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-SetOf_Float_release_handle_nullable(FfiOpaqueHandle handle)
+library_SetOf_Float_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_set<float>>*>(handle);
 }
 FfiOpaqueHandle
-SetOf_Float_get_value_nullable(FfiOpaqueHandle handle)
+library_SetOf_Float_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_set<float>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_set<float>>*>(handle)
     );
 }
 FfiOpaqueHandle
-SetOf_Int_create_handle() {
+library_SetOf_Int_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<int32_t>());
 }
 void
-SetOf_Int_release_handle(FfiOpaqueHandle handle) {
+library_SetOf_Int_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_set<int32_t>*>(handle);
 }
 void
-SetOf_Int_insert(FfiOpaqueHandle handle, int32_t value) {
+library_SetOf_Int_insert(FfiOpaqueHandle handle, int32_t value) {
     reinterpret_cast<std::unordered_set<int32_t>*>(handle)->insert(
         gluecodium::ffi::Conversion<int32_t>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-SetOf_Int_iterator(FfiOpaqueHandle handle) {
+library_SetOf_Int_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<int32_t>::iterator(
         reinterpret_cast<std::unordered_set<int32_t>*>(handle)->begin()
     ));
 }
 void
-SetOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_SetOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_set<int32_t>::iterator*>(iterator_handle);
 }
 bool
-SetOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_SetOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_set<int32_t>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_set<int32_t>*>(handle)->end();
 }
 void
-SetOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_SetOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_set<int32_t>::iterator*>(iterator_handle);
 }
 int32_t
-SetOf_Int_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_SetOf_Int_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<int32_t>::toFfi(
         **reinterpret_cast<std::unordered_set<int32_t>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-SetOf_Int_create_handle_nullable(FfiOpaqueHandle value)
+library_SetOf_Int_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_set<int32_t>>(
@@ -2114,238 +2114,58 @@ SetOf_Int_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-SetOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
+library_SetOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_set<int32_t>>*>(handle);
 }
 FfiOpaqueHandle
-SetOf_Int_get_value_nullable(FfiOpaqueHandle handle)
+library_SetOf_Int_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_set<int32_t>>*>(handle)
     );
 }
 FfiOpaqueHandle
-SetOf_ListOf_Int_create_handle() {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>());
-}
-void
-SetOf_ListOf_Int_release_handle(FfiOpaqueHandle handle) {
-    delete reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>*>(handle);
-}
-void
-SetOf_ListOf_Int_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
-    reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>*>(handle)->insert(
-        gluecodium::ffi::Conversion<std::vector<int32_t>>::toCpp(value)
-    );
-}
-FfiOpaqueHandle
-SetOf_ListOf_Int_iterator(FfiOpaqueHandle handle) {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>::iterator(
-        reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>*>(handle)->begin()
-    ));
-}
-void
-SetOf_ListOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
-    delete reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle);
-}
-bool
-SetOf_ListOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
-    return *reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle) !=
-        reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>*>(handle)->end();
-}
-void
-SetOf_ListOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
-    ++*reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle);
-}
-FfiOpaqueHandle
-SetOf_ListOf_Int_iterator_get(FfiOpaqueHandle iterator_handle) {
-    return gluecodium::ffi::Conversion<std::vector<int32_t>>::toFfi(
-        **reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle)
-    );
-}
-FfiOpaqueHandle
-SetOf_ListOf_Int_create_handle_nullable(FfiOpaqueHandle value)
-{
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) gluecodium::optional<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>>(
-            gluecodium::ffi::Conversion<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>>::toCpp(value)
-        )
-    );
-}
-void
-SetOf_ListOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
-{
-    delete reinterpret_cast<gluecodium::optional<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>>*>(handle);
-}
-FfiOpaqueHandle
-SetOf_ListOf_Int_get_value_nullable(FfiOpaqueHandle handle)
-{
-    return gluecodium::ffi::Conversion<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>>::toFfi(
-        **reinterpret_cast<gluecodium::optional<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>>*>(handle)
-    );
-}
-FfiOpaqueHandle
-SetOf_MapOf_Int_to_Boolean_create_handle() {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>());
-}
-void
-SetOf_MapOf_Int_to_Boolean_release_handle(FfiOpaqueHandle handle) {
-    delete reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle);
-}
-void
-SetOf_MapOf_Int_to_Boolean_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
-    reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle)->insert(
-        gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toCpp(value)
-    );
-}
-FfiOpaqueHandle
-SetOf_MapOf_Int_to_Boolean_iterator(FfiOpaqueHandle handle) {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator(
-        reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle)->begin()
-    ));
-}
-void
-SetOf_MapOf_Int_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
-    delete reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle);
-}
-bool
-SetOf_MapOf_Int_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
-    return *reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle) !=
-        reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle)->end();
-}
-void
-SetOf_MapOf_Int_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
-    ++*reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle);
-}
-FfiOpaqueHandle
-SetOf_MapOf_Int_to_Boolean_iterator_get(FfiOpaqueHandle iterator_handle) {
-    return gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toFfi(
-        **reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle)
-    );
-}
-FfiOpaqueHandle
-SetOf_MapOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
-{
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) gluecodium::optional<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>>(
-            gluecodium::ffi::Conversion<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>>::toCpp(value)
-        )
-    );
-}
-void
-SetOf_MapOf_Int_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
-{
-    delete reinterpret_cast<gluecodium::optional<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>>*>(handle);
-}
-FfiOpaqueHandle
-SetOf_MapOf_Int_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
-{
-    return gluecodium::ffi::Conversion<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>>::toFfi(
-        **reinterpret_cast<gluecodium::optional<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>>*>(handle)
-    );
-}
-FfiOpaqueHandle
-SetOf_SetOf_Int_create_handle() {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>());
-}
-void
-SetOf_SetOf_Int_release_handle(FfiOpaqueHandle handle) {
-    delete reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle);
-}
-void
-SetOf_SetOf_Int_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
-    reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle)->insert(
-        gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toCpp(value)
-    );
-}
-FfiOpaqueHandle
-SetOf_SetOf_Int_iterator(FfiOpaqueHandle handle) {
-    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>::iterator(
-        reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle)->begin()
-    ));
-}
-void
-SetOf_SetOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
-    delete reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle);
-}
-bool
-SetOf_SetOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
-    return *reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle) !=
-        reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle)->end();
-}
-void
-SetOf_SetOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
-    ++*reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle);
-}
-FfiOpaqueHandle
-SetOf_SetOf_Int_iterator_get(FfiOpaqueHandle iterator_handle) {
-    return gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toFfi(
-        **reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle)
-    );
-}
-FfiOpaqueHandle
-SetOf_SetOf_Int_create_handle_nullable(FfiOpaqueHandle value)
-{
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) gluecodium::optional<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>>(
-            gluecodium::ffi::Conversion<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>>::toCpp(value)
-        )
-    );
-}
-void
-SetOf_SetOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
-{
-    delete reinterpret_cast<gluecodium::optional<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>>*>(handle);
-}
-FfiOpaqueHandle
-SetOf_SetOf_Int_get_value_nullable(FfiOpaqueHandle handle)
-{
-    return gluecodium::ffi::Conversion<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>>::toFfi(
-        **reinterpret_cast<gluecodium::optional<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>>*>(handle)
-    );
-}
-FfiOpaqueHandle
-SetOf_String_create_handle() {
+library_SetOf_String_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::string>());
 }
 void
-SetOf_String_release_handle(FfiOpaqueHandle handle) {
+library_SetOf_String_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_set<std::string>*>(handle);
 }
 void
-SetOf_String_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+library_SetOf_String_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
     reinterpret_cast<std::unordered_set<std::string>*>(handle)->insert(
         gluecodium::ffi::Conversion<std::string>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-SetOf_String_iterator(FfiOpaqueHandle handle) {
+library_SetOf_String_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::string>::iterator(
         reinterpret_cast<std::unordered_set<std::string>*>(handle)->begin()
     ));
 }
 void
-SetOf_String_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_SetOf_String_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_set<std::string>::iterator*>(iterator_handle);
 }
 bool
-SetOf_String_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_SetOf_String_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_set<std::string>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_set<std::string>*>(handle)->end();
 }
 void
-SetOf_String_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_SetOf_String_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_set<std::string>::iterator*>(iterator_handle);
 }
 FfiOpaqueHandle
-SetOf_String_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_SetOf_String_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<std::string>::toFfi(
         **reinterpret_cast<std::unordered_set<std::string>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-SetOf_String_create_handle_nullable(FfiOpaqueHandle value)
+library_SetOf_String_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_set<std::string>>(
@@ -2354,58 +2174,58 @@ SetOf_String_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-SetOf_String_release_handle_nullable(FfiOpaqueHandle handle)
+library_SetOf_String_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_set<std::string>>*>(handle);
 }
 FfiOpaqueHandle
-SetOf_String_get_value_nullable(FfiOpaqueHandle handle)
+library_SetOf_String_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_set<std::string>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_set<std::string>>*>(handle)
     );
 }
 FfiOpaqueHandle
-SetOf_UByte_create_handle() {
+library_SetOf_UByte_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<uint8_t>());
 }
 void
-SetOf_UByte_release_handle(FfiOpaqueHandle handle) {
+library_SetOf_UByte_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_set<uint8_t>*>(handle);
 }
 void
-SetOf_UByte_insert(FfiOpaqueHandle handle, uint8_t value) {
+library_SetOf_UByte_insert(FfiOpaqueHandle handle, uint8_t value) {
     reinterpret_cast<std::unordered_set<uint8_t>*>(handle)->insert(
         gluecodium::ffi::Conversion<uint8_t>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-SetOf_UByte_iterator(FfiOpaqueHandle handle) {
+library_SetOf_UByte_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<uint8_t>::iterator(
         reinterpret_cast<std::unordered_set<uint8_t>*>(handle)->begin()
     ));
 }
 void
-SetOf_UByte_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_SetOf_UByte_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_set<uint8_t>::iterator*>(iterator_handle);
 }
 bool
-SetOf_UByte_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_SetOf_UByte_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_set<uint8_t>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_set<uint8_t>*>(handle)->end();
 }
 void
-SetOf_UByte_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_SetOf_UByte_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_set<uint8_t>::iterator*>(iterator_handle);
 }
 uint8_t
-SetOf_UByte_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_SetOf_UByte_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<uint8_t>::toFfi(
         **reinterpret_cast<std::unordered_set<uint8_t>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-SetOf_UByte_create_handle_nullable(FfiOpaqueHandle value)
+library_SetOf_UByte_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_set<uint8_t>>(
@@ -2414,58 +2234,238 @@ SetOf_UByte_create_handle_nullable(FfiOpaqueHandle value)
     );
 }
 void
-SetOf_UByte_release_handle_nullable(FfiOpaqueHandle handle)
+library_SetOf_UByte_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_set<uint8_t>>*>(handle);
 }
 FfiOpaqueHandle
-SetOf_UByte_get_value_nullable(FfiOpaqueHandle handle)
+library_SetOf_UByte_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_set<uint8_t>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_set<uint8_t>>*>(handle)
     );
 }
 FfiOpaqueHandle
-SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle() {
+library_SetOf_library_ListOf_Int_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>());
+}
+void
+library_SetOf_library_ListOf_Int_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>*>(handle);
+}
+void
+library_SetOf_library_ListOf_Int_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+    reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>*>(handle)->insert(
+        gluecodium::ffi::Conversion<std::vector<int32_t>>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_SetOf_library_ListOf_Int_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>::iterator(
+        reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>*>(handle)->begin()
+    ));
+}
+void
+library_SetOf_library_ListOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle);
+}
+bool
+library_SetOf_library_ListOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>*>(handle)->end();
+}
+void
+library_SetOf_library_ListOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_SetOf_library_ListOf_Int_iterator_get(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::vector<int32_t>>::toFfi(
+        **reinterpret_cast<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>::iterator*>(iterator_handle)
+    );
+}
+FfiOpaqueHandle
+library_SetOf_library_ListOf_Int_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>>(
+            gluecodium::ffi::Conversion<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>>::toCpp(value)
+        )
+    );
+}
+void
+library_SetOf_library_ListOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>>*>(handle);
+}
+FfiOpaqueHandle
+library_SetOf_library_ListOf_Int_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_SetOf_library_MapOf_Int_to_Boolean_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>());
+}
+void
+library_SetOf_library_MapOf_Int_to_Boolean_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle);
+}
+void
+library_SetOf_library_MapOf_Int_to_Boolean_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+    reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle)->insert(
+        gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_SetOf_library_MapOf_Int_to_Boolean_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator(
+        reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle)->begin()
+    ));
+}
+void
+library_SetOf_library_MapOf_Int_to_Boolean_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle);
+}
+bool
+library_SetOf_library_MapOf_Int_to_Boolean_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>*>(handle)->end();
+}
+void
+library_SetOf_library_MapOf_Int_to_Boolean_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_SetOf_library_MapOf_Int_to_Boolean_iterator_get(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::unordered_map<int32_t, bool>>::toFfi(
+        **reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>(iterator_handle)
+    );
+}
+FfiOpaqueHandle
+library_SetOf_library_MapOf_Int_to_Boolean_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>>(
+            gluecodium::ffi::Conversion<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>>::toCpp(value)
+        )
+    );
+}
+void
+library_SetOf_library_MapOf_Int_to_Boolean_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>>*>(handle);
+}
+FfiOpaqueHandle
+library_SetOf_library_MapOf_Int_to_Boolean_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_SetOf_library_SetOf_Int_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>());
+}
+void
+library_SetOf_library_SetOf_Int_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle);
+}
+void
+library_SetOf_library_SetOf_Int_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+    reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle)->insert(
+        gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_SetOf_library_SetOf_Int_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>::iterator(
+        reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle)->begin()
+    ));
+}
+void
+library_SetOf_library_SetOf_Int_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle);
+}
+bool
+library_SetOf_library_SetOf_Int_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>*>(handle)->end();
+}
+void
+library_SetOf_library_SetOf_Int_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_SetOf_library_SetOf_Int_iterator_get(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::unordered_set<int32_t>>::toFfi(
+        **reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>(iterator_handle)
+    );
+}
+FfiOpaqueHandle
+library_SetOf_library_SetOf_Int_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>>(
+            gluecodium::ffi::Conversion<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>>::toCpp(value)
+        )
+    );
+}
+void
+library_SetOf_library_SetOf_Int_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>>*>(handle);
+}
+FfiOpaqueHandle
+library_SetOf_library_SetOf_Int_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>());
 }
 void
-SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(FfiOpaqueHandle handle) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>*>(handle);
 }
 void
-SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(FfiOpaqueHandle handle, uint32_t value) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(FfiOpaqueHandle handle, uint32_t value) {
     reinterpret_cast<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>*>(handle)->insert(
         gluecodium::ffi::Conversion<::alien::FooEnum>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(FfiOpaqueHandle handle) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>::iterator(
         reinterpret_cast<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>*>(handle)->begin()
     ));
 }
 void
-SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>::iterator*>(iterator_handle);
 }
 bool
-SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>*>(handle)->end();
 }
 void
-SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>::iterator*>(iterator_handle);
 }
 uint32_t
-SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<::alien::FooEnum>::toFfi(
         **reinterpret_cast<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(FfiOpaqueHandle value)
+library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>>(
@@ -2474,58 +2474,58 @@ SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(Ff
     );
 }
 void
-SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(FfiOpaqueHandle handle)
+library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>>*>(handle);
 }
 FfiOpaqueHandle
-SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(FfiOpaqueHandle handle)
+library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>>*>(handle)
     );
 }
 FfiOpaqueHandle
-SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle() {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>());
 }
 void
-SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(FfiOpaqueHandle handle) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>(handle);
 }
 void
-SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(FfiOpaqueHandle handle, uint32_t value) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(FfiOpaqueHandle handle, uint32_t value) {
     reinterpret_cast<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>(handle)->insert(
         gluecodium::ffi::Conversion<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::toCpp(value)
     );
 }
 FfiOpaqueHandle
-SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(FfiOpaqueHandle handle) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator(
         reinterpret_cast<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>(handle)->begin()
     ));
 }
 void
-SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>(iterator_handle);
 }
 bool
-SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>(iterator_handle) !=
         reinterpret_cast<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>(handle)->end();
 }
 void
-SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(FfiOpaqueHandle iterator_handle) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>(iterator_handle);
 }
 uint32_t
-SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get(FfiOpaqueHandle iterator_handle) {
+library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get(FfiOpaqueHandle iterator_handle) {
     return gluecodium::ffi::Conversion<::smoke::GenericTypesWithCompoundTypes::SomeEnum>::toFfi(
         **reinterpret_cast<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>(iterator_handle)
     );
 }
 FfiOpaqueHandle
-SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(FfiOpaqueHandle value)
+library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(FfiOpaqueHandle value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(
@@ -2534,12 +2534,12 @@ SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(FfiOpa
     );
 }
 void
-SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable(FfiOpaqueHandle handle)
+library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<gluecodium::optional<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>*>(handle);
 }
 FfiOpaqueHandle
-SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(FfiOpaqueHandle handle)
+library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>*>(handle)

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithBasicTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithBasicTypes.dart
@@ -18,70 +18,70 @@ class GenericTypesWithBasicTypes {
   void release() => _smoke_GenericTypesWithBasicTypes_release_handle(_handle);
   List<int> methodWithList(List<int> input) {
     final _methodWithList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_methodWithList__ListOf_1Int');
-    final _input_handle = ListOf_Int_toFfi(input);
+    final _input_handle = library_ListOf_Int_toFfi(input);
     final __result_handle = _methodWithList_ffi(_handle, _input_handle);
-    ListOf_Int_releaseFfiHandle(_input_handle);
-    final _result = ListOf_Int_fromFfi(__result_handle);
-    ListOf_Int_releaseFfiHandle(__result_handle);
+    library_ListOf_Int_releaseFfiHandle(_input_handle);
+    final _result = library_ListOf_Int_fromFfi(__result_handle);
+    library_ListOf_Int_releaseFfiHandle(__result_handle);
     return _result;
   }
   Map<int, bool> methodWithMap(Map<int, bool> input) {
     final _methodWithMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_methodWithMap__MapOf_1Int_1to_1Boolean');
-    final _input_handle = MapOf_Int_to_Boolean_toFfi(input);
+    final _input_handle = library_MapOf_Int_to_Boolean_toFfi(input);
     final __result_handle = _methodWithMap_ffi(_handle, _input_handle);
-    MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
-    final _result = MapOf_Int_to_Boolean_fromFfi(__result_handle);
-    MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
+    library_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
+    final _result = library_MapOf_Int_to_Boolean_fromFfi(__result_handle);
+    library_MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
     return _result;
   }
   Set<int> methodWithSet(Set<int> input) {
     final _methodWithSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_methodWithSet__SetOf_1Int');
-    final _input_handle = SetOf_Int_toFfi(input);
+    final _input_handle = library_SetOf_Int_toFfi(input);
     final __result_handle = _methodWithSet_ffi(_handle, _input_handle);
-    SetOf_Int_releaseFfiHandle(_input_handle);
-    final _result = SetOf_Int_fromFfi(__result_handle);
-    SetOf_Int_releaseFfiHandle(__result_handle);
+    library_SetOf_Int_releaseFfiHandle(_input_handle);
+    final _result = library_SetOf_Int_fromFfi(__result_handle);
+    library_SetOf_Int_releaseFfiHandle(__result_handle);
     return _result;
   }
   List<String> methodWithListTypeAlias(List<String> input) {
     final _methodWithListTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias__ListOf_1String');
-    final _input_handle = ListOf_String_toFfi(input);
+    final _input_handle = library_ListOf_String_toFfi(input);
     final __result_handle = _methodWithListTypeAlias_ffi(_handle, _input_handle);
-    ListOf_String_releaseFfiHandle(_input_handle);
-    final _result = ListOf_String_fromFfi(__result_handle);
-    ListOf_String_releaseFfiHandle(__result_handle);
+    library_ListOf_String_releaseFfiHandle(_input_handle);
+    final _result = library_ListOf_String_fromFfi(__result_handle);
+    library_ListOf_String_releaseFfiHandle(__result_handle);
     return _result;
   }
   Map<String, String> methodWithMapTypeAlias(Map<String, String> input) {
     final _methodWithMapTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias__MapOf_1String_1to_1String');
-    final _input_handle = MapOf_String_to_String_toFfi(input);
+    final _input_handle = library_MapOf_String_to_String_toFfi(input);
     final __result_handle = _methodWithMapTypeAlias_ffi(_handle, _input_handle);
-    MapOf_String_to_String_releaseFfiHandle(_input_handle);
-    final _result = MapOf_String_to_String_fromFfi(__result_handle);
-    MapOf_String_to_String_releaseFfiHandle(__result_handle);
+    library_MapOf_String_to_String_releaseFfiHandle(_input_handle);
+    final _result = library_MapOf_String_to_String_fromFfi(__result_handle);
+    library_MapOf_String_to_String_releaseFfiHandle(__result_handle);
     return _result;
   }
   Set<String> methodWithSetTypeAlias(Set<String> input) {
     final _methodWithSetTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias__SetOf_1String');
-    final _input_handle = SetOf_String_toFfi(input);
+    final _input_handle = library_SetOf_String_toFfi(input);
     final __result_handle = _methodWithSetTypeAlias_ffi(_handle, _input_handle);
-    SetOf_String_releaseFfiHandle(_input_handle);
-    final _result = SetOf_String_fromFfi(__result_handle);
-    SetOf_String_releaseFfiHandle(__result_handle);
+    library_SetOf_String_releaseFfiHandle(_input_handle);
+    final _result = library_SetOf_String_fromFfi(__result_handle);
+    library_SetOf_String_releaseFfiHandle(__result_handle);
     return _result;
   }
   List<double> get listProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_listProperty_get');
     final __result_handle = _get_ffi(_handle);
-    final _result = ListOf_Float_fromFfi(__result_handle);
-    ListOf_Float_releaseFfiHandle(__result_handle);
+    final _result = library_ListOf_Float_fromFfi(__result_handle);
+    library_ListOf_Float_releaseFfiHandle(__result_handle);
     return _result;
   }
   set listProperty(List<double> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_listProperty_set__ListOf_1Float');
-    final _value_handle = ListOf_Float_toFfi(value);
+    final _value_handle = library_ListOf_Float_toFfi(value);
     final __result_handle = _set_ffi(_handle, _value_handle);
-    ListOf_Float_releaseFfiHandle(_value_handle);
+    library_ListOf_Float_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
@@ -89,15 +89,15 @@ class GenericTypesWithBasicTypes {
   Map<double, double> get mapProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_mapProperty_get');
     final __result_handle = _get_ffi(_handle);
-    final _result = MapOf_Float_to_Double_fromFfi(__result_handle);
-    MapOf_Float_to_Double_releaseFfiHandle(__result_handle);
+    final _result = library_MapOf_Float_to_Double_fromFfi(__result_handle);
+    library_MapOf_Float_to_Double_releaseFfiHandle(__result_handle);
     return _result;
   }
   set mapProperty(Map<double, double> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_mapProperty_set__MapOf_1Float_1to_1Double');
-    final _value_handle = MapOf_Float_to_Double_toFfi(value);
+    final _value_handle = library_MapOf_Float_to_Double_toFfi(value);
     final __result_handle = _set_ffi(_handle, _value_handle);
-    MapOf_Float_to_Double_releaseFfiHandle(_value_handle);
+    library_MapOf_Float_to_Double_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
@@ -105,15 +105,15 @@ class GenericTypesWithBasicTypes {
   Set<double> get setProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_setProperty_get');
     final __result_handle = _get_ffi(_handle);
-    final _result = SetOf_Float_fromFfi(__result_handle);
-    SetOf_Float_releaseFfiHandle(__result_handle);
+    final _result = library_SetOf_Float_fromFfi(__result_handle);
+    library_SetOf_Float_releaseFfiHandle(__result_handle);
     return _result;
   }
   set setProperty(Set<double> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithBasicTypes_setProperty_set__SetOf_1Float');
-    final _value_handle = SetOf_Float_toFfi(value);
+    final _value_handle = library_SetOf_Float_toFfi(value);
     final __result_handle = _set_ffi(_handle, _value_handle);
-    SetOf_Float_releaseFfiHandle(_value_handle);
+    library_SetOf_Float_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
@@ -159,13 +159,13 @@ final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersSet 
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersSet');
 Pointer<Void> smoke_GenericTypesWithBasicTypes_StructWithGenerics_toFfi(GenericTypesWithBasicTypes_StructWithGenerics value) {
-  final _numbersList_handle = ListOf_UByte_toFfi(value.numbersList);
-  final _numbersMap_handle = MapOf_UByte_to_String_toFfi(value.numbersMap);
-  final _numbersSet_handle = SetOf_UByte_toFfi(value.numbersSet);
+  final _numbersList_handle = library_ListOf_UByte_toFfi(value.numbersList);
+  final _numbersMap_handle = library_MapOf_UByte_to_String_toFfi(value.numbersMap);
+  final _numbersSet_handle = library_SetOf_UByte_toFfi(value.numbersSet);
   final _result = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle(_numbersList_handle, _numbersMap_handle, _numbersSet_handle);
-  ListOf_UByte_releaseFfiHandle(_numbersList_handle);
-  MapOf_UByte_to_String_releaseFfiHandle(_numbersMap_handle);
-  SetOf_UByte_releaseFfiHandle(_numbersSet_handle);
+  library_ListOf_UByte_releaseFfiHandle(_numbersList_handle);
+  library_MapOf_UByte_to_String_releaseFfiHandle(_numbersMap_handle);
+  library_SetOf_UByte_releaseFfiHandle(_numbersSet_handle);
   return _result;
 }
 GenericTypesWithBasicTypes_StructWithGenerics smoke_GenericTypesWithBasicTypes_StructWithGenerics_fromFfi(Pointer<Void> handle) {
@@ -173,13 +173,13 @@ GenericTypesWithBasicTypes_StructWithGenerics smoke_GenericTypesWithBasicTypes_S
   final _numbersMap_handle = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersMap(handle);
   final _numbersSet_handle = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersSet(handle);
   final _result = GenericTypesWithBasicTypes_StructWithGenerics(
-    ListOf_UByte_fromFfi(_numbersList_handle),
-    MapOf_UByte_to_String_fromFfi(_numbersMap_handle),
-    SetOf_UByte_fromFfi(_numbersSet_handle)
+    library_ListOf_UByte_fromFfi(_numbersList_handle),
+    library_MapOf_UByte_to_String_fromFfi(_numbersMap_handle),
+    library_SetOf_UByte_fromFfi(_numbersSet_handle)
   );
-  ListOf_UByte_releaseFfiHandle(_numbersList_handle);
-  MapOf_UByte_to_String_releaseFfiHandle(_numbersMap_handle);
-  SetOf_UByte_releaseFfiHandle(_numbersSet_handle);
+  library_ListOf_UByte_releaseFfiHandle(_numbersList_handle);
+  library_MapOf_UByte_to_String_releaseFfiHandle(_numbersMap_handle);
+  library_SetOf_UByte_releaseFfiHandle(_numbersSet_handle);
   return _result;
 }
 void smoke_GenericTypesWithBasicTypes_StructWithGenerics_releaseFfiHandle(Pointer<Void> handle) => _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithCompoundTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithCompoundTypes.dart
@@ -21,74 +21,74 @@ class GenericTypesWithCompoundTypes {
   void release() => _smoke_GenericTypesWithCompoundTypes_release_handle(_handle);
   List<GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructList(List<GenericTypesWithCompoundTypes_BasicStruct> input) {
     final _methodWithStructList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithStructList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct');
-    final _input_handle = ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
+    final _input_handle = library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
     final __result_handle = _methodWithStructList_ffi(_handle, _input_handle);
-    ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
-    final _result = ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
-    ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
+    library_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
+    final _result = library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
+    library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
     return _result;
   }
   Map<String, GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructMap(Map<String, GenericTypesWithCompoundTypes_BasicStruct> input) {
     final _methodWithStructMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithStructMap__MapOf_1String_1to_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct');
-    final _input_handle = MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
+    final _input_handle = library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
     final __result_handle = _methodWithStructMap_ffi(_handle, _input_handle);
-    MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
-    final _result = MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
-    MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
+    library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
+    final _result = library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
+    library_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
     return _result;
   }
   List<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumList(List<GenericTypesWithCompoundTypes_SomeEnum> input) {
     final _methodWithEnumList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithEnumList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
-    final _input_handle = ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
+    final _input_handle = library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
     final __result_handle = _methodWithEnumList_ffi(_handle, _input_handle);
-    ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
-    final _result = ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
-    ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
+    library_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
+    final _result = library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
+    library_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
     return _result;
   }
   Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> methodWithEnumMapKey(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> input) {
     final _methodWithEnumMapKey_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey__MapOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum_1to_1Boolean');
-    final _input_handle = MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(input);
+    final _input_handle = library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(input);
     final __result_handle = _methodWithEnumMapKey_ffi(_handle, _input_handle);
-    MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(_input_handle);
-    final _result = MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi(__result_handle);
-    MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(__result_handle);
+    library_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(_input_handle);
+    final _result = library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi(__result_handle);
+    library_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(__result_handle);
     return _result;
   }
   Map<int, GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumMapValue(Map<int, GenericTypesWithCompoundTypes_SomeEnum> input) {
     final _methodWithEnumMapValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue__MapOf_1Int_1to_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
-    final _input_handle = MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
+    final _input_handle = library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
     final __result_handle = _methodWithEnumMapValue_ffi(_handle, _input_handle);
-    MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
-    final _result = MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
-    MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
+    library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
+    final _result = library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
+    library_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
     return _result;
   }
   Set<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumSet(Set<GenericTypesWithCompoundTypes_SomeEnum> input) {
     final _methodWithEnumSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithEnumSet__SetOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
-    final _input_handle = SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
+    final _input_handle = library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
     final __result_handle = _methodWithEnumSet_ffi(_handle, _input_handle);
-    SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
-    final _result = SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
-    SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
+    library_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
+    final _result = library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
+    library_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
     return _result;
   }
   List<DummyInterface> methodWithInstancesList(List<DummyClass> input) {
     final _methodWithInstancesList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithInstancesList__ListOf_1smoke_1DummyClass');
-    final _input_handle = ListOf_smoke_DummyClass_toFfi(input);
+    final _input_handle = library_ListOf_smoke_DummyClass_toFfi(input);
     final __result_handle = _methodWithInstancesList_ffi(_handle, _input_handle);
-    ListOf_smoke_DummyClass_releaseFfiHandle(_input_handle);
-    final _result = ListOf_smoke_DummyInterface_fromFfi(__result_handle);
-    ListOf_smoke_DummyInterface_releaseFfiHandle(__result_handle);
+    library_ListOf_smoke_DummyClass_releaseFfiHandle(_input_handle);
+    final _result = library_ListOf_smoke_DummyInterface_fromFfi(__result_handle);
+    library_ListOf_smoke_DummyInterface_releaseFfiHandle(__result_handle);
     return _result;
   }
   Map<int, DummyInterface> methodWithInstancesMap(Map<int, DummyClass> input) {
     final _methodWithInstancesMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap__MapOf_1Int_1to_1smoke_1DummyClass');
-    final _input_handle = MapOf_Int_to_smoke_DummyClass_toFfi(input);
+    final _input_handle = library_MapOf_Int_to_smoke_DummyClass_toFfi(input);
     final __result_handle = _methodWithInstancesMap_ffi(_handle, _input_handle);
-    MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(_input_handle);
-    final _result = MapOf_Int_to_smoke_DummyInterface_fromFfi(__result_handle);
-    MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(__result_handle);
+    library_MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(_input_handle);
+    final _result = library_MapOf_Int_to_smoke_DummyInterface_fromFfi(__result_handle);
+    library_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(__result_handle);
     return _result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithGenericTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithGenericTypes.dart
@@ -17,66 +17,66 @@ class GenericTypesWithGenericTypes {
   GenericTypesWithGenericTypes._(this._handle);
   void release() => _smoke_GenericTypesWithGenericTypes_release_handle(_handle);
   List<List<int>> methodWithListOfLists(List<List<int>> input) {
-    final _methodWithListOfLists_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithListOfLists__ListOf_1ListOf_1Int');
-    final _input_handle = ListOf_ListOf_Int_toFfi(input);
+    final _methodWithListOfLists_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithListOfLists__ListOf_1library_1ListOf_1Int');
+    final _input_handle = library_ListOf_library_ListOf_Int_toFfi(input);
     final __result_handle = _methodWithListOfLists_ffi(_handle, _input_handle);
-    ListOf_ListOf_Int_releaseFfiHandle(_input_handle);
-    final _result = ListOf_ListOf_Int_fromFfi(__result_handle);
-    ListOf_ListOf_Int_releaseFfiHandle(__result_handle);
+    library_ListOf_library_ListOf_Int_releaseFfiHandle(_input_handle);
+    final _result = library_ListOf_library_ListOf_Int_fromFfi(__result_handle);
+    library_ListOf_library_ListOf_Int_releaseFfiHandle(__result_handle);
     return _result;
   }
   Map<Map<int, bool>, bool> methodWithMapOfMaps(Map<int, Map<int, bool>> input) {
-    final _methodWithMapOfMaps_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps__MapOf_1Int_1to_1MapOf_1Int_1to_1Boolean');
-    final _input_handle = MapOf_Int_to_MapOf_Int_to_Boolean_toFfi(input);
+    final _methodWithMapOfMaps_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps__MapOf_1Int_1to_1library_1MapOf_1Int_1to_1Boolean');
+    final _input_handle = library_MapOf_Int_to_library_MapOf_Int_to_Boolean_toFfi(input);
     final __result_handle = _methodWithMapOfMaps_ffi(_handle, _input_handle);
-    MapOf_Int_to_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
-    final _result = MapOf_MapOf_Int_to_Boolean_to_Boolean_fromFfi(__result_handle);
-    MapOf_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(__result_handle);
+    library_MapOf_Int_to_library_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
+    final _result = library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_fromFfi(__result_handle);
+    library_MapOf_library_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(__result_handle);
     return _result;
   }
   Set<Set<int>> methodWithSetOfSets(Set<Set<int>> input) {
-    final _methodWithSetOfSets_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithSetOfSets__SetOf_1SetOf_1Int');
-    final _input_handle = SetOf_SetOf_Int_toFfi(input);
+    final _methodWithSetOfSets_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithSetOfSets__SetOf_1library_1SetOf_1Int');
+    final _input_handle = library_SetOf_library_SetOf_Int_toFfi(input);
     final __result_handle = _methodWithSetOfSets_ffi(_handle, _input_handle);
-    SetOf_SetOf_Int_releaseFfiHandle(_input_handle);
-    final _result = SetOf_SetOf_Int_fromFfi(__result_handle);
-    SetOf_SetOf_Int_releaseFfiHandle(__result_handle);
+    library_SetOf_library_SetOf_Int_releaseFfiHandle(_input_handle);
+    final _result = library_SetOf_library_SetOf_Int_fromFfi(__result_handle);
+    library_SetOf_library_SetOf_Int_releaseFfiHandle(__result_handle);
     return _result;
   }
   Map<int, List<int>> methodWithListAndMap(List<Map<int, bool>> input) {
-    final _methodWithListAndMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithListAndMap__ListOf_1MapOf_1Int_1to_1Boolean');
-    final _input_handle = ListOf_MapOf_Int_to_Boolean_toFfi(input);
+    final _methodWithListAndMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithListAndMap__ListOf_1library_1MapOf_1Int_1to_1Boolean');
+    final _input_handle = library_ListOf_library_MapOf_Int_to_Boolean_toFfi(input);
     final __result_handle = _methodWithListAndMap_ffi(_handle, _input_handle);
-    ListOf_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
-    final _result = MapOf_Int_to_ListOf_Int_fromFfi(__result_handle);
-    MapOf_Int_to_ListOf_Int_releaseFfiHandle(__result_handle);
+    library_ListOf_library_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
+    final _result = library_MapOf_Int_to_library_ListOf_Int_fromFfi(__result_handle);
+    library_MapOf_Int_to_library_ListOf_Int_releaseFfiHandle(__result_handle);
     return _result;
   }
   Set<List<int>> methodWithListAndSet(List<Set<int>> input) {
-    final _methodWithListAndSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithListAndSet__ListOf_1SetOf_1Int');
-    final _input_handle = ListOf_SetOf_Int_toFfi(input);
+    final _methodWithListAndSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithListAndSet__ListOf_1library_1SetOf_1Int');
+    final _input_handle = library_ListOf_library_SetOf_Int_toFfi(input);
     final __result_handle = _methodWithListAndSet_ffi(_handle, _input_handle);
-    ListOf_SetOf_Int_releaseFfiHandle(_input_handle);
-    final _result = SetOf_ListOf_Int_fromFfi(__result_handle);
-    SetOf_ListOf_Int_releaseFfiHandle(__result_handle);
+    library_ListOf_library_SetOf_Int_releaseFfiHandle(_input_handle);
+    final _result = library_SetOf_library_ListOf_Int_fromFfi(__result_handle);
+    library_SetOf_library_ListOf_Int_releaseFfiHandle(__result_handle);
     return _result;
   }
   Set<Map<int, bool>> methodWithMapAndSet(Map<int, Set<int>> input) {
-    final _methodWithMapAndSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithMapAndSet__MapOf_1Int_1to_1SetOf_1Int');
-    final _input_handle = MapOf_Int_to_SetOf_Int_toFfi(input);
+    final _methodWithMapAndSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithMapAndSet__MapOf_1Int_1to_1library_1SetOf_1Int');
+    final _input_handle = library_MapOf_Int_to_library_SetOf_Int_toFfi(input);
     final __result_handle = _methodWithMapAndSet_ffi(_handle, _input_handle);
-    MapOf_Int_to_SetOf_Int_releaseFfiHandle(_input_handle);
-    final _result = SetOf_MapOf_Int_to_Boolean_fromFfi(__result_handle);
-    SetOf_MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
+    library_MapOf_Int_to_library_SetOf_Int_releaseFfiHandle(_input_handle);
+    final _result = library_SetOf_library_MapOf_Int_to_Boolean_fromFfi(__result_handle);
+    library_SetOf_library_MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
     return _result;
   }
   Map<List<int>, bool> methodWithMapGenericKeys(Map<Set<int>, bool> input) {
-    final _methodWithMapGenericKeys_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys__MapOf_1SetOf_1Int_1to_1Boolean');
-    final _input_handle = MapOf_SetOf_Int_to_Boolean_toFfi(input);
+    final _methodWithMapGenericKeys_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys__MapOf_1library_1SetOf_1Int_1to_1Boolean');
+    final _input_handle = library_MapOf_library_SetOf_Int_to_Boolean_toFfi(input);
     final __result_handle = _methodWithMapGenericKeys_ffi(_handle, _input_handle);
-    MapOf_SetOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
-    final _result = MapOf_ListOf_Int_to_Boolean_fromFfi(__result_handle);
-    MapOf_ListOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
+    library_MapOf_library_SetOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
+    final _result = library_MapOf_library_ListOf_Int_to_Boolean_fromFfi(__result_handle);
+    library_MapOf_library_ListOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
     return _result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/Lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/Lambdas.dart
@@ -29,13 +29,13 @@ class Lambdas {
   }
   static Map<int, String> fuse(List<String> items, Lambdas_Indexer callback) {
     final _fuse_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_Lambdas_fuse__ListOf_1String_Indexer');
-    final _items_handle = ListOf_String_toFfi(items);
+    final _items_handle = library_ListOf_String_toFfi(items);
     final _callback_handle = smoke_Lambdas_Indexer_toFfi(callback);
     final __result_handle = _fuse_ffi(_items_handle, _callback_handle);
-    ListOf_String_releaseFfiHandle(_items_handle);
+    library_ListOf_String_releaseFfiHandle(_items_handle);
     smoke_Lambdas_Indexer_releaseFfiHandle(_callback_handle);
-    final _result = MapOf_Int_to_String_fromFfi(__result_handle);
-    MapOf_Int_to_String_releaseFfiHandle(__result_handle);
+    final _result = library_MapOf_Int_to_String_fromFfi(__result_handle);
+    library_MapOf_Int_to_String_releaseFfiHandle(__result_handle);
     return _result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/CalculatorListener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/CalculatorListener.dart
@@ -140,9 +140,9 @@ class CalculatorListener__Impl implements CalculatorListener {
   @override
   onCalculationResultArray(List<double> calculationResult) {
     final _onCalculationResultArray_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_CalculatorListener_onCalculationResultArray__ListOf_1Double');
-    final _calculationResult_handle = ListOf_Double_toFfi(calculationResult);
+    final _calculationResult_handle = library_ListOf_Double_toFfi(calculationResult);
     final __result_handle = _onCalculationResultArray_ffi(_handle, _calculationResult_handle);
-    ListOf_Double_releaseFfiHandle(_calculationResult_handle);
+    library_ListOf_Double_releaseFfiHandle(_calculationResult_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
@@ -150,9 +150,9 @@ class CalculatorListener__Impl implements CalculatorListener {
   @override
   onCalculationResultMap(Map<String, double> calculationResults) {
     final _onCalculationResultMap_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_CalculatorListener_onCalculationResultMap__MapOf_1String_1to_1Double');
-    final _calculationResults_handle = MapOf_String_to_Double_toFfi(calculationResults);
+    final _calculationResults_handle = library_MapOf_String_to_Double_toFfi(calculationResults);
     final __result_handle = _onCalculationResultMap_ffi(_handle, _calculationResults_handle);
-    MapOf_String_to_Double_releaseFfiHandle(_calculationResults_handle);
+    library_MapOf_String_to_Double_releaseFfiHandle(_calculationResults_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
@@ -184,13 +184,13 @@ int _CalculatorListener_onCalculationResultStruct_static(int _token, Pointer<Voi
   return 0;
 }
 int _CalculatorListener_onCalculationResultArray_static(int _token, Pointer<Void> calculationResult) {
-  _CalculatorListener_instance_cache[_token].onCalculationResultArray(ListOf_Double_fromFfi(calculationResult));
-  ListOf_Double_releaseFfiHandle(calculationResult);
+  _CalculatorListener_instance_cache[_token].onCalculationResultArray(library_ListOf_Double_fromFfi(calculationResult));
+  library_ListOf_Double_releaseFfiHandle(calculationResult);
   return 0;
 }
 int _CalculatorListener_onCalculationResultMap_static(int _token, Pointer<Void> calculationResults) {
-  _CalculatorListener_instance_cache[_token].onCalculationResultMap(MapOf_String_to_Double_fromFfi(calculationResults));
-  MapOf_String_to_Double_releaseFfiHandle(calculationResults);
+  _CalculatorListener_instance_cache[_token].onCalculationResultMap(library_MapOf_String_to_Double_fromFfi(calculationResults));
+  library_MapOf_String_to_Double_releaseFfiHandle(calculationResults);
   return 0;
 }
 int _CalculatorListener_onCalculationResultInstance_static(int _token, Pointer<Void> calculationResult) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenerWithProperties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenerWithProperties.dart
@@ -242,15 +242,15 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   List<String> get arrayedMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_ListenerWithProperties_arrayedMessage_get');
     final __result_handle = _get_ffi(_handle);
-    final _result = ListOf_String_fromFfi(__result_handle);
-    ListOf_String_releaseFfiHandle(__result_handle);
+    final _result = library_ListOf_String_fromFfi(__result_handle);
+    library_ListOf_String_releaseFfiHandle(__result_handle);
     return _result;
   }
   set arrayedMessage(List<String> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_ListenerWithProperties_arrayedMessage_set__ListOf_1String');
-    final _value_handle = ListOf_String_toFfi(value);
+    final _value_handle = library_ListOf_String_toFfi(value);
     final __result_handle = _set_ffi(_handle, _value_handle);
-    ListOf_String_releaseFfiHandle(_value_handle);
+    library_ListOf_String_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
@@ -258,15 +258,15 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   Map<String, double> get mappedMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_ListenerWithProperties_mappedMessage_get');
     final __result_handle = _get_ffi(_handle);
-    final _result = MapOf_String_to_Double_fromFfi(__result_handle);
-    MapOf_String_to_Double_releaseFfiHandle(__result_handle);
+    final _result = library_MapOf_String_to_Double_fromFfi(__result_handle);
+    library_MapOf_String_to_Double_releaseFfiHandle(__result_handle);
     return _result;
   }
   set mappedMessage(Map<String, double> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_ListenerWithProperties_mappedMessage_set__MapOf_1String_1to_1Double');
-    final _value_handle = MapOf_String_to_Double_toFfi(value);
+    final _value_handle = library_MapOf_String_to_Double_toFfi(value);
     final __result_handle = _set_ffi(_handle, _value_handle);
-    MapOf_String_to_Double_releaseFfiHandle(_value_handle);
+    library_MapOf_String_to_Double_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
@@ -325,21 +325,21 @@ int _ListenerWithProperties_enumeratedMessage_set_static(int _token, int _value)
   return 0;
 }
 int _ListenerWithProperties_arrayedMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {
-  _result.value = ListOf_String_toFfi(_ListenerWithProperties_instance_cache[_token].arrayedMessage);
+  _result.value = library_ListOf_String_toFfi(_ListenerWithProperties_instance_cache[_token].arrayedMessage);
   return 0;
 }
 int _ListenerWithProperties_arrayedMessage_set_static(int _token, Pointer<Void> _value) {
-  _ListenerWithProperties_instance_cache[_token].arrayedMessage = ListOf_String_fromFfi(_value);
-  ListOf_String_releaseFfiHandle(_value);
+  _ListenerWithProperties_instance_cache[_token].arrayedMessage = library_ListOf_String_fromFfi(_value);
+  library_ListOf_String_releaseFfiHandle(_value);
   return 0;
 }
 int _ListenerWithProperties_mappedMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {
-  _result.value = MapOf_String_to_Double_toFfi(_ListenerWithProperties_instance_cache[_token].mappedMessage);
+  _result.value = library_MapOf_String_to_Double_toFfi(_ListenerWithProperties_instance_cache[_token].mappedMessage);
   return 0;
 }
 int _ListenerWithProperties_mappedMessage_set_static(int _token, Pointer<Void> _value) {
-  _ListenerWithProperties_instance_cache[_token].mappedMessage = MapOf_String_to_Double_fromFfi(_value);
-  MapOf_String_to_Double_releaseFfiHandle(_value);
+  _ListenerWithProperties_instance_cache[_token].mappedMessage = library_MapOf_String_to_Double_fromFfi(_value);
+  library_MapOf_String_to_Double_releaseFfiHandle(_value);
   return 0;
 }
 int _ListenerWithProperties_bufferedMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenersWithReturnValues.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenersWithReturnValues.dart
@@ -203,16 +203,16 @@ class ListenersWithReturnValues__Impl implements ListenersWithReturnValues {
   List<double> fetchDataArray() {
     final _fetchDataArray_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_ListenersWithReturnValues_fetchDataArray');
     final __result_handle = _fetchDataArray_ffi(_handle);
-    final _result = ListOf_Double_fromFfi(__result_handle);
-    ListOf_Double_releaseFfiHandle(__result_handle);
+    final _result = library_ListOf_Double_fromFfi(__result_handle);
+    library_ListOf_Double_releaseFfiHandle(__result_handle);
     return _result;
   }
   @override
   Map<String, double> fetchDataMap() {
     final _fetchDataMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_ListenersWithReturnValues_fetchDataMap');
     final __result_handle = _fetchDataMap_ffi(_handle);
-    final _result = MapOf_String_to_Double_fromFfi(__result_handle);
-    MapOf_String_to_Double_releaseFfiHandle(__result_handle);
+    final _result = library_MapOf_String_to_Double_fromFfi(__result_handle);
+    library_MapOf_String_to_Double_releaseFfiHandle(__result_handle);
     return _result;
   }
   @override
@@ -246,12 +246,12 @@ int _ListenersWithReturnValues_fetchDataEnum_static(int _token, Pointer<Uint32> 
 }
 int _ListenersWithReturnValues_fetchDataArray_static(int _token, Pointer<Pointer<Void>> _result) {
   final _result_object = _ListenersWithReturnValues_instance_cache[_token].fetchDataArray();
-  _result.value = ListOf_Double_toFfi(_result_object);
+  _result.value = library_ListOf_Double_toFfi(_result_object);
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataMap_static(int _token, Pointer<Pointer<Void>> _result) {
   final _result_object = _ListenersWithReturnValues_instance_cache[_token].fetchDataMap();
-  _result.value = MapOf_String_to_Double_toFfi(_result_object);
+  _result.value = library_MapOf_String_to_Double_toFfi(_result_object);
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataInstance_static(int _token, Pointer<Pointer<Void>> _result) {

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/MethodOverloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/MethodOverloads.dart
@@ -69,18 +69,18 @@ class MethodOverloads {
   }
   bool isBooleanStringArray(List<String> input) {
     final _isBooleanStringArray_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('smoke_MethodOverloads_isBoolean__ListOf_1String');
-    final _input_handle = ListOf_String_toFfi(input);
+    final _input_handle = library_ListOf_String_toFfi(input);
     final __result_handle = _isBooleanStringArray_ffi(_handle, _input_handle);
-    ListOf_String_releaseFfiHandle(_input_handle);
+    library_ListOf_String_releaseFfiHandle(_input_handle);
     final _result = Boolean_fromFfi(__result_handle);
     Boolean_releaseFfiHandle(__result_handle);
     return _result;
   }
   bool isBooleanIntArray(List<int> input) {
     final _isBooleanIntArray_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('smoke_MethodOverloads_isBoolean__ListOf_1Byte');
-    final _input_handle = ListOf_Byte_toFfi(input);
+    final _input_handle = library_ListOf_Byte_toFfi(input);
     final __result_handle = _isBooleanIntArray_ffi(_handle, _input_handle);
-    ListOf_Byte_releaseFfiHandle(_input_handle);
+    library_ListOf_Byte_releaseFfiHandle(_input_handle);
     final _result = Boolean_fromFfi(__result_handle);
     Boolean_releaseFfiHandle(__result_handle);
     return _result;
@@ -103,9 +103,9 @@ class MethodOverloads {
   }
   bool isFloatList(List<int> input) {
     final _isFloatList_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('smoke_MethodOverloads_isFloat__ListOf_1Byte');
-    final _input_handle = ListOf_Byte_toFfi(input);
+    final _input_handle = library_ListOf_Byte_toFfi(input);
     final __result_handle = _isFloatList_ffi(_handle, _input_handle);
-    ListOf_Byte_releaseFfiHandle(_input_handle);
+    library_ListOf_Byte_releaseFfiHandle(_input_handle);
     final _result = Boolean_fromFfi(__result_handle);
     Boolean_releaseFfiHandle(__result_handle);
     return _result;

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/GenericTypes__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/GenericTypes__conversion.dart
@@ -4,349 +4,349 @@ import 'package:library/src/smoke/Nullable.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _ListOf_Nullable_Date_create_handle = __lib.nativeLibrary.lookupFunction<
+final _library_ListOf_Nullable_Date_create_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('ListOf_Nullable_Date_create_handle');
-final _ListOf_Nullable_Date_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Nullable_Date_create_handle');
+final _library_ListOf_Nullable_Date_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('ListOf_Nullable_Date_release_handle');
-final _ListOf_Nullable_Date_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Nullable_Date_release_handle');
+final _library_ListOf_Nullable_Date_insert = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('ListOf_Nullable_Date_insert');
-final _ListOf_Nullable_Date_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Nullable_Date_insert');
+final _library_ListOf_Nullable_Date_iterator = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('ListOf_Nullable_Date_iterator');
-final _ListOf_Nullable_Date_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_Nullable_Date_iterator');
+final _library_ListOf_Nullable_Date_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('ListOf_Nullable_Date_iterator_release_handle');
-final _ListOf_Nullable_Date_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_Nullable_Date_iterator_release_handle');
+final _library_ListOf_Nullable_Date_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('ListOf_Nullable_Date_iterator_is_valid');
-final _ListOf_Nullable_Date_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_Nullable_Date_iterator_is_valid');
+final _library_ListOf_Nullable_Date_iterator_increment = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('ListOf_Nullable_Date_iterator_increment');
-final _ListOf_Nullable_Date_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_Nullable_Date_iterator_increment');
+final _library_ListOf_Nullable_Date_iterator_get = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('ListOf_Nullable_Date_iterator_get');
-Pointer<Void> ListOf_Nullable_Date_toFfi(List<DateTime> value) {
-  final _result = _ListOf_Nullable_Date_create_handle();
+>('library_ListOf_Nullable_Date_iterator_get');
+Pointer<Void> library_ListOf_Nullable_Date_toFfi(List<DateTime> value) {
+  final _result = _library_ListOf_Nullable_Date_create_handle();
   for (final element in value) {
     final _element_handle = Date_toFfi_nullable(element);
-    _ListOf_Nullable_Date_insert(_result, _element_handle);
+    _library_ListOf_Nullable_Date_insert(_result, _element_handle);
     Date_releaseFfiHandle_nullable(_element_handle);
   }
   return _result;
 }
-List<DateTime> ListOf_Nullable_Date_fromFfi(Pointer<Void> handle) {
+List<DateTime> library_ListOf_Nullable_Date_fromFfi(Pointer<Void> handle) {
   final result = List<DateTime>();
-  final _iterator_handle = _ListOf_Nullable_Date_iterator(handle);
-  while (_ListOf_Nullable_Date_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _ListOf_Nullable_Date_iterator_get(_iterator_handle);
+  final _iterator_handle = _library_ListOf_Nullable_Date_iterator(handle);
+  while (_library_ListOf_Nullable_Date_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _element_handle = _library_ListOf_Nullable_Date_iterator_get(_iterator_handle);
     result.add(Date_fromFfi_nullable(_element_handle));
     Date_releaseFfiHandle_nullable(_element_handle);
-    _ListOf_Nullable_Date_iterator_increment(_iterator_handle);
+    _library_ListOf_Nullable_Date_iterator_increment(_iterator_handle);
   }
-  _ListOf_Nullable_Date_iterator_release_handle(_iterator_handle);
+  _library_ListOf_Nullable_Date_iterator_release_handle(_iterator_handle);
   return result;
 }
-void ListOf_Nullable_Date_releaseFfiHandle(Pointer<Void> handle) => _ListOf_Nullable_Date_release_handle(handle);
-final _ListOf_Nullable_Date_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+void library_ListOf_Nullable_Date_releaseFfiHandle(Pointer<Void> handle) => _library_ListOf_Nullable_Date_release_handle(handle);
+final _library_ListOf_Nullable_Date_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('ListOf_Nullable_Date_create_handle_nullable');
-final _ListOf_Nullable_Date_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Nullable_Date_create_handle_nullable');
+final _library_ListOf_Nullable_Date_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('ListOf_Nullable_Date_release_handle_nullable');
-final _ListOf_Nullable_Date_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Nullable_Date_release_handle_nullable');
+final _library_ListOf_Nullable_Date_get_value_nullable = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('ListOf_Nullable_Date_get_value_nullable');
-Pointer<Void> ListOf_Nullable_Date_toFfi_nullable(List<DateTime> value) {
+  >('library_ListOf_Nullable_Date_get_value_nullable');
+Pointer<Void> library_ListOf_Nullable_Date_toFfi_nullable(List<DateTime> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
-  final _handle = ListOf_Nullable_Date_toFfi(value);
-  final result = _ListOf_Nullable_Date_create_handle_nullable(_handle);
-  ListOf_Nullable_Date_releaseFfiHandle(_handle);
+  final _handle = library_ListOf_Nullable_Date_toFfi(value);
+  final result = _library_ListOf_Nullable_Date_create_handle_nullable(_handle);
+  library_ListOf_Nullable_Date_releaseFfiHandle(_handle);
   return result;
 }
-List<DateTime> ListOf_Nullable_Date_fromFfi_nullable(Pointer<Void> handle) {
+List<DateTime> library_ListOf_Nullable_Date_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _ListOf_Nullable_Date_get_value_nullable(handle);
-  final result = ListOf_Nullable_Date_fromFfi(_handle);
-  ListOf_Nullable_Date_releaseFfiHandle(_handle);
+  final _handle = _library_ListOf_Nullable_Date_get_value_nullable(handle);
+  final result = library_ListOf_Nullable_Date_fromFfi(_handle);
+  library_ListOf_Nullable_Date_releaseFfiHandle(_handle);
   return result;
 }
-void ListOf_Nullable_Date_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _ListOf_Nullable_Date_release_handle_nullable(handle);
-final _ListOf_String_create_handle = __lib.nativeLibrary.lookupFunction<
+void library_ListOf_Nullable_Date_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _library_ListOf_Nullable_Date_release_handle_nullable(handle);
+final _library_ListOf_String_create_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('ListOf_String_create_handle');
-final _ListOf_String_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_create_handle');
+final _library_ListOf_String_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('ListOf_String_release_handle');
-final _ListOf_String_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_release_handle');
+final _library_ListOf_String_insert = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('ListOf_String_insert');
-final _ListOf_String_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_insert');
+final _library_ListOf_String_iterator = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('ListOf_String_iterator');
-final _ListOf_String_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_String_iterator');
+final _library_ListOf_String_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('ListOf_String_iterator_release_handle');
-final _ListOf_String_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_String_iterator_release_handle');
+final _library_ListOf_String_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('ListOf_String_iterator_is_valid');
-final _ListOf_String_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_String_iterator_is_valid');
+final _library_ListOf_String_iterator_increment = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('ListOf_String_iterator_increment');
-final _ListOf_String_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_String_iterator_increment');
+final _library_ListOf_String_iterator_get = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('ListOf_String_iterator_get');
-Pointer<Void> ListOf_String_toFfi(List<String> value) {
-  final _result = _ListOf_String_create_handle();
+>('library_ListOf_String_iterator_get');
+Pointer<Void> library_ListOf_String_toFfi(List<String> value) {
+  final _result = _library_ListOf_String_create_handle();
   for (final element in value) {
     final _element_handle = String_toFfi(element);
-    _ListOf_String_insert(_result, _element_handle);
+    _library_ListOf_String_insert(_result, _element_handle);
     String_releaseFfiHandle(_element_handle);
   }
   return _result;
 }
-List<String> ListOf_String_fromFfi(Pointer<Void> handle) {
+List<String> library_ListOf_String_fromFfi(Pointer<Void> handle) {
   final result = List<String>();
-  final _iterator_handle = _ListOf_String_iterator(handle);
-  while (_ListOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _ListOf_String_iterator_get(_iterator_handle);
+  final _iterator_handle = _library_ListOf_String_iterator(handle);
+  while (_library_ListOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _element_handle = _library_ListOf_String_iterator_get(_iterator_handle);
     result.add(String_fromFfi(_element_handle));
     String_releaseFfiHandle(_element_handle);
-    _ListOf_String_iterator_increment(_iterator_handle);
+    _library_ListOf_String_iterator_increment(_iterator_handle);
   }
-  _ListOf_String_iterator_release_handle(_iterator_handle);
+  _library_ListOf_String_iterator_release_handle(_iterator_handle);
   return result;
 }
-void ListOf_String_releaseFfiHandle(Pointer<Void> handle) => _ListOf_String_release_handle(handle);
-final _ListOf_String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+void library_ListOf_String_releaseFfiHandle(Pointer<Void> handle) => _library_ListOf_String_release_handle(handle);
+final _library_ListOf_String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('ListOf_String_create_handle_nullable');
-final _ListOf_String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_create_handle_nullable');
+final _library_ListOf_String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('ListOf_String_release_handle_nullable');
-final _ListOf_String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_release_handle_nullable');
+final _library_ListOf_String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('ListOf_String_get_value_nullable');
-Pointer<Void> ListOf_String_toFfi_nullable(List<String> value) {
+  >('library_ListOf_String_get_value_nullable');
+Pointer<Void> library_ListOf_String_toFfi_nullable(List<String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
-  final _handle = ListOf_String_toFfi(value);
-  final result = _ListOf_String_create_handle_nullable(_handle);
-  ListOf_String_releaseFfiHandle(_handle);
+  final _handle = library_ListOf_String_toFfi(value);
+  final result = _library_ListOf_String_create_handle_nullable(_handle);
+  library_ListOf_String_releaseFfiHandle(_handle);
   return result;
 }
-List<String> ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
+List<String> library_ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _ListOf_String_get_value_nullable(handle);
-  final result = ListOf_String_fromFfi(_handle);
-  ListOf_String_releaseFfiHandle(_handle);
+  final _handle = _library_ListOf_String_get_value_nullable(handle);
+  final result = library_ListOf_String_fromFfi(_handle);
+  library_ListOf_String_releaseFfiHandle(_handle);
   return result;
 }
-void ListOf_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _ListOf_String_release_handle_nullable(handle);
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+void library_ListOf_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _library_ListOf_String_release_handle_nullable(handle);
+final _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle');
+final _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle');
+final _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
-  >('MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put');
+final _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator');
+final _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle');
+final _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid');
+final _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment');
+final _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key = __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key');
+final _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value');
-Pointer<Void> MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi(Map<int, Nullable_SomeStruct> value) {
-  final _result = _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle();
+>('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value');
+Pointer<Void> library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi(Map<int, Nullable_SomeStruct> value) {
+  final _result = _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle();
   for (final entry in value.entries) {
     final _key_handle = (entry.key);
     final _value_handle = smoke_Nullable_SomeStruct_toFfi_nullable(entry.value);
-    _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put(_result, _key_handle, _value_handle);
+    _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put(_result, _key_handle, _value_handle);
     (_key_handle);
     smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_value_handle);
   }
   return _result;
 }
-Map<int, Nullable_SomeStruct> MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi(Pointer<Void> handle) {
+Map<int, Nullable_SomeStruct> library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi(Pointer<Void> handle) {
   final result = Map<int, Nullable_SomeStruct>();
-  final _iterator_handle = _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator(handle);
-  while (_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key(_iterator_handle);
-    final _value_handle = _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value(_iterator_handle);
+  final _iterator_handle = _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator(handle);
+  while (_library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _key_handle = _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key(_iterator_handle);
+    final _value_handle = _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value(_iterator_handle);
     result[(_key_handle)] =
       smoke_Nullable_SomeStruct_fromFfi_nullable(_value_handle);
     (_key_handle);
     smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_value_handle);
-    _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment(_iterator_handle);
+    _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment(_iterator_handle);
   }
-  _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle(_iterator_handle);
+  _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle(_iterator_handle);
   return result;
 }
-void MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle(handle);
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+void library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle(handle);
+final _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable');
+final _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable');
+final _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable');
-Pointer<Void> MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi_nullable(Map<int, Nullable_SomeStruct> value) {
+  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable');
+Pointer<Void> library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi_nullable(Map<int, Nullable_SomeStruct> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
-  final _handle = MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi(value);
-  final result = _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable(_handle);
-  MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle(_handle);
+  final _handle = library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi(value);
+  final result = _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable(_handle);
+  library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, Nullable_SomeStruct> MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, Nullable_SomeStruct> library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable(handle);
-  final result = MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi(_handle);
-  MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle(_handle);
+  final _handle = _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable(handle);
+  final result = library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi(_handle);
+  library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-void MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable(handle);
-final _MapOf_Long_to_String_create_handle = __lib.nativeLibrary.lookupFunction<
+void library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable(handle);
+final _library_MapOf_Long_to_String_create_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('MapOf_Long_to_String_create_handle');
-final _MapOf_Long_to_String_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Long_to_String_create_handle');
+final _library_MapOf_Long_to_String_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('MapOf_Long_to_String_release_handle');
-final _MapOf_Long_to_String_put = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Long_to_String_release_handle');
+final _library_MapOf_Long_to_String_put = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int64, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
-  >('MapOf_Long_to_String_put');
-final _MapOf_Long_to_String_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Long_to_String_put');
+final _library_MapOf_Long_to_String_iterator = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('MapOf_Long_to_String_iterator');
-final _MapOf_Long_to_String_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Long_to_String_iterator');
+final _library_MapOf_Long_to_String_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('MapOf_Long_to_String_iterator_release_handle');
-final _MapOf_Long_to_String_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Long_to_String_iterator_release_handle');
+final _library_MapOf_Long_to_String_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('MapOf_Long_to_String_iterator_is_valid');
-final _MapOf_Long_to_String_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Long_to_String_iterator_is_valid');
+final _library_MapOf_Long_to_String_iterator_increment = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('MapOf_Long_to_String_iterator_increment');
-final _MapOf_Long_to_String_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Long_to_String_iterator_increment');
+final _library_MapOf_Long_to_String_iterator_get_key = __lib.nativeLibrary.lookupFunction<
     Int64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('MapOf_Long_to_String_iterator_get_key');
-final _MapOf_Long_to_String_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Long_to_String_iterator_get_key');
+final _library_MapOf_Long_to_String_iterator_get_value = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('MapOf_Long_to_String_iterator_get_value');
-Pointer<Void> MapOf_Long_to_String_toFfi(Map<int, String> value) {
-  final _result = _MapOf_Long_to_String_create_handle();
+>('library_MapOf_Long_to_String_iterator_get_value');
+Pointer<Void> library_MapOf_Long_to_String_toFfi(Map<int, String> value) {
+  final _result = _library_MapOf_Long_to_String_create_handle();
   for (final entry in value.entries) {
     final _key_handle = (entry.key);
     final _value_handle = String_toFfi(entry.value);
-    _MapOf_Long_to_String_put(_result, _key_handle, _value_handle);
+    _library_MapOf_Long_to_String_put(_result, _key_handle, _value_handle);
     (_key_handle);
     String_releaseFfiHandle(_value_handle);
   }
   return _result;
 }
-Map<int, String> MapOf_Long_to_String_fromFfi(Pointer<Void> handle) {
+Map<int, String> library_MapOf_Long_to_String_fromFfi(Pointer<Void> handle) {
   final result = Map<int, String>();
-  final _iterator_handle = _MapOf_Long_to_String_iterator(handle);
-  while (_MapOf_Long_to_String_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _MapOf_Long_to_String_iterator_get_key(_iterator_handle);
-    final _value_handle = _MapOf_Long_to_String_iterator_get_value(_iterator_handle);
+  final _iterator_handle = _library_MapOf_Long_to_String_iterator(handle);
+  while (_library_MapOf_Long_to_String_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _key_handle = _library_MapOf_Long_to_String_iterator_get_key(_iterator_handle);
+    final _value_handle = _library_MapOf_Long_to_String_iterator_get_value(_iterator_handle);
     result[(_key_handle)] =
       String_fromFfi(_value_handle);
     (_key_handle);
     String_releaseFfiHandle(_value_handle);
-    _MapOf_Long_to_String_iterator_increment(_iterator_handle);
+    _library_MapOf_Long_to_String_iterator_increment(_iterator_handle);
   }
-  _MapOf_Long_to_String_iterator_release_handle(_iterator_handle);
+  _library_MapOf_Long_to_String_iterator_release_handle(_iterator_handle);
   return result;
 }
-void MapOf_Long_to_String_releaseFfiHandle(Pointer<Void> handle) => _MapOf_Long_to_String_release_handle(handle);
-final _MapOf_Long_to_String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+void library_MapOf_Long_to_String_releaseFfiHandle(Pointer<Void> handle) => _library_MapOf_Long_to_String_release_handle(handle);
+final _library_MapOf_Long_to_String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('MapOf_Long_to_String_create_handle_nullable');
-final _MapOf_Long_to_String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Long_to_String_create_handle_nullable');
+final _library_MapOf_Long_to_String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('MapOf_Long_to_String_release_handle_nullable');
-final _MapOf_Long_to_String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Long_to_String_release_handle_nullable');
+final _library_MapOf_Long_to_String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('MapOf_Long_to_String_get_value_nullable');
-Pointer<Void> MapOf_Long_to_String_toFfi_nullable(Map<int, String> value) {
+  >('library_MapOf_Long_to_String_get_value_nullable');
+Pointer<Void> library_MapOf_Long_to_String_toFfi_nullable(Map<int, String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
-  final _handle = MapOf_Long_to_String_toFfi(value);
-  final result = _MapOf_Long_to_String_create_handle_nullable(_handle);
-  MapOf_Long_to_String_releaseFfiHandle(_handle);
+  final _handle = library_MapOf_Long_to_String_toFfi(value);
+  final result = _library_MapOf_Long_to_String_create_handle_nullable(_handle);
+  library_MapOf_Long_to_String_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, String> MapOf_Long_to_String_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, String> library_MapOf_Long_to_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _MapOf_Long_to_String_get_value_nullable(handle);
-  final result = MapOf_Long_to_String_fromFfi(_handle);
-  MapOf_Long_to_String_releaseFfiHandle(_handle);
+  final _handle = _library_MapOf_Long_to_String_get_value_nullable(handle);
+  final result = library_MapOf_Long_to_String_fromFfi(_handle);
+  library_MapOf_Long_to_String_releaseFfiHandle(_handle);
   return result;
 }
-void MapOf_Long_to_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _MapOf_Long_to_String_release_handle_nullable(handle);
+void library_MapOf_Long_to_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _library_MapOf_Long_to_String_release_handle_nullable(handle);

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/Nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/Nullable.dart
@@ -73,29 +73,29 @@ class Nullable {
   }
   List<String> methodWithSomeArray(List<String> input) {
     final _methodWithSomeArray_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_Nullable_methodWithSomeArray__ListOf_1String');
-    final _input_handle = ListOf_String_toFfi_nullable(input);
+    final _input_handle = library_ListOf_String_toFfi_nullable(input);
     final __result_handle = _methodWithSomeArray_ffi(_handle, _input_handle);
-    ListOf_String_releaseFfiHandle_nullable(_input_handle);
-    final _result = ListOf_String_fromFfi_nullable(__result_handle);
-    ListOf_String_releaseFfiHandle_nullable(__result_handle);
+    library_ListOf_String_releaseFfiHandle_nullable(_input_handle);
+    final _result = library_ListOf_String_fromFfi_nullable(__result_handle);
+    library_ListOf_String_releaseFfiHandle_nullable(__result_handle);
     return _result;
   }
   List<String> methodWithInlineArray(List<String> input) {
     final _methodWithInlineArray_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_Nullable_methodWithInlineArray__ListOf_1String');
-    final _input_handle = ListOf_String_toFfi_nullable(input);
+    final _input_handle = library_ListOf_String_toFfi_nullable(input);
     final __result_handle = _methodWithInlineArray_ffi(_handle, _input_handle);
-    ListOf_String_releaseFfiHandle_nullable(_input_handle);
-    final _result = ListOf_String_fromFfi_nullable(__result_handle);
-    ListOf_String_releaseFfiHandle_nullable(__result_handle);
+    library_ListOf_String_releaseFfiHandle_nullable(_input_handle);
+    final _result = library_ListOf_String_fromFfi_nullable(__result_handle);
+    library_ListOf_String_releaseFfiHandle_nullable(__result_handle);
     return _result;
   }
   Map<int, String> methodWithSomeMap(Map<int, String> input) {
     final _methodWithSomeMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('smoke_Nullable_methodWithSomeMap__MapOf_1Long_1to_1String');
-    final _input_handle = MapOf_Long_to_String_toFfi_nullable(input);
+    final _input_handle = library_MapOf_Long_to_String_toFfi_nullable(input);
     final __result_handle = _methodWithSomeMap_ffi(_handle, _input_handle);
-    MapOf_Long_to_String_releaseFfiHandle_nullable(_input_handle);
-    final _result = MapOf_Long_to_String_fromFfi_nullable(__result_handle);
-    MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
+    library_MapOf_Long_to_String_releaseFfiHandle_nullable(_input_handle);
+    final _result = library_MapOf_Long_to_String_fromFfi_nullable(__result_handle);
+    library_MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
     return _result;
   }
   SomeInterface methodWithInstance(SomeInterface input) {
@@ -206,15 +206,15 @@ class Nullable {
   List<String> get arrayProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Nullable_arrayProperty_get');
     final __result_handle = _get_ffi(_handle);
-    final _result = ListOf_String_fromFfi_nullable(__result_handle);
-    ListOf_String_releaseFfiHandle_nullable(__result_handle);
+    final _result = library_ListOf_String_fromFfi_nullable(__result_handle);
+    library_ListOf_String_releaseFfiHandle_nullable(__result_handle);
     return _result;
   }
   set arrayProperty(List<String> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_Nullable_arrayProperty_set__ListOf_1String');
-    final _value_handle = ListOf_String_toFfi_nullable(value);
+    final _value_handle = library_ListOf_String_toFfi_nullable(value);
     final __result_handle = _set_ffi(_handle, _value_handle);
-    ListOf_String_releaseFfiHandle_nullable(_value_handle);
+    library_ListOf_String_releaseFfiHandle_nullable(_value_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
@@ -222,15 +222,15 @@ class Nullable {
   List<String> get inlineArrayProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Nullable_inlineArrayProperty_get');
     final __result_handle = _get_ffi(_handle);
-    final _result = ListOf_String_fromFfi_nullable(__result_handle);
-    ListOf_String_releaseFfiHandle_nullable(__result_handle);
+    final _result = library_ListOf_String_fromFfi_nullable(__result_handle);
+    library_ListOf_String_releaseFfiHandle_nullable(__result_handle);
     return _result;
   }
   set inlineArrayProperty(List<String> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_Nullable_inlineArrayProperty_set__ListOf_1String');
-    final _value_handle = ListOf_String_toFfi_nullable(value);
+    final _value_handle = library_ListOf_String_toFfi_nullable(value);
     final __result_handle = _set_ffi(_handle, _value_handle);
-    ListOf_String_releaseFfiHandle_nullable(_value_handle);
+    library_ListOf_String_releaseFfiHandle_nullable(_value_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
@@ -238,15 +238,15 @@ class Nullable {
   Map<int, String> get mapProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Nullable_mapProperty_get');
     final __result_handle = _get_ffi(_handle);
-    final _result = MapOf_Long_to_String_fromFfi_nullable(__result_handle);
-    MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
+    final _result = library_MapOf_Long_to_String_fromFfi_nullable(__result_handle);
+    library_MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
     return _result;
   }
   set mapProperty(Map<int, String> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_Nullable_mapProperty_set__MapOf_1Long_1to_1String');
-    final _value_handle = MapOf_Long_to_String_toFfi_nullable(value);
+    final _value_handle = library_MapOf_Long_to_String_toFfi_nullable(value);
     final __result_handle = _set_ffi(_handle, _value_handle);
-    MapOf_Long_to_String_releaseFfiHandle_nullable(_value_handle);
+    library_MapOf_Long_to_String_releaseFfiHandle_nullable(_value_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
@@ -464,9 +464,9 @@ Pointer<Void> smoke_Nullable_NullableStruct_toFfi(Nullable_NullableStruct value)
   final _doubleField_handle = Double_toFfi_nullable(value.doubleField);
   final _structField_handle = smoke_Nullable_SomeStruct_toFfi_nullable(value.structField);
   final _enumField_handle = smoke_Nullable_SomeEnum_toFfi_nullable(value.enumField);
-  final _arrayField_handle = ListOf_String_toFfi_nullable(value.arrayField);
-  final _inlineArrayField_handle = ListOf_String_toFfi_nullable(value.inlineArrayField);
-  final _mapField_handle = MapOf_Long_to_String_toFfi_nullable(value.mapField);
+  final _arrayField_handle = library_ListOf_String_toFfi_nullable(value.arrayField);
+  final _inlineArrayField_handle = library_ListOf_String_toFfi_nullable(value.inlineArrayField);
+  final _mapField_handle = library_MapOf_Long_to_String_toFfi_nullable(value.mapField);
   final _instanceField_handle = smoke_SomeInterface_toFfi_nullable(value.instanceField);
   final _result = _smoke_Nullable_NullableStruct_create_handle(_stringField_handle, _boolField_handle, _doubleField_handle, _structField_handle, _enumField_handle, _arrayField_handle, _inlineArrayField_handle, _mapField_handle, _instanceField_handle);
   String_releaseFfiHandle_nullable(_stringField_handle);
@@ -474,9 +474,9 @@ Pointer<Void> smoke_Nullable_NullableStruct_toFfi(Nullable_NullableStruct value)
   Double_releaseFfiHandle_nullable(_doubleField_handle);
   smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_structField_handle);
   smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
-  ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
-  ListOf_String_releaseFfiHandle_nullable(_inlineArrayField_handle);
-  MapOf_Long_to_String_releaseFfiHandle_nullable(_mapField_handle);
+  library_ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
+  library_ListOf_String_releaseFfiHandle_nullable(_inlineArrayField_handle);
+  library_MapOf_Long_to_String_releaseFfiHandle_nullable(_mapField_handle);
   smoke_SomeInterface_releaseFfiHandle_nullable(_instanceField_handle);
   return _result;
 }
@@ -496,9 +496,9 @@ Nullable_NullableStruct smoke_Nullable_NullableStruct_fromFfi(Pointer<Void> hand
     Double_fromFfi_nullable(_doubleField_handle),
     smoke_Nullable_SomeStruct_fromFfi_nullable(_structField_handle),
     smoke_Nullable_SomeEnum_fromFfi_nullable(_enumField_handle),
-    ListOf_String_fromFfi_nullable(_arrayField_handle),
-    ListOf_String_fromFfi_nullable(_inlineArrayField_handle),
-    MapOf_Long_to_String_fromFfi_nullable(_mapField_handle),
+    library_ListOf_String_fromFfi_nullable(_arrayField_handle),
+    library_ListOf_String_fromFfi_nullable(_inlineArrayField_handle),
+    library_MapOf_Long_to_String_fromFfi_nullable(_mapField_handle),
     smoke_SomeInterface_fromFfi_nullable(_instanceField_handle)
   );
   String_releaseFfiHandle_nullable(_stringField_handle);
@@ -506,9 +506,9 @@ Nullable_NullableStruct smoke_Nullable_NullableStruct_fromFfi(Pointer<Void> hand
   Double_releaseFfiHandle_nullable(_doubleField_handle);
   smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_structField_handle);
   smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
-  ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
-  ListOf_String_releaseFfiHandle_nullable(_inlineArrayField_handle);
-  MapOf_Long_to_String_releaseFfiHandle_nullable(_mapField_handle);
+  library_ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
+  library_ListOf_String_releaseFfiHandle_nullable(_inlineArrayField_handle);
+  library_MapOf_Long_to_String_releaseFfiHandle_nullable(_mapField_handle);
   smoke_SomeInterface_releaseFfiHandle_nullable(_instanceField_handle);
   return _result;
 }

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
@@ -61,15 +61,15 @@ class Properties {
   List<String> get arrayProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_Properties_arrayProperty_get');
     final __result_handle = _get_ffi(_handle);
-    final _result = ListOf_String_fromFfi(__result_handle);
-    ListOf_String_releaseFfiHandle(__result_handle);
+    final _result = library_ListOf_String_fromFfi(__result_handle);
+    library_ListOf_String_releaseFfiHandle(__result_handle);
     return _result;
   }
   set arrayProperty(List<String> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_Properties_arrayProperty_set__ListOf_1String');
-    final _value_handle = ListOf_String_toFfi(value);
+    final _value_handle = library_ListOf_String_toFfi(value);
     final __result_handle = _set_ffi(_handle, _value_handle);
-    ListOf_String_releaseFfiHandle(_value_handle);
+    library_ListOf_String_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
@@ -520,12 +520,12 @@ final _smoke_Structs_ExternalStruct_get_field_externalStructField = __lib.native
 Pointer<Void> smoke_Structs_ExternalStruct_toFfi(Structs_ExternalStruct value) {
   final _stringField_handle = String_toFfi(value.stringField);
   final _externalStringField_handle = String_toFfi(value.externalStringField);
-  final _externalArrayField_handle = ListOf_Byte_toFfi(value.externalArrayField);
+  final _externalArrayField_handle = library_ListOf_Byte_toFfi(value.externalArrayField);
   final _externalStructField_handle = smoke_Structs_AnotherExternalStruct_toFfi(value.externalStructField);
   final _result = _smoke_Structs_ExternalStruct_create_handle(_stringField_handle, _externalStringField_handle, _externalArrayField_handle, _externalStructField_handle);
   String_releaseFfiHandle(_stringField_handle);
   String_releaseFfiHandle(_externalStringField_handle);
-  ListOf_Byte_releaseFfiHandle(_externalArrayField_handle);
+  library_ListOf_Byte_releaseFfiHandle(_externalArrayField_handle);
   smoke_Structs_AnotherExternalStruct_releaseFfiHandle(_externalStructField_handle);
   return _result;
 }
@@ -537,12 +537,12 @@ Structs_ExternalStruct smoke_Structs_ExternalStruct_fromFfi(Pointer<Void> handle
   final _result = Structs_ExternalStruct(
     String_fromFfi(_stringField_handle),
     String_fromFfi(_externalStringField_handle),
-    ListOf_Byte_fromFfi(_externalArrayField_handle),
+    library_ListOf_Byte_fromFfi(_externalArrayField_handle),
     smoke_Structs_AnotherExternalStruct_fromFfi(_externalStructField_handle)
   );
   String_releaseFfiHandle(_stringField_handle);
   String_releaseFfiHandle(_externalStringField_handle);
-  ListOf_Byte_releaseFfiHandle(_externalArrayField_handle);
+  library_ListOf_Byte_releaseFfiHandle(_externalArrayField_handle);
   smoke_Structs_AnotherExternalStruct_releaseFfiHandle(_externalStructField_handle);
   return _result;
 }
@@ -843,17 +843,17 @@ final _smoke_Structs_StructWithArrayOfImmutable_get_field_arrayField = __lib.nat
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_Structs_StructWithArrayOfImmutable_get_field_arrayField');
 Pointer<Void> smoke_Structs_StructWithArrayOfImmutable_toFfi(Structs_StructWithArrayOfImmutable value) {
-  final _arrayField_handle = ListOf_smoke_Structs_AllTypesStruct_toFfi(value.arrayField);
+  final _arrayField_handle = library_ListOf_smoke_Structs_AllTypesStruct_toFfi(value.arrayField);
   final _result = _smoke_Structs_StructWithArrayOfImmutable_create_handle(_arrayField_handle);
-  ListOf_smoke_Structs_AllTypesStruct_releaseFfiHandle(_arrayField_handle);
+  library_ListOf_smoke_Structs_AllTypesStruct_releaseFfiHandle(_arrayField_handle);
   return _result;
 }
 Structs_StructWithArrayOfImmutable smoke_Structs_StructWithArrayOfImmutable_fromFfi(Pointer<Void> handle) {
   final _arrayField_handle = _smoke_Structs_StructWithArrayOfImmutable_get_field_arrayField(handle);
   final _result = Structs_StructWithArrayOfImmutable(
-    ListOf_smoke_Structs_AllTypesStruct_fromFfi(_arrayField_handle)
+    library_ListOf_smoke_Structs_AllTypesStruct_fromFfi(_arrayField_handle)
   );
-  ListOf_smoke_Structs_AllTypesStruct_releaseFfiHandle(_arrayField_handle);
+  library_ListOf_smoke_Structs_AllTypesStruct_releaseFfiHandle(_arrayField_handle);
   return _result;
 }
 void smoke_Structs_StructWithArrayOfImmutable_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_StructWithArrayOfImmutable_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/TypeDefs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/TypeDefs.dart
@@ -28,11 +28,11 @@ class TypeDefs {
   }
   static List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) {
     final _methodWithComplexTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_TypeDefs_methodWithComplexTypeDef__ListOf_1smoke_1TypeDefs_1TestStruct');
-    final _input_handle = ListOf_smoke_TypeDefs_TestStruct_toFfi(input);
+    final _input_handle = library_ListOf_smoke_TypeDefs_TestStruct_toFfi(input);
     final __result_handle = _methodWithComplexTypeDef_ffi(_input_handle);
-    ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
-    final _result = ListOf_smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
-    ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
+    library_ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
+    final _result = library_ListOf_smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
+    library_ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
     return _result;
   }
   static double returnNestedIntTypeDef(double input) {
@@ -74,15 +74,15 @@ class TypeDefs {
   List<double> get primitiveTypeProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('smoke_TypeDefs_primitiveTypeProperty_get');
     final __result_handle = _get_ffi(_handle);
-    final _result = ListOf_Double_fromFfi(__result_handle);
-    ListOf_Double_releaseFfiHandle(__result_handle);
+    final _result = library_ListOf_Double_fromFfi(__result_handle);
+    library_ListOf_Double_releaseFfiHandle(__result_handle);
     return _result;
   }
   set primitiveTypeProperty(List<double> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('smoke_TypeDefs_primitiveTypeProperty_set__ListOf_1Double');
-    final _value_handle = ListOf_Double_toFfi(value);
+    final _value_handle = library_ListOf_Double_toFfi(value);
     final __result_handle = _set_ffi(_handle, _value_handle);
-    ListOf_Double_releaseFfiHandle(_value_handle);
+    library_ListOf_Double_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;


### PR DESCRIPTION
Updated FfiNameResolver to add an prefix to the names of
collection conversion functions. The prefix is the same as the library
name (mandatory value for Dart bindings).

Resolves: #172
Signed-off-by: Daniel Kamkha daniel.kamkha@here.com