### PR TITLE
Fixes filtering of list of *.lime files

### DIFF
--- a/cmake/modules/gluecodium/gluecodium/runGenerate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/runGenerate.cmake
@@ -38,7 +38,7 @@ function(_generate)
         unset(_gluecodium_time)
     endif()
 
-    list(FILTER APIGEN_AUX_FILES INCLUDE REGEX ".*.lime")
+    list(FILTER APIGEN_AUX_FILES INCLUDE REGEX ".*\\.lime$")
     foreach(_aux_lime IN LISTS APIGEN_AUX_FILES)
       string(APPEND APIGEN_GLUECODIUM_ARGS " -auxinput \"${_aux_lime}\"")
     endforeach()


### PR DESCRIPTION
If some path to file contained 'lime' then this file passed
filtering no matter of file's extension

Signed-off-by: Yauheni Khnykin <yauheni.khnykin@here.com>