### PR TITLE
Add optional prefix to collection conversion functions in CBridge

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
@@ -52,11 +52,13 @@ class CBridgeGenerator(
     private val includeResolver: CBridgeIncludeResolver,
     private val cppNameResolver: CppNameResolver,
     private val internalNamespace: List<String>,
-    private val swiftNameRules: SwiftNameRules
+    private val swiftNameRules: SwiftNameRules,
+    internalPrefix: String?
 ) {
     private val signatureResolver = LimeSignatureResolver(limeReferenceMap)
-    private val nameResolver = SwiftNameResolver(limeReferenceMap, swiftNameRules)
-    private val swiftTypeMapper = SwiftTypeMapper(nameResolver)
+    private val swiftNameResolver = SwiftNameResolver(limeReferenceMap, swiftNameRules)
+    private val nameResolver = CBridgeNameResolver(internalPrefix ?: "")
+    private val swiftTypeMapper = SwiftTypeMapper(swiftNameResolver, nameResolver)
 
     val collectionsGenerator = CCollectionsGenerator(internalNamespace)
 
@@ -121,7 +123,7 @@ class CBridgeGenerator(
             SwiftModelBuilder(
                 limeReferenceMap = limeReferenceMap,
                 signatureResolver = signatureResolver,
-                nameResolver = nameResolver,
+                nameResolver = swiftNameResolver,
                 typeMapper = swiftTypeMapper,
                 nameRules = swiftNameRules,
                 buildTransientModel = { buildTransientSwiftModel(it) }
@@ -130,6 +132,7 @@ class CBridgeGenerator(
             cppIncludeResolver,
             cppNameResolver,
             includeResolver,
+            nameResolver,
             internalNamespace
         )
 
@@ -157,7 +160,7 @@ class CBridgeGenerator(
             SwiftModelBuilder(
                 limeReferenceMap = limeReferenceMap,
                 signatureResolver = signatureResolver,
-                nameResolver = nameResolver,
+                nameResolver = swiftNameResolver,
                 typeMapper = swiftTypeMapper,
                 nameRules = swiftNameRules,
                 buildTransientModel = { buildTransientSwiftModel(it) }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeNameResolver.kt
@@ -25,16 +25,16 @@ import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeAlias
 
-object CBridgeNameResolver {
+class CBridgeNameResolver(private val internalPrefix: String) {
     fun getCollectionName(limeType: LimeType): String = when (limeType) {
         is LimeTypeAlias -> getCollectionName(limeType.typeRef.type)
-        is LimeList -> "ArrayOf_${getCollectionName(limeType.elementType.type)}"
+        is LimeList -> "${internalPrefix}ArrayOf_${getCollectionName(limeType.elementType.type)}"
         is LimeMap -> {
             val keyTypeName = getCollectionName(limeType.keyType.type)
             val valueTypeName = getCollectionName(limeType.valueType.type)
-            "MapOf_${keyTypeName}_To_$valueTypeName"
+            "${internalPrefix}MapOf_${keyTypeName}_To_$valueTypeName"
         }
-        is LimeSet -> "SetOf_${getCollectionName(limeType.elementType.type)}"
+        is LimeSet -> "${internalPrefix}SetOf_${getCollectionName(limeType.elementType.type)}"
         else -> CBridgeNameRules.getTypeName(limeType)
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeTypeMapper.kt
@@ -52,6 +52,7 @@ class CBridgeTypeMapper(
     private val cppIncludeResolver: CppIncludeResolver,
     private val cppNameResolver: CppNameResolver,
     private val includeResolver: CBridgeIncludeResolver,
+    private val nameResolver: CBridgeNameResolver,
     private val internalNamespace: List<String>
 ) {
     private val genericsCollector = mutableMapOf<String, CCollectionType>()
@@ -166,7 +167,7 @@ class CBridgeTypeMapper(
             valueType
         )
 
-        val mapName = CBridgeNameResolver.getCollectionName(limeType)
+        val mapName = nameResolver.getCollectionName(limeType)
         val cMap = CMap(mapName, keyType, valueType, CppLibraryIncludes.MAP, hasStdHash)
         genericsCollector.putIfAbsent(mapName, cMap)
         return result
@@ -198,7 +199,7 @@ class CBridgeTypeMapper(
             elementType
         )
 
-        val setName = CBridgeNameResolver.getCollectionName(limeType)
+        val setName = nameResolver.getCollectionName(limeType)
         val cSet = CSet(setName, elementType, CppLibraryIncludes.SET, hasStdHash)
         genericsCollector.putIfAbsent(setName, cSet)
 
@@ -221,7 +222,7 @@ class CBridgeTypeMapper(
             elementType
         )
 
-        val arrayName = CBridgeNameResolver.getCollectionName(limeType)
+        val arrayName = nameResolver.getCollectionName(limeType)
         genericsCollector.putIfAbsent(arrayName, CArray(arrayName, result))
 
         return result

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -19,6 +19,7 @@
 
 package com.here.gluecodium.generator.swift
 
+import com.here.gluecodium.generator.cbridge.CBridgeNameResolver
 import com.here.gluecodium.generator.common.modelbuilder.LimeTreeWalker
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeNamedElement
@@ -40,9 +41,10 @@ class SwiftGenerator(
     val builtinOptionalsGenerator = SwiftBuiltinOptionalsGenerator()
     private val signatureResolver = LimeSignatureResolver(limeReferenceMap)
     private val nameResolver = SwiftNameResolver(limeReferenceMap, nameRules)
+    private val cBridgeNameResolver = CBridgeNameResolver(internalPrefix ?: "")
 
     fun generateModel(rootElement: LimeNamedElement): SwiftModel {
-        val typeMapper = SwiftTypeMapper(nameResolver)
+        val typeMapper = SwiftTypeMapper(nameResolver, cBridgeNameResolver)
         val modelBuilder =
             SwiftModelBuilder(
                 limeReferenceMap = limeReferenceMap,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftTypeMapper.kt
@@ -45,7 +45,10 @@ import com.here.gluecodium.model.swift.SwiftSet
 import com.here.gluecodium.model.swift.SwiftStruct
 import com.here.gluecodium.model.swift.SwiftType
 
-class SwiftTypeMapper(private val nameResolver: SwiftNameResolver) {
+class SwiftTypeMapper(
+    private val nameResolver: SwiftNameResolver,
+    private val cbridgeNameResolver: CBridgeNameResolver
+) {
 
     private val genericsCollector = mutableMapOf<String, SwiftType>()
     val generics: Map<String, SwiftType> = genericsCollector
@@ -104,7 +107,7 @@ class SwiftTypeMapper(private val nameResolver: SwiftNameResolver) {
     private fun mapArrayType(limeType: LimeList): SwiftArray {
         val result = SwiftArray(
             mapType(limeType.elementType.type),
-            CBridgeNameResolver.getCollectionName(limeType)
+            cbridgeNameResolver.getCollectionName(limeType)
         )
         val actualType = limeType.actualType as LimeList
         val elementTypeKey = getActualTypeKey(actualType.elementType.type)
@@ -117,7 +120,7 @@ class SwiftTypeMapper(private val nameResolver: SwiftNameResolver) {
         val result = SwiftDictionary(
             mapType(limeType.keyType.type),
             mapType(limeType.valueType.type),
-            CBridgeNameResolver.getCollectionName(limeType)
+            cbridgeNameResolver.getCollectionName(limeType)
         )
         val actualType = limeType.actualType as LimeMap
         val keyTypeKey = getActualTypeKey(actualType.keyType.type)
@@ -130,7 +133,7 @@ class SwiftTypeMapper(private val nameResolver: SwiftNameResolver) {
     private fun mapSetType(limeType: LimeSet): SwiftSet {
         val result = SwiftSet(
             mapType(limeType.elementType.type),
-            CBridgeNameResolver.getCollectionName(limeType)
+            cbridgeNameResolver.getCollectionName(limeType)
         )
         val actualType = limeType.actualType as LimeSet
         val elementTypeKey = getActualTypeKey(actualType.elementType.type)

--- a/gluecodium/src/main/java/com/here/gluecodium/model/cbridge/CArray.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/cbridge/CArray.kt
@@ -25,21 +25,21 @@ import com.here.gluecodium.generator.cbridge.CppTypeInfo
 class CArray(name: String, typeInfo: CppArrayTypeInfo) : CCollectionType(name) {
 
     val arrayType: CppTypeInfo = typeInfo
-    val underlyingType: CppTypeInfo = typeInfo.innerType
+    val elementType: CppTypeInfo = typeInfo.innerType
     val type = arrayType.functionReturnType.toString()
     @Suppress("unused")
-    val innerType = underlyingType.functionReturnType.toString()
+    val innerType = elementType.functionReturnType.toString()
     @Suppress("unused")
-    val argument = underlyingType.cType.toString()
+    val argument = elementType.cType.toString()
     @Suppress("unused")
-    val innerBaseApi = underlyingType.name
+    val innerBaseApi = elementType.name
 
     override val returnTypeIncludes
-        get() = getLastType(underlyingType).functionReturnType.includes +
+        get() = getLastType(elementType).functionReturnType.includes +
                 arrayType.functionReturnType.includes
 
     override val includes
-        get() = getLastType(underlyingType).includes + arrayType.includes
+        get() = getLastType(elementType).includes + arrayType.includes
 
     private fun getLastType(typeInfo: CppTypeInfo): CppTypeInfo =
         if (typeInfo is CppArrayTypeInfo) getLastType(typeInfo.innerType) else typeInfo

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuite.kt
@@ -64,7 +64,8 @@ class SwiftGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
             includeResolver = CBridgeIncludeResolver(rootNamespace, limeReferenceMap),
             cppNameResolver = CppNameResolver(rootNamespace, limeReferenceMap, cppNameRules),
             internalNamespace = internalNamespace,
-            swiftNameRules = swiftNameRules
+            swiftNameRules = swiftNameRules,
+            internalPrefix = internalPrefix
         )
         val swiftModel =
             limeModel.topElements.fold(SwiftModel(emptyMap(), emptyList())) { model, rootElement ->

--- a/gluecodium/src/main/resources/templates/cbridge/ArrayFunctionImplementations.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/ArrayFunctionImplementations.mustache
@@ -35,19 +35,19 @@ uint64_t {{name}}_count(_baseRef handle) {
 }
 
 {{innerType}} {{name}}_get( _baseRef handle, uint64_t index ) { {{!!
-    }}{{#switch underlyingType.typeCategory.toString}}{{!!
+    }}{{#switch elementType.typeCategory.toString}}{{!!
     }}{{#case "ENUM"}}{{prefixPartial 'enumGetConversion' '    '}}{{/case}}{{!!
     }}{{#case "BUILTIN_SIMPLE"}}{{prefixPartial 'builtinGetConversion' '    '}}{{/case}}{{!!
-    }}{{#default}}return Conversion<{{underlyingType}}>::referenceBaseRef(Conversion<{{arrayType}}>::toCpp( handle )[index]);{{/default}}{{!!
+    }}{{#default}}return Conversion<{{elementType}}>::referenceBaseRef(Conversion<{{arrayType}}>::toCpp( handle )[index]);{{/default}}{{!!
     }}{{/switch}}
 }
 
 void {{name}}_append( _baseRef handle, {{argument}} item )
 {
-{{#switch underlyingType.typeCategory.toString}}{{!!
+{{#switch elementType.typeCategory.toString}}{{!!
     }}{{#case "ENUM"}}{{prefixPartial 'enumAppendConversion' '    '}}{{/case}}{{!!
     }}{{#case "BUILTIN_SIMPLE"}}{{prefixPartial 'builtinAppendConversion' '    '}}{{/case}}{{!!
-    }}{{#default}}Conversion<{{arrayType}}>::toCpp(handle).push_back(Conversion<{{underlyingType}}>::toCpp(item));{{/default}}{{!!
+    }}{{#default}}Conversion<{{arrayType}}>::toCpp(handle).push_back(Conversion<{{elementType}}>::toCpp(item));{{/default}}{{!!
     }}{{/switch}}
 }
 

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/cbridge/CBridgeTypeMapperTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/cbridge/CBridgeTypeMapperTest.kt
@@ -65,8 +65,13 @@ class CBridgeTypeMapperTest {
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
 
-        typeMapper =
-            CBridgeTypeMapper(cppIncludeResolver, cppNameResolver, includeResolver, emptyList())
+        typeMapper = CBridgeTypeMapper(
+            cppIncludeResolver,
+            cppNameResolver,
+            includeResolver,
+            CBridgeNameResolver(""),
+            emptyList()
+        )
     }
 
     @Test

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/swift/SwiftTypeMapperTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/swift/SwiftTypeMapperTest.kt
@@ -19,6 +19,7 @@
 
 package com.here.gluecodium.generator.swift
 
+import com.here.gluecodium.generator.cbridge.CBridgeNameResolver
 import com.here.gluecodium.model.lime.LimeBasicTypeRef
 import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeEnumeration
@@ -52,7 +53,7 @@ class SwiftTypeMapperTest {
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
 
-        typeMapper = SwiftTypeMapper(nameResolver)
+        typeMapper = SwiftTypeMapper(nameResolver, CBridgeNameResolver(""))
 
         every { nameResolver.getFullName(any()) } returns "nonsense"
     }


### PR DESCRIPTION
Updated CBridge name resolver to add an optional prefix to the names of
collection conversion functions.

Resolves: #167
Signed-off-by: Daniel Kamkha daniel.kamkha@here.com