### PR TITLE
Make Dart token cache global

### DIFF
--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -77,10 +77,6 @@ final _{{resolveName "Ffi"}}_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>)
   >('{{resolveName "Ffi"}}_get_type_id');
 
-int _{{resolveName}}_instance_counter = 1024;
-final Map<int, {{resolveName}}> _{{resolveName}}_instance_cache = {};
-final Map<Pointer<Void>, {{resolveName}}> _{{resolveName}}_reverse_cache = {};
-
 {{#functions}}
 {{>dart/DartFunctionException}}
 
@@ -113,7 +109,7 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
   try {
   {{/if}}
   {{#isNotEq returnType.typeRef.toString "Void"}}final _result_object = {{/isNotEq}}{{!!
-  }}_{{resolveName parent}}_instance_cache[_token].{{resolveName visibility}}{{resolveName}}({{#parameters}}{{!!
+  }}(__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}}({{#parameters}}{{!!
   }}{{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}}){{#if iter.hasNext}}, {{/if}}{{!!
   }}{{/parameters}});{{#isNotEq returnType.typeRef.toString "Void"}}
   _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/isNotEq}}
@@ -140,13 +136,13 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 {{#each inheritedProperties properties}}
 int _{{resolveName parent}}_{{resolveName}}_get_static(int _token, Pointer<{{resolveName typeRef "FfiApiTypes"}}> _result) {
   _result.value = {{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{!!
-  }}_{{resolveName parent}}_instance_cache[_token].{{resolveName visibility}}{{resolveName}});
+  }}(__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}});
   return 0;
 }
 {{#if setter}}
 
 int _{{resolveName parent}}_{{resolveName}}_set_static(int _token, {{resolveName typeRef "FfiDartTypes"}} _value) {
-  _{{resolveName parent}}_instance_cache[_token].{{resolveName visibility}}{{resolveName}} = {{!!
+  (__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}} = {{!!
   }}{{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value);
   {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value);
   return 0;
@@ -157,25 +153,24 @@ int _{{resolveName parent}}_{{resolveName}}_set_static(int _token, {{resolveName
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
   if (value is {{resolveName}}__Impl) return _{{resolveName "Ffi"}}_copy_handle(value.handle);
 
-  const UNKNOWN_ERROR = -1;
-  final token = _{{resolveName}}_instance_counter++;
-  _{{resolveName}}_instance_cache[token] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
 
   final result = _{{resolveName "Ffi"}}_create_proxy(token{{!!
   }}{{#set parent=this}}{{#if inheritedFunctions functions logic="or"}}, {{#each inheritedFunctions functions}}{{!!
-  }}Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName}}_static, UNKNOWN_ERROR){{#if iter.hasNext}}, {{/if}}{{!!
+  }}Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName}}_static, __lib.unknownError){{#if iter.hasNext}}, {{/if}}{{!!
   }}{{/each}}{{/if}}{{#if inheritedProperties properties logic="or"}}, {{!!
   }}{{#each inheritedProperties properties}}{{#set property=this}}{{!!
-  }}{{#getter}}Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName property}}_get_static, UNKNOWN_ERROR){{/getter}}{{!!
-  }}{{#setter}}, Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName property}}_set_static, UNKNOWN_ERROR){{/setter}}{{!!
+  }}{{#getter}}Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName property}}_get_static, __lib.unknownError){{/getter}}{{!!
+  }}{{#setter}}, Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName property}}_set_static, __lib.unknownError){{/setter}}{{!!
   }}{{#if iter.hasNext}}, {{/if}}{{/set}}{{/each}}{{/if}}{{/set}});
-  _{{resolveName}}_reverse_cache[_{{resolveName "Ffi"}}_get_raw_pointer(result)] = value;
+  __lib.reverseCache[_{{resolveName "Ffi"}}_get_raw_pointer(result)] = value;
 
   return result;
 }
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
-  final instance = _{{resolveName}}_reverse_cache[_{{resolveName "Ffi"}}_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_{{resolveName "Ffi"}}_get_raw_pointer(handle)] as {{resolveName}};
   if (instance != null) return instance;
 
   final _copied_handle = _{{resolveName "Ffi"}}_copy_handle(handle);

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -41,10 +41,6 @@ final _{{resolveName "Ffi"}}_get_raw_pointer = __lib.nativeLibrary.lookupFunctio
       Pointer<Void> Function(Pointer<Void>)
     >('{{resolveName "Ffi"}}_get_raw_pointer');
 
-int _{{resolveName}}_instance_counter = 1024;
-final Map<int, {{resolveName}}> _{{resolveName}}_instance_cache = {};
-final Map<Pointer<Void>, {{resolveName}}> _{{resolveName}}_reverse_cache = {};
-
 class {{resolveName}}__Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -63,7 +59,7 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 }}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
 }}{{#isNotEq returnType.typeRef.toString "Void"}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/isNotEq}}) {
   {{#isNotEq returnType.typeRef.toString "Void"}}final _result_object = {{/isNotEq}}{{!!
-  }}_{{resolveName parent}}_instance_cache[_token]({{#parameters}}{{!!
+  }}(__lib.instanceCache[_token] as {{resolveName parent}})({{#parameters}}{{!!
   }}{{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}}){{#if iter.hasNext}}, {{/if}}{{!!
   }}{{/parameters}});{{#isNotEq returnType.typeRef.toString "Void"}}
   _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/isNotEq}}
@@ -79,20 +75,19 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 {{/asFunction}}{{/set}}
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
-  const UNKNOWN_ERROR = -1;
-  final token = _{{resolveName}}_instance_counter++;
-  _{{resolveName}}_instance_cache[token] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
 
   final result = _{{resolveName "Ffi"}}_create_proxy(token, {{#set parent=this}}{{#asFunction}}{{!!
-  }}Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName}}_static, UNKNOWN_ERROR){{!!
+  }}Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName}}_static, __lib.unknownError){{!!
   }}{{/asFunction}}{{/set}});
-  _{{resolveName}}_reverse_cache[_{{resolveName "Ffi"}}_get_raw_pointer(result)] = value;
+  __lib.reverseCache[_{{resolveName "Ffi"}}_get_raw_pointer(result)] = value;
 
   return result;
 }
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
-  final instance = _{{resolveName}}_reverse_cache[_{{resolveName "Ffi"}}_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_{{resolveName "Ffi"}}_get_raw_pointer(handle)] as {{resolveName}};
   if (instance != null) return instance;
   final _impl = {{resolveName}}__Impl(_{{resolveName "Ffi"}}_copy_handle(handle));
   return ({{#asFunction}}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{/asFunction}}){{!!

--- a/gluecodium/src/main/resources/templates/dart/DartTokenCache.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartTokenCache.mustache
@@ -1,0 +1,37 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#if copyrightHeader}}{{prefix copyrightHeader "// "}}{{/if}}
+
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+
+const unknownError = -1;
+
+int _instanceCounter = 1024;
+final Map<int, Object> instanceCache = {};
+final Map<Pointer<Void>, Object> reverseCache = {};
+
+int getNewToken() => _instanceCounter++;
+
+int uncacheObject(int token, Pointer<Void> rawPointer) {
+  instanceCache.remove(token);
+  reverseCache.remove(rawPointer);
+}

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/ErrorsInterface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/ErrorsInterface.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/smoke/Payload.dart';
 import 'package:library/src/smoke/WithPayloadException.dart';
@@ -168,9 +169,6 @@ final _smoke_ErrorsInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_ErrorsInterface_get_type_id');
-int _ErrorsInterface_instance_counter = 1024;
-final Map<int, ErrorsInterface> _ErrorsInterface_instance_cache = {};
-final Map<Pointer<Void>, ErrorsInterface> _ErrorsInterface_reverse_cache = {};
 final _methodWithErrors_return_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -337,7 +335,7 @@ class ErrorsInterface__Impl implements ErrorsInterface {
 int _ErrorsInterface_methodWithErrors_static(int _token) {
   int _error = 0;
   try {
-  _ErrorsInterface_instance_cache[_token].methodWithErrors();
+  (__lib.instanceCache[_token] as ErrorsInterface).methodWithErrors();
   } on ErrorsInterface_InternalException catch(e) {
     _error = smoke_ErrorsInterface_InternalError_toFfi(e.error);
   } finally {
@@ -347,7 +345,7 @@ int _ErrorsInterface_methodWithErrors_static(int _token) {
 int _ErrorsInterface_methodWithExternalErrors_static(int _token) {
   int _error = 0;
   try {
-  _ErrorsInterface_instance_cache[_token].methodWithExternalErrors();
+  (__lib.instanceCache[_token] as ErrorsInterface).methodWithExternalErrors();
   } on ErrorsInterface_ExternalException catch(e) {
     _error = smoke_ErrorsInterface_ExternalErrors_toFfi(e.error);
   } finally {
@@ -357,7 +355,7 @@ int _ErrorsInterface_methodWithExternalErrors_static(int _token) {
 int _ErrorsInterface_methodWithErrorsAndReturnValue_static(int _token, Pointer<Pointer<Void>> _result) {
   int _error = 0;
   try {
-  final _result_object = _ErrorsInterface_instance_cache[_token].methodWithErrorsAndReturnValue();
+  final _result_object = (__lib.instanceCache[_token] as ErrorsInterface).methodWithErrorsAndReturnValue();
   _result.value = String_toFfi(_result_object);
   } on ErrorsInterface_InternalException catch(e) {
     _error = smoke_ErrorsInterface_InternalError_toFfi(e.error);
@@ -368,7 +366,7 @@ int _ErrorsInterface_methodWithErrorsAndReturnValue_static(int _token, Pointer<P
 int _ErrorsInterface_methodWithPayloadError_static(int _token) {
   int _error = 0;
   try {
-  _ErrorsInterface_instance_cache[_token].methodWithPayloadError();
+  (__lib.instanceCache[_token] as ErrorsInterface).methodWithPayloadError();
   } on WithPayloadException catch(e) {
   } finally {
   }
@@ -377,7 +375,7 @@ int _ErrorsInterface_methodWithPayloadError_static(int _token) {
 int _ErrorsInterface_methodWithPayloadErrorAndReturnValue_static(int _token, Pointer<Pointer<Void>> _result) {
   int _error = 0;
   try {
-  final _result_object = _ErrorsInterface_instance_cache[_token].methodWithPayloadErrorAndReturnValue();
+  final _result_object = (__lib.instanceCache[_token] as ErrorsInterface).methodWithPayloadErrorAndReturnValue();
   _result.value = String_toFfi(_result_object);
   } on WithPayloadException catch(e) {
   } finally {
@@ -386,15 +384,14 @@ int _ErrorsInterface_methodWithPayloadErrorAndReturnValue_static(int _token, Poi
 }
 Pointer<Void> smoke_ErrorsInterface_toFfi(ErrorsInterface value) {
   if (value is ErrorsInterface__Impl) return _smoke_ErrorsInterface_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _ErrorsInterface_instance_counter++;
-  _ErrorsInterface_instance_cache[token] = value;
-  final result = _smoke_ErrorsInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithErrors_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithExternalErrors_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ErrorsInterface_methodWithErrorsAndReturnValue_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithPayloadError_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ErrorsInterface_methodWithPayloadErrorAndReturnValue_static, UNKNOWN_ERROR));
-  _ErrorsInterface_reverse_cache[_smoke_ErrorsInterface_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_ErrorsInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithErrors_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithExternalErrors_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ErrorsInterface_methodWithErrorsAndReturnValue_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithPayloadError_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ErrorsInterface_methodWithPayloadErrorAndReturnValue_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_ErrorsInterface_get_raw_pointer(result)] = value;
   return result;
 }
 ErrorsInterface smoke_ErrorsInterface_fromFfi(Pointer<Void> handle) {
-  final instance = _ErrorsInterface_reverse_cache[_smoke_ErrorsInterface_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_ErrorsInterface_get_raw_pointer(handle)] as ErrorsInterface;
   if (instance != null) return instance;
   final _copied_handle = _smoke_ErrorsInterface_copy_handle(handle);
   final _type_id_handle = _smoke_ErrorsInterface_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Interface.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -28,9 +29,6 @@ final _package_Interface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('package_Interface_get_type_id');
-int _Interface_instance_counter = 1024;
-final Map<int, Interface> _Interface_instance_cache = {};
-final Map<Pointer<Void>, Interface> _Interface_reverse_cache = {};
 class Interface__Impl implements Interface {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -40,15 +38,14 @@ class Interface__Impl implements Interface {
 }
 Pointer<Void> package_Interface_toFfi(Interface value) {
   if (value is Interface__Impl) return _package_Interface_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _Interface_instance_counter++;
-  _Interface_instance_cache[token] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
   final result = _package_Interface_create_proxy(token);
-  _Interface_reverse_cache[_package_Interface_get_raw_pointer(result)] = value;
+  __lib.reverseCache[_package_Interface_get_raw_pointer(result)] = value;
   return result;
 }
 Interface package_Interface_fromFfi(Pointer<Void> handle) {
-  final instance = _Interface_reverse_cache[_package_Interface_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_package_Interface_get_raw_pointer(handle)] as Interface;
   if (instance != null) return instance;
   final _copied_handle = _package_Interface_copy_handle(handle);
   final _type_id_handle = _package_Interface_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithCompoundTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithCompoundTypes.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
-import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/smoke/DummyClass.dart';
 import 'package:library/src/smoke/DummyInterface.dart';
 import 'dart:ffi';

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
@@ -1,5 +1,3 @@
-import 'package:library/src/BuiltInTypes__conversion.dart';
-import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/smoke/ChildClassFromClass.dart';
 import 'package:library/src/smoke/ChildClassFromInterface.dart';
 import 'package:library/src/smoke/ChildInterface.dart';

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildInterface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildInterface.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/smoke/ParentInterface.dart';
 import 'dart:ffi';
@@ -30,9 +31,6 @@ final _smoke_ChildInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_ChildInterface_get_type_id');
-int _ChildInterface_instance_counter = 1024;
-final Map<int, ChildInterface> _ChildInterface_instance_cache = {};
-final Map<Pointer<Void>, ChildInterface> _ChildInterface_reverse_cache = {};
 class ChildInterface__Impl extends ParentInterface__Impl implements ChildInterface {
   Pointer<Void> get _handle => handle;
   ChildInterface__Impl(Pointer<Void> handle) : super(handle);
@@ -48,33 +46,32 @@ class ChildInterface__Impl extends ParentInterface__Impl implements ChildInterfa
   }
 }
 int _ChildInterface_rootMethod_static(int _token) {
-  _ChildInterface_instance_cache[_token].rootMethod();
+  (__lib.instanceCache[_token] as ChildInterface).rootMethod();
   return 0;
 }
 int _ChildInterface_childMethod_static(int _token) {
-  _ChildInterface_instance_cache[_token].childMethod();
+  (__lib.instanceCache[_token] as ChildInterface).childMethod();
   return 0;
 }
 int _ChildInterface_rootProperty_get_static(int _token, Pointer<Pointer<Void>> _result) {
-  _result.value = String_toFfi(_ChildInterface_instance_cache[_token].rootProperty);
+  _result.value = String_toFfi((__lib.instanceCache[_token] as ChildInterface).rootProperty);
   return 0;
 }
 int _ChildInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
-  _ChildInterface_instance_cache[_token].rootProperty = String_fromFfi(_value);
+  (__lib.instanceCache[_token] as ChildInterface).rootProperty = String_fromFfi(_value);
   String_releaseFfiHandle(_value);
   return 0;
 }
 Pointer<Void> smoke_ChildInterface_toFfi(ChildInterface value) {
   if (value is ChildInterface__Impl) return _smoke_ChildInterface_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _ChildInterface_instance_counter++;
-  _ChildInterface_instance_cache[token] = value;
-  final result = _smoke_ChildInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64)>(_ChildInterface_rootMethod_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64)>(_ChildInterface_childMethod_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ChildInterface_rootProperty_get_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ChildInterface_rootProperty_set_static, UNKNOWN_ERROR));
-  _ChildInterface_reverse_cache[_smoke_ChildInterface_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_ChildInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64)>(_ChildInterface_rootMethod_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64)>(_ChildInterface_childMethod_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ChildInterface_rootProperty_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ChildInterface_rootProperty_set_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_ChildInterface_get_raw_pointer(result)] = value;
   return result;
 }
 ChildInterface smoke_ChildInterface_fromFfi(Pointer<Void> handle) {
-  final instance = _ChildInterface_reverse_cache[_smoke_ChildInterface_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_ChildInterface_get_raw_pointer(handle)] as ChildInterface;
   if (instance != null) return instance;
   final _copied_handle = _smoke_ChildInterface_copy_handle(handle);
   final _type_id_handle = _smoke_ChildInterface_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentInterface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentInterface.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -31,9 +32,6 @@ final _smoke_ParentInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_ParentInterface_get_type_id');
-int _ParentInterface_instance_counter = 1024;
-final Map<int, ParentInterface> _ParentInterface_instance_cache = {};
-final Map<Pointer<Void>, ParentInterface> _ParentInterface_reverse_cache = {};
 class ParentInterface__Impl implements ParentInterface {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -66,29 +64,28 @@ class ParentInterface__Impl implements ParentInterface {
   }
 }
 int _ParentInterface_rootMethod_static(int _token) {
-  _ParentInterface_instance_cache[_token].rootMethod();
+  (__lib.instanceCache[_token] as ParentInterface).rootMethod();
   return 0;
 }
 int _ParentInterface_rootProperty_get_static(int _token, Pointer<Pointer<Void>> _result) {
-  _result.value = String_toFfi(_ParentInterface_instance_cache[_token].rootProperty);
+  _result.value = String_toFfi((__lib.instanceCache[_token] as ParentInterface).rootProperty);
   return 0;
 }
 int _ParentInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
-  _ParentInterface_instance_cache[_token].rootProperty = String_fromFfi(_value);
+  (__lib.instanceCache[_token] as ParentInterface).rootProperty = String_fromFfi(_value);
   String_releaseFfiHandle(_value);
   return 0;
 }
 Pointer<Void> smoke_ParentInterface_toFfi(ParentInterface value) {
   if (value is ParentInterface__Impl) return _smoke_ParentInterface_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _ParentInterface_instance_counter++;
-  _ParentInterface_instance_cache[token] = value;
-  final result = _smoke_ParentInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64)>(_ParentInterface_rootMethod_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ParentInterface_rootProperty_get_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ParentInterface_rootProperty_set_static, UNKNOWN_ERROR));
-  _ParentInterface_reverse_cache[_smoke_ParentInterface_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_ParentInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64)>(_ParentInterface_rootMethod_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ParentInterface_rootProperty_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ParentInterface_rootProperty_set_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_ParentInterface_get_raw_pointer(result)] = value;
   return result;
 }
 ParentInterface smoke_ParentInterface_fromFfi(Pointer<Void> handle) {
-  final instance = _ParentInterface_reverse_cache[_smoke_ParentInterface_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_ParentInterface_get_raw_pointer(handle)] as ParentInterface;
   if (instance != null) return instance;
   final _copied_handle = _smoke_ParentInterface_copy_handle(handle);
   final _type_id_handle = _smoke_ParentInterface_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalInterface.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -144,9 +145,6 @@ final _smoke_ExternalInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_ExternalInterface_get_type_id');
-int _ExternalInterface_instance_counter = 1024;
-final Map<int, ExternalInterface> _ExternalInterface_instance_cache = {};
-final Map<Pointer<Void>, ExternalInterface> _ExternalInterface_reverse_cache = {};
 class ExternalInterface__Impl implements ExternalInterface {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -172,25 +170,24 @@ class ExternalInterface__Impl implements ExternalInterface {
   }
 }
 int _ExternalInterface_someMethod_static(int _token, int someParameter) {
-  _ExternalInterface_instance_cache[_token].someMethod((someParameter));
+  (__lib.instanceCache[_token] as ExternalInterface).someMethod((someParameter));
   (someParameter);
   return 0;
 }
 int _ExternalInterface_someProperty_get_static(int _token, Pointer<Pointer<Void>> _result) {
-  _result.value = String_toFfi(_ExternalInterface_instance_cache[_token].someProperty);
+  _result.value = String_toFfi((__lib.instanceCache[_token] as ExternalInterface).someProperty);
   return 0;
 }
 Pointer<Void> smoke_ExternalInterface_toFfi(ExternalInterface value) {
   if (value is ExternalInterface__Impl) return _smoke_ExternalInterface_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _ExternalInterface_instance_counter++;
-  _ExternalInterface_instance_cache[token] = value;
-  final result = _smoke_ExternalInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Int8)>(_ExternalInterface_someMethod_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ExternalInterface_someProperty_get_static, UNKNOWN_ERROR));
-  _ExternalInterface_reverse_cache[_smoke_ExternalInterface_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_ExternalInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Int8)>(_ExternalInterface_someMethod_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ExternalInterface_someProperty_get_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_ExternalInterface_get_raw_pointer(result)] = value;
   return result;
 }
 ExternalInterface smoke_ExternalInterface_fromFfi(Pointer<Void> handle) {
-  final instance = _ExternalInterface_reverse_cache[_smoke_ExternalInterface_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_ExternalInterface_get_raw_pointer(handle)] as ExternalInterface;
   if (instance != null) return instance;
   final _copied_handle = _smoke_ExternalInterface_copy_handle(handle);
   final _type_id_handle = _smoke_ExternalInterface_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleInterface.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -30,9 +31,6 @@ final _smoke_SimpleInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_SimpleInterface_get_type_id');
-int _SimpleInterface_instance_counter = 1024;
-final Map<int, SimpleInterface> _SimpleInterface_instance_cache = {};
-final Map<Pointer<Void>, SimpleInterface> _SimpleInterface_reverse_cache = {};
 class SimpleInterface__Impl implements SimpleInterface {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -59,12 +57,12 @@ class SimpleInterface__Impl implements SimpleInterface {
   }
 }
 int _SimpleInterface_getStringValue_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = _SimpleInterface_instance_cache[_token].getStringValue();
+  final _result_object = (__lib.instanceCache[_token] as SimpleInterface).getStringValue();
   _result.value = String_toFfi(_result_object);
   return 0;
 }
 int _SimpleInterface_useSimpleInterface_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  final _result_object = _SimpleInterface_instance_cache[_token].useSimpleInterface(smoke_SimpleInterface_fromFfi(input));
+  final _result_object = (__lib.instanceCache[_token] as SimpleInterface).useSimpleInterface(smoke_SimpleInterface_fromFfi(input));
   _result.value = smoke_SimpleInterface_toFfi(_result_object);
   smoke_SimpleInterface_releaseFfiHandle(input);
   if (_result_object != null) _result_object.release();
@@ -72,15 +70,14 @@ int _SimpleInterface_useSimpleInterface_static(int _token, Pointer<Void> input, 
 }
 Pointer<Void> smoke_SimpleInterface_toFfi(SimpleInterface value) {
   if (value is SimpleInterface__Impl) return _smoke_SimpleInterface_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _SimpleInterface_instance_counter++;
-  _SimpleInterface_instance_cache[token] = value;
-  final result = _smoke_SimpleInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_SimpleInterface_getStringValue_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_SimpleInterface_useSimpleInterface_static, UNKNOWN_ERROR));
-  _SimpleInterface_reverse_cache[_smoke_SimpleInterface_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_SimpleInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_SimpleInterface_getStringValue_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_SimpleInterface_useSimpleInterface_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_SimpleInterface_get_raw_pointer(result)] = value;
   return result;
 }
 SimpleInterface smoke_SimpleInterface_fromFfi(Pointer<Void> handle) {
-  final instance = _SimpleInterface_reverse_cache[_smoke_SimpleInterface_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_SimpleInterface_get_raw_pointer(handle)] as SimpleInterface;
   if (instance != null) return instance;
   final _copied_handle = _smoke_SimpleInterface_copy_handle(handle);
   final _type_id_handle = _smoke_SimpleInterface_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/StructWithInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/StructWithInterface.dart
@@ -1,5 +1,3 @@
-import 'package:library/src/BuiltInTypes__conversion.dart';
-import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/smoke/SimpleInterface.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/Lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/Lambdas.dart
@@ -1,5 +1,6 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
@@ -69,9 +70,6 @@ final _smoke_Lambdas_Producer_get_raw_pointer = __lib.nativeLibrary.lookupFuncti
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('smoke_Lambdas_Producer_get_raw_pointer');
-int _Lambdas_Producer_instance_counter = 1024;
-final Map<int, Lambdas_Producer> _Lambdas_Producer_instance_cache = {};
-final Map<Pointer<Void>, Lambdas_Producer> _Lambdas_Producer_reverse_cache = {};
 class Lambdas_Producer__Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -86,20 +84,19 @@ class Lambdas_Producer__Impl {
   }
 }
 int _Lambdas_Producer_call_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = _Lambdas_Producer_instance_cache[_token]();
+  final _result_object = (__lib.instanceCache[_token] as Lambdas_Producer)();
   _result.value = String_toFfi(_result_object);
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Producer_toFfi(Lambdas_Producer value) {
-  const UNKNOWN_ERROR = -1;
-  final token = _Lambdas_Producer_instance_counter++;
-  _Lambdas_Producer_instance_cache[token] = value;
-  final result = _smoke_Lambdas_Producer_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_Lambdas_Producer_call_static, UNKNOWN_ERROR));
-  _Lambdas_Producer_reverse_cache[_smoke_Lambdas_Producer_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_Lambdas_Producer_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_Lambdas_Producer_call_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_Lambdas_Producer_get_raw_pointer(result)] = value;
   return result;
 }
 Lambdas_Producer smoke_Lambdas_Producer_fromFfi(Pointer<Void> handle) {
-  final instance = _Lambdas_Producer_reverse_cache[_smoke_Lambdas_Producer_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_Lambdas_Producer_get_raw_pointer(handle)] as Lambdas_Producer;
   if (instance != null) return instance;
   final _impl = Lambdas_Producer__Impl(_smoke_Lambdas_Producer_copy_handle(handle));
   return () {
@@ -159,9 +156,6 @@ final _smoke_Lambdas_Confuser_get_raw_pointer = __lib.nativeLibrary.lookupFuncti
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('smoke_Lambdas_Confuser_get_raw_pointer');
-int _Lambdas_Confuser_instance_counter = 1024;
-final Map<int, Lambdas_Confuser> _Lambdas_Confuser_instance_cache = {};
-final Map<Pointer<Void>, Lambdas_Confuser> _Lambdas_Confuser_reverse_cache = {};
 class Lambdas_Confuser__Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -178,21 +172,20 @@ class Lambdas_Confuser__Impl {
   }
 }
 int _Lambdas_Confuser_call_static(int _token, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
-  final _result_object = _Lambdas_Confuser_instance_cache[_token](String_fromFfi(p0));
+  final _result_object = (__lib.instanceCache[_token] as Lambdas_Confuser)(String_fromFfi(p0));
   _result.value = smoke_Lambdas_Producer_toFfi(_result_object);
   String_releaseFfiHandle(p0);
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Confuser_toFfi(Lambdas_Confuser value) {
-  const UNKNOWN_ERROR = -1;
-  final token = _Lambdas_Confuser_instance_counter++;
-  _Lambdas_Confuser_instance_cache[token] = value;
-  final result = _smoke_Lambdas_Confuser_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_Lambdas_Confuser_call_static, UNKNOWN_ERROR));
-  _Lambdas_Confuser_reverse_cache[_smoke_Lambdas_Confuser_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_Lambdas_Confuser_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_Lambdas_Confuser_call_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_Lambdas_Confuser_get_raw_pointer(result)] = value;
   return result;
 }
 Lambdas_Confuser smoke_Lambdas_Confuser_fromFfi(Pointer<Void> handle) {
-  final instance = _Lambdas_Confuser_reverse_cache[_smoke_Lambdas_Confuser_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_Lambdas_Confuser_get_raw_pointer(handle)] as Lambdas_Confuser;
   if (instance != null) return instance;
   final _impl = Lambdas_Confuser__Impl(_smoke_Lambdas_Confuser_copy_handle(handle));
   return (String p0) {
@@ -251,9 +244,6 @@ final _smoke_Lambdas_Consumer_get_raw_pointer = __lib.nativeLibrary.lookupFuncti
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('smoke_Lambdas_Consumer_get_raw_pointer');
-int _Lambdas_Consumer_instance_counter = 1024;
-final Map<int, Lambdas_Consumer> _Lambdas_Consumer_instance_cache = {};
-final Map<Pointer<Void>, Lambdas_Consumer> _Lambdas_Consumer_reverse_cache = {};
 class Lambdas_Consumer__Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -270,20 +260,19 @@ class Lambdas_Consumer__Impl {
   }
 }
 int _Lambdas_Consumer_call_static(int _token, Pointer<Void> p0) {
-  _Lambdas_Consumer_instance_cache[_token](String_fromFfi(p0));
+  (__lib.instanceCache[_token] as Lambdas_Consumer)(String_fromFfi(p0));
   String_releaseFfiHandle(p0);
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Consumer_toFfi(Lambdas_Consumer value) {
-  const UNKNOWN_ERROR = -1;
-  final token = _Lambdas_Consumer_instance_counter++;
-  _Lambdas_Consumer_instance_cache[token] = value;
-  final result = _smoke_Lambdas_Consumer_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_Lambdas_Consumer_call_static, UNKNOWN_ERROR));
-  _Lambdas_Consumer_reverse_cache[_smoke_Lambdas_Consumer_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_Lambdas_Consumer_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_Lambdas_Consumer_call_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_Lambdas_Consumer_get_raw_pointer(result)] = value;
   return result;
 }
 Lambdas_Consumer smoke_Lambdas_Consumer_fromFfi(Pointer<Void> handle) {
-  final instance = _Lambdas_Consumer_reverse_cache[_smoke_Lambdas_Consumer_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_Lambdas_Consumer_get_raw_pointer(handle)] as Lambdas_Consumer;
   if (instance != null) return instance;
   final _impl = Lambdas_Consumer__Impl(_smoke_Lambdas_Consumer_copy_handle(handle));
   return (String p0) {
@@ -342,9 +331,6 @@ final _smoke_Lambdas_Indexer_get_raw_pointer = __lib.nativeLibrary.lookupFunctio
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('smoke_Lambdas_Indexer_get_raw_pointer');
-int _Lambdas_Indexer_instance_counter = 1024;
-final Map<int, Lambdas_Indexer> _Lambdas_Indexer_instance_cache = {};
-final Map<Pointer<Void>, Lambdas_Indexer> _Lambdas_Indexer_reverse_cache = {};
 class Lambdas_Indexer__Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -363,22 +349,21 @@ class Lambdas_Indexer__Impl {
   }
 }
 int _Lambdas_Indexer_call_static(int _token, Pointer<Void> p0, double p1, Pointer<Int32> _result) {
-  final _result_object = _Lambdas_Indexer_instance_cache[_token](String_fromFfi(p0), (p1));
+  final _result_object = (__lib.instanceCache[_token] as Lambdas_Indexer)(String_fromFfi(p0), (p1));
   _result.value = (_result_object);
   String_releaseFfiHandle(p0);
   (p1);
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Indexer_toFfi(Lambdas_Indexer value) {
-  const UNKNOWN_ERROR = -1;
-  final token = _Lambdas_Indexer_instance_counter++;
-  _Lambdas_Indexer_instance_cache[token] = value;
-  final result = _smoke_Lambdas_Indexer_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Float, Pointer<Int32>)>(_Lambdas_Indexer_call_static, UNKNOWN_ERROR));
-  _Lambdas_Indexer_reverse_cache[_smoke_Lambdas_Indexer_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_Lambdas_Indexer_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Float, Pointer<Int32>)>(_Lambdas_Indexer_call_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_Lambdas_Indexer_get_raw_pointer(result)] = value;
   return result;
 }
 Lambdas_Indexer smoke_Lambdas_Indexer_fromFfi(Pointer<Void> handle) {
-  final instance = _Lambdas_Indexer_reverse_cache[_smoke_Lambdas_Indexer_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_Lambdas_Indexer_get_raw_pointer(handle)] as Lambdas_Indexer;
   if (instance != null) return instance;
   final _impl = Lambdas_Indexer__Impl(_smoke_Lambdas_Indexer_copy_handle(handle));
   return (String p0, double p1) {
@@ -437,9 +422,6 @@ final _smoke_Lambdas_NullableConfuser_get_raw_pointer = __lib.nativeLibrary.look
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('smoke_Lambdas_NullableConfuser_get_raw_pointer');
-int _Lambdas_NullableConfuser_instance_counter = 1024;
-final Map<int, Lambdas_NullableConfuser> _Lambdas_NullableConfuser_instance_cache = {};
-final Map<Pointer<Void>, Lambdas_NullableConfuser> _Lambdas_NullableConfuser_reverse_cache = {};
 class Lambdas_NullableConfuser__Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -456,21 +438,20 @@ class Lambdas_NullableConfuser__Impl {
   }
 }
 int _Lambdas_NullableConfuser_call_static(int _token, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
-  final _result_object = _Lambdas_NullableConfuser_instance_cache[_token](String_fromFfi_nullable(p0));
+  final _result_object = (__lib.instanceCache[_token] as Lambdas_NullableConfuser)(String_fromFfi_nullable(p0));
   _result.value = smoke_Lambdas_Producer_toFfi_nullable(_result_object);
   String_releaseFfiHandle_nullable(p0);
   return 0;
 }
 Pointer<Void> smoke_Lambdas_NullableConfuser_toFfi(Lambdas_NullableConfuser value) {
-  const UNKNOWN_ERROR = -1;
-  final token = _Lambdas_NullableConfuser_instance_counter++;
-  _Lambdas_NullableConfuser_instance_cache[token] = value;
-  final result = _smoke_Lambdas_NullableConfuser_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_Lambdas_NullableConfuser_call_static, UNKNOWN_ERROR));
-  _Lambdas_NullableConfuser_reverse_cache[_smoke_Lambdas_NullableConfuser_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_Lambdas_NullableConfuser_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_Lambdas_NullableConfuser_call_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_Lambdas_NullableConfuser_get_raw_pointer(result)] = value;
   return result;
 }
 Lambdas_NullableConfuser smoke_Lambdas_NullableConfuser_fromFfi(Pointer<Void> handle) {
-  final instance = _Lambdas_NullableConfuser_reverse_cache[_smoke_Lambdas_NullableConfuser_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_Lambdas_NullableConfuser_get_raw_pointer(handle)] as Lambdas_NullableConfuser;
   if (instance != null) return instance;
   final _impl = Lambdas_NullableConfuser__Impl(_smoke_Lambdas_NullableConfuser_copy_handle(handle));
   return (String p0) {

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/LambdasWithStructuredTypes.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/LambdasWithStructuredTypes.dart
@@ -1,5 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
-import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/smoke/LambdasDeclarationOrder.dart';
 import 'package:library/src/smoke/LambdasInterface.dart';
 import 'dart:ffi';
@@ -67,9 +67,6 @@ final _smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer = __lib.na
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer');
-int _LambdasWithStructuredTypes_ClassCallback_instance_counter = 1024;
-final Map<int, LambdasWithStructuredTypes_ClassCallback> _LambdasWithStructuredTypes_ClassCallback_instance_cache = {};
-final Map<Pointer<Void>, LambdasWithStructuredTypes_ClassCallback> _LambdasWithStructuredTypes_ClassCallback_reverse_cache = {};
 class LambdasWithStructuredTypes_ClassCallback__Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -86,20 +83,19 @@ class LambdasWithStructuredTypes_ClassCallback__Impl {
   }
 }
 int _LambdasWithStructuredTypes_ClassCallback_call_static(int _token, Pointer<Void> p0) {
-  _LambdasWithStructuredTypes_ClassCallback_instance_cache[_token](smoke_LambdasInterface_fromFfi(p0));
+  (__lib.instanceCache[_token] as LambdasWithStructuredTypes_ClassCallback)(smoke_LambdasInterface_fromFfi(p0));
   smoke_LambdasInterface_releaseFfiHandle(p0);
   return 0;
 }
 Pointer<Void> smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(LambdasWithStructuredTypes_ClassCallback value) {
-  const UNKNOWN_ERROR = -1;
-  final token = _LambdasWithStructuredTypes_ClassCallback_instance_counter++;
-  _LambdasWithStructuredTypes_ClassCallback_instance_cache[token] = value;
-  final result = _smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_LambdasWithStructuredTypes_ClassCallback_call_static, UNKNOWN_ERROR));
-  _LambdasWithStructuredTypes_ClassCallback_reverse_cache[_smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_LambdasWithStructuredTypes_ClassCallback_call_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer(result)] = value;
   return result;
 }
 LambdasWithStructuredTypes_ClassCallback smoke_LambdasWithStructuredTypes_ClassCallback_fromFfi(Pointer<Void> handle) {
-  final instance = _LambdasWithStructuredTypes_ClassCallback_reverse_cache[_smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer(handle)] as LambdasWithStructuredTypes_ClassCallback;
   if (instance != null) return instance;
   final _impl = LambdasWithStructuredTypes_ClassCallback__Impl(_smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle(handle));
   return (LambdasInterface p0) {
@@ -158,9 +154,6 @@ final _smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer = __lib.n
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer');
-int _LambdasWithStructuredTypes_StructCallback_instance_counter = 1024;
-final Map<int, LambdasWithStructuredTypes_StructCallback> _LambdasWithStructuredTypes_StructCallback_instance_cache = {};
-final Map<Pointer<Void>, LambdasWithStructuredTypes_StructCallback> _LambdasWithStructuredTypes_StructCallback_reverse_cache = {};
 class LambdasWithStructuredTypes_StructCallback__Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -177,20 +170,19 @@ class LambdasWithStructuredTypes_StructCallback__Impl {
   }
 }
 int _LambdasWithStructuredTypes_StructCallback_call_static(int _token, Pointer<Void> p0) {
-  _LambdasWithStructuredTypes_StructCallback_instance_cache[_token](smoke_LambdasDeclarationOrder_SomeStruct_fromFfi(p0));
+  (__lib.instanceCache[_token] as LambdasWithStructuredTypes_StructCallback)(smoke_LambdasDeclarationOrder_SomeStruct_fromFfi(p0));
   smoke_LambdasDeclarationOrder_SomeStruct_releaseFfiHandle(p0);
   return 0;
 }
 Pointer<Void> smoke_LambdasWithStructuredTypes_StructCallback_toFfi(LambdasWithStructuredTypes_StructCallback value) {
-  const UNKNOWN_ERROR = -1;
-  final token = _LambdasWithStructuredTypes_StructCallback_instance_counter++;
-  _LambdasWithStructuredTypes_StructCallback_instance_cache[token] = value;
-  final result = _smoke_LambdasWithStructuredTypes_StructCallback_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_LambdasWithStructuredTypes_StructCallback_call_static, UNKNOWN_ERROR));
-  _LambdasWithStructuredTypes_StructCallback_reverse_cache[_smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_LambdasWithStructuredTypes_StructCallback_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_LambdasWithStructuredTypes_StructCallback_call_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer(result)] = value;
   return result;
 }
 LambdasWithStructuredTypes_StructCallback smoke_LambdasWithStructuredTypes_StructCallback_fromFfi(Pointer<Void> handle) {
-  final instance = _LambdasWithStructuredTypes_StructCallback_reverse_cache[_smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer(handle)] as LambdasWithStructuredTypes_StructCallback;
   if (instance != null) return instance;
   final _impl = LambdasWithStructuredTypes_StructCallback__Impl(_smoke_LambdasWithStructuredTypes_StructCallback_copy_handle(handle));
   return (LambdasDeclarationOrder_SomeStruct p0) {

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/StandaloneProducer.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/StandaloneProducer.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
@@ -21,9 +22,6 @@ final _smoke_StandaloneProducer_get_raw_pointer = __lib.nativeLibrary.lookupFunc
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('smoke_StandaloneProducer_get_raw_pointer');
-int _StandaloneProducer_instance_counter = 1024;
-final Map<int, StandaloneProducer> _StandaloneProducer_instance_cache = {};
-final Map<Pointer<Void>, StandaloneProducer> _StandaloneProducer_reverse_cache = {};
 class StandaloneProducer__Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -38,20 +36,19 @@ class StandaloneProducer__Impl {
   }
 }
 int _StandaloneProducer_call_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = _StandaloneProducer_instance_cache[_token]();
+  final _result_object = (__lib.instanceCache[_token] as StandaloneProducer)();
   _result.value = String_toFfi(_result_object);
   return 0;
 }
 Pointer<Void> smoke_StandaloneProducer_toFfi(StandaloneProducer value) {
-  const UNKNOWN_ERROR = -1;
-  final token = _StandaloneProducer_instance_counter++;
-  _StandaloneProducer_instance_cache[token] = value;
-  final result = _smoke_StandaloneProducer_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_StandaloneProducer_call_static, UNKNOWN_ERROR));
-  _StandaloneProducer_reverse_cache[_smoke_StandaloneProducer_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_StandaloneProducer_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_StandaloneProducer_call_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_StandaloneProducer_get_raw_pointer(result)] = value;
   return result;
 }
 StandaloneProducer smoke_StandaloneProducer_fromFfi(Pointer<Void> handle) {
-  final instance = _StandaloneProducer_reverse_cache[_smoke_StandaloneProducer_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_StandaloneProducer_get_raw_pointer(handle)] as StandaloneProducer;
   if (instance != null) return instance;
   final _impl = StandaloneProducer__Impl(_smoke_StandaloneProducer_copy_handle(handle));
   return () {

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/_token_cache.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/_token_cache.dart
@@ -1,0 +1,11 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+const unknownError = -1;
+int _instanceCounter = 1024;
+final Map<int, Object> instanceCache = {};
+final Map<Pointer<Void>, Object> reverseCache = {};
+int getNewToken() => _instanceCounter++;
+int uncacheObject(int token, Pointer<Void> rawPointer) {
+  instanceCache.remove(token);
+  reverseCache.remove(rawPointer);
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/CalculatorListener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/CalculatorListener.dart
@@ -1,5 +1,6 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/smoke/CalculationResult.dart';
 import 'dart:ffi';
@@ -98,9 +99,6 @@ final _smoke_CalculatorListener_get_type_id = __lib.nativeLibrary.lookupFunction
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_CalculatorListener_get_type_id');
-int _CalculatorListener_instance_counter = 1024;
-final Map<int, CalculatorListener> _CalculatorListener_instance_cache = {};
-final Map<Pointer<Void>, CalculatorListener> _CalculatorListener_reverse_cache = {};
 class CalculatorListener__Impl implements CalculatorListener {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -169,46 +167,45 @@ class CalculatorListener__Impl implements CalculatorListener {
   }
 }
 int _CalculatorListener_onCalculationResult_static(int _token, double calculationResult) {
-  _CalculatorListener_instance_cache[_token].onCalculationResult((calculationResult));
+  (__lib.instanceCache[_token] as CalculatorListener).onCalculationResult((calculationResult));
   (calculationResult);
   return 0;
 }
 int _CalculatorListener_onCalculationResultConst_static(int _token, double calculationResult) {
-  _CalculatorListener_instance_cache[_token].onCalculationResultConst((calculationResult));
+  (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultConst((calculationResult));
   (calculationResult);
   return 0;
 }
 int _CalculatorListener_onCalculationResultStruct_static(int _token, Pointer<Void> calculationResult) {
-  _CalculatorListener_instance_cache[_token].onCalculationResultStruct(smoke_CalculatorListener_ResultStruct_fromFfi(calculationResult));
+  (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultStruct(smoke_CalculatorListener_ResultStruct_fromFfi(calculationResult));
   smoke_CalculatorListener_ResultStruct_releaseFfiHandle(calculationResult);
   return 0;
 }
 int _CalculatorListener_onCalculationResultArray_static(int _token, Pointer<Void> calculationResult) {
-  _CalculatorListener_instance_cache[_token].onCalculationResultArray(library_ListOf_Double_fromFfi(calculationResult));
+  (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultArray(library_ListOf_Double_fromFfi(calculationResult));
   library_ListOf_Double_releaseFfiHandle(calculationResult);
   return 0;
 }
 int _CalculatorListener_onCalculationResultMap_static(int _token, Pointer<Void> calculationResults) {
-  _CalculatorListener_instance_cache[_token].onCalculationResultMap(library_MapOf_String_to_Double_fromFfi(calculationResults));
+  (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultMap(library_MapOf_String_to_Double_fromFfi(calculationResults));
   library_MapOf_String_to_Double_releaseFfiHandle(calculationResults);
   return 0;
 }
 int _CalculatorListener_onCalculationResultInstance_static(int _token, Pointer<Void> calculationResult) {
-  _CalculatorListener_instance_cache[_token].onCalculationResultInstance(smoke_CalculationResult_fromFfi(calculationResult));
+  (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultInstance(smoke_CalculationResult_fromFfi(calculationResult));
   smoke_CalculationResult_releaseFfiHandle(calculationResult);
   return 0;
 }
 Pointer<Void> smoke_CalculatorListener_toFfi(CalculatorListener value) {
   if (value is CalculatorListener__Impl) return _smoke_CalculatorListener_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _CalculatorListener_instance_counter++;
-  _CalculatorListener_instance_cache[token] = value;
-  final result = _smoke_CalculatorListener_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Double)>(_CalculatorListener_onCalculationResult_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Double)>(_CalculatorListener_onCalculationResultConst_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultStruct_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultArray_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultMap_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultInstance_static, UNKNOWN_ERROR));
-  _CalculatorListener_reverse_cache[_smoke_CalculatorListener_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_CalculatorListener_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Double)>(_CalculatorListener_onCalculationResult_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Double)>(_CalculatorListener_onCalculationResultConst_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultStruct_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultArray_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultMap_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultInstance_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_CalculatorListener_get_raw_pointer(result)] = value;
   return result;
 }
 CalculatorListener smoke_CalculatorListener_fromFfi(Pointer<Void> handle) {
-  final instance = _CalculatorListener_reverse_cache[_smoke_CalculatorListener_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_CalculatorListener_get_raw_pointer(handle)] as CalculatorListener;
   if (instance != null) return instance;
   final _copied_handle = _smoke_CalculatorListener_copy_handle(handle);
   final _type_id_handle = _smoke_CalculatorListener_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenerWithProperties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenerWithProperties.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/smoke/CalculationResult.dart';
 import 'dart:ffi';
@@ -166,9 +167,6 @@ final _smoke_ListenerWithProperties_get_type_id = __lib.nativeLibrary.lookupFunc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_ListenerWithProperties_get_type_id');
-int _ListenerWithProperties_instance_counter = 1024;
-final Map<int, ListenerWithProperties> _ListenerWithProperties_instance_cache = {};
-final Map<Pointer<Void>, ListenerWithProperties> _ListenerWithProperties_reverse_cache = {};
 class ListenerWithProperties__Impl implements ListenerWithProperties {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -289,79 +287,78 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   }
 }
 int _ListenerWithProperties_message_get_static(int _token, Pointer<Pointer<Void>> _result) {
-  _result.value = String_toFfi(_ListenerWithProperties_instance_cache[_token].message);
+  _result.value = String_toFfi((__lib.instanceCache[_token] as ListenerWithProperties).message);
   return 0;
 }
 int _ListenerWithProperties_message_set_static(int _token, Pointer<Void> _value) {
-  _ListenerWithProperties_instance_cache[_token].message = String_fromFfi(_value);
+  (__lib.instanceCache[_token] as ListenerWithProperties).message = String_fromFfi(_value);
   String_releaseFfiHandle(_value);
   return 0;
 }
 int _ListenerWithProperties_packedMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {
-  _result.value = smoke_CalculationResult_toFfi(_ListenerWithProperties_instance_cache[_token].packedMessage);
+  _result.value = smoke_CalculationResult_toFfi((__lib.instanceCache[_token] as ListenerWithProperties).packedMessage);
   return 0;
 }
 int _ListenerWithProperties_packedMessage_set_static(int _token, Pointer<Void> _value) {
-  _ListenerWithProperties_instance_cache[_token].packedMessage = smoke_CalculationResult_fromFfi(_value);
+  (__lib.instanceCache[_token] as ListenerWithProperties).packedMessage = smoke_CalculationResult_fromFfi(_value);
   smoke_CalculationResult_releaseFfiHandle(_value);
   return 0;
 }
 int _ListenerWithProperties_structuredMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {
-  _result.value = smoke_ListenerWithProperties_ResultStruct_toFfi(_ListenerWithProperties_instance_cache[_token].structuredMessage);
+  _result.value = smoke_ListenerWithProperties_ResultStruct_toFfi((__lib.instanceCache[_token] as ListenerWithProperties).structuredMessage);
   return 0;
 }
 int _ListenerWithProperties_structuredMessage_set_static(int _token, Pointer<Void> _value) {
-  _ListenerWithProperties_instance_cache[_token].structuredMessage = smoke_ListenerWithProperties_ResultStruct_fromFfi(_value);
+  (__lib.instanceCache[_token] as ListenerWithProperties).structuredMessage = smoke_ListenerWithProperties_ResultStruct_fromFfi(_value);
   smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(_value);
   return 0;
 }
 int _ListenerWithProperties_enumeratedMessage_get_static(int _token, Pointer<Uint32> _result) {
-  _result.value = smoke_ListenerWithProperties_ResultEnum_toFfi(_ListenerWithProperties_instance_cache[_token].enumeratedMessage);
+  _result.value = smoke_ListenerWithProperties_ResultEnum_toFfi((__lib.instanceCache[_token] as ListenerWithProperties).enumeratedMessage);
   return 0;
 }
 int _ListenerWithProperties_enumeratedMessage_set_static(int _token, int _value) {
-  _ListenerWithProperties_instance_cache[_token].enumeratedMessage = smoke_ListenerWithProperties_ResultEnum_fromFfi(_value);
+  (__lib.instanceCache[_token] as ListenerWithProperties).enumeratedMessage = smoke_ListenerWithProperties_ResultEnum_fromFfi(_value);
   smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(_value);
   return 0;
 }
 int _ListenerWithProperties_arrayedMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {
-  _result.value = library_ListOf_String_toFfi(_ListenerWithProperties_instance_cache[_token].arrayedMessage);
+  _result.value = library_ListOf_String_toFfi((__lib.instanceCache[_token] as ListenerWithProperties).arrayedMessage);
   return 0;
 }
 int _ListenerWithProperties_arrayedMessage_set_static(int _token, Pointer<Void> _value) {
-  _ListenerWithProperties_instance_cache[_token].arrayedMessage = library_ListOf_String_fromFfi(_value);
+  (__lib.instanceCache[_token] as ListenerWithProperties).arrayedMessage = library_ListOf_String_fromFfi(_value);
   library_ListOf_String_releaseFfiHandle(_value);
   return 0;
 }
 int _ListenerWithProperties_mappedMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {
-  _result.value = library_MapOf_String_to_Double_toFfi(_ListenerWithProperties_instance_cache[_token].mappedMessage);
+  _result.value = library_MapOf_String_to_Double_toFfi((__lib.instanceCache[_token] as ListenerWithProperties).mappedMessage);
   return 0;
 }
 int _ListenerWithProperties_mappedMessage_set_static(int _token, Pointer<Void> _value) {
-  _ListenerWithProperties_instance_cache[_token].mappedMessage = library_MapOf_String_to_Double_fromFfi(_value);
+  (__lib.instanceCache[_token] as ListenerWithProperties).mappedMessage = library_MapOf_String_to_Double_fromFfi(_value);
   library_MapOf_String_to_Double_releaseFfiHandle(_value);
   return 0;
 }
 int _ListenerWithProperties_bufferedMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {
-  _result.value = Blob_toFfi(_ListenerWithProperties_instance_cache[_token].bufferedMessage);
+  _result.value = Blob_toFfi((__lib.instanceCache[_token] as ListenerWithProperties).bufferedMessage);
   return 0;
 }
 int _ListenerWithProperties_bufferedMessage_set_static(int _token, Pointer<Void> _value) {
-  _ListenerWithProperties_instance_cache[_token].bufferedMessage = Blob_fromFfi(_value);
+  (__lib.instanceCache[_token] as ListenerWithProperties).bufferedMessage = Blob_fromFfi(_value);
   Blob_releaseFfiHandle(_value);
   return 0;
 }
 Pointer<Void> smoke_ListenerWithProperties_toFfi(ListenerWithProperties value) {
   if (value is ListenerWithProperties__Impl) return _smoke_ListenerWithProperties_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _ListenerWithProperties_instance_counter++;
-  _ListenerWithProperties_instance_cache[token] = value;
-  final result = _smoke_ListenerWithProperties_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_message_get_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_message_set_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_packedMessage_get_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_packedMessage_set_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_structuredMessage_get_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_structuredMessage_set_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint32>)>(_ListenerWithProperties_enumeratedMessage_get_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Uint32)>(_ListenerWithProperties_enumeratedMessage_set_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_arrayedMessage_get_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_arrayedMessage_set_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_mappedMessage_get_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_mappedMessage_set_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_bufferedMessage_get_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_bufferedMessage_set_static, UNKNOWN_ERROR));
-  _ListenerWithProperties_reverse_cache[_smoke_ListenerWithProperties_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_ListenerWithProperties_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_message_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_message_set_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_packedMessage_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_packedMessage_set_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_structuredMessage_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_structuredMessage_set_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint32>)>(_ListenerWithProperties_enumeratedMessage_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Uint32)>(_ListenerWithProperties_enumeratedMessage_set_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_arrayedMessage_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_arrayedMessage_set_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_mappedMessage_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_mappedMessage_set_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_bufferedMessage_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_bufferedMessage_set_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_ListenerWithProperties_get_raw_pointer(result)] = value;
   return result;
 }
 ListenerWithProperties smoke_ListenerWithProperties_fromFfi(Pointer<Void> handle) {
-  final instance = _ListenerWithProperties_reverse_cache[_smoke_ListenerWithProperties_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_ListenerWithProperties_get_raw_pointer(handle)] as ListenerWithProperties;
   if (instance != null) return instance;
   final _copied_handle = _smoke_ListenerWithProperties_copy_handle(handle);
   final _type_id_handle = _smoke_ListenerWithProperties_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenersWithReturnValues.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenersWithReturnValues.dart
@@ -1,5 +1,6 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/smoke/CalculationResult.dart';
 import 'dart:ffi';
@@ -158,9 +159,6 @@ final _smoke_ListenersWithReturnValues_get_type_id = __lib.nativeLibrary.lookupF
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_ListenersWithReturnValues_get_type_id');
-int _ListenersWithReturnValues_instance_counter = 1024;
-final Map<int, ListenersWithReturnValues> _ListenersWithReturnValues_instance_cache = {};
-final Map<Pointer<Void>, ListenersWithReturnValues> _ListenersWithReturnValues_reverse_cache = {};
 class ListenersWithReturnValues__Impl implements ListenersWithReturnValues {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -225,52 +223,51 @@ class ListenersWithReturnValues__Impl implements ListenersWithReturnValues {
   }
 }
 int _ListenersWithReturnValues_fetchDataDouble_static(int _token, Pointer<Double> _result) {
-  final _result_object = _ListenersWithReturnValues_instance_cache[_token].fetchDataDouble();
+  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataDouble();
   _result.value = (_result_object);
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataString_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = _ListenersWithReturnValues_instance_cache[_token].fetchDataString();
+  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataString();
   _result.value = String_toFfi(_result_object);
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataStruct_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = _ListenersWithReturnValues_instance_cache[_token].fetchDataStruct();
+  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataStruct();
   _result.value = smoke_ListenersWithReturnValues_ResultStruct_toFfi(_result_object);
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataEnum_static(int _token, Pointer<Uint32> _result) {
-  final _result_object = _ListenersWithReturnValues_instance_cache[_token].fetchDataEnum();
+  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataEnum();
   _result.value = smoke_ListenersWithReturnValues_ResultEnum_toFfi(_result_object);
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataArray_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = _ListenersWithReturnValues_instance_cache[_token].fetchDataArray();
+  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataArray();
   _result.value = library_ListOf_Double_toFfi(_result_object);
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataMap_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = _ListenersWithReturnValues_instance_cache[_token].fetchDataMap();
+  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataMap();
   _result.value = library_MapOf_String_to_Double_toFfi(_result_object);
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataInstance_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = _ListenersWithReturnValues_instance_cache[_token].fetchDataInstance();
+  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataInstance();
   _result.value = smoke_CalculationResult_toFfi(_result_object);
   if (_result_object != null) _result_object.release();
   return 0;
 }
 Pointer<Void> smoke_ListenersWithReturnValues_toFfi(ListenersWithReturnValues value) {
   if (value is ListenersWithReturnValues__Impl) return _smoke_ListenersWithReturnValues_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _ListenersWithReturnValues_instance_counter++;
-  _ListenersWithReturnValues_instance_cache[token] = value;
-  final result = _smoke_ListenersWithReturnValues_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Double>)>(_ListenersWithReturnValues_fetchDataDouble_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataString_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataStruct_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint32>)>(_ListenersWithReturnValues_fetchDataEnum_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataArray_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataMap_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataInstance_static, UNKNOWN_ERROR));
-  _ListenersWithReturnValues_reverse_cache[_smoke_ListenersWithReturnValues_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_ListenersWithReturnValues_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Double>)>(_ListenersWithReturnValues_fetchDataDouble_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataString_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataStruct_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint32>)>(_ListenersWithReturnValues_fetchDataEnum_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataArray_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataMap_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataInstance_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_ListenersWithReturnValues_get_raw_pointer(result)] = value;
   return result;
 }
 ListenersWithReturnValues smoke_ListenersWithReturnValues_fromFfi(Pointer<Void> handle) {
-  final instance = _ListenersWithReturnValues_reverse_cache[_smoke_ListenersWithReturnValues_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_ListenersWithReturnValues_get_raw_pointer(handle)] as ListenersWithReturnValues;
   if (instance != null) return instance;
   final _copied_handle = _smoke_ListenersWithReturnValues_copy_handle(handle);
   final _type_id_handle = _smoke_ListenersWithReturnValues_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/LevelOne.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/LevelOne.dart
@@ -1,5 +1,4 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
-import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/smoke/OuterClass.dart';
 import 'package:library/src/smoke/OuterInterface.dart';
 import 'dart:ffi';

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterClass.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterClass.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -97,9 +98,6 @@ final _smoke_OuterClass_InnerInterface_get_type_id = __lib.nativeLibrary.lookupF
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_OuterClass_InnerInterface_get_type_id');
-int _OuterClass_InnerInterface_instance_counter = 1024;
-final Map<int, OuterClass_InnerInterface> _OuterClass_InnerInterface_instance_cache = {};
-final Map<Pointer<Void>, OuterClass_InnerInterface> _OuterClass_InnerInterface_reverse_cache = {};
 class OuterClass_InnerInterface__Impl implements OuterClass_InnerInterface {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -118,22 +116,21 @@ class OuterClass_InnerInterface__Impl implements OuterClass_InnerInterface {
   }
 }
 int _OuterClass_InnerInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  final _result_object = _OuterClass_InnerInterface_instance_cache[_token].foo(String_fromFfi(input));
+  final _result_object = (__lib.instanceCache[_token] as OuterClass_InnerInterface).foo(String_fromFfi(input));
   _result.value = String_toFfi(_result_object);
   String_releaseFfiHandle(input);
   return 0;
 }
 Pointer<Void> smoke_OuterClass_InnerInterface_toFfi(OuterClass_InnerInterface value) {
   if (value is OuterClass_InnerInterface__Impl) return _smoke_OuterClass_InnerInterface_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _OuterClass_InnerInterface_instance_counter++;
-  _OuterClass_InnerInterface_instance_cache[token] = value;
-  final result = _smoke_OuterClass_InnerInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterClass_InnerInterface_foo_static, UNKNOWN_ERROR));
-  _OuterClass_InnerInterface_reverse_cache[_smoke_OuterClass_InnerInterface_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_OuterClass_InnerInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterClass_InnerInterface_foo_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_OuterClass_InnerInterface_get_raw_pointer(result)] = value;
   return result;
 }
 OuterClass_InnerInterface smoke_OuterClass_InnerInterface_fromFfi(Pointer<Void> handle) {
-  final instance = _OuterClass_InnerInterface_reverse_cache[_smoke_OuterClass_InnerInterface_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_OuterClass_InnerInterface_get_raw_pointer(handle)] as OuterClass_InnerInterface;
   if (instance != null) return instance;
   final _copied_handle = _smoke_OuterClass_InnerInterface_copy_handle(handle);
   final _type_id_handle = _smoke_OuterClass_InnerInterface_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterInterface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterInterface.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -67,9 +68,6 @@ final _smoke_OuterInterface_InnerInterface_get_type_id = __lib.nativeLibrary.loo
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_OuterInterface_InnerInterface_get_type_id');
-int _OuterInterface_InnerInterface_instance_counter = 1024;
-final Map<int, OuterInterface_InnerInterface> _OuterInterface_InnerInterface_instance_cache = {};
-final Map<Pointer<Void>, OuterInterface_InnerInterface> _OuterInterface_InnerInterface_reverse_cache = {};
 class OuterInterface_InnerInterface__Impl implements OuterInterface_InnerInterface {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -88,22 +86,21 @@ class OuterInterface_InnerInterface__Impl implements OuterInterface_InnerInterfa
   }
 }
 int _OuterInterface_InnerInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  final _result_object = _OuterInterface_InnerInterface_instance_cache[_token].foo(String_fromFfi(input));
+  final _result_object = (__lib.instanceCache[_token] as OuterInterface_InnerInterface).foo(String_fromFfi(input));
   _result.value = String_toFfi(_result_object);
   String_releaseFfiHandle(input);
   return 0;
 }
 Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi(OuterInterface_InnerInterface value) {
   if (value is OuterInterface_InnerInterface__Impl) return _smoke_OuterInterface_InnerInterface_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _OuterInterface_InnerInterface_instance_counter++;
-  _OuterInterface_InnerInterface_instance_cache[token] = value;
-  final result = _smoke_OuterInterface_InnerInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterInterface_InnerInterface_foo_static, UNKNOWN_ERROR));
-  _OuterInterface_InnerInterface_reverse_cache[_smoke_OuterInterface_InnerInterface_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_OuterInterface_InnerInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterInterface_InnerInterface_foo_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_OuterInterface_InnerInterface_get_raw_pointer(result)] = value;
   return result;
 }
 OuterInterface_InnerInterface smoke_OuterInterface_InnerInterface_fromFfi(Pointer<Void> handle) {
-  final instance = _OuterInterface_InnerInterface_reverse_cache[_smoke_OuterInterface_InnerInterface_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_OuterInterface_InnerInterface_get_raw_pointer(handle)] as OuterInterface_InnerInterface;
   if (instance != null) return instance;
   final _copied_handle = _smoke_OuterInterface_InnerInterface_copy_handle(handle);
   final _type_id_handle = _smoke_OuterInterface_InnerInterface_get_type_id(handle);
@@ -144,9 +141,6 @@ final _smoke_OuterInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_OuterInterface_get_type_id');
-int _OuterInterface_instance_counter = 1024;
-final Map<int, OuterInterface> _OuterInterface_instance_cache = {};
-final Map<Pointer<Void>, OuterInterface> _OuterInterface_reverse_cache = {};
 class OuterInterface__Impl implements OuterInterface {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -165,22 +159,21 @@ class OuterInterface__Impl implements OuterInterface {
   }
 }
 int _OuterInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  final _result_object = _OuterInterface_instance_cache[_token].foo(String_fromFfi(input));
+  final _result_object = (__lib.instanceCache[_token] as OuterInterface).foo(String_fromFfi(input));
   _result.value = String_toFfi(_result_object);
   String_releaseFfiHandle(input);
   return 0;
 }
 Pointer<Void> smoke_OuterInterface_toFfi(OuterInterface value) {
   if (value is OuterInterface__Impl) return _smoke_OuterInterface_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _OuterInterface_instance_counter++;
-  _OuterInterface_instance_cache[token] = value;
-  final result = _smoke_OuterInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterInterface_foo_static, UNKNOWN_ERROR));
-  _OuterInterface_reverse_cache[_smoke_OuterInterface_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_OuterInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterInterface_foo_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_OuterInterface_get_raw_pointer(result)] = value;
   return result;
 }
 OuterInterface smoke_OuterInterface_fromFfi(Pointer<Void> handle) {
-  final instance = _OuterInterface_reverse_cache[_smoke_OuterInterface_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_OuterInterface_get_raw_pointer(handle)] as OuterInterface;
   if (instance != null) return instance;
   final _copied_handle = _smoke_OuterInterface_copy_handle(handle);
   final _type_id_handle = _smoke_OuterInterface_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeListener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeListener.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -29,9 +30,6 @@ final _smoke_PlatformNamesListener_get_type_id = __lib.nativeLibrary.lookupFunct
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_PlatformNamesListener_get_type_id');
-int _weeListener_instance_counter = 1024;
-final Map<int, weeListener> _weeListener_instance_cache = {};
-final Map<Pointer<Void>, weeListener> _weeListener_reverse_cache = {};
 class weeListener__Impl implements weeListener {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -50,21 +48,20 @@ class weeListener__Impl implements weeListener {
   }
 }
 int _weeListener_WeeMethod_static(int _token, Pointer<Void> WeeParameter) {
-  _weeListener_instance_cache[_token].WeeMethod(String_fromFfi(WeeParameter));
+  (__lib.instanceCache[_token] as weeListener).WeeMethod(String_fromFfi(WeeParameter));
   String_releaseFfiHandle(WeeParameter);
   return 0;
 }
 Pointer<Void> smoke_PlatformNamesListener_toFfi(weeListener value) {
   if (value is weeListener__Impl) return _smoke_PlatformNamesListener_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _weeListener_instance_counter++;
-  _weeListener_instance_cache[token] = value;
-  final result = _smoke_PlatformNamesListener_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_weeListener_WeeMethod_static, UNKNOWN_ERROR));
-  _weeListener_reverse_cache[_smoke_PlatformNamesListener_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_PlatformNamesListener_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_weeListener_WeeMethod_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_PlatformNamesListener_get_raw_pointer(result)] = value;
   return result;
 }
 weeListener smoke_PlatformNamesListener_fromFfi(Pointer<Void> handle) {
-  final instance = _weeListener_reverse_cache[_smoke_PlatformNamesListener_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_PlatformNamesListener_get_raw_pointer(handle)] as weeListener;
   if (instance != null) return instance;
   final _copied_handle = _smoke_PlatformNamesListener_copy_handle(handle);
   final _type_id_handle = _smoke_PlatformNamesListener_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
-import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/smoke/PropertiesInterface.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/PropertiesInterface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/PropertiesInterface.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -92,9 +93,6 @@ final _smoke_PropertiesInterface_get_type_id = __lib.nativeLibrary.lookupFunctio
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_PropertiesInterface_get_type_id');
-int _PropertiesInterface_instance_counter = 1024;
-final Map<int, PropertiesInterface> _PropertiesInterface_instance_cache = {};
-final Map<Pointer<Void>, PropertiesInterface> _PropertiesInterface_reverse_cache = {};
 class PropertiesInterface__Impl implements PropertiesInterface {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -119,25 +117,24 @@ class PropertiesInterface__Impl implements PropertiesInterface {
   }
 }
 int _PropertiesInterface_structProperty_get_static(int _token, Pointer<Pointer<Void>> _result) {
-  _result.value = smoke_PropertiesInterface_ExampleStruct_toFfi(_PropertiesInterface_instance_cache[_token].structProperty);
+  _result.value = smoke_PropertiesInterface_ExampleStruct_toFfi((__lib.instanceCache[_token] as PropertiesInterface).structProperty);
   return 0;
 }
 int _PropertiesInterface_structProperty_set_static(int _token, Pointer<Void> _value) {
-  _PropertiesInterface_instance_cache[_token].structProperty = smoke_PropertiesInterface_ExampleStruct_fromFfi(_value);
+  (__lib.instanceCache[_token] as PropertiesInterface).structProperty = smoke_PropertiesInterface_ExampleStruct_fromFfi(_value);
   smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(_value);
   return 0;
 }
 Pointer<Void> smoke_PropertiesInterface_toFfi(PropertiesInterface value) {
   if (value is PropertiesInterface__Impl) return _smoke_PropertiesInterface_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _PropertiesInterface_instance_counter++;
-  _PropertiesInterface_instance_cache[token] = value;
-  final result = _smoke_PropertiesInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_PropertiesInterface_structProperty_get_static, UNKNOWN_ERROR), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_PropertiesInterface_structProperty_set_static, UNKNOWN_ERROR));
-  _PropertiesInterface_reverse_cache[_smoke_PropertiesInterface_get_raw_pointer(result)] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
+  final result = _smoke_PropertiesInterface_create_proxy(token, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_PropertiesInterface_structProperty_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_PropertiesInterface_structProperty_set_static, __lib.unknownError));
+  __lib.reverseCache[_smoke_PropertiesInterface_get_raw_pointer(result)] = value;
   return result;
 }
 PropertiesInterface smoke_PropertiesInterface_fromFfi(Pointer<Void> handle) {
-  final instance = _PropertiesInterface_reverse_cache[_smoke_PropertiesInterface_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_PropertiesInterface_get_raw_pointer(handle)] as PropertiesInterface;
   if (instance != null) return instance;
   final _copied_handle = _smoke_PropertiesInterface_copy_handle(handle);
   final _type_id_handle = _smoke_PropertiesInterface_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalInterface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalInterface.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -28,9 +29,6 @@ final _smoke_InternalInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_InternalInterface_get_type_id');
-int _InternalInterface_instance_counter = 1024;
-final Map<int, InternalInterface> _InternalInterface_instance_cache = {};
-final Map<Pointer<Void>, InternalInterface> _InternalInterface_reverse_cache = {};
 class InternalInterface__Impl implements InternalInterface {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -40,15 +38,14 @@ class InternalInterface__Impl implements InternalInterface {
 }
 Pointer<Void> smoke_InternalInterface_toFfi(InternalInterface value) {
   if (value is InternalInterface__Impl) return _smoke_InternalInterface_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _InternalInterface_instance_counter++;
-  _InternalInterface_instance_cache[token] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
   final result = _smoke_InternalInterface_create_proxy(token);
-  _InternalInterface_reverse_cache[_smoke_InternalInterface_get_raw_pointer(result)] = value;
+  __lib.reverseCache[_smoke_InternalInterface_get_raw_pointer(result)] = value;
   return result;
 }
 InternalInterface smoke_InternalInterface_fromFfi(Pointer<Void> handle) {
-  final instance = _InternalInterface_reverse_cache[_smoke_InternalInterface_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_InternalInterface_get_raw_pointer(handle)] as InternalInterface;
   if (instance != null) return instance;
   final _copied_handle = _smoke_InternalInterface_copy_handle(handle);
   final _type_id_handle = _smoke_InternalInterface_get_type_id(handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicInterface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicInterface.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/smoke/PublicClass.dart';
 import 'dart:ffi';
@@ -91,9 +92,6 @@ final _smoke_PublicInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('smoke_PublicInterface_get_type_id');
-int _PublicInterface_instance_counter = 1024;
-final Map<int, PublicInterface> _PublicInterface_instance_cache = {};
-final Map<Pointer<Void>, PublicInterface> _PublicInterface_reverse_cache = {};
 class PublicInterface__Impl implements PublicInterface {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
@@ -103,15 +101,14 @@ class PublicInterface__Impl implements PublicInterface {
 }
 Pointer<Void> smoke_PublicInterface_toFfi(PublicInterface value) {
   if (value is PublicInterface__Impl) return _smoke_PublicInterface_copy_handle(value.handle);
-  const UNKNOWN_ERROR = -1;
-  final token = _PublicInterface_instance_counter++;
-  _PublicInterface_instance_cache[token] = value;
+  final token = __lib.getNewToken();
+  __lib.instanceCache[token] = value;
   final result = _smoke_PublicInterface_create_proxy(token);
-  _PublicInterface_reverse_cache[_smoke_PublicInterface_get_raw_pointer(result)] = value;
+  __lib.reverseCache[_smoke_PublicInterface_get_raw_pointer(result)] = value;
   return result;
 }
 PublicInterface smoke_PublicInterface_fromFfi(Pointer<Void> handle) {
-  final instance = _PublicInterface_reverse_cache[_smoke_PublicInterface_get_raw_pointer(handle)];
+  final instance = __lib.reverseCache[_smoke_PublicInterface_get_raw_pointer(handle)] as PublicInterface;
   if (instance != null) return instance;
   final _copied_handle = _smoke_PublicInterface_copy_handle(handle);
   final _type_id_handle = _smoke_PublicInterface_get_type_id(handle);


### PR DESCRIPTION
Updated Dart templates to have one single global "token" cache (a cache
of Dart objects callable from C++) instead of many per-type local
caches. This simplifies the code and prepares it for token-cache cleanup
implementation (issue #166).

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>