### PR TITLE
Don't export Dart files with no symbols

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -135,7 +135,9 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
         val allSymbols = (allTypes + freeConstants)
             .filterNot { it.visibility.isInternal }
             .map { dartNameResolver.resolveName(it) }
-        exportsCollector += DartExport(relativePath, allSymbols)
+        if (allSymbols.isNotEmpty()) {
+            exportsCollector += DartExport(relativePath, allSymbols)
+        }
         typeRepositoriesCollector += getTypeRepositories(allTypes)
 
         val parentImports = (rootElement as? LimeContainerWithInheritance)?.parent

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/library.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/library.dart
@@ -1,5 +1,3 @@
-export 'src/smoke/InternalInterface.dart';
-export 'src/smoke/InternalClass.dart';
 export 'src/smoke/PublicInterface.dart' show PublicInterface;
 export 'src/smoke/PublicClass.dart' show PublicClass, PublicClass_PublicStruct, PublicClass_PublicStructWithInternalDefaults;
 export 'src/smoke/PublicTypeCollection.dart' show PublicTypeCollection;


### PR DESCRIPTION
Updated Dart export logic to avoid "export" statements with no "show"
clause. Such statement exports ALL symbols found in a file, but it did
happen for types marked as "internal", where NONE of the symbols should
be exported.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>