### PR TITLE
Provide a fallback for Dart native library loading

### DIFF
--- a/gluecodium/src/main/resources/templates/dart/DartLibraryInit.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLibraryInit.mustache
@@ -25,10 +25,18 @@ import 'dart:io' show Platform;
 
 import 'package:ffi/ffi.dart';
 
-final nativeLibrary = DynamicLibrary.open(_getLibraryPath());
+final nativeLibrary = _loadNativeLibrary();
+
+DynamicLibrary _loadNativeLibrary() {
+  try {
+    return DynamicLibrary.open(_getLibraryPath());
+  } catch (e) {
+    return DynamicLibrary.process();
+  }
+}
 
 String _getLibraryPath() {
   if (Platform.isWindows) return 'lib{{libraryName}}.dll';
-  if (Platform.isMacOS) return 'lib{{libraryName}}.dylib';
+  if (Platform.isMacOS || Platform.isIOS) return 'lib{{libraryName}}.dylib';
   return 'lib{{libraryName}}.so';
 }


### PR DESCRIPTION
Updated the template for Dart native library loading to fall back to
using "current" binary as a native library if loading library by name
fails. This is the expected scenario for "fused" Flutter plugin build,
i.e. when Swift and Dart bindings are compiled into a single dynamic
library.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>