### PR TITLE
Add caching of C++ proxies in Dart FFI

### DIFF
--- a/examples/libhello/lime/test/StringListeners.lime
+++ b/examples/libhello/lime/test/StringListeners.lime
@@ -40,19 +40,22 @@ class DummyLogger {
     // Send the message to our Mobile overlords through the registered listeners
     static fun relayMessage(
         listener: StringListener,
-
         message: String
     )
     // Send the message to our Mobile overlords through the registered listeners
     static fun relayMessageAsStruct(
         listener: StringListener,
-
         message: String
     )
     // Send the message to our Mobile overlords through the registered listeners
     static fun relayConstMessage(
         listener: StringListener,
-
         message: String
     )
+}
+
+class PersistingLogger {
+    static fun addListener(listener: StringListener)
+    // Returns `false` if listeners was not found, returns `true` otherwise.
+    static fun removeListener(listener: StringListener): Boolean
 }

--- a/examples/libhello/src/test/StringListeners.cpp
+++ b/examples/libhello/src/test/StringListeners.cpp
@@ -19,6 +19,7 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "test/DummyLogger.h"
+#include "test/PersistingLogger.h"
 #include "test/StringListener.h"
 
 #include <algorithm>
@@ -48,6 +49,25 @@ DummyLogger::relay_const_message( const ::std::shared_ptr<::test::StringListener
                                   const ::std::string& message )
 {
     listener->on_const_message( message );
+}
+
+namespace
+{
+std::vector<std::shared_ptr<::test::StringListener>> s_listeners{};
+}
+
+void
+PersistingLogger::add_listener(const std::shared_ptr<test::StringListener>& listener) {
+    s_listeners.push_back(listener);
+}
+
+bool
+PersistingLogger::remove_listener(const std::shared_ptr<test::StringListener>& listener) {
+    auto iter = std::find(s_listeners.begin(), s_listeners.end(), listener);
+    if (iter == s_listeners.end()) return false;
+
+    s_listeners.erase(iter);
+    return true;
 }
 
 }  // namespace test

--- a/examples/platforms/dart/test/Listeners_test.dart
+++ b/examples/platforms/dart/test/Listeners_test.dart
@@ -71,4 +71,12 @@ void main() {
     expect(RouteProviderImpl.setRouteWasRun, isTrue);
     expect(RouteProviderImpl.setRouteCouldCast, isTrue);
   });
+  _testSuite.test("Proxy cache works", () {
+    final listener = new MessageListener();
+
+    PersistingLogger.addListener(listener);
+    final result = PersistingLogger.removeListener(listener);
+
+    expect(result, isTrue);
+  });
 }

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -153,17 +153,15 @@ int _{{resolveName parent}}_{{resolveName}}_set_static(int _token, {{resolveName
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
   if (value is {{resolveName}}__Impl) return _{{resolveName "Ffi"}}_copy_handle(value.handle);
 
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-
-  final result = _{{resolveName "Ffi"}}_create_proxy(token, __lib.uncacheObjectFfi{{!!
-  }}{{#set parent=this}}{{#if inheritedFunctions functions logic="or"}}, {{#each inheritedFunctions functions}}{{!!
-  }}Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName}}_static, __lib.unknownError){{#if iter.hasNext}}, {{/if}}{{!!
-  }}{{/each}}{{/if}}{{#if inheritedProperties properties logic="or"}}, {{!!
-  }}{{#each inheritedProperties properties}}{{#set property=this}}{{!!
-  }}{{#getter}}Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName property}}_get_static, __lib.unknownError){{/getter}}{{!!
-  }}{{#setter}}, Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName property}}_set_static, __lib.unknownError){{/setter}}{{!!
-  }}{{#if iter.hasNext}}, {{/if}}{{/set}}{{/each}}{{/if}}{{/set}});
+  final result = _{{resolveName "Ffi"}}_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi{{#set parent=this}}{{#each inheritedFunctions functions}},
+    Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName}}_static, __lib.unknownError){{!!
+    }}{{/each}}{{#each inheritedProperties properties}}{{#set property=this}}{{#getter}},
+    Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName property}}_get_static, __lib.unknownError){{/getter}}{{#setter}},
+    Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName property}}_set_static, __lib.unknownError){{/setter}}{{!!
+    }}{{/set}}{{/each}}{{/set}}
+  );
   __lib.reverseCache[_{{resolveName "Ffi"}}_get_raw_pointer(result)] = value;
 
   return result;

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -75,12 +75,11 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 {{/asFunction}}{{/set}}
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-
-  final result = _{{resolveName "Ffi"}}_create_proxy(token, __lib.uncacheObjectFfi, {{#set parent=this}}{{#asFunction}}{{!!
-  }}Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName}}_static, __lib.unknownError){{!!
-  }}{{/asFunction}}{{/set}});
+  final result = _{{resolveName "Ffi"}}_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,{{#set parent=this}}{{#asFunction}}
+    Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName}}_static, __lib.unknownError){{/asFunction}}{{/set}}
+  );
   __lib.reverseCache[_{{resolveName "Ffi"}}_get_raw_pointer(result)] = value;
 
   return result;

--- a/gluecodium/src/main/resources/templates/dart/DartTokenCache.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartTokenCache.mustache
@@ -27,11 +27,21 @@ const unknownError = -1;
 
 int _instanceCounter = 1024;
 final Map<int, Object> instanceCache = {};
+final Map<Object, int> tokenCache = {};
 final Map<Pointer<Void>, Object> reverseCache = {};
 
-int getNewToken() => _instanceCounter++;
+int cacheObject(Object obj) {
+  int token = tokenCache[obj];
+  if (token == null) {
+    token = _instanceCounter++;
+    instanceCache[token] = obj;
+    tokenCache[obj] = token;
+  }
+  return token;
+}
 
 void uncacheObject(int token, Pointer<Void> rawPointer) {
+  tokenCache.remove(instanceCache[token]);
   instanceCache.remove(token);
   reverseCache.remove(rawPointer);
 }

--- a/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
@@ -107,15 +107,22 @@ FfiOpaqueHandle
 }}{{#if inheritedProperties properties logic="or"}}, {{!!
 }}{{#each inheritedProperties properties}}FfiOpaqueHandle p{{iter.position}}g{{!!
 }}{{#if setter}}, FfiOpaqueHandle p{{iter.position}}s{{/if}}{{#if iter.hasNext}}, {{/if}}{{/each}}{{/if}}) {
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) std::shared_ptr<{{resolveName "C++"}}>(
+    auto cached_proxy = {{>ffi/FfiInternal}}::get_cached_proxy<{{resolveName}}_Proxy>(token);
+    std::shared_ptr<{{resolveName}}_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<{{resolveName}}_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<{{resolveName}}_Proxy>(
             new (std::nothrow) {{resolveName}}_Proxy(token, deleter{{#if inheritedFunctions functions logic="or"}}, {{!!
             }}{{#each inheritedFunctions functions}}f{{iter.position}}{{#if iter.hasNext}}, {{/if}}{{/each}}{{/if}}{{!!
             }}{{#if inheritedProperties properties logic="or"}}, {{!!
             }}{{#each inheritedProperties properties}}p{{iter.position}}g{{!!
             }}{{#if setter}}, p{{iter.position}}s{{/if}}{{#if iter.hasNext}}, {{/if}}{{/each}}{{/if}})
-        )
-    );
+        );
+        {{>ffi/FfiInternal}}::cache_proxy(token, *proxy_ptr);
+    }
+
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }
 
 FfiOpaqueHandle
@@ -129,10 +136,15 @@ FfiOpaqueHandle
 {{#lambdas}}
 FfiOpaqueHandle
 {{libraryName}}_{{resolveName}}_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
+    auto cached_proxy = {{>ffi/FfiInternal}}::get_cached_proxy<{{resolveName}}_Proxy>(token);
+    if (!cached_proxy) {
+        cached_proxy = std::make_shared<{{resolveName}}_Proxy>(token, deleter, f0);
+        {{>ffi/FfiInternal}}::cache_proxy(token, cached_proxy);
+    }
+
     return reinterpret_cast<FfiOpaqueHandle>(
         new {{resolveName "C++"}}(
-            std::bind(&{{resolveName}}_Proxy::operator(), std::make_shared<{{resolveName}}_Proxy>(token, deleter, f0){{!!
-            }}{{#parameters}}, std::placeholders::_{{iter.index}}{{/parameters}})
+            std::bind(&{{resolveName}}_Proxy::operator(), cached_proxy{{#parameters}}, std::placeholders::_{{iter.index}}{{/parameters}})
         )
     );
 }

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyCache.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyCache.mustache
@@ -1,0 +1,58 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{>ffi/FfiCopyrightHeader}}
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+{{#internalNamespace}}
+namespace {{.}}
+{
+{{/internalNamespace}}
+namespace ffi
+{
+static std::unordered_map<uint64_t, std::weak_ptr<void>> _proxy_cache{};
+static std::mutex _cache_mutex;
+
+template<class T>
+std::shared_ptr<T>
+get_cached_proxy(uint64_t token) {
+    const std::lock_guard<std::mutex> lock(_cache_mutex);
+    auto iter = _proxy_cache.find(token);
+    return (iter != _proxy_cache.end())
+        ? std::static_pointer_cast<T>(iter->second.lock())
+        : std::shared_ptr<T>{};
+}
+
+template<class T>
+void
+cache_proxy(uint64_t token, std::shared_ptr<T> proxy) {
+    const std::lock_guard<std::mutex> lock(_cache_mutex);
+    _proxy_cache[token] = std::weak_ptr<void>(std::static_pointer_cast<void>(proxy));
+}
+
+}
+{{#internalNamespace}}
+}
+{{/internalNamespace}}

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
@@ -1,5 +1,6 @@
 #include "ffi_smoke_ErrorsInterface.h"
 #include "ConversionBase.h"
+#include "ProxyCache.h"
 #include "smoke/ErrorsInterface.h"
 #include "smoke/Payload.h"
 #include <memory>
@@ -209,11 +210,17 @@ library_smoke_ErrorsInterface_release_handle(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_ErrorsInterface_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4) {
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) std::shared_ptr<::smoke::ErrorsInterface>(
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ErrorsInterface_Proxy>(token);
+    std::shared_ptr<smoke_ErrorsInterface_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ErrorsInterface_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ErrorsInterface_Proxy>(
             new (std::nothrow) smoke_ErrorsInterface_Proxy(token, deleter, f0, f1, f2, f3, f4)
-        )
-    );
+        );
+        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }
 FfiOpaqueHandle
 library_smoke_ErrorsInterface_get_raw_pointer(FfiOpaqueHandle handle) {

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/ErrorsInterface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/ErrorsInterface.dart
@@ -384,9 +384,15 @@ int _ErrorsInterface_methodWithPayloadErrorAndReturnValue_static(int _token, Poi
 }
 Pointer<Void> smoke_ErrorsInterface_toFfi(ErrorsInterface value) {
   if (value is ErrorsInterface__Impl) return _smoke_ErrorsInterface_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_ErrorsInterface_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithErrors_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithExternalErrors_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ErrorsInterface_methodWithErrorsAndReturnValue_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithPayloadError_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ErrorsInterface_methodWithPayloadErrorAndReturnValue_static, __lib.unknownError));
+  final result = _smoke_ErrorsInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithErrors_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithExternalErrors_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ErrorsInterface_methodWithErrorsAndReturnValue_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64)>(_ErrorsInterface_methodWithPayloadError_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ErrorsInterface_methodWithPayloadErrorAndReturnValue_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_ErrorsInterface_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Interface.dart
@@ -38,9 +38,10 @@ class Interface__Impl implements Interface {
 }
 Pointer<Void> package_Interface_toFfi(Interface value) {
   if (value is Interface__Impl) return _package_Interface_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _package_Interface_create_proxy(token, __lib.uncacheObjectFfi);
+  final result = _package_Interface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi
+  );
   __lib.reverseCache[_package_Interface_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildInterface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildInterface.dart
@@ -64,9 +64,14 @@ int _ChildInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
 }
 Pointer<Void> smoke_ChildInterface_toFfi(ChildInterface value) {
   if (value is ChildInterface__Impl) return _smoke_ChildInterface_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_ChildInterface_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64)>(_ChildInterface_rootMethod_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64)>(_ChildInterface_childMethod_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ChildInterface_rootProperty_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ChildInterface_rootProperty_set_static, __lib.unknownError));
+  final result = _smoke_ChildInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64)>(_ChildInterface_rootMethod_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64)>(_ChildInterface_childMethod_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ChildInterface_rootProperty_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ChildInterface_rootProperty_set_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_ChildInterface_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentInterface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentInterface.dart
@@ -78,9 +78,13 @@ int _ParentInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
 }
 Pointer<Void> smoke_ParentInterface_toFfi(ParentInterface value) {
   if (value is ParentInterface__Impl) return _smoke_ParentInterface_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_ParentInterface_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64)>(_ParentInterface_rootMethod_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ParentInterface_rootProperty_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ParentInterface_rootProperty_set_static, __lib.unknownError));
+  final result = _smoke_ParentInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64)>(_ParentInterface_rootMethod_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ParentInterface_rootProperty_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ParentInterface_rootProperty_set_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_ParentInterface_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
@@ -1,5 +1,6 @@
 #include "ffi_smoke_SimpleInterface.h"
 #include "ConversionBase.h"
+#include "ProxyCache.h"
 #include "smoke/SimpleInterface.h"
 #include <memory>
 #include <string>
@@ -70,11 +71,17 @@ library_smoke_SimpleInterface_release_handle(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_SimpleInterface_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1) {
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) std::shared_ptr<::smoke::SimpleInterface>(
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_SimpleInterface_Proxy>(token);
+    std::shared_ptr<smoke_SimpleInterface_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_SimpleInterface_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_SimpleInterface_Proxy>(
             new (std::nothrow) smoke_SimpleInterface_Proxy(token, deleter, f0, f1)
-        )
-    );
+        );
+        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }
 FfiOpaqueHandle
 library_smoke_SimpleInterface_get_raw_pointer(FfiOpaqueHandle handle) {

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalInterface.dart
@@ -180,9 +180,12 @@ int _ExternalInterface_someProperty_get_static(int _token, Pointer<Pointer<Void>
 }
 Pointer<Void> smoke_ExternalInterface_toFfi(ExternalInterface value) {
   if (value is ExternalInterface__Impl) return _smoke_ExternalInterface_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_ExternalInterface_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Int8)>(_ExternalInterface_someMethod_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ExternalInterface_someProperty_get_static, __lib.unknownError));
+  final result = _smoke_ExternalInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Int8)>(_ExternalInterface_someMethod_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ExternalInterface_someProperty_get_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_ExternalInterface_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleInterface.dart
@@ -70,9 +70,12 @@ int _SimpleInterface_useSimpleInterface_static(int _token, Pointer<Void> input, 
 }
 Pointer<Void> smoke_SimpleInterface_toFfi(SimpleInterface value) {
   if (value is SimpleInterface__Impl) return _smoke_SimpleInterface_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_SimpleInterface_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_SimpleInterface_getStringValue_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_SimpleInterface_useSimpleInterface_static, __lib.unknownError));
+  final result = _smoke_SimpleInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_SimpleInterface_getStringValue_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_SimpleInterface_useSimpleInterface_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_SimpleInterface_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
@@ -1,5 +1,6 @@
 #include "ffi_smoke_Lambdas.h"
 #include "ConversionBase.h"
+#include "ProxyCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/UnorderedMapHash.h"
 #include "gluecodium/VectorHash.h"
@@ -359,9 +360,14 @@ library_smoke_Lambdas_NullableConfuser_get_value_nullable(FfiOpaqueHandle handle
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_Producer_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Producer_Proxy>(token);
+    if (!cached_proxy) {
+        cached_proxy = std::make_shared<smoke_Lambdas_Producer_Proxy>(token, deleter, f0);
+        gluecodium::ffi::cache_proxy(token, cached_proxy);
+    }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::Producer(
-            std::bind(&smoke_Lambdas_Producer_Proxy::operator(), std::make_shared<smoke_Lambdas_Producer_Proxy>(token, deleter, f0))
+            std::bind(&smoke_Lambdas_Producer_Proxy::operator(), cached_proxy)
         )
     );
 }
@@ -371,9 +377,14 @@ library_smoke_Lambdas_Producer_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_Confuser_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Confuser_Proxy>(token);
+    if (!cached_proxy) {
+        cached_proxy = std::make_shared<smoke_Lambdas_Confuser_Proxy>(token, deleter, f0);
+        gluecodium::ffi::cache_proxy(token, cached_proxy);
+    }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::Confuser(
-            std::bind(&smoke_Lambdas_Confuser_Proxy::operator(), std::make_shared<smoke_Lambdas_Confuser_Proxy>(token, deleter, f0), std::placeholders::_1)
+            std::bind(&smoke_Lambdas_Confuser_Proxy::operator(), cached_proxy, std::placeholders::_1)
         )
     );
 }
@@ -383,9 +394,14 @@ library_smoke_Lambdas_Confuser_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_Consumer_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Consumer_Proxy>(token);
+    if (!cached_proxy) {
+        cached_proxy = std::make_shared<smoke_Lambdas_Consumer_Proxy>(token, deleter, f0);
+        gluecodium::ffi::cache_proxy(token, cached_proxy);
+    }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::Consumer(
-            std::bind(&smoke_Lambdas_Consumer_Proxy::operator(), std::make_shared<smoke_Lambdas_Consumer_Proxy>(token, deleter, f0), std::placeholders::_1)
+            std::bind(&smoke_Lambdas_Consumer_Proxy::operator(), cached_proxy, std::placeholders::_1)
         )
     );
 }
@@ -395,9 +411,14 @@ library_smoke_Lambdas_Consumer_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_Indexer_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Indexer_Proxy>(token);
+    if (!cached_proxy) {
+        cached_proxy = std::make_shared<smoke_Lambdas_Indexer_Proxy>(token, deleter, f0);
+        gluecodium::ffi::cache_proxy(token, cached_proxy);
+    }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::Indexer(
-            std::bind(&smoke_Lambdas_Indexer_Proxy::operator(), std::make_shared<smoke_Lambdas_Indexer_Proxy>(token, deleter, f0), std::placeholders::_1, std::placeholders::_2)
+            std::bind(&smoke_Lambdas_Indexer_Proxy::operator(), cached_proxy, std::placeholders::_1, std::placeholders::_2)
         )
     );
 }
@@ -407,9 +428,14 @@ library_smoke_Lambdas_Indexer_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_NullableConfuser_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_NullableConfuser_Proxy>(token);
+    if (!cached_proxy) {
+        cached_proxy = std::make_shared<smoke_Lambdas_NullableConfuser_Proxy>(token, deleter, f0);
+        gluecodium::ffi::cache_proxy(token, cached_proxy);
+    }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::NullableConfuser(
-            std::bind(&smoke_Lambdas_NullableConfuser_Proxy::operator(), std::make_shared<smoke_Lambdas_NullableConfuser_Proxy>(token, deleter, f0), std::placeholders::_1)
+            std::bind(&smoke_Lambdas_NullableConfuser_Proxy::operator(), cached_proxy, std::placeholders::_1)
         )
     );
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
@@ -1,5 +1,6 @@
 #include "ffi_smoke_StandaloneProducer.h"
 #include "ConversionBase.h"
+#include "ProxyCache.h"
 #include "smoke/StandaloneProducer.h"
 #include <functional>
 #include <string>
@@ -71,9 +72,14 @@ library_smoke_StandaloneProducer_get_value_nullable(FfiOpaqueHandle handle)
 }
 FfiOpaqueHandle
 library_smoke_StandaloneProducer_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_StandaloneProducer_Proxy>(token);
+    if (!cached_proxy) {
+        cached_proxy = std::make_shared<smoke_StandaloneProducer_Proxy>(token, deleter, f0);
+        gluecodium::ffi::cache_proxy(token, cached_proxy);
+    }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::StandaloneProducer(
-            std::bind(&smoke_StandaloneProducer_Proxy::operator(), std::make_shared<smoke_StandaloneProducer_Proxy>(token, deleter, f0))
+            std::bind(&smoke_StandaloneProducer_Proxy::operator(), cached_proxy)
         )
     );
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/Lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/Lambdas.dart
@@ -89,9 +89,11 @@ int _Lambdas_Producer_call_static(int _token, Pointer<Pointer<Void>> _result) {
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Producer_toFfi(Lambdas_Producer value) {
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_Lambdas_Producer_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_Lambdas_Producer_call_static, __lib.unknownError));
+  final result = _smoke_Lambdas_Producer_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_Lambdas_Producer_call_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_Lambdas_Producer_get_raw_pointer(result)] = value;
   return result;
 }
@@ -178,9 +180,11 @@ int _Lambdas_Confuser_call_static(int _token, Pointer<Void> p0, Pointer<Pointer<
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Confuser_toFfi(Lambdas_Confuser value) {
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_Lambdas_Confuser_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_Lambdas_Confuser_call_static, __lib.unknownError));
+  final result = _smoke_Lambdas_Confuser_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_Lambdas_Confuser_call_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_Lambdas_Confuser_get_raw_pointer(result)] = value;
   return result;
 }
@@ -265,9 +269,11 @@ int _Lambdas_Consumer_call_static(int _token, Pointer<Void> p0) {
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Consumer_toFfi(Lambdas_Consumer value) {
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_Lambdas_Consumer_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_Lambdas_Consumer_call_static, __lib.unknownError));
+  final result = _smoke_Lambdas_Consumer_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_Lambdas_Consumer_call_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_Lambdas_Consumer_get_raw_pointer(result)] = value;
   return result;
 }
@@ -356,9 +362,11 @@ int _Lambdas_Indexer_call_static(int _token, Pointer<Void> p0, double p1, Pointe
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Indexer_toFfi(Lambdas_Indexer value) {
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_Lambdas_Indexer_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Float, Pointer<Int32>)>(_Lambdas_Indexer_call_static, __lib.unknownError));
+  final result = _smoke_Lambdas_Indexer_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Float, Pointer<Int32>)>(_Lambdas_Indexer_call_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_Lambdas_Indexer_get_raw_pointer(result)] = value;
   return result;
 }
@@ -444,9 +452,11 @@ int _Lambdas_NullableConfuser_call_static(int _token, Pointer<Void> p0, Pointer<
   return 0;
 }
 Pointer<Void> smoke_Lambdas_NullableConfuser_toFfi(Lambdas_NullableConfuser value) {
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_Lambdas_NullableConfuser_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_Lambdas_NullableConfuser_call_static, __lib.unknownError));
+  final result = _smoke_Lambdas_NullableConfuser_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_Lambdas_NullableConfuser_call_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_Lambdas_NullableConfuser_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/LambdasWithStructuredTypes.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/LambdasWithStructuredTypes.dart
@@ -88,9 +88,11 @@ int _LambdasWithStructuredTypes_ClassCallback_call_static(int _token, Pointer<Vo
   return 0;
 }
 Pointer<Void> smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(LambdasWithStructuredTypes_ClassCallback value) {
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_LambdasWithStructuredTypes_ClassCallback_call_static, __lib.unknownError));
+  final result = _smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_LambdasWithStructuredTypes_ClassCallback_call_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer(result)] = value;
   return result;
 }
@@ -175,9 +177,11 @@ int _LambdasWithStructuredTypes_StructCallback_call_static(int _token, Pointer<V
   return 0;
 }
 Pointer<Void> smoke_LambdasWithStructuredTypes_StructCallback_toFfi(LambdasWithStructuredTypes_StructCallback value) {
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_LambdasWithStructuredTypes_StructCallback_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_LambdasWithStructuredTypes_StructCallback_call_static, __lib.unknownError));
+  final result = _smoke_LambdasWithStructuredTypes_StructCallback_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_LambdasWithStructuredTypes_StructCallback_call_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/StandaloneProducer.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/StandaloneProducer.dart
@@ -41,9 +41,11 @@ int _StandaloneProducer_call_static(int _token, Pointer<Pointer<Void>> _result) 
   return 0;
 }
 Pointer<Void> smoke_StandaloneProducer_toFfi(StandaloneProducer value) {
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_StandaloneProducer_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_StandaloneProducer_call_static, __lib.unknownError));
+  final result = _smoke_StandaloneProducer_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_StandaloneProducer_call_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_StandaloneProducer_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
@@ -1,5 +1,6 @@
 #include "ffi_smoke_CalculatorListener.h"
 #include "ConversionBase.h"
+#include "ProxyCache.h"
 #include "gluecodium/VectorHash.h"
 #include "smoke/CalculationResult.h"
 #include "smoke/CalculatorListener.h"
@@ -113,11 +114,17 @@ library_smoke_CalculatorListener_release_handle(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_CalculatorListener_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4, FfiOpaqueHandle f5) {
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) std::shared_ptr<::smoke::CalculatorListener>(
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_CalculatorListener_Proxy>(token);
+    std::shared_ptr<smoke_CalculatorListener_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_CalculatorListener_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_CalculatorListener_Proxy>(
             new (std::nothrow) smoke_CalculatorListener_Proxy(token, deleter, f0, f1, f2, f3, f4, f5)
-        )
-    );
+        );
+        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }
 FfiOpaqueHandle
 library_smoke_CalculatorListener_get_raw_pointer(FfiOpaqueHandle handle) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
@@ -1,5 +1,6 @@
 #include "ffi_smoke_ListenerWithProperties.h"
 #include "ConversionBase.h"
+#include "ProxyCache.h"
 #include "smoke/ListenerWithProperties.h"
 #include <memory>
 #include <memory>
@@ -228,11 +229,17 @@ library_smoke_ListenerWithProperties_release_handle(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_ListenerWithProperties_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s, FfiOpaqueHandle p1g, FfiOpaqueHandle p1s, FfiOpaqueHandle p2g, FfiOpaqueHandle p2s, FfiOpaqueHandle p3g, FfiOpaqueHandle p3s, FfiOpaqueHandle p4g, FfiOpaqueHandle p4s, FfiOpaqueHandle p5g, FfiOpaqueHandle p5s, FfiOpaqueHandle p6g, FfiOpaqueHandle p6s) {
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) std::shared_ptr<::smoke::ListenerWithProperties>(
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ListenerWithProperties_Proxy>(token);
+    std::shared_ptr<smoke_ListenerWithProperties_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ListenerWithProperties_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ListenerWithProperties_Proxy>(
             new (std::nothrow) smoke_ListenerWithProperties_Proxy(token, deleter, p0g, p0s, p1g, p1s, p2g, p2s, p3g, p3s, p4g, p4s, p5g, p5s, p6g, p6s)
-        )
-    );
+        );
+        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }
 FfiOpaqueHandle
 library_smoke_ListenerWithProperties_get_raw_pointer(FfiOpaqueHandle handle) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
@@ -1,5 +1,6 @@
 #include "ffi_smoke_ListenersWithReturnValues.h"
 #include "ConversionBase.h"
+#include "ProxyCache.h"
 #include "gluecodium/VectorHash.h"
 #include "smoke/CalculationResult.h"
 #include "smoke/ListenersWithReturnValues.h"
@@ -155,11 +156,17 @@ library_smoke_ListenersWithReturnValues_release_handle(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_ListenersWithReturnValues_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4, FfiOpaqueHandle f5, FfiOpaqueHandle f6) {
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) std::shared_ptr<::smoke::ListenersWithReturnValues>(
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ListenersWithReturnValues_Proxy>(token);
+    std::shared_ptr<smoke_ListenersWithReturnValues_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ListenersWithReturnValues_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ListenersWithReturnValues_Proxy>(
             new (std::nothrow) smoke_ListenersWithReturnValues_Proxy(token, deleter, f0, f1, f2, f3, f4, f5, f6)
-        )
-    );
+        );
+        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }
 FfiOpaqueHandle
 library_smoke_ListenersWithReturnValues_get_raw_pointer(FfiOpaqueHandle handle) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/_token_cache.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/_token_cache.dart
@@ -3,9 +3,19 @@ import 'package:ffi/ffi.dart';
 const unknownError = -1;
 int _instanceCounter = 1024;
 final Map<int, Object> instanceCache = {};
+final Map<Object, int> tokenCache = {};
 final Map<Pointer<Void>, Object> reverseCache = {};
-int getNewToken() => _instanceCounter++;
+int cacheObject(Object obj) {
+  int token = tokenCache[obj];
+  if (token == null) {
+    token = _instanceCounter++;
+    instanceCache[token] = obj;
+    tokenCache[obj] = token;
+  }
+  return token;
+}
 void uncacheObject(int token, Pointer<Void> rawPointer) {
+  tokenCache.remove(instanceCache[token]);
   instanceCache.remove(token);
   reverseCache.remove(rawPointer);
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/CalculatorListener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/CalculatorListener.dart
@@ -198,9 +198,16 @@ int _CalculatorListener_onCalculationResultInstance_static(int _token, Pointer<V
 }
 Pointer<Void> smoke_CalculatorListener_toFfi(CalculatorListener value) {
   if (value is CalculatorListener__Impl) return _smoke_CalculatorListener_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_CalculatorListener_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Double)>(_CalculatorListener_onCalculationResult_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Double)>(_CalculatorListener_onCalculationResultConst_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultStruct_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultArray_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultMap_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultInstance_static, __lib.unknownError));
+  final result = _smoke_CalculatorListener_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Double)>(_CalculatorListener_onCalculationResult_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Double)>(_CalculatorListener_onCalculationResultConst_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultStruct_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultArray_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultMap_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_CalculatorListener_onCalculationResultInstance_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_CalculatorListener_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenerWithProperties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenerWithProperties.dart
@@ -351,9 +351,24 @@ int _ListenerWithProperties_bufferedMessage_set_static(int _token, Pointer<Void>
 }
 Pointer<Void> smoke_ListenerWithProperties_toFfi(ListenerWithProperties value) {
   if (value is ListenerWithProperties__Impl) return _smoke_ListenerWithProperties_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_ListenerWithProperties_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_message_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_message_set_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_packedMessage_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_packedMessage_set_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_structuredMessage_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_structuredMessage_set_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint32>)>(_ListenerWithProperties_enumeratedMessage_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Uint32)>(_ListenerWithProperties_enumeratedMessage_set_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_arrayedMessage_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_arrayedMessage_set_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_mappedMessage_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_mappedMessage_set_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_bufferedMessage_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_bufferedMessage_set_static, __lib.unknownError));
+  final result = _smoke_ListenerWithProperties_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_message_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_message_set_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_packedMessage_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_packedMessage_set_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_structuredMessage_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_structuredMessage_set_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint32>)>(_ListenerWithProperties_enumeratedMessage_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Uint32)>(_ListenerWithProperties_enumeratedMessage_set_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_arrayedMessage_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_arrayedMessage_set_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_mappedMessage_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_mappedMessage_set_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithProperties_bufferedMessage_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_ListenerWithProperties_bufferedMessage_set_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_ListenerWithProperties_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenersWithReturnValues.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenersWithReturnValues.dart
@@ -260,9 +260,17 @@ int _ListenersWithReturnValues_fetchDataInstance_static(int _token, Pointer<Poin
 }
 Pointer<Void> smoke_ListenersWithReturnValues_toFfi(ListenersWithReturnValues value) {
   if (value is ListenersWithReturnValues__Impl) return _smoke_ListenersWithReturnValues_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_ListenersWithReturnValues_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Double>)>(_ListenersWithReturnValues_fetchDataDouble_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataString_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataStruct_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint32>)>(_ListenersWithReturnValues_fetchDataEnum_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataArray_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataMap_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataInstance_static, __lib.unknownError));
+  final result = _smoke_ListenersWithReturnValues_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Double>)>(_ListenersWithReturnValues_fetchDataDouble_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataString_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataStruct_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Uint32>)>(_ListenersWithReturnValues_fetchDataEnum_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataArray_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataMap_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValues_fetchDataInstance_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_ListenersWithReturnValues_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
@@ -1,5 +1,6 @@
 #include "ffi_smoke_OuterClass.h"
 #include "ConversionBase.h"
+#include "ProxyCache.h"
 #include "smoke/OuterClass.h"
 #include <memory>
 #include <string>
@@ -77,11 +78,17 @@ library_smoke_OuterClass_InnerInterface_release_handle(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_OuterClass_InnerInterface_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) std::shared_ptr<::smoke::OuterClass::InnerInterface>(
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterClass_InnerInterface_Proxy>(token);
+    std::shared_ptr<smoke_OuterClass_InnerInterface_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterClass_InnerInterface_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterClass_InnerInterface_Proxy>(
             new (std::nothrow) smoke_OuterClass_InnerInterface_Proxy(token, deleter, f0)
-        )
-    );
+        );
+        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }
 FfiOpaqueHandle
 library_smoke_OuterClass_InnerInterface_get_raw_pointer(FfiOpaqueHandle handle) {

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
@@ -1,5 +1,6 @@
 #include "ffi_smoke_OuterInterface.h"
 #include "ConversionBase.h"
+#include "ProxyCache.h"
 #include "smoke/OuterInterface.h"
 #include <memory>
 #include <string>
@@ -100,11 +101,17 @@ library_smoke_OuterInterface_InnerInterface_release_handle(FfiOpaqueHandle handl
 }
 FfiOpaqueHandle
 library_smoke_OuterInterface_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) std::shared_ptr<::smoke::OuterInterface>(
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterInterface_Proxy>(token);
+    std::shared_ptr<smoke_OuterInterface_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterInterface_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterInterface_Proxy>(
             new (std::nothrow) smoke_OuterInterface_Proxy(token, deleter, f0)
-        )
-    );
+        );
+        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }
 FfiOpaqueHandle
 library_smoke_OuterInterface_get_raw_pointer(FfiOpaqueHandle handle) {
@@ -114,11 +121,17 @@ library_smoke_OuterInterface_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_OuterInterface_InnerInterface_create_proxy(uint64_t token, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) std::shared_ptr<::smoke::OuterInterface::InnerInterface>(
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterInterface_InnerInterface_Proxy>(token);
+    std::shared_ptr<smoke_OuterInterface_InnerInterface_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterInterface_InnerInterface_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterInterface_InnerInterface_Proxy>(
             new (std::nothrow) smoke_OuterInterface_InnerInterface_Proxy(token, deleter, f0)
-        )
-    );
+        );
+        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }
 FfiOpaqueHandle
 library_smoke_OuterInterface_InnerInterface_get_raw_pointer(FfiOpaqueHandle handle) {

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterClass.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterClass.dart
@@ -123,9 +123,11 @@ int _OuterClass_InnerInterface_foo_static(int _token, Pointer<Void> input, Point
 }
 Pointer<Void> smoke_OuterClass_InnerInterface_toFfi(OuterClass_InnerInterface value) {
   if (value is OuterClass_InnerInterface__Impl) return _smoke_OuterClass_InnerInterface_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_OuterClass_InnerInterface_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterClass_InnerInterface_foo_static, __lib.unknownError));
+  final result = _smoke_OuterClass_InnerInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterClass_InnerInterface_foo_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_OuterClass_InnerInterface_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterInterface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterInterface.dart
@@ -93,9 +93,11 @@ int _OuterInterface_InnerInterface_foo_static(int _token, Pointer<Void> input, P
 }
 Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi(OuterInterface_InnerInterface value) {
   if (value is OuterInterface_InnerInterface__Impl) return _smoke_OuterInterface_InnerInterface_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_OuterInterface_InnerInterface_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterInterface_InnerInterface_foo_static, __lib.unknownError));
+  final result = _smoke_OuterInterface_InnerInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterInterface_InnerInterface_foo_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_OuterInterface_InnerInterface_get_raw_pointer(result)] = value;
   return result;
 }
@@ -166,9 +168,11 @@ int _OuterInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<
 }
 Pointer<Void> smoke_OuterInterface_toFfi(OuterInterface value) {
   if (value is OuterInterface__Impl) return _smoke_OuterInterface_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_OuterInterface_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterInterface_foo_static, __lib.unknownError));
+  final result = _smoke_OuterInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterInterface_foo_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_OuterInterface_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeListener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeListener.dart
@@ -54,9 +54,11 @@ int _weeListener_WeeMethod_static(int _token, Pointer<Void> WeeParameter) {
 }
 Pointer<Void> smoke_PlatformNamesListener_toFfi(weeListener value) {
   if (value is weeListener__Impl) return _smoke_PlatformNamesListener_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_PlatformNamesListener_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_weeListener_WeeMethod_static, __lib.unknownError));
+  final result = _smoke_PlatformNamesListener_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_weeListener_WeeMethod_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_PlatformNamesListener_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/PropertiesInterface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/PropertiesInterface.dart
@@ -127,9 +127,12 @@ int _PropertiesInterface_structProperty_set_static(int _token, Pointer<Void> _va
 }
 Pointer<Void> smoke_PropertiesInterface_toFfi(PropertiesInterface value) {
   if (value is PropertiesInterface__Impl) return _smoke_PropertiesInterface_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_PropertiesInterface_create_proxy(token, __lib.uncacheObjectFfi, Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_PropertiesInterface_structProperty_get_static, __lib.unknownError), Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_PropertiesInterface_structProperty_set_static, __lib.unknownError));
+  final result = _smoke_PropertiesInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_PropertiesInterface_structProperty_get_static, __lib.unknownError),
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_PropertiesInterface_structProperty_set_static, __lib.unknownError)
+  );
   __lib.reverseCache[_smoke_PropertiesInterface_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalInterface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalInterface.dart
@@ -38,9 +38,10 @@ class InternalInterface__Impl implements InternalInterface {
 }
 Pointer<Void> smoke_InternalInterface_toFfi(InternalInterface value) {
   if (value is InternalInterface__Impl) return _smoke_InternalInterface_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_InternalInterface_create_proxy(token, __lib.uncacheObjectFfi);
+  final result = _smoke_InternalInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi
+  );
   __lib.reverseCache[_smoke_InternalInterface_get_raw_pointer(result)] = value;
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicInterface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicInterface.dart
@@ -101,9 +101,10 @@ class PublicInterface__Impl implements PublicInterface {
 }
 Pointer<Void> smoke_PublicInterface_toFfi(PublicInterface value) {
   if (value is PublicInterface__Impl) return _smoke_PublicInterface_copy_handle(value.handle);
-  final token = __lib.getNewToken();
-  __lib.instanceCache[token] = value;
-  final result = _smoke_PublicInterface_create_proxy(token, __lib.uncacheObjectFfi);
+  final result = _smoke_PublicInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi
+  );
   __lib.reverseCache[_smoke_PublicInterface_get_raw_pointer(result)] = value;
   return result;
 }


### PR DESCRIPTION
In the current Dart FFI implementation, when the same Dart object is
passed down to C++ twice, it is represented by two different unrelated
C++ proxy objects. This makes the use case of "add listener, then remove
listener" impossible, since the "remove" call will never find the object
passed by the "add" call.

To fix this, an FFI-level proxy cache was added. The cache does not
extent the lifetime of cached proxies, but only retains them through
std::weak_ptr<> instead.

Added a functional test, updates smoke tests, as appropriate.

Resolves: #165
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>