### PR TITLE
Improve generated documentation for @FunctionalInterface in Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Features:
   * Updated C++ struct constructors to use move semantics to avoid unnecessary copying.
+  * Added support for structured documentation comments on lambda type declaration in IDL.
 ### Bug fixes:
   * Fixed C++ compilation issue for when "-intnamespace" command line parameter is not specified.
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeModelBuilder.kt
@@ -157,8 +157,7 @@ class CBridgeModelBuilder(
             typeMapper.mapType(limeErrorTypeRef, cppErrorType)
         } else null
 
-        val errorTypeIsEnum =
-            limeErrorTypeRef?.type?.let { it.actualType } is LimeEnumeration
+        val errorTypeIsEnum = limeErrorTypeRef?.type?.actualType is LimeEnumeration
         val result = CFunction(
             shortName = swiftMethod.cShortName,
             nestedSpecifier = swiftMethod.cNestedSpecifier,
@@ -304,7 +303,7 @@ class CBridgeModelBuilder(
         val cFunction = CFunction(
             shortName = "call",
             nestedSpecifier = CBridgeNameRules.getNestedSpecifierString(limeLambda),
-            returnType = typeMapper.mapType(limeLambda.returnType, cppFunction.returnType),
+            returnType = typeMapper.mapType(limeLambda.returnType.typeRef, cppFunction.returnType),
             parameters = parameters,
             selfParameter = CParameter("_instance", selfType),
             delegateCallIncludes = cppIncludeResolver.resolveIncludes(limeLambda).toSet(),

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppTypeMapper.kt
@@ -92,13 +92,12 @@ class CppTypeMapper(
     fun mapLambda(limeLambda: LimeLambda): CppTypeRef =
         CppFunctionTypeRef(
             limeLambda.parameters.map { mapType(it.typeRef) },
-            mapType(limeLambda.returnType)
+            mapType(limeLambda.returnType.typeRef)
         )
 
     fun mapReturnType(returnType: LimeReturnType, exceptionType: LimeException?): CppTypeRef {
         val cppReturnType = mapType(returnType.typeRef)
-        val errorTypeIsEnum =
-            exceptionType?.errorType?.type?.let { it.actualType } is LimeEnumeration
+        val errorTypeIsEnum = exceptionType?.errorType?.type?.actualType is LimeEnumeration
         return when {
             exceptionType == null -> cppReturnType
             errorTypeIsEnum && cppReturnType == CppPrimitiveTypeRef.VOID -> STD_ERROR_CODE_TYPE

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeResolver.kt
@@ -74,7 +74,7 @@ internal class FfiCppIncludeResolver(
                 cppIncludeResolver.createInternalNamespaceInclude("UnorderedMapHash.h")
             )
             is LimeLambda -> cppIncludeResolver.resolveIncludes(limeType) +
-                getTypeRefIncludes(limeType.returnType) +
+                getTypeRefIncludes(limeType.returnType.typeRef) +
                 limeType.parameters.flatMap { getTypeRefIncludes(it.typeRef) } +
                 CppLibraryIncludes.FUNCTIONAL
             is LimeContainerWithInheritance -> cppIncludeResolver.resolveIncludes(limeType) +

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniModelBuilder.kt
@@ -166,8 +166,7 @@ class JniModelBuilder(
         val limeErrorTypeRef = limeMethod.exception?.errorType
         val jniException = if (limeErrorTypeRef != null) {
             val javaExceptionType = javaMethod.exception!!
-            val limeErrorTypeIsEnum =
-                limeErrorTypeRef.type.let { it.actualType } is LimeEnumeration
+            val limeErrorTypeIsEnum = limeErrorTypeRef.type.actualType is LimeEnumeration
             val conversionIncludes = JniIncludeResolver.getConversionIncludes(
                 limeErrorTypeRef,
                 javaExceptionType.errorType
@@ -335,7 +334,7 @@ class JniModelBuilder(
 
         val javaMethod = javaInterface.methods.first()
         val cppFunctionRef = cppUsing.definition as CppFunctionTypeRef
-        val limeReturnType = limeLambda.returnType
+        val limeReturnType = limeLambda.returnType.typeRef
         jniContainer.methods += JniMethod(
             javaMethodName = getMangledName(javaMethod.name),
             cppMethodName = "operator()",

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/lime/LimeGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/lime/LimeGeneratorSuite.kt
@@ -90,7 +90,7 @@ class LimeGeneratorSuite : GeneratorSuite() {
             is LimeReturnType -> collectImports(context, limeElement.typeRef)
             is LimeException -> collectImports(context, limeElement.errorType)
             is LimeLambda -> (
-                    limeElement.parameters + limeElement.returnType
+                    limeElement.parameters + limeElement.returnType.typeRef
                 ).flatMap { collectImports(limeElement.path, it) }
             is LimeTypeRef -> {
                 val limeType = limeElement.type

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
@@ -449,7 +449,7 @@ class SwiftModelBuilder(
             comment = createComments(limeLambda),
             functionTableName = CBridgeNameRules.getFunctionTableName(limeLambda),
             parameters = limeLambda.parameters.map { typeMapper.mapType(it.typeRef) },
-            returnType = typeMapper.mapType(limeLambda.returnType)
+            returnType = typeMapper.mapType(limeLambda.returnType.typeRef)
         )
 
         storeNamedResult(limeLambda, swiftElement)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftTypeMapper.kt
@@ -90,7 +90,7 @@ class SwiftTypeMapper(
                 SwiftClosure(
                     name = nameResolver.getFullName(limeType),
                     parameters = limeType.parameters.map { mapType(it.typeRef.type) },
-                    returnType = mapType(limeType.returnType.type)
+                    returnType = mapType(limeType.returnType.typeRef.type)
                 )
             else -> throw GluecodiumExecutionException("Unmapped type: " + limeType.name)
         }

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>dart/DartDocumentation}}
-typedef {{resolveName}} = {{resolveName returnType}} Function({{!!
+typedef {{resolveName}} = {{resolveName returnType.typeRef}} Function({{!!
 }}{{#parameters}}{{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
 
 // {{resolveName}} "private" section, not exported.

--- a/gluecodium/src/main/resources/templates/lime/LimeLambda.mustache
+++ b/gluecodium/src/main/resources/templates/lime/LimeLambda.mustache
@@ -21,4 +21,4 @@
 {{>lime/LimeDocumentation}}
 {{visibility}}lambda {{escapedName}} = ({{!!
 }}{{#parameters}}{{#if attributes.toString}}{{attributes}} {{/if}}{{typeRef.escapedName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
-}}) -> {{returnType.escapedName}}
+}}) -> {{returnType.typeRef.escapedName}}

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/swift/SwiftTypeMapperTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/swift/SwiftTypeMapperTest.kt
@@ -27,6 +27,7 @@ import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimePath
+import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypesCollection
@@ -142,7 +143,7 @@ class SwiftTypeMapperTest {
     fun mapListInLambdaDoesNotCollectGenerics() {
         val limeElement = LimeLambda(
             path = LimePath.EMPTY_PATH,
-            returnType = LimeDirectTypeRef(LimeList(LimeBasicTypeRef.FLOAT))
+            returnType = LimeReturnType(LimeDirectTypeRef(LimeList(LimeBasicTypeRef.FLOAT)))
         )
 
         typeMapper.mapType(LimeDirectTypeRef(limeElement))

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -81,6 +81,13 @@ class comments {
 
     // This is some very useful exception.
     exception SomethingWrong(SomeEnum)
+
+    // This is some very useful lambda that does it.
+    // @param[p0] Very useful input parameter
+    // @param[p1] Slightly less useful input parameter
+    // @return Usefulness of the input
+    @Java(FunctionName = "doIt")
+    lambda SomeLambda = (String, @Java("index") Int) -> Double
 }
 
 // This is some very useful interface.

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
@@ -40,6 +40,24 @@ public final class Comments extends NativeBase {
         }
         public final Comments.SomeEnum error;
     }
+    static class SomeLambdaImpl extends NativeBase implements SomeLambda {
+        protected SomeLambdaImpl(final long nativeHandle) {
+            super(nativeHandle, new Disposer() {
+                @Override
+                public void disposeNative(long handle) {
+                    disposeNativeHandle(handle);
+                }
+            });
+        }
+        private static native void disposeNativeHandle(long nativeHandle);
+        /**
+         * This is some very useful lambda that does it.
+         * @param p0 Very useful input parameter
+         * @param index Slightly less useful input parameter
+         * @return Usefulness of the input
+         */
+        public native double doIt(@NonNull final String p0, final int index);
+    }
     /**
      * <p>This is some very useful struct.</p>
      */
@@ -64,6 +82,19 @@ public final class Comments extends NativeBase {
             this.someField = someField;
             this.nullableField = nullableField;
         }
+    }
+    /**
+     * This is some very useful lambda that does it.
+     */
+    @FunctionalInterface
+    public interface SomeLambda {
+        /**
+         * This is some very useful lambda that does it.
+         * @param p0 Very useful input parameter
+         * @param index Slightly less useful input parameter
+         * @return Usefulness of the input
+         */
+        double doIt(@NonNull final String p0, final int index);
     }
     /**
      * For internal use only.

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
@@ -7,6 +7,7 @@
 #include "gluecodium/Optional.h"
 #include "gluecodium/Return.h"
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <system_error>
 namespace smoke {
@@ -31,6 +32,10 @@ public:
          */
         USEFUL
     };
+    /**
+     * This is some very useful lambda that does it.
+     */
+    using SomeLambda = ::std::function<double(const ::std::string&, const int32_t)>;
     /**
      * This is some very useful typedef.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/Comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/Comments.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
@@ -337,3 +338,97 @@ Comments_SomeStruct smoke_Comments_SomeStruct_fromFfi_nullable(Pointer<Void> han
 void smoke_Comments_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Comments_SomeStruct_release_handle_nullable(handle);
 // End of Comments_SomeStruct "private" section.
+/// This is some very useful lambda that does it.
+typedef Comments_SomeLambda = double Function(String, int);
+// Comments_SomeLambda "private" section, not exported.
+final _smoke_Comments_SomeLambda_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeLambda_copy_handle');
+final _smoke_Comments_SomeLambda_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeLambda_release_handle');
+final _smoke_Comments_SomeLambda_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Pointer, Pointer),
+    Pointer<Void> Function(int, Pointer, Pointer)
+  >('library_smoke_Comments_SomeLambda_create_proxy');
+final _smoke_Comments_SomeLambda_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_Comments_SomeLambda_get_raw_pointer');
+class Comments_SomeLambda__Impl {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  Comments_SomeLambda__Impl(this.handle);
+  void release() => _smoke_Comments_SomeLambda_release_handle(handle);
+  double call(String p0, int p1) {
+    final _call_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Pointer<Void>, Int32), double Function(Pointer<Void>, Pointer<Void>, int)>('library_smoke_Comments_SomeLambda_call__String_Int');
+    final _p0_handle = String_toFfi(p0);
+    final _p1_handle = (p1);
+    final __result_handle = _call_ffi(_handle, _p0_handle, _p1_handle);
+    String_releaseFfiHandle(_p0_handle);
+    (_p1_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+int _Comments_SomeLambda_call_static(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
+  final _result_object = (__lib.instanceCache[_token] as Comments_SomeLambda)(String_fromFfi(p0), (p1));
+  _result.value = (_result_object);
+  String_releaseFfiHandle(p0);
+  (p1);
+  return 0;
+}
+Pointer<Void> smoke_Comments_SomeLambda_toFfi(Comments_SomeLambda value) {
+  final result = _smoke_Comments_SomeLambda_create_proxy(
+    __lib.cacheObject(value),
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Int32, Pointer<Double>)>(_Comments_SomeLambda_call_static, __lib.unknownError)
+  );
+  __lib.reverseCache[_smoke_Comments_SomeLambda_get_raw_pointer(result)] = value;
+  return result;
+}
+Comments_SomeLambda smoke_Comments_SomeLambda_fromFfi(Pointer<Void> handle) {
+  final instance = __lib.reverseCache[_smoke_Comments_SomeLambda_get_raw_pointer(handle)] as Comments_SomeLambda;
+  if (instance != null) return instance;
+  final _impl = Comments_SomeLambda__Impl(_smoke_Comments_SomeLambda_copy_handle(handle));
+  return (String p0, int p1) {
+    final _result =_impl.call(p0, p1);
+    _impl.release();
+    return _result;
+  };
+}
+void smoke_Comments_SomeLambda_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Comments_SomeLambda_release_handle(handle);
+// Nullable Comments_SomeLambda
+final _smoke_Comments_SomeLambda_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeLambda_create_handle_nullable');
+final _smoke_Comments_SomeLambda_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeLambda_release_handle_nullable');
+final _smoke_Comments_SomeLambda_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Comments_SomeLambda_get_value_nullable');
+Pointer<Void> smoke_Comments_SomeLambda_toFfi_nullable(Comments_SomeLambda value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_Comments_SomeLambda_toFfi(value);
+  final result = _smoke_Comments_SomeLambda_create_handle_nullable(_handle);
+  smoke_Comments_SomeLambda_releaseFfiHandle(_handle);
+  return result;
+}
+Comments_SomeLambda smoke_Comments_SomeLambda_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_Comments_SomeLambda_get_value_nullable(handle);
+  final result = smoke_Comments_SomeLambda_fromFfi(_handle);
+  smoke_Comments_SomeLambda_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_Comments_SomeLambda_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Comments_SomeLambda_release_handle_nullable(handle);
+// End of Comments_SomeLambda "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/comments.lime
@@ -3,6 +3,9 @@ package smoke
 class comments {
     // This is some very useful typedef.
     typealias Usefulness = Boolean
+    // This is some very useful lambda that does it.
+    @Java(FunctionName = "doIt")
+    lambda SomeLambda = (String, @Java("index") Int) -> Double
     // This is some very useful enum.
     enum SomeEnum {
         // Not quite useful
@@ -20,6 +23,9 @@ class comments {
         someField: Usefulness
         // Can be `null`
         nullableField: String?
+        // This is some very useful lambda that does it.
+        @Java(FunctionName = "doIt")
+        lambda SomeLambda = (String, @Java("index") Int) -> Double
     }
     // This is some very useful constant.
     const VeryUseful: Usefulness = true

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -7,6 +7,8 @@ public class Comments {
     public typealias Usefulness = Bool
     /// This is some very useful exception.
     public typealias SomethingWrongError = Comments.SomeEnum
+    /// This is some very useful lambda that does it.
+    public typealias SomeLambda = (String, Int32) -> Double
     /// This is some very useful constant.
     public static let veryUseful: Comments.Usefulness = true
     /// Some very useful property.
@@ -179,6 +181,69 @@ internal func copyToCType(_ swiftClass: Comments?) -> RefHolder {
 }
 internal func moveToCType(_ swiftClass: Comments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
+}
+internal func copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
+    return moveFromCType(smoke_Comments_SomeLambda_copy_handle(handle))
+}
+internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
+    let refHolder = RefHolder(ref: handle, release: smoke_Comments_SomeLambda_release_handle)
+    return { (p0: String, p1: Int32) -> Double in
+        return moveFromCType(smoke_Comments_SomeLambda_call(refHolder.ref, moveToCType(p0).ref, moveToCType(p1).ref))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda? {
+    guard handle != 0 else {
+        return nil
+    }
+    return copyFromCType(handle) as Comments.SomeLambda
+}
+internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeLambda? {
+    guard handle != 0 else {
+        return nil
+    }
+    return moveFromCType(handle) as Comments.SomeLambda
+}
+internal func createFunctionalTable(_ swiftType: @escaping Comments.SomeLambda) -> smoke_Comments_SomeLambda_FunctionTable {
+    class smoke_Comments_SomeLambda_Holder {
+        let closure: Comments.SomeLambda
+        init(_ closure: @escaping Comments.SomeLambda) {
+            self.closure = closure
+        }
+    }
+    var functions = smoke_Comments_SomeLambda_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(smoke_Comments_SomeLambda_Holder(swiftType)).toOpaque()
+    functions.release = { swift_closure_pointer in
+        if let swift_closure = swift_closure_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_closure).release()
+        }
+    }
+    functions.smoke_Comments_SomeLambda_call = { swift_closure_pointer, p0, p1 in
+        let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_Comments_SomeLambda_Holder
+        return copyToCType(closure_holder.closure(moveFromCType(p0), moveFromCType(p1))).ref
+    }
+    return functions
+}
+internal func copyToCType(_ swiftType: @escaping Comments.SomeLambda) -> RefHolder {
+    let handle = smoke_Comments_SomeLambda_create_proxy(createFunctionalTable(swiftType))
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftType: @escaping Comments.SomeLambda) -> RefHolder {
+    let handle = smoke_Comments_SomeLambda_create_proxy(createFunctionalTable(swiftType))
+    return RefHolder(ref: handle, release: smoke_Comments_SomeLambda_release_handle)
+}
+internal func copyToCType(_ swiftType: Comments.SomeLambda?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let handle = smoke_Comments_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftType: Comments.SomeLambda?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let handle = smoke_Comments_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    return RefHolder(ref: handle, release: smoke_Comments_SomeLambda_release_handle)
 }
 internal func copyFromCType(_ handle: _baseRef) -> Comments.SomeStruct {
     return Comments.SomeStruct(cHandle: handle)

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/com/example/smoke/Lambdas.java
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/com/example/smoke/Lambdas.java
@@ -31,6 +31,11 @@ public final class Lambdas extends NativeBase {
             });
         }
         private static native void disposeNativeHandle(long nativeHandle);
+        /**
+         * Should confuse everyone thoroughly
+         * @param p0
+         * @return
+         */
         @NonNull
         public native Lambdas.Producer confuse(@NonNull final String p0);
     }
@@ -81,6 +86,11 @@ public final class Lambdas extends NativeBase {
      */
     @FunctionalInterface
     public interface Confounder {
+        /**
+         * Should confuse everyone thoroughly
+         * @param p0
+         * @return
+         */
         @NonNull
         Lambdas.Producer confuse(@NonNull final String p0);
     }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeLambda.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeLambda.kt
@@ -25,7 +25,7 @@ class LimeLambda(
     comment: LimeComment = LimeComment(),
     attributes: LimeAttributes? = null,
     val parameters: List<LimeLambdaParameter> = emptyList(),
-    val returnType: LimeTypeRef = LimeBasicTypeRef(LimeBasicType.TypeId.VOID)
+    val returnType: LimeReturnType = LimeReturnType.VOID
 ) : LimeType(path, visibility, comment, attributes) {
 
     fun asFunction() = LimeFunction(
@@ -33,7 +33,7 @@ class LimeLambda(
         visibility = visibility,
         comment = comment,
         attributes = attributes,
-        returnType = LimeReturnType(returnType),
+        returnType = returnType,
         parameters = parameters.mapIndexed { idx, it -> it.asParameter(path.child("p$idx")) }
     )
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeLambdaParameter.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeLambdaParameter.kt
@@ -21,8 +21,9 @@ package com.here.gluecodium.model.lime
 
 class LimeLambdaParameter(
     val typeRef: LimeTypeRef,
+    val comment: LimeComment = LimeComment(),
     val attributes: LimeAttributes? = null
 ) : LimeElement {
     fun asParameter(path: LimePath) =
-        LimeParameter(path = path, attributes = attributes, typeRef = typeRef)
+        LimeParameter(path = path, comment = comment, attributes = attributes, typeRef = typeRef)
 }


### PR DESCRIPTION
Updated LimeLambda and LimeLambdaParameter classes to allow for
representing dedicated comments on lambda's parameters and return type.

Updated JavaModelBuilder to propagate these dedicated comments into a
structured JavaDoc comment on the method of the lambdas's
@FunctionalInterface.

Updated "Comments" smoke test to include a use case for structured
comments on a lambda.

Resolves: #37
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>