### PR TITLE
Fix conversion functions for Swift collection types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed Swift compilation issue for "-swiftinternalprefix" modularization helper.
+
 ## 6.3.1.
 Release date: 2020-03-02
 ### Bug fixes:

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/swift/SwiftTypeMapperTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/swift/SwiftTypeMapperTest.kt
@@ -24,6 +24,7 @@ import com.here.gluecodium.model.lime.LimeBasicTypeRef
 import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimePath
 import com.here.gluecodium.model.lime.LimeStruct
@@ -37,6 +38,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -133,5 +135,18 @@ class SwiftTypeMapperTest {
         assertTrue(result is SwiftArray)
         assertEquals("ArrayOf__Float", result.cPrefix)
         assertEquals(SwiftType.FLOAT, (result as SwiftArray).elementType)
+        assertFalse(typeMapper.generics.isEmpty())
+    }
+
+    @Test
+    fun mapListInLambdaDoesNotCollectGenerics() {
+        val limeElement = LimeLambda(
+            path = LimePath.EMPTY_PATH,
+            returnType = LimeDirectTypeRef(LimeList(LimeBasicTypeRef.FLOAT))
+        )
+
+        typeMapper.mapType(LimeDirectTypeRef(limeElement))
+
+        assertTrue(typeMapper.generics.isEmpty())
     }
 }


### PR DESCRIPTION
Updated SwiftTypeMapper to accumulate collection types only when
mapType() is called on such type directly, but not for other cases (e.g.
when a collection type is a parameter or a return type of a lambda).

Previously, over-eager accumulation of generics by SwiftTypeMapper led
to extraneous Swift conversion functions for collection types in
modularized builds. This failed compilation, as corresponding CBridge
functions were not present (because CBridge accumulation logic was
correct).

Added a unit test as a regression test.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>