### PR TITLE
Add validation against @PointerEquatable on interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Breaking changes:
+  * Added validation against using `@PointerEquatable` attribute on interfaces in IDL files. This
+    usage is currently unsupported but was erroneously allowed before.
+
 ## 6.3.2
 Release date: 2020-03-10
 ### Bug fixes:
@@ -85,7 +90,6 @@ Release date: 2019-11-21
 ### Bug fixes:
   * Fixed C++ compilation issue for `@Equatable` structs with `Date` type fields.
   * Fixed Java compilation issue for interfaces with same name in different packages.
-
 ### Breaking changes:
   * Removed "stdout" command line option.
 

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/LimeBasedLimeModelLoader.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/LimeBasedLimeModelLoader.kt
@@ -33,6 +33,7 @@ import com.here.gluecodium.validator.LimeFunctionsValidator
 import com.here.gluecodium.validator.LimeGenericTypesValidator
 import com.here.gluecodium.validator.LimeImportsValidator
 import com.here.gluecodium.validator.LimeInheritanceValidator
+import com.here.gluecodium.validator.LimeInterfacesValidator
 import com.here.gluecodium.validator.LimeSerializableStructsValidator
 import com.here.gluecodium.validator.LimeStructsValidator
 import com.here.gluecodium.validator.LimeTypeRefTargetValidator
@@ -156,7 +157,8 @@ internal class LimeBasedLimeModelLoader : LimeModelLoader {
     private fun getIndependentValidators(limeLogger: LimeLogger) =
         listOf<(LimeModel) -> Boolean>(
             { LimeEnumeratorRefsValidator(limeLogger).validate(it) },
-            { LimeExternalTypesValidator(limeLogger).validate(it) }
+            { LimeExternalTypesValidator(limeLogger).validate(it) },
+            { LimeInterfacesValidator(limeLogger).validate(it) }
         )
 }
 

--- a/lime-loader/src/main/java/com/here/gluecodium/validator/LimeInterfacesValidator.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/validator/LimeInterfacesValidator.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeModel
+
+/**
+ * Validates interfaces against having @PointerEquatable attribute, which is unsupported.
+ */
+internal class LimeInterfacesValidator(private val logger: LimeLogger) {
+
+    fun validate(limeModel: LimeModel): Boolean {
+        val allInterfaces = limeModel.referenceMap.values.filterIsInstance<LimeInterface>()
+        val validationResults = allInterfaces.map { validatePointerEquatable(it) }
+
+        return !validationResults.contains(false)
+    }
+
+    private fun validatePointerEquatable(limeInterface: LimeInterface) =
+        when {
+            limeInterface.attributes.have(LimeAttributeType.POINTER_EQUATABLE) -> {
+                logger.error(limeInterface, "@PointerEquatable is not supported for interfaces")
+                false
+            }
+            else -> true
+        }
+}

--- a/lime-loader/src/test/java/com/here/gluecodium/validator/LimeInterfacesValidatorTest.kt
+++ b/lime-loader/src/test/java/com/here/gluecodium/validator/LimeInterfacesValidatorTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributes
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class LimeInterfacesValidatorTest {
+
+    private val allElements = mutableMapOf<String, LimeElement>()
+    private val limeModel = LimeModel(allElements, emptyList())
+
+    private val validator = LimeInterfacesValidator(mockk(relaxed = true))
+
+    @Test
+    fun validateInterfaceWithoutAttributes() {
+        allElements[""] = LimeInterface(EMPTY_PATH)
+
+        assertTrue(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateInterfaceWithPointerEquatable() {
+        allElements[""] = LimeInterface(
+            EMPTY_PATH,
+            attributes = LimeAttributes.Builder()
+                .addAttribute(LimeAttributeType.POINTER_EQUATABLE)
+                .build()
+        )
+
+        assertFalse(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateInterfaceWithEquatable() {
+        allElements[""] = LimeInterface(
+            EMPTY_PATH,
+            attributes = LimeAttributes.Builder()
+                .addAttribute(LimeAttributeType.EQUATABLE)
+                .build()
+        )
+
+        assertTrue(validator.validate(limeModel))
+    }
+}


### PR DESCRIPTION
Added LimeInterfacesValidator to validate against usage of
@PointerEquatable attribute on interfaces. As interfaces are used
bidirectionally between Platform code and C++ code, referential equality
is not supported in both directions (see #46).

@Equatable, however, can be supported and thus is not validated against
(see #108).

Added unit tests for LimeInterfacesValidator.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>