### PR TITLE
Add support for @Equatable interfaces in C++

### DIFF
--- a/examples/libhello/lime/test/Equatable.lime
+++ b/examples/libhello/lime/test/Equatable.lime
@@ -174,3 +174,12 @@ struct EquatableStructWithInternalFields {
     internal internalMapField: Map<String, String>
     internal internalSetField: Set<String>
 }
+
+@Equatable
+interface EquatableInterface {
+    property name: String { get }
+}
+
+internal class EquatableInterfaceFactory {
+    static fun createEquatableInterface(name: String): EquatableInterface
+}

--- a/examples/libhello/src/test/EquatableImpl.cpp
+++ b/examples/libhello/src/test/EquatableImpl.cpp
@@ -19,6 +19,8 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "test/EquatableClass.h"
+#include "test/EquatableInterface.h"
+#include "test/EquatableInterfaceFactory.h"
 #include "test/PointerEquatableClass.h"
 
 namespace test
@@ -31,6 +33,21 @@ public:
     {}
 
     ~EquatableClassImpl() = default;
+
+    std::string get_name() const override {
+        return m_name;
+    }
+private:
+    std::string m_name;
+};
+
+class EquatableInterfaceImpl: public EquatableInterface {
+public:
+    EquatableInterfaceImpl(const std::string& name)
+        : m_name(name)
+    {}
+
+    ~EquatableInterfaceImpl() = default;
 
     std::string get_name() const override {
         return m_name;
@@ -141,9 +158,24 @@ EquatableClass::operator == ( const EquatableClass& rhs ) {
     return get_name( ) == rhs.get_name( );
 }
 
+bool
+EquatableInterface::operator==(const EquatableInterface& rhs) {
+    return get_name() == rhs.get_name();
+}
+
+std::shared_ptr<EquatableInterface>
+EquatableInterfaceFactory::create_equatable_interface(const std::string& name) {
+    return std::make_shared<EquatableInterfaceImpl>(name);
+}
+
 }  // namespace test
 
 std::size_t
 lorem_ipsum::test::hash <::test::EquatableClass>::operator( )( const ::test::EquatableClass& t ) const {
     return 11 ^ std::hash<std::string>( )( t.get_name( ) );
+}
+
+std::size_t
+lorem_ipsum::test::hash<::test::EquatableInterface>::operator()(const ::test::EquatableInterface& t) const {
+    return 11 ^ std::hash<std::string>()(t.get_name());
 }

--- a/examples/platforms/cpp/tests/EquatableTest.cpp
+++ b/examples/platforms/cpp/tests/EquatableTest.cpp
@@ -19,6 +19,8 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "test/Equatable.h"
+#include "test/EquatableInterface.h"
+#include "test/EquatableInterfaceFactory.h"
 #include "test/SomeEquatableClass.h"
 #include "test/SomePointerEquatableClass.h"
 #include <gmock/gmock.h>
@@ -98,6 +100,30 @@ TEST( EquatableTest, pointer_unequal_classes )
 
     lorem_ipsum::test::hash<decltype(one_class)> hasher;
 
+    EXPECT_NE(hasher(one_class), hasher(other_class));
+}
+
+TEST( EquatableTest, equal_interfaces )
+{
+    auto one_class = test::EquatableInterfaceFactory::create_equatable_interface("foo");
+    auto other_class = test::EquatableInterfaceFactory::create_equatable_interface("foo");
+
+    lorem_ipsum::test::EqualityEqualTo<test::EquatableInterface> equalizer;
+    lorem_ipsum::test::EqualityHash<decltype(one_class)> hasher;
+
+    EXPECT_TRUE(equalizer(one_class, other_class));
+    EXPECT_EQ(hasher(one_class), hasher(other_class));
+}
+
+TEST( EquatableTest, unequal_interfaces )
+{
+    auto one_class = test::EquatableInterfaceFactory::create_equatable_interface("foo");
+    auto other_class = test::EquatableInterfaceFactory::create_equatable_interface("bar");
+
+    lorem_ipsum::test::EqualityEqualTo<test::EquatableInterface> equalizer;
+    lorem_ipsum::test::EqualityHash<decltype(one_class)> hasher;
+
+    EXPECT_FALSE(equalizer(one_class, other_class));
     EXPECT_NE(hasher(one_class), hasher(other_class));
 }
 

--- a/gluecodium/src/test/resources/smoke/equatable/input/Equatable.lime
+++ b/gluecodium/src/test/resources/smoke/equatable/input/Equatable.lime
@@ -85,3 +85,7 @@ struct EquatableStructWithInternalFields {
     internal internalMapField: Map<String, String>
     internal internalSetField: Set<String>
 }
+
+@Equatable
+interface EquatableInterface {
+}

--- a/gluecodium/src/test/resources/smoke/equatable/output/cpp/include/smoke/EquatableInterface.h
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cpp/include/smoke/EquatableInterface.h
@@ -1,0 +1,32 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include "gluecodium/Hash.h"
+#include "gluecodium/TypeRepository.h"
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT EquatableInterface {
+public:
+    EquatableInterface();
+    virtual ~EquatableInterface() = 0;
+public:
+    bool operator==( const EquatableInterface& rhs );
+    bool operator!=( const EquatableInterface& rhs );
+};
+}
+namespace gluecodium {
+template<>
+struct hash< ::smoke::EquatableInterface > {
+    _GLUECODIUM_CPP_EXPORT std::size_t operator( )( const ::smoke::EquatableInterface& t ) const;
+};
+template <>
+struct EqualityHash< std::shared_ptr< ::smoke::EquatableInterface > >
+{
+    _GLUECODIUM_CPP_EXPORT std::size_t operator( )( const std::shared_ptr< ::smoke::EquatableInterface >& t ) const;
+};
+}
+namespace gluecodium {
+_GLUECODIUM_CPP_EXPORT TypeRepository& get_type_repository(const ::smoke::EquatableInterface*);
+}


### PR DESCRIPTION
Added smoke and functional tests for @Equatable interfaces in C++. Since
the generated code for interfaces and classes is identical for C++
generator, no changes to Mustache templates is necessary to support
@Equatable interfaces in C++.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>