### PR TITLE
Adds synchronisation between processes to generate sources.

### DIFF
--- a/cmake/modules/gluecodium/gluecodium/runGenerate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/runGenerate.cmake
@@ -49,6 +49,9 @@ function(_generate)
         set(_common_output_dir .)
     endif()
 
+    message ("Using locking file to generate sources: ${_common_output_dir}-lock.cmake")
+    file (LOCK ${_common_output_dir}-lock.cmake TIMEOUT 3600)
+
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E make_directory ${APIGEN_OUTPUT_DIR} # otherwise java.io.File won't have permissions to create files at configure time
         COMMAND ${CMAKE_COMMAND} -E make_directory ${_common_output_dir}


### PR DESCRIPTION
Since Gluecodium is running runtime it's possible that
more than one instance of it is executed which may lead to
undefined bahviour especially in common generated code.
The patch adds CMake-like synchronisation to avoid
such situations.

Signed-off-by: Yauheni Khnykin <yauheni.khnykin@here.com>