### PR TITLE
Add Dart FFI common headers to include path in CMake

### DIFF
--- a/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
+++ b/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
@@ -81,6 +81,10 @@ function(apigen_target_include_directories target)
       target_include_directories(${target}
         PUBLIC $<BUILD_INTERFACE:${COMMON_OUTPUT_DIR}/android/jni>)
     endif()
+    if(${GENERATOR} MATCHES dart)
+      target_include_directories(${target}
+        PUBLIC $<BUILD_INTERFACE:${COMMON_OUTPUT_DIR}/dart/ffi>)
+    endif()
   endif()
 
   if(${GENERATOR} MATCHES android)


### PR DESCRIPTION
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>