### PR TITLE
Use "internal prefix" for Dart FFI collection conversion functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Bug fixes:
   * Fixed C++ compilation issue for when "-intnamespace" command line parameter is not specified.
   * Fixed more issues in CMake helpers related to modularization.
-  * Fixed Dart compilation issue related to modularization.
+  * Fixed Dart compilation issues related to modularization.
 
 ## 6.3.2
 Release date: 2020-03-10

--- a/cmake/modules/gluecodium/gluecodium/Generate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/Generate.cmake
@@ -88,7 +88,7 @@ function(apigen_generate)
       CPP_EXPORT
       CPP_NAMERULES
       SWIFT_NAMERULES
-      SWIFT_INTERNAL_PREFIX
+      INTERNAL_PREFIX
       OUTPUT_DIR
       COMMON_OUTPUT_DIR
       BUILD_OUTPUT_DIR
@@ -157,7 +157,7 @@ function(apigen_generate)
   _apigen_parse_path_option(-swiftnamerules SWIFT_NAMERULES)
   _apigen_parse_path_option(-commonoutput COMMON_OUTPUT_DIR)
   _apigen_parse_option(-libraryname DART_LIBRARY_NAME)
-  _apigen_parse_option(-swiftinternalprefix SWIFT_INTERNAL_PREFIX)
+  _apigen_parse_option(-internalprefix INTERNAL_PREFIX)
   _apigen_parse_option(-cppexport CPP_EXPORT)
 
   if(NOT apigen_generate_CPP_EXPORT)

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -410,7 +410,7 @@ apigen_generate(TARGET hello
         JAVA_NONNULL_ANNOTATION android.support.annotation.NonNull
         JAVA_NULLABLE_ANNOTATION android.support.annotation.Nullable
         CPP_INTERNAL_NAMESPACE lorem_ipsum.test
-        SWIFT_INTERNAL_PREFIX "libhello_"
+        INTERNAL_PREFIX "libhello_"
         DART_LIBRARY_NAME "hello"
         COPYRIGHT_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/../config/COPYRIGHT"
         VERBOSE)

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -174,7 +174,7 @@ class Gluecodium(
         var cppInternalNamespace: List<String> = emptyList(),
         var cppRootNamespace: List<String> = listOf(),
         var cppExport: String = DEFAULT_CPP_EXPORT_MACRO_NAME,
-        var swiftInternalPrefix: String? = null,
+        var internalPrefix: String? = null,
         var libraryName: String = "library",
         var cppNameRules: Configuration = ConfigurationProperties.fromResource(
             Gluecodium::class.java,

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -104,7 +104,7 @@ object OptionReader {
         )
         addOption("cppnamespace", true, "C++ namespace for public (API) headers.")
         addOption("cppexport", true, "C++ export macro name for explicit symbol exporting.")
-        addOption("swiftinternalprefix", true, "Name prefix for internal conversion functions in Swift.")
+        addOption("internalprefix", true, "Name prefix for internal conversion functions in Swift.")
         addOption("libraryname", true, "Name of the generated library for some generators (e.g. Dart).")
         addOption("cppnamerules", true, "C++ name rules property file.")
         addOption("javanamerules", true, "Java name rules property file.")
@@ -163,7 +163,7 @@ object OptionReader {
         options.cppRootNamespace = getStringValue("cppnamespace")?.split(".") ?: emptyList()
         options.cppInternalNamespace = getStringValue("intnamespace")?.split(".") ?: emptyList()
         getStringValue("cppexport")?.let { options.cppExport = it }
-        getStringValue("swiftinternalprefix")?.let { options.swiftInternalPrefix = it }
+        getStringValue("internalprefix")?.let { options.internalPrefix = it }
         getStringValue("libraryname")?.let { options.libraryName = it }
 
         options.cppNameRules = readConfigFile(getStringValue("cppnamerules"), options.cppNameRules)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -71,6 +71,7 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
         CppNameRules(options.cppRootNamespace, nameRuleSetFromConfig(options.cppNameRules))
     private val rootNamespace = options.cppRootNamespace
     private val internalNamespace = options.cppInternalNamespace
+    private val internalPrefix = options.internalPrefix
 
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
         val dartNameResolver = DartNameResolver(
@@ -357,6 +358,7 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
             "dart/DartGenericTypesConversion",
             mapOf(
                 "libraryName" to libraryName,
+                "internalPrefix" to internalPrefix,
                 "imports" to imports.distinct().sorted(),
                 "genericTypes" to genericTypes
             ),
@@ -376,6 +378,7 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
         val fileName = "GenericTypesConversion"
         val data = mapOf(
             "libraryName" to libraryName,
+            "internalPrefix" to internalPrefix,
             "genericTypes" to genericTypes,
             "internalNamespace" to internalNamespace,
             "headerName" to fileName,

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuite.kt
@@ -52,7 +52,7 @@ class SwiftGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
     private val commentsProcessor = SwiftCommentsProcessor()
     private val cppNameRules = CppNameRules(rootNamespace, nameRuleSetFromConfig(options.cppNameRules))
     private val swiftNameRules = SwiftNameRules(nameRuleSetFromConfig(options.swiftNameRules))
-    private val internalPrefix = options.swiftInternalPrefix
+    private val internalPrefix = options.internalPrefix
 
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
         val limeReferenceMap = limeModel.referenceMap

--- a/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
@@ -33,54 +33,54 @@ import 'package:{{libraryName}}/src/_library_init.dart' as __lib;
 final _{{resolveName "Ffi"}}_create_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('{{libraryName}}_{{resolveName "Ffi"}}_create_handle');
+  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_create_handle');
 final _{{resolveName "Ffi"}}_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle');
+  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_release_handle');
 {{#instanceOf this "LimeMap"}}
 final _{{resolveName "Ffi"}}_put = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, {{resolveName keyType "FfiApiTypes"}}, {{resolveName valueType "FfiApiTypes"}}),
     void Function(Pointer<Void>, {{resolveName keyType "FfiDartTypes"}}, {{resolveName valueType "FfiDartTypes"}})
-  >('{{libraryName}}_{{resolveName "Ffi"}}_put');
+  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_put');
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
 final _{{resolveName "Ffi"}}_insert = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, {{resolveName elementType "FfiApiTypes"}}),
     void Function(Pointer<Void>, {{resolveName elementType "FfiDartTypes"}})
-  >('{{libraryName}}_{{resolveName "Ffi"}}_insert');
+  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_insert');
 {{/notInstanceOf}}
 final _{{resolveName "Ffi"}}_iterator = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator');
+>('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_iterator');
 final _{{resolveName "Ffi"}}_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator_release_handle');
+>('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_iterator_release_handle');
 final _{{resolveName "Ffi"}}_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator_is_valid');
+>('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_iterator_is_valid');
 final _{{resolveName "Ffi"}}_iterator_increment = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator_increment');
+>('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_iterator_increment');
 {{#instanceOf this "LimeMap"}}
 final _{{resolveName "Ffi"}}_iterator_get_key = __lib.nativeLibrary.lookupFunction<
     {{resolveName keyType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName keyType "FfiDartTypes"}} Function(Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator_get_key');
+>('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_iterator_get_key');
 final _{{resolveName "Ffi"}}_iterator_get_value = __lib.nativeLibrary.lookupFunction<
     {{resolveName valueType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName valueType "FfiDartTypes"}} Function(Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator_get_value');
+>('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_iterator_get_value');
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
 final _{{resolveName "Ffi"}}_iterator_get = __lib.nativeLibrary.lookupFunction<
     {{resolveName elementType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName elementType "FfiDartTypes"}} Function(Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator_get');
+>('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_iterator_get');
 {{/notInstanceOf}}
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {

--- a/gluecodium/src/main/resources/templates/dart/DartNullableTypeConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartNullableTypeConversion.mustache
@@ -21,15 +21,15 @@
 final _{{resolveName "Ffi"}}_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function({{resolveName "FfiApiTypes"}}),
     Pointer<Void> Function({{resolveName "FfiDartTypes"}})
-  >('{{libraryName}}_{{resolveName "Ffi"}}_create_handle_nullable');
+  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_create_handle_nullable');
 final _{{resolveName "Ffi"}}_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle_nullable');
+  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_release_handle_nullable');
 final _{{resolveName "Ffi"}}_get_value_nullable = __lib.nativeLibrary.lookupFunction<
     {{resolveName "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName "FfiDartTypes"}} Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_get_value_nullable');
+  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_get_value_nullable');
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}} value) {
   if (value == null) return Pointer<Void>.fromAddress(0);

--- a/gluecodium/src/main/resources/templates/ffi/FfiGenericTypesHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiGenericTypesHeader.mustache
@@ -30,24 +30,24 @@ extern "C" {
 #endif
 
 {{#genericTypes}}
-_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{resolveName}}_create_handle();
-_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{resolveName}}_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{internalPrefix}}{{resolveName}}_create_handle();
+_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{internalPrefix}}{{resolveName}}_release_handle(FfiOpaqueHandle handle);
 {{#instanceOf this "LimeMap"}}
-_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{resolveName}}_put(FfiOpaqueHandle handle, {{resolveName keyType}} key, {{resolveName valueType}} value);
+_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{internalPrefix}}{{resolveName}}_put(FfiOpaqueHandle handle, {{resolveName keyType}} key, {{resolveName valueType}} value);
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
-_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{resolveName}}_insert(FfiOpaqueHandle handle, {{resolveName elementType}} value);
+_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{internalPrefix}}{{resolveName}}_insert(FfiOpaqueHandle handle, {{resolveName elementType}} value);
 {{/notInstanceOf}}
-_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{resolveName}}_iterator(FfiOpaqueHandle handle);
-_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{resolveName}}_iterator_release_handle(FfiOpaqueHandle iterator_handle);
-_GLUECODIUM_FFI_EXPORT bool {{libraryName}}_{{resolveName}}_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle);
-_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{resolveName}}_iterator_increment(FfiOpaqueHandle iterator_handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator_release_handle(FfiOpaqueHandle iterator_handle);
+_GLUECODIUM_FFI_EXPORT bool {{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle);
+_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator_increment(FfiOpaqueHandle iterator_handle);
 {{#instanceOf this "LimeMap"}}
-_GLUECODIUM_FFI_EXPORT {{resolveName keyType}} {{libraryName}}_{{resolveName}}_iterator_get_key(FfiOpaqueHandle iterator_handle);
-_GLUECODIUM_FFI_EXPORT {{resolveName valueType}} {{libraryName}}_{{resolveName}}_iterator_get_value(FfiOpaqueHandle iterator_handle);
+_GLUECODIUM_FFI_EXPORT {{resolveName keyType}} {{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator_get_key(FfiOpaqueHandle iterator_handle);
+_GLUECODIUM_FFI_EXPORT {{resolveName valueType}} {{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator_get_value(FfiOpaqueHandle iterator_handle);
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
-_GLUECODIUM_FFI_EXPORT {{resolveName elementType}} {{libraryName}}_{{resolveName}}_iterator_get(FfiOpaqueHandle iterator_handle);
+_GLUECODIUM_FFI_EXPORT {{resolveName elementType}} {{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator_get(FfiOpaqueHandle iterator_handle);
 {{/notInstanceOf}}
 {{#set type=this handleType="FfiOpaqueHandle"}}{{>ffi/FfiNullableDeclaration}}{{/set}}
 

--- a/gluecodium/src/main/resources/templates/ffi/FfiGenericTypesImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiGenericTypesImpl.mustache
@@ -35,18 +35,18 @@ extern "C" {
 
 {{#genericTypes}}
 FfiOpaqueHandle
-{{libraryName}}_{{resolveName}}_create_handle() {
+{{libraryName}}_{{internalPrefix}}{{resolveName}}_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) {{resolveName "C++"}}());
 }
 
 void
-{{libraryName}}_{{resolveName}}_release_handle(FfiOpaqueHandle handle) {
+{{libraryName}}_{{internalPrefix}}{{resolveName}}_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<{{resolveName "C++"}}*>(handle);
 }
 
 {{#instanceOf this "LimeMap"}}
 void
-{{libraryName}}_{{resolveName}}_put(FfiOpaqueHandle handle, {{resolveName keyType}} key, {{resolveName valueType}} value) {
+{{libraryName}}_{{internalPrefix}}{{resolveName}}_put(FfiOpaqueHandle handle, {{resolveName keyType}} key, {{resolveName valueType}} value) {
     reinterpret_cast<{{resolveName "C++"}}*>(handle)->emplace(
         {{>ffi/FfiInternal}}::Conversion<{{resolveName keyType "C++"}}>::toCpp(key),
         {{>ffi/FfiInternal}}::Conversion<{{resolveName valueType "C++"}}>::toCpp(value)
@@ -55,7 +55,7 @@ void
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
 void
-{{libraryName}}_{{resolveName}}_insert(FfiOpaqueHandle handle, {{resolveName elementType}} value) {
+{{libraryName}}_{{internalPrefix}}{{resolveName}}_insert(FfiOpaqueHandle handle, {{resolveName elementType}} value) {
     reinterpret_cast<{{resolveName "C++"}}*>(handle)->{{!!
     }}{{#instanceOf this "LimeList"}}push_back{{/instanceOf}}{{!!
     }}{{#notInstanceOf this "LimeList"}}insert{{/notInstanceOf}}(
@@ -65,38 +65,38 @@ void
 {{/notInstanceOf}}
 
 FfiOpaqueHandle
-{{libraryName}}_{{resolveName}}_iterator(FfiOpaqueHandle handle) {
+{{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) {{resolveName "C++"}}::iterator(
         reinterpret_cast<{{resolveName "C++"}}*>(handle)->begin()
     ));
 }
 
 void
-{{libraryName}}_{{resolveName}}_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+{{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
     delete reinterpret_cast<{{resolveName "C++"}}::iterator*>(iterator_handle);
 }
 
 bool
-{{libraryName}}_{{resolveName}}_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+{{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
     return *reinterpret_cast<{{resolveName "C++"}}::iterator*>(iterator_handle) !=
         reinterpret_cast<{{resolveName "C++"}}*>(handle)->end();
 }
 
 void
-{{libraryName}}_{{resolveName}}_iterator_increment(FfiOpaqueHandle iterator_handle) {
+{{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator_increment(FfiOpaqueHandle iterator_handle) {
     ++*reinterpret_cast<{{resolveName "C++"}}::iterator*>(iterator_handle);
 }
 
 {{#instanceOf this "LimeMap"}}
 {{resolveName keyType}}
-{{libraryName}}_{{resolveName}}_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+{{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator_get_key(FfiOpaqueHandle iterator_handle) {
     return {{>ffi/FfiInternal}}::Conversion<{{resolveName keyType "C++"}}>::toFfi(
         (*reinterpret_cast<{{resolveName "C++"}}::iterator*>(iterator_handle))->first
     );
 }
 
 {{resolveName valueType}}
-{{libraryName}}_{{resolveName}}_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+{{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator_get_value(FfiOpaqueHandle iterator_handle) {
     return {{>ffi/FfiInternal}}::Conversion<{{resolveName valueType "C++"}}>::toFfi(
         (*reinterpret_cast<{{resolveName "C++"}}::iterator*>(iterator_handle))->second
     );
@@ -104,7 +104,7 @@ void
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
 {{resolveName elementType}}
-{{libraryName}}_{{resolveName}}_iterator_get(FfiOpaqueHandle iterator_handle) {
+{{libraryName}}_{{internalPrefix}}{{resolveName}}_iterator_get(FfiOpaqueHandle iterator_handle) {
     return {{>ffi/FfiInternal}}::Conversion<{{resolveName elementType "C++"}}>::toFfi(
         **reinterpret_cast<{{resolveName "C++"}}::iterator*>(iterator_handle)
     );

--- a/gluecodium/src/main/resources/templates/ffi/FfiNullableDeclaration.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiNullableDeclaration.mustache
@@ -18,6 +18,6 @@
   ! License-Filename: LICENSE
   !
   !}}
-_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{resolveName type}}_create_handle_nullable({{handleType}} value);
-_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{resolveName type}}_release_handle_nullable(FfiOpaqueHandle handle);
-_GLUECODIUM_FFI_EXPORT {{handleType}} {{libraryName}}_{{resolveName type}}_get_value_nullable(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{internalPrefix}}{{resolveName type}}_create_handle_nullable({{handleType}} value);
+_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{internalPrefix}}{{resolveName type}}_release_handle_nullable(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT {{handleType}} {{libraryName}}_{{internalPrefix}}{{resolveName type}}_get_value_nullable(FfiOpaqueHandle handle);

--- a/gluecodium/src/main/resources/templates/ffi/FfiNullableImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiNullableImpl.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 FfiOpaqueHandle
-{{libraryName}}_{{resolveName type}}_create_handle_nullable({{handleType}} value)
+{{libraryName}}_{{internalPrefix}}{{resolveName type}}_create_handle_nullable({{handleType}} value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) {{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<{{resolveName type "C++"}}>(
@@ -29,13 +29,13 @@ FfiOpaqueHandle
 }
 
 void
-{{libraryName}}_{{resolveName type}}_release_handle_nullable(FfiOpaqueHandle handle)
+{{libraryName}}_{{internalPrefix}}{{resolveName type}}_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<{{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<{{resolveName type "C++"}}>*>(handle);
 }
 
 {{handleType}}
-{{libraryName}}_{{resolveName type}}_get_value_nullable(FfiOpaqueHandle handle)
+{{libraryName}}_{{internalPrefix}}{{resolveName type}}_get_value_nullable(FfiOpaqueHandle handle)
 {
     return {{>ffi/FfiInternal}}::Conversion<{{resolveName type "C++"}}>::toFfi(
         **reinterpret_cast<{{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<{{resolveName type "C++"}}>*>(handle)


### PR DESCRIPTION
Updated Dart FFI templates to use "internal prefix" for collection
conversion functions. This allows for necessary duplication of those
functions in modularized builds.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>