### PR TITLE
Fixes CMake issue when Dart is enabled with Swift.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed issue with Dart generator enabled with Swift.
+
 ## 6.3.3
 Release date: 2020-03-17
 ### Features:

--- a/cmake/modules/gluecodium/gluecodium/TargetSources.cmake
+++ b/cmake/modules/gluecodium/gluecodium/TargetSources.cmake
@@ -81,7 +81,7 @@ function(apigen_target_sources target)
     BUILD_OUTPUT_DIR "${BUILD_OUTPUT_DIR}")
   source_group("Generated Source Files" FILES ${_generated_files})
 
-  if(NOT GENERATOR STREQUAL swift)
+  if(NOT GENERATOR MATCHES swift)
     target_sources(${target} PRIVATE ${_generated_files})
   else()
     apigen_set_generated_files(${target})


### PR DESCRIPTION
No bridging headers were stored in targets.

Signed-off-by: Yauheni Khnykin <yauheni.khnykin@here.com>