### PR TITLE
Hide implementation details in Dart classes

### DIFF
--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -18,6 +18,50 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{>dart/DartDocumentation}}
+abstract class {{resolveName}} {{#if parent}}implements {{resolveName parent}} {{/if}}{
+{{#set parent=this}}{{#constructors}}
+{{prefixPartial "dart/DartFunctionDocs" "  "}}
+  factory {{resolveName parent}}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}({{!!
+  }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
+  }}){{>dartImplRedirect}};
+{{/constructors}}{{/set}}
+
+  void release();
+
+{{#set isInClass=true}}{{#constants}}
+{{prefixPartial "dart/DartConstant" "  "}}
+{{/constants}}{{/set}}
+{{#set parent=this}}{{#functions}}{{#unless isConstructor}}
+{{prefixPartial "dart/DartFunctionDocs" "  "}}
+{{prefixPartial "dart/DartFunctionSignature" "  "}}{{#if isStatic}}{{>dartImplRedirect}}{{/if}};
+{{/unless}}{{/functions}}{{/set}}
+{{#set parent=this}}{{#properties}}
+{{#set property=this}}{{prefixPartial "dartPropertyRedirect" "  "}}{{/set}}
+{{/properties}}{{/set}}
+}
+
+{{#enumerations}}
+{{>dart/DartEnumeration}}
+{{/enumerations}}
+{{#exceptions}}
+{{>dart/DartException}}
+{{/exceptions}}
+{{#structs}}
+{{>dart/DartStruct}}
+{{/structs}}
+{{#classes}}
+{{>dart/DartClass}}
+{{/classes}}
+{{#interfaces}}
+{{>dart/DartInterface}}
+{{/interfaces}}
+{{#lambdas}}
+{{>dart/DartLambda}}
+{{/lambdas}}
+
+// {{resolveName}} "private" section, not exported.
+
 final _{{resolveName "Ffi"}}_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -38,52 +82,44 @@ final _{{resolveName "Ffi"}}_get_type_id = __lib.nativeLibrary.lookupFunction<
 {{#functions}}
 {{>dart/DartFunctionException}}
 
-{{/functions}}{{!!
-}}{{>dart/DartDocumentation}}
-class {{resolveName}} {{!!
-}}{{#if parent}}{{#if hasClassParent}}extends{{/if}}{{!!
-}}{{#unless hasClassParent}}implements{{/unless}} {{resolveName parent}} {{/if}}{
-  {{#if hasClassParent}}Pointer<Void> get _handle => handle;{{/if}}{{!!
-  }}{{#unless hasClassParent}}{{#if visibility.isOpen}}@protected
+{{/functions}}
+class {{resolveName}}$Impl{{!!
+}}{{#if hasClassParent}} extends {{resolveName parent}}$Impl{{/if}} implements {{resolveName}} {
+{{#unless hasClassParent}}
   final Pointer<Void> handle;
-  Pointer<Void> get _handle => handle;{{/if}}{{!!
-  }}{{#unless visibility.isOpen}}final Pointer<Void> _handle;{{/unless}}{{/unless}}
-  {{#if visibility.isOpen}}@protected
-  {{resolveName}}{{/if}}{{#unless visibility.isOpen}}{{resolveName}}._{{/unless}}{{!!
-  }}{{#unless hasClassParent}}(this.{{#unless visibility.isOpen}}_{{/unless}}handle){{/unless}}{{!!
-  }}{{#if hasClassParent}}(Pointer<Void> handle) : super(handle){{/if}};
 
-  void release() => _{{resolveName "Ffi"}}_release_handle(_handle);
+{{/unless}}
+  {{resolveName}}$Impl({{#if hasClassParent}}Pointer<Void> {{/if}}{{#unless hasClassParent}}this.{{/unless}}handle){{!!
+  }}{{#if hasClassParent}} : super(handle){{/if}};
 
-{{#set isInClass=true}}{{#constants}}
-{{prefixPartial "dart/DartConstant" "  "}}
-{{/constants}}{{/set}}
+  @override
+  void release() => _{{resolveName "Ffi"}}_release_handle(handle);
+
 {{#set inheritanceParent=parent parent=this}}{{#constructors}}
-{{prefixPartial "dart/DartFunctionDocs" "  "}}
 {{prefixPartial "dartConstructor" "  "}}
 {{/constructors}}
 {{#functions}}
-{{prefixPartial "dart/DartFunctionDocs" "  "}}
+{{#unless isStatic}}  @override
+{{/unless}}
 {{prefixPartial "dart/DartFunction" "  "}}
 {{/functions}}{{#if inheritanceParent}}{{#instanceOf inheritanceParent.type "LimeInterface"}}
 {{#inheritedFunctions}}
-{{prefixPartial "dart/DartFunctionDocs" "  "}}
-  @override
+{{#unless isStatic}}  @override
+{{/unless}}
 {{prefixPartial "dart/DartFunction" "  "}}
 {{/inheritedFunctions}}{{/instanceOf}}{{/if}}{{/set}}
-{{#properties}}
+{{#set override=true skipDocs=true}}{{#properties}}
 {{prefixPartial "dart/DartProperty" "  "}}
 {{/properties}}
 {{#inheritedProperties}}
-  @override
 {{prefixPartial "dart/DartProperty" "  "}}
-{{/inheritedProperties}}
+{{/inheritedProperties}}{{/set}}
 {{#ifHasAttribute "Equatable"}}{{>dartFfiEqualityOperator}}{{/ifHasAttribute}}{{!!
 }}{{#ifHasAttribute "PointerEquatable"}}{{>dartFfiEqualityOperator}}{{/ifHasAttribute}}
 }
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) =>
-  _{{resolveName "Ffi"}}_copy_handle(value._handle);
+  _{{resolveName "Ffi"}}_copy_handle((value as {{resolveName}}$Impl).handle);
 
 {{#if parent visibility.isOpen logic="or"}}
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
@@ -91,14 +127,14 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) =>
   final _type_id_handle = _{{resolveName "Ffi"}}_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? {{resolveName}}{{#unless visibility.isOpen}}._{{/unless}}(_copied_handle)
+    ? {{resolveName}}$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;
 }
 {{/if}}{{#unless parent visibility.isOpen logic="and"}}
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) =>
-  {{resolveName}}{{#unless visibility.isOpen}}._{{/unless}}(_{{resolveName "Ffi"}}_copy_handle(handle));
+  {{resolveName}}$Impl(_{{resolveName "Ffi"}}_copy_handle(handle));
 {{/unless}}
 
 void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) =>
@@ -113,35 +149,11 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}} value) =>
 void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _{{resolveName "Ffi"}}_release_handle(handle);
 
-{{#if parent visibility.isOpen logic="or"}}
-// Internal, not exported.
-class {{resolveName}}__Factory {
-  static {{resolveName}} create(Pointer<Void> handle) => {{resolveName}}{{#unless visibility.isOpen}}._{{/unless}}(handle);
-}
-{{/if}}
+// End of {{resolveName}} "private" section.{{!!
 
-{{#enumerations}}
-{{>dart/DartEnumeration}}
-{{/enumerations}}
-{{#exceptions}}
-{{>dart/DartException}}
-{{/exceptions}}
-{{#structs}}
-{{>dart/DartStruct}}
-{{/structs}}
-{{#classes}}
-{{>dart/DartClass}}
-{{/classes}}
-{{#interfaces}}
-{{>dart/DartInterface}}
-{{/interfaces}}
-{{#lambdas}}
-{{>dart/DartLambda}}
-{{/lambdas}}{{!!
-
-}}{{+dartConstructor}}{{resolveName parent}}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}({{!!
+}}{{+dartConstructor}}{{resolveName parent}}$Impl.{{resolveName}}({{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) : {{!!
-}}this{{#unless parent.visibility.isOpen}}._{{/unless}}(_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}));
+}}this(_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}));
 {{/dartConstructor}}{{!!
 
 }}{{+dartFfiEqualityFunction}}
@@ -155,8 +167,24 @@ final __are_equal = __lib.nativeLibrary.lookupFunction<
   @override
   bool operator ==(dynamic other) {
     if (identical(this, other)) return true;
-    if (other is! {{resolveName}}) return false;
-    {{resolveName}} _other = other;
-    return __are_equal(_handle, _other._handle) != 0;
+    if (other is! {{resolveName}}$Impl) return false;
+    return __are_equal((this as {{resolveName}}$Impl).handle, other.handle) != 0;
   }
-{{/dartFfiEqualityOperator}}
+{{/dartFfiEqualityOperator}}{{!!
+
+}}{{+dartImplRedirect}} => {{resolveName parent}}$Impl.{{resolveName}}({{!!
+    }}{{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
+}}{{/dartImplRedirect}}{{!!
+
+}}{{+dartPropertyRedirect}}
+{{#getter}}
+{{>dart/DartDocumentation}}
+{{#if isStatic}}static {{/if}}{{resolveName property.typeRef}} get {{resolveName visibility}}{{resolveName property}}{{!!
+}}{{#if isStatic}} => {{resolveName parent}}$Impl.{{resolveName property}}{{/if}};
+{{/getter}}
+{{#setter}}
+{{>dart/DartDocumentation}}
+{{#if isStatic}}static {{/if}}set {{resolveName visibility}}{{resolveName property}}({{resolveName property.typeRef}} value){{!!
+}}{{#if isStatic}} { {{resolveName parent}}$Impl.{{resolveName property}} = value; }{{/if}}{{#unless isStatic}};{{/unless}}
+{{/setter}}
+{{/dartPropertyRedirect}}

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
@@ -22,9 +22,10 @@
   final _{{resolveName}}_ffi = __lib.nativeLibrary.lookupFunction<{{>ffiApi}}, {{>ffiDart}}>('{{libraryName}}_{{resolveName "Ffi"}}');
 {{#parameters}}
   final _{{resolveName}}_handle = {{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
-{{/parameters}}{{#if isStruct}}{{#unless isStatic}}
-  final _handle = {{resolveName parent "Ffi"}}_toFfi(this);
-{{/unless}}{{/if}}
+{{/parameters}}{{#unless isStatic}}
+  final _handle = {{#if isStruct}}{{resolveName parent "Ffi"}}_toFfi(this){{/if}}{{!!
+  }}{{#unless isStruct}}this.handle{{/unless}};
+{{/unless}}
   final __{{#if thrownType}}call_{{/if}}result_handle = _{{resolveName}}_ffi({{!!
   }}{{#unless isStatic}}_handle{{#if parameters}}, {{/if}}{{/unless}}{{!!
   }}{{#parameters}}_{{resolveName}}_handle{{#if iter.hasNext}}, {{/if}}{{/parameters}});

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -81,11 +81,10 @@ final _{{resolveName "Ffi"}}_get_type_id = __lib.nativeLibrary.lookupFunction<
 {{>dart/DartFunctionException}}
 
 {{/functions}}{{!!
-}}class {{resolveName}}__Impl {{#if parent}}extends {{resolveName parent}}__Impl {{/if}}implements {{resolveName}} {
-  Pointer<Void> get _handle => handle;
-  {{#if parent}}{{resolveName}}__Impl(Pointer<Void> handle) : super(handle);{{/if}}{{!!
+}}class {{resolveName}}$Impl {{#if parent}}extends {{resolveName parent}}$Impl {{/if}}implements {{resolveName}} {
+  {{#if parent}}{{resolveName}}$Impl(Pointer<Void> handle) : super(handle);{{/if}}{{!!
   }}{{#unless parent}}final Pointer<Void> handle;
-  {{resolveName}}__Impl(this.handle);{{/unless}}
+  {{resolveName}}$Impl(this.handle);{{/unless}}
 
   @override
   void release() => _{{resolveName "Ffi"}}_release_handle(handle);
@@ -151,7 +150,7 @@ int _{{resolveName parent}}_{{resolveName}}_set_static(int _token, {{resolveName
 {{/each}}{{/set}}
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
-  if (value is {{resolveName}}__Impl) return _{{resolveName "Ffi"}}_copy_handle(value.handle);
+  if (value is {{resolveName}}$Impl) return _{{resolveName "Ffi"}}_copy_handle(value.handle);
 
   final result = _{{resolveName "Ffi"}}_create_proxy(
     __lib.cacheObject(value),
@@ -175,7 +174,7 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
   final _type_id_handle = _{{resolveName "Ffi"}}_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? {{resolveName}}__Impl(_copied_handle)
+    ? {{resolveName}}$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -41,10 +41,10 @@ final _{{resolveName "Ffi"}}_get_raw_pointer = __lib.nativeLibrary.lookupFunctio
       Pointer<Void> Function(Pointer<Void>)
     >('{{libraryName}}_{{resolveName "Ffi"}}_get_raw_pointer');
 
-class {{resolveName}}__Impl {
+class {{resolveName}}$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
-  {{resolveName}}__Impl(this.handle);
+  {{resolveName}}$Impl(this.handle);
 
   void release() => _{{resolveName "Ffi"}}_release_handle(handle);
 
@@ -88,7 +88,7 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
   final instance = __lib.reverseCache[_{{resolveName "Ffi"}}_get_raw_pointer(handle)] as {{resolveName}};
   if (instance != null) return instance;
-  final _impl = {{resolveName}}__Impl(_{{resolveName "Ffi"}}_copy_handle(handle));
+  final _impl = {{resolveName}}$Impl(_{{resolveName "Ffi"}}_copy_handle(handle));
   return ({{#asFunction}}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{/asFunction}}){{!!
   }} {
     final _result =_impl.call({{#asFunction}}{{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{/asFunction}});

--- a/gluecodium/src/main/resources/templates/dart/DartProperty.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartProperty.mustache
@@ -20,12 +20,18 @@
   !}}
 {{#set property=this}}
 {{#getter}}
-{{>dart/DartDocumentation}}
+{{#unless skipDocs}}{{>dart/DartDocumentation}}
+{{/unless}}
+{{#if override}}{{#unless isStatic}}@override
+{{/unless}}{{/if}}
 {{#if isStatic}}static {{/if}}{{resolveName property.typeRef}} get {{resolveName visibility}}{{resolveName property}}{{!!
 }}{{#unless skipBody}}{{>dart/DartFunctionBody}}{{/unless}}{{#if skipBody}};{{/if}}
 {{/getter}}
 {{#setter}}
-{{>dart/DartDocumentation}}
+{{#unless skipDocs}}{{>dart/DartDocumentation}}
+{{/unless}}
+{{#if override}}{{#unless isStatic}}@override
+{{/unless}}{{/if}}
 {{#if isStatic}}static {{/if}}set {{resolveName visibility}}{{resolveName property}}({{resolveName property.typeRef}} value){{!!
 }}{{#unless skipBody}}{{>dart/DartFunctionBody}}{{/unless}}{{#if skipBody}};{{/if}}
 {{/setter}}

--- a/gluecodium/src/main/resources/templates/dart/DartTypeRepository.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartTypeRepository.mustache
@@ -28,6 +28,5 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 
 final Map<String, Function> typeRepository = { {{#typeRepositories}}
-  "{{resolveName "Ffi"}}": (handle) => {{resolveName}}{{#instanceOf this "LimeInterface"}}__Impl{{/instanceOf}}{{!!
-  }}{{#notInstanceOf this "LimeInterface"}}{{#unless visibility.isOpen}}__Factory.create{{/unless}}{{/notInstanceOf}}(handle),
+  "{{resolveName "Ffi"}}": (handle) => {{resolveName}}$Impl(handle),
 {{/typeRepositories}} };

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/BasicTypes.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/BasicTypes.dart
@@ -3,6 +3,22 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
+abstract class BasicTypes {
+  void release();
+  static String stringFunction(String input) => BasicTypes$Impl.stringFunction(input);
+  static bool boolFunction(bool input) => BasicTypes$Impl.boolFunction(input);
+  static double floatFunction(double input) => BasicTypes$Impl.floatFunction(input);
+  static double doubleFunction(double input) => BasicTypes$Impl.doubleFunction(input);
+  static int byteFunction(int input) => BasicTypes$Impl.byteFunction(input);
+  static int shortFunction(int input) => BasicTypes$Impl.shortFunction(input);
+  static int intFunction(int input) => BasicTypes$Impl.intFunction(input);
+  static int longFunction(int input) => BasicTypes$Impl.longFunction(input);
+  static int ubyteFunction(int input) => BasicTypes$Impl.ubyteFunction(input);
+  static int ushortFunction(int input) => BasicTypes$Impl.ushortFunction(input);
+  static int uintFunction(int input) => BasicTypes$Impl.uintFunction(input);
+  static int ulongFunction(int input) => BasicTypes$Impl.ulongFunction(input);
+}
+// BasicTypes "private" section, not exported.
 final _smoke_BasicTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -11,10 +27,11 @@ final _smoke_BasicTypes_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_BasicTypes_release_handle');
-class BasicTypes {
-  final Pointer<Void> _handle;
-  BasicTypes._(this._handle);
-  void release() => _smoke_BasicTypes_release_handle(_handle);
+class BasicTypes$Impl implements BasicTypes {
+  final Pointer<Void> handle;
+  BasicTypes$Impl(this.handle);
+  @override
+  void release() => _smoke_BasicTypes_release_handle(handle);
   static String stringFunction(String input) {
     final _stringFunction_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_BasicTypes_stringFunction__String');
     final _input_handle = String_toFfi(input);
@@ -125,9 +142,9 @@ class BasicTypes {
   }
 }
 Pointer<Void> smoke_BasicTypes_toFfi(BasicTypes value) =>
-  _smoke_BasicTypes_copy_handle(value._handle);
+  _smoke_BasicTypes_copy_handle((value as BasicTypes$Impl).handle);
 BasicTypes smoke_BasicTypes_fromFfi(Pointer<Void> handle) =>
-  BasicTypes._(_smoke_BasicTypes_copy_handle(handle));
+  BasicTypes$Impl(_smoke_BasicTypes_copy_handle(handle));
 void smoke_BasicTypes_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_BasicTypes_release_handle(handle);
 Pointer<Void> smoke_BasicTypes_toFfi_nullable(BasicTypes value) =>
@@ -136,3 +153,4 @@ BasicTypes smoke_BasicTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_BasicTypes_fromFfi(handle) : null;
 void smoke_BasicTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_BasicTypes_release_handle(handle);
+// End of BasicTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/Comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/Comments.dart
@@ -4,197 +4,46 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_Comments_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Comments_copy_handle');
-final _smoke_Comments_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Comments_release_handle');
-final _someMethodWithAllComments_return_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Comments_someMethodWithAllComments__String_return_release_handle');
-final _someMethodWithAllComments_return_get_result = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Comments_someMethodWithAllComments__String_return_get_result');
-final _someMethodWithAllComments_return_get_error = __lib.nativeLibrary.lookupFunction<
-    Uint32 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Comments_someMethodWithAllComments__String_return_get_error');
-final _someMethodWithAllComments_return_has_error = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Comments_someMethodWithAllComments__String_return_has_error');
 /// This is some very useful interface.
-class Comments {
-  final Pointer<Void> _handle;
-  Comments._(this._handle);
-  void release() => _smoke_Comments_release_handle(_handle);
+abstract class Comments {
+  void release();
   /// This is some very useful constant.
   static final bool veryUseful = true;
   /// This is some very useful method that measures the usefulness of its input.
   /// @param[input] Very useful input parameter
   /// @return Usefulness of the input
   /// @throws Sometimes it happens.
-  bool someMethodWithAllComments(String input) {
-    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithAllComments__String');
-    final _input_handle = String_toFfi(input);
-    final __call_result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
-        _someMethodWithAllComments_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Comments_SomeEnum_fromFfi(__error_handle);
-        smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
-        throw Comments_SomethingWrongException(_error_value);
-    }
-    final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
-    _someMethodWithAllComments_return_release_handle(__call_result_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+  bool someMethodWithAllComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   /// @param[input] Very useful input parameter
-  bool someMethodWithInputComments(String input) {
-    final _someMethodWithInputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithInputComments__String');
-    final _input_handle = String_toFfi(input);
-    final __result_handle = _someMethodWithInputComments_ffi(_handle, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+  bool someMethodWithInputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   /// @return Usefulness of the input
-  bool someMethodWithOutputComments(String input) {
-    final _someMethodWithOutputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithOutputComments__String');
-    final _input_handle = String_toFfi(input);
-    final __result_handle = _someMethodWithOutputComments_ffi(_handle, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+  bool someMethodWithOutputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
-  bool someMethodWithNoComments(String input) {
-    final _someMethodWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithNoComments__String');
-    final _input_handle = String_toFfi(input);
-    final __result_handle = _someMethodWithNoComments_ffi(_handle, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+  bool someMethodWithNoComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
   /// @param[input] Very useful input parameter
-  someMethodWithoutReturnTypeWithAllComments(String input) {
-    final _someMethodWithoutReturnTypeWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithAllComments__String');
-    final _input_handle = String_toFfi(input);
-    final __result_handle = _someMethodWithoutReturnTypeWithAllComments_ffi(_handle, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+  someMethodWithoutReturnTypeWithAllComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
-  someMethodWithoutReturnTypeWithNoComments(String input) {
-    final _someMethodWithoutReturnTypeWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithNoComments__String');
-    final _input_handle = String_toFfi(input);
-    final __result_handle = _someMethodWithoutReturnTypeWithNoComments_ffi(_handle, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+  someMethodWithoutReturnTypeWithNoComments(String input);
   /// This is some very useful method that measures the usefulness of something.
   /// @return Usefulness of the input
-  bool someMethodWithoutInputParametersWithAllComments() {
-    final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Comments_someMethodWithoutInputParametersWithAllComments');
-    final __result_handle = _someMethodWithoutInputParametersWithAllComments_ffi(_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+  bool someMethodWithoutInputParametersWithAllComments();
   /// This is some very useful method that measures the usefulness of something.
-  bool someMethodWithoutInputParametersWithNoComments() {
-    final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Comments_someMethodWithoutInputParametersWithNoComments');
-    final __result_handle = _someMethodWithoutInputParametersWithNoComments_ffi(_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  someMethodWithNothing() {
-    final _someMethodWithNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_Comments_someMethodWithNothing');
-    final __result_handle = _someMethodWithNothing_ffi(_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+  bool someMethodWithoutInputParametersWithNoComments();
+  someMethodWithNothing();
   /// This is some very useful method that does nothing.
-  someMethodWithoutReturnTypeOrInputParameters() {
-    final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeOrInputParameters');
-    final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+  someMethodWithoutReturnTypeOrInputParameters();
   /// @param[documented] nicely documented
-  String oneParameterCommentOnly(String undocumented, String documented) {
-    final _oneParameterCommentOnly_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_oneParameterCommentOnly__String_String');
-    final _undocumented_handle = String_toFfi(undocumented);
-    final _documented_handle = String_toFfi(documented);
-    final __result_handle = _oneParameterCommentOnly_ffi(_handle, _undocumented_handle, _documented_handle);
-    String_releaseFfiHandle(_undocumented_handle);
-    String_releaseFfiHandle(_documented_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+  String oneParameterCommentOnly(String undocumented, String documented);
   /// @return nicely documented
-  String returnCommentOnly(String undocumented) {
-    final _returnCommentOnly_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_returnCommentOnly__String');
-    final _undocumented_handle = String_toFfi(undocumented);
-    final __result_handle = _returnCommentOnly_ffi(_handle, _undocumented_handle);
-    String_releaseFfiHandle(_undocumented_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+  String returnCommentOnly(String undocumented);
   /// Gets some very useful property.
-  bool get isSomeProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Comments_isSomeProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+  bool get isSomeProperty;
   /// Sets some very useful property.
-  set isSomeProperty(bool value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint8), void Function(Pointer<Void>, int)>('library_smoke_Comments_isSomeProperty_set__Boolean');
-    final _value_handle = Boolean_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    Boolean_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+  set isSomeProperty(bool value);
 }
-Pointer<Void> smoke_Comments_toFfi(Comments value) =>
-  _smoke_Comments_copy_handle(value._handle);
-Comments smoke_Comments_fromFfi(Pointer<Void> handle) =>
-  Comments._(_smoke_Comments_copy_handle(handle));
-void smoke_Comments_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Comments_release_handle(handle);
-Pointer<Void> smoke_Comments_toFfi_nullable(Comments value) =>
-  value != null ? smoke_Comments_toFfi(value) : Pointer<Void>.fromAddress(0);
-Comments smoke_Comments_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_Comments_fromFfi(handle) : null;
-void smoke_Comments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Comments_release_handle(handle);
 /// This is some very useful enum.
 enum Comments_SomeEnum {
     /// Not quite useful
@@ -357,15 +206,16 @@ final _smoke_Comments_SomeLambda_get_raw_pointer = __lib.nativeLibrary.lookupFun
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('library_smoke_Comments_SomeLambda_get_raw_pointer');
-class Comments_SomeLambda__Impl {
+class Comments_SomeLambda$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
-  Comments_SomeLambda__Impl(this.handle);
+  Comments_SomeLambda$Impl(this.handle);
   void release() => _smoke_Comments_SomeLambda_release_handle(handle);
   double call(String p0, int p1) {
     final _call_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Pointer<Void>, Int32), double Function(Pointer<Void>, Pointer<Void>, int)>('library_smoke_Comments_SomeLambda_call__String_Int');
     final _p0_handle = String_toFfi(p0);
     final _p1_handle = (p1);
+    final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, _p0_handle, _p1_handle);
     String_releaseFfiHandle(_p0_handle);
     (_p1_handle);
@@ -393,7 +243,7 @@ Pointer<Void> smoke_Comments_SomeLambda_toFfi(Comments_SomeLambda value) {
 Comments_SomeLambda smoke_Comments_SomeLambda_fromFfi(Pointer<Void> handle) {
   final instance = __lib.reverseCache[_smoke_Comments_SomeLambda_get_raw_pointer(handle)] as Comments_SomeLambda;
   if (instance != null) return instance;
-  final _impl = Comments_SomeLambda__Impl(_smoke_Comments_SomeLambda_copy_handle(handle));
+  final _impl = Comments_SomeLambda$Impl(_smoke_Comments_SomeLambda_copy_handle(handle));
   return (String p0, int p1) {
     final _result =_impl.call(p0, p1);
     _impl.release();
@@ -432,3 +282,202 @@ Comments_SomeLambda smoke_Comments_SomeLambda_fromFfi_nullable(Pointer<Void> han
 void smoke_Comments_SomeLambda_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Comments_SomeLambda_release_handle_nullable(handle);
 // End of Comments_SomeLambda "private" section.
+// Comments "private" section, not exported.
+final _smoke_Comments_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Comments_copy_handle');
+final _smoke_Comments_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Comments_release_handle');
+final _someMethodWithAllComments_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Comments_someMethodWithAllComments__String_return_release_handle');
+final _someMethodWithAllComments_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Comments_someMethodWithAllComments__String_return_get_result');
+final _someMethodWithAllComments_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Comments_someMethodWithAllComments__String_return_get_error');
+final _someMethodWithAllComments_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Comments_someMethodWithAllComments__String_return_has_error');
+class Comments$Impl implements Comments {
+  final Pointer<Void> handle;
+  Comments$Impl(this.handle);
+  @override
+  void release() => _smoke_Comments_release_handle(handle);
+  @override
+  bool someMethodWithAllComments(String input) {
+    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithAllComments__String');
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __call_result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
+        _someMethodWithAllComments_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Comments_SomeEnum_fromFfi(__error_handle);
+        smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
+        throw Comments_SomethingWrongException(_error_value);
+    }
+    final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
+    _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool someMethodWithInputComments(String input) {
+    final _someMethodWithInputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithInputComments__String');
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _someMethodWithInputComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool someMethodWithOutputComments(String input) {
+    final _someMethodWithOutputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithOutputComments__String');
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _someMethodWithOutputComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool someMethodWithNoComments(String input) {
+    final _someMethodWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithNoComments__String');
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _someMethodWithNoComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  someMethodWithoutReturnTypeWithAllComments(String input) {
+    final _someMethodWithoutReturnTypeWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithAllComments__String');
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _someMethodWithoutReturnTypeWithAllComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  someMethodWithoutReturnTypeWithNoComments(String input) {
+    final _someMethodWithoutReturnTypeWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithNoComments__String');
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _someMethodWithoutReturnTypeWithNoComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  bool someMethodWithoutInputParametersWithAllComments() {
+    final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Comments_someMethodWithoutInputParametersWithAllComments');
+    final _handle = this.handle;
+    final __result_handle = _someMethodWithoutInputParametersWithAllComments_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool someMethodWithoutInputParametersWithNoComments() {
+    final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Comments_someMethodWithoutInputParametersWithNoComments');
+    final _handle = this.handle;
+    final __result_handle = _someMethodWithoutInputParametersWithNoComments_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  someMethodWithNothing() {
+    final _someMethodWithNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_Comments_someMethodWithNothing');
+    final _handle = this.handle;
+    final __result_handle = _someMethodWithNothing_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  someMethodWithoutReturnTypeOrInputParameters() {
+    final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeOrInputParameters');
+    final _handle = this.handle;
+    final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  String oneParameterCommentOnly(String undocumented, String documented) {
+    final _oneParameterCommentOnly_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_oneParameterCommentOnly__String_String');
+    final _undocumented_handle = String_toFfi(undocumented);
+    final _documented_handle = String_toFfi(documented);
+    final _handle = this.handle;
+    final __result_handle = _oneParameterCommentOnly_ffi(_handle, _undocumented_handle, _documented_handle);
+    String_releaseFfiHandle(_undocumented_handle);
+    String_releaseFfiHandle(_documented_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  String returnCommentOnly(String undocumented) {
+    final _returnCommentOnly_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_returnCommentOnly__String');
+    final _undocumented_handle = String_toFfi(undocumented);
+    final _handle = this.handle;
+    final __result_handle = _returnCommentOnly_ffi(_handle, _undocumented_handle);
+    String_releaseFfiHandle(_undocumented_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool get isSomeProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Comments_isSomeProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set isSomeProperty(bool value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint8), void Function(Pointer<Void>, int)>('library_smoke_Comments_isSomeProperty_set__Boolean');
+    final _value_handle = Boolean_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Boolean_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_Comments_toFfi(Comments value) =>
+  _smoke_Comments_copy_handle((value as Comments$Impl).handle);
+Comments smoke_Comments_fromFfi(Pointer<Void> handle) =>
+  Comments$Impl(_smoke_Comments_copy_handle(handle));
+void smoke_Comments_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Comments_release_handle(handle);
+Pointer<Void> smoke_Comments_toFfi_nullable(Comments value) =>
+  value != null ? smoke_Comments_toFfi(value) : Pointer<Void>.fromAddress(0);
+Comments smoke_Comments_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_Comments_fromFfi(handle) : null;
+void smoke_Comments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Comments_release_handle(handle);
+// End of Comments "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsInterface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsInterface.dart
@@ -187,16 +187,16 @@ final _smoke_CommentsInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_get_type_id');
-class CommentsInterface__Impl implements CommentsInterface {
-  Pointer<Void> get _handle => handle;
+class CommentsInterface$Impl implements CommentsInterface {
   final Pointer<Void> handle;
-  CommentsInterface__Impl(this.handle);
+  CommentsInterface$Impl(this.handle);
   @override
   void release() => _smoke_CommentsInterface_release_handle(handle);
   @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithAllComments__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = Boolean_fromFfi(__result_handle);
@@ -207,6 +207,7 @@ class CommentsInterface__Impl implements CommentsInterface {
   bool someMethodWithInputComments(String input) {
     final _someMethodWithInputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithInputComments__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _someMethodWithInputComments_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = Boolean_fromFfi(__result_handle);
@@ -217,6 +218,7 @@ class CommentsInterface__Impl implements CommentsInterface {
   bool someMethodWithOutputComments(String input) {
     final _someMethodWithOutputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithOutputComments__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _someMethodWithOutputComments_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = Boolean_fromFfi(__result_handle);
@@ -227,6 +229,7 @@ class CommentsInterface__Impl implements CommentsInterface {
   bool someMethodWithNoComments(String input) {
     final _someMethodWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithNoComments__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _someMethodWithNoComments_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = Boolean_fromFfi(__result_handle);
@@ -237,6 +240,7 @@ class CommentsInterface__Impl implements CommentsInterface {
   someMethodWithoutReturnTypeWithAllComments(String input) {
     final _someMethodWithoutReturnTypeWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithAllComments__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeWithAllComments_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = (__result_handle);
@@ -247,6 +251,7 @@ class CommentsInterface__Impl implements CommentsInterface {
   someMethodWithoutReturnTypeWithNoComments(String input) {
     final _someMethodWithoutReturnTypeWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithNoComments__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeWithNoComments_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = (__result_handle);
@@ -256,6 +261,7 @@ class CommentsInterface__Impl implements CommentsInterface {
   @override
   bool someMethodWithoutInputParametersWithAllComments() {
     final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithAllComments');
+    final _handle = this.handle;
     final __result_handle = _someMethodWithoutInputParametersWithAllComments_ffi(_handle);
     final _result = Boolean_fromFfi(__result_handle);
     Boolean_releaseFfiHandle(__result_handle);
@@ -264,6 +270,7 @@ class CommentsInterface__Impl implements CommentsInterface {
   @override
   bool someMethodWithoutInputParametersWithNoComments() {
     final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithNoComments');
+    final _handle = this.handle;
     final __result_handle = _someMethodWithoutInputParametersWithNoComments_ffi(_handle);
     final _result = Boolean_fromFfi(__result_handle);
     Boolean_releaseFfiHandle(__result_handle);
@@ -272,6 +279,7 @@ class CommentsInterface__Impl implements CommentsInterface {
   @override
   someMethodWithNothing() {
     final _someMethodWithNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithNothing');
+    final _handle = this.handle;
     final __result_handle = _someMethodWithNothing_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
@@ -280,6 +288,7 @@ class CommentsInterface__Impl implements CommentsInterface {
   @override
   someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeOrInputParameters');
+    final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
@@ -288,6 +297,7 @@ class CommentsInterface__Impl implements CommentsInterface {
   /// Gets some very useful property.
   bool get isSomeProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_CommentsInterface_isSomeProperty_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = Boolean_fromFfi(__result_handle);
     Boolean_releaseFfiHandle(__result_handle);
@@ -297,6 +307,7 @@ class CommentsInterface__Impl implements CommentsInterface {
   set isSomeProperty(bool value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint8), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_isSomeProperty_set__Boolean');
     final _value_handle = Boolean_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     Boolean_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -366,7 +377,7 @@ int _CommentsInterface_isSomeProperty_set_static(int _token, int _value) {
   return 0;
 }
 Pointer<Void> smoke_CommentsInterface_toFfi(CommentsInterface value) {
-  if (value is CommentsInterface__Impl) return _smoke_CommentsInterface_copy_handle(value.handle);
+  if (value is CommentsInterface$Impl) return _smoke_CommentsInterface_copy_handle(value.handle);
   final result = _smoke_CommentsInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -393,7 +404,7 @@ CommentsInterface smoke_CommentsInterface_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_CommentsInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? CommentsInterface__Impl(_copied_handle)
+    ? CommentsInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
@@ -3,30 +3,6 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_CommentsLinks_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_copy_handle');
-final _smoke_CommentsLinks_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_release_handle');
-final _randomMethod_return_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_release_handle');
-final _randomMethod_return_get_result = __lib.nativeLibrary.lookupFunction<
-    Uint32 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_result');
-final _randomMethod_return_get_error = __lib.nativeLibrary.lookupFunction<
-    Uint32 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_error');
-final _randomMethod_return_has_error = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_has_error');
 /// The nested types like [random_method] don't need full name prefix, but it's
 /// possible to references other interfaces like [CommentsInterface] or other members
 /// [comments.someMethodWithAllComments].
@@ -34,10 +10,8 @@ final _randomMethod_return_has_error = __lib.nativeLibrary.lookupFunction<
 /// Weblinks are not modified like this [example] or [www.example.com].
 ///
 /// [example]: http://example.com
-class CommentsLinks {
-  final Pointer<Void> _handle;
-  CommentsLinks._(this._handle);
-  void release() => _smoke_CommentsLinks_release_handle(_handle);
+abstract class CommentsLinks {
+  void release();
   /// Link types:
   /// * constant: [veryUseful]
   /// * struct: [Comments_SomeStruct]
@@ -65,37 +39,8 @@ class CommentsLinks {
   /// @param[inputParameter] Sometimes takes [useful]
   /// @return Sometimes returns [useful]
   /// @throws May or may not throw [Comments_SomethingWrongException]
-  Comments_SomeEnum randomMethod(Comments_SomeEnum inputParameter) {
-    final _randomMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_CommentsLinks_randomMethod__SomeEnum');
-    final _inputParameter_handle = smoke_Comments_SomeEnum_toFfi(inputParameter);
-    final __call_result_handle = _randomMethod_ffi(_handle, _inputParameter_handle);
-    smoke_Comments_SomeEnum_releaseFfiHandle(_inputParameter_handle);
-    if (_randomMethod_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _randomMethod_return_get_error(__call_result_handle);
-        _randomMethod_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Comments_SomeEnum_fromFfi(__error_handle);
-        smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
-        throw Comments_SomethingWrongException(_error_value);
-    }
-    final __result_handle = _randomMethod_return_get_result(__call_result_handle);
-    _randomMethod_return_release_handle(__call_result_handle);
-    final _result = smoke_Comments_SomeEnum_fromFfi(__result_handle);
-    smoke_Comments_SomeEnum_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+  Comments_SomeEnum randomMethod(Comments_SomeEnum inputParameter);
 }
-Pointer<Void> smoke_CommentsLinks_toFfi(CommentsLinks value) =>
-  _smoke_CommentsLinks_copy_handle(value._handle);
-CommentsLinks smoke_CommentsLinks_fromFfi(Pointer<Void> handle) =>
-  CommentsLinks._(_smoke_CommentsLinks_copy_handle(handle));
-void smoke_CommentsLinks_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_CommentsLinks_release_handle(handle);
-Pointer<Void> smoke_CommentsLinks_toFfi_nullable(CommentsLinks value) =>
-  value != null ? smoke_CommentsLinks_toFfi(value) : Pointer<Void>.fromAddress(0);
-CommentsLinks smoke_CommentsLinks_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_CommentsLinks_fromFfi(handle) : null;
-void smoke_CommentsLinks_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_CommentsLinks_release_handle(handle);
 /// Links also work in:
 class CommentsLinks_RandomStruct {
   /// Some random field [Comments_SomeStruct]
@@ -160,3 +105,67 @@ CommentsLinks_RandomStruct smoke_CommentsLinks_RandomStruct_fromFfi_nullable(Poi
 void smoke_CommentsLinks_RandomStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_CommentsLinks_RandomStruct_release_handle_nullable(handle);
 // End of CommentsLinks_RandomStruct "private" section.
+// CommentsLinks "private" section, not exported.
+final _smoke_CommentsLinks_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_copy_handle');
+final _smoke_CommentsLinks_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_release_handle');
+final _randomMethod_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_release_handle');
+final _randomMethod_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_result');
+final _randomMethod_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_error');
+final _randomMethod_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_has_error');
+class CommentsLinks$Impl implements CommentsLinks {
+  final Pointer<Void> handle;
+  CommentsLinks$Impl(this.handle);
+  @override
+  void release() => _smoke_CommentsLinks_release_handle(handle);
+  @override
+  Comments_SomeEnum randomMethod(Comments_SomeEnum inputParameter) {
+    final _randomMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_CommentsLinks_randomMethod__SomeEnum');
+    final _inputParameter_handle = smoke_Comments_SomeEnum_toFfi(inputParameter);
+    final _handle = this.handle;
+    final __call_result_handle = _randomMethod_ffi(_handle, _inputParameter_handle);
+    smoke_Comments_SomeEnum_releaseFfiHandle(_inputParameter_handle);
+    if (_randomMethod_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _randomMethod_return_get_error(__call_result_handle);
+        _randomMethod_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Comments_SomeEnum_fromFfi(__error_handle);
+        smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
+        throw Comments_SomethingWrongException(_error_value);
+    }
+    final __result_handle = _randomMethod_return_get_result(__call_result_handle);
+    _randomMethod_return_release_handle(__call_result_handle);
+    final _result = smoke_Comments_SomeEnum_fromFfi(__result_handle);
+    smoke_Comments_SomeEnum_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_CommentsLinks_toFfi(CommentsLinks value) =>
+  _smoke_CommentsLinks_copy_handle((value as CommentsLinks$Impl).handle);
+CommentsLinks smoke_CommentsLinks_fromFfi(Pointer<Void> handle) =>
+  CommentsLinks$Impl(_smoke_CommentsLinks_copy_handle(handle));
+void smoke_CommentsLinks_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_CommentsLinks_release_handle(handle);
+Pointer<Void> smoke_CommentsLinks_toFfi_nullable(CommentsLinks value) =>
+  value != null ? smoke_CommentsLinks_toFfi(value) : Pointer<Void>.fromAddress(0);
+CommentsLinks smoke_CommentsLinks_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_CommentsLinks_fromFfi(handle) : null;
+void smoke_CommentsLinks_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_CommentsLinks_release_handle(handle);
+// End of CommentsLinks "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationComments.dart
@@ -177,16 +177,16 @@ final _smoke_DeprecationComments_get_type_id = __lib.nativeLibrary.lookupFunctio
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_get_type_id');
-class DeprecationComments__Impl implements DeprecationComments {
-  Pointer<Void> get _handle => handle;
+class DeprecationComments$Impl implements DeprecationComments {
   final Pointer<Void> handle;
-  DeprecationComments__Impl(this.handle);
+  DeprecationComments$Impl(this.handle);
   @override
   void release() => _smoke_DeprecationComments_release_handle(handle);
   @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_DeprecationComments_someMethodWithAllComments__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = Boolean_fromFfi(__result_handle);
@@ -198,6 +198,7 @@ class DeprecationComments__Impl implements DeprecationComments {
   Use [comments.SomeProperty.get] instead.")
   bool get isSomeProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_DeprecationComments_isSomeProperty_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = Boolean_fromFfi(__result_handle);
     Boolean_releaseFfiHandle(__result_handle);
@@ -209,6 +210,7 @@ class DeprecationComments__Impl implements DeprecationComments {
   set isSomeProperty(bool value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint8), void Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_isSomeProperty_set__Boolean');
     final _value_handle = Boolean_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     Boolean_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -232,7 +234,7 @@ int _DeprecationComments_isSomeProperty_set_static(int _token, int _value) {
   return 0;
 }
 Pointer<Void> smoke_DeprecationComments_toFfi(DeprecationComments value) {
-  if (value is DeprecationComments__Impl) return _smoke_DeprecationComments_copy_handle(value.handle);
+  if (value is DeprecationComments$Impl) return _smoke_DeprecationComments_copy_handle(value.handle);
   final result = _smoke_DeprecationComments_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -250,7 +252,7 @@ DeprecationComments smoke_DeprecationComments_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_DeprecationComments_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? DeprecationComments__Impl(_copied_handle)
+    ? DeprecationComments$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationCommentsOnly.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationCommentsOnly.dart
@@ -158,16 +158,16 @@ final _smoke_DeprecationCommentsOnly_get_type_id = __lib.nativeLibrary.lookupFun
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_get_type_id');
-class DeprecationCommentsOnly__Impl implements DeprecationCommentsOnly {
-  Pointer<Void> get _handle => handle;
+class DeprecationCommentsOnly$Impl implements DeprecationCommentsOnly {
   final Pointer<Void> handle;
-  DeprecationCommentsOnly__Impl(this.handle);
+  DeprecationCommentsOnly$Impl(this.handle);
   @override
   void release() => _smoke_DeprecationCommentsOnly_release_handle(handle);
   @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_DeprecationCommentsOnly_someMethodWithAllComments__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = Boolean_fromFfi(__result_handle);
@@ -177,6 +177,7 @@ class DeprecationCommentsOnly__Impl implements DeprecationCommentsOnly {
   @Deprecated("Unfortunately, this property's getter is deprecated.")
   bool get isSomeProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = Boolean_fromFfi(__result_handle);
     Boolean_releaseFfiHandle(__result_handle);
@@ -186,6 +187,7 @@ class DeprecationCommentsOnly__Impl implements DeprecationCommentsOnly {
   set isSomeProperty(bool value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint8), void Function(Pointer<Void>, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_set__Boolean');
     final _value_handle = Boolean_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     Boolean_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -209,7 +211,7 @@ int _DeprecationCommentsOnly_isSomeProperty_set_static(int _token, int _value) {
   return 0;
 }
 Pointer<Void> smoke_DeprecationCommentsOnly_toFfi(DeprecationCommentsOnly value) {
-  if (value is DeprecationCommentsOnly__Impl) return _smoke_DeprecationCommentsOnly_copy_handle(value.handle);
+  if (value is DeprecationCommentsOnly$Impl) return _smoke_DeprecationCommentsOnly_copy_handle(value.handle);
   final result = _smoke_DeprecationCommentsOnly_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -227,7 +229,7 @@ DeprecationCommentsOnly smoke_DeprecationCommentsOnly_fromFfi(Pointer<Void> hand
   final _type_id_handle = _smoke_DeprecationCommentsOnly_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? DeprecationCommentsOnly__Impl(_copied_handle)
+    ? DeprecationCommentsOnly$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/MultiLineComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/MultiLineComments.dart
@@ -3,14 +3,6 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_MultiLineComments_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_MultiLineComments_copy_handle');
-final _smoke_MultiLineComments_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_MultiLineComments_release_handle');
 /// This is some very useful interface.
 /// There is a lot to say about this interface.
 /// at least it has multiline comments.
@@ -24,10 +16,8 @@ final _smoke_MultiLineComments_release_handle = __lib.nativeLibrary.lookupFuncti
 /// * escaping
 ///
 /// ```Some example code;```
-class MultiLineComments {
-  final Pointer<Void> _handle;
-  MultiLineComments._(this._handle);
-  void release() => _smoke_MultiLineComments_release_handle(_handle);
+abstract class MultiLineComments {
+  void release();
   /// This is very important method.
   /// It has very important parameters.
   /// It has side effects.
@@ -41,10 +31,28 @@ class MultiLineComments {
   /// and a useful ratio you can expect a useful output.
   /// Just kidding do not expect anything from a method until
   /// you see its body.
+  double someMethodWithLongComment(String input, double ratio);
+}
+// MultiLineComments "private" section, not exported.
+final _smoke_MultiLineComments_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MultiLineComments_copy_handle');
+final _smoke_MultiLineComments_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MultiLineComments_release_handle');
+class MultiLineComments$Impl implements MultiLineComments {
+  final Pointer<Void> handle;
+  MultiLineComments$Impl(this.handle);
+  @override
+  void release() => _smoke_MultiLineComments_release_handle(handle);
+  @override
   double someMethodWithLongComment(String input, double ratio) {
     final _someMethodWithLongComment_ffi = __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Pointer<Void>, Double), double Function(Pointer<Void>, Pointer<Void>, double)>('library_smoke_MultiLineComments_someMethodWithLongComment__String_Double');
     final _input_handle = String_toFfi(input);
     final _ratio_handle = (ratio);
+    final _handle = this.handle;
     final __result_handle = _someMethodWithLongComment_ffi(_handle, _input_handle, _ratio_handle);
     String_releaseFfiHandle(_input_handle);
     (_ratio_handle);
@@ -54,9 +62,9 @@ class MultiLineComments {
   }
 }
 Pointer<Void> smoke_MultiLineComments_toFfi(MultiLineComments value) =>
-  _smoke_MultiLineComments_copy_handle(value._handle);
+  _smoke_MultiLineComments_copy_handle((value as MultiLineComments$Impl).handle);
 MultiLineComments smoke_MultiLineComments_fromFfi(Pointer<Void> handle) =>
-  MultiLineComments._(_smoke_MultiLineComments_copy_handle(handle));
+  MultiLineComments$Impl(_smoke_MultiLineComments_copy_handle(handle));
 void smoke_MultiLineComments_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_MultiLineComments_release_handle(handle);
 Pointer<Void> smoke_MultiLineComments_toFfi_nullable(MultiLineComments value) =>
@@ -65,3 +73,4 @@ MultiLineComments smoke_MultiLineComments_fromFfi_nullable(Pointer<Void> handle)
   handle.address != 0 ? smoke_MultiLineComments_fromFfi(handle) : null;
 void smoke_MultiLineComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_MultiLineComments_release_handle(handle);
+// End of MultiLineComments "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/PlatformComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/PlatformComments.dart
@@ -3,85 +3,18 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_PlatformComments_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_copy_handle');
-final _smoke_PlatformComments_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_release_handle');
-final _someMethodWithAllComments_return_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_release_handle');
-final _someMethodWithAllComments_return_get_result = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_result');
-final _someMethodWithAllComments_return_get_error = __lib.nativeLibrary.lookupFunction<
-    Uint32 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_error');
-final _someMethodWithAllComments_return_has_error = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_has_error');
-class PlatformComments {
-  final Pointer<Void> _handle;
-  PlatformComments._(this._handle);
-  void release() => _smoke_PlatformComments_release_handle(_handle);
+abstract class PlatformComments {
+  void release();
   /// This is some very useless method that cannot have overloads.
-  doNothing() {
-    final _doNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_PlatformComments_doNothing');
-    final __result_handle = _doNothing_ffi(_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+  doNothing();
   /// Colors everything in fuchsia.
-  doMagic() {
-    final _doMagic_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_PlatformComments_doMagic');
-    final __result_handle = _doMagic_ffi(_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+  doMagic();
   /// This is some very useful method that measures the usefulness of its input or \esc@pe{s}.
   /// @param[input] Very useful parameter that \esc@pe{s}
   /// @return Uselessness [PlatformComments_SomeEnum] of the input
   /// @throws Sometimes it happens.
-  bool someMethodWithAllComments(String input) {
-    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_PlatformComments_someMethodWithAllComments__String');
-    final _input_handle = String_toFfi(input);
-    final __call_result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
-        _someMethodWithAllComments_return_release_handle(__call_result_handle);
-        final _error_value = smoke_PlatformComments_SomeEnum_fromFfi(__error_handle);
-        smoke_PlatformComments_SomeEnum_releaseFfiHandle(__error_handle);
-        throw PlatformComments_SomethingWrongException(_error_value);
-    }
-    final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
-    _someMethodWithAllComments_return_release_handle(__call_result_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+  bool someMethodWithAllComments(String input);
 }
-Pointer<Void> smoke_PlatformComments_toFfi(PlatformComments value) =>
-  _smoke_PlatformComments_copy_handle(value._handle);
-PlatformComments smoke_PlatformComments_fromFfi(Pointer<Void> handle) =>
-  PlatformComments._(_smoke_PlatformComments_copy_handle(handle));
-void smoke_PlatformComments_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_PlatformComments_release_handle(handle);
-Pointer<Void> smoke_PlatformComments_toFfi_nullable(PlatformComments value) =>
-  value != null ? smoke_PlatformComments_toFfi(value) : Pointer<Void>.fromAddress(0);
-PlatformComments smoke_PlatformComments_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_PlatformComments_fromFfi(handle) : null;
-void smoke_PlatformComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PlatformComments_release_handle(handle);
 enum PlatformComments_SomeEnum {
     useless,
     useful
@@ -209,3 +142,85 @@ PlatformComments_Something smoke_PlatformComments_Something_fromFfi_nullable(Poi
 void smoke_PlatformComments_Something_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_PlatformComments_Something_release_handle_nullable(handle);
 // End of PlatformComments_Something "private" section.
+// PlatformComments "private" section, not exported.
+final _smoke_PlatformComments_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_copy_handle');
+final _smoke_PlatformComments_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_release_handle');
+final _someMethodWithAllComments_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_release_handle');
+final _someMethodWithAllComments_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_result');
+final _someMethodWithAllComments_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_error');
+final _someMethodWithAllComments_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_has_error');
+class PlatformComments$Impl implements PlatformComments {
+  final Pointer<Void> handle;
+  PlatformComments$Impl(this.handle);
+  @override
+  void release() => _smoke_PlatformComments_release_handle(handle);
+  @override
+  doNothing() {
+    final _doNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_PlatformComments_doNothing');
+    final _handle = this.handle;
+    final __result_handle = _doNothing_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  doMagic() {
+    final _doMagic_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_PlatformComments_doMagic');
+    final _handle = this.handle;
+    final __result_handle = _doMagic_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  bool someMethodWithAllComments(String input) {
+    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_PlatformComments_someMethodWithAllComments__String');
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __call_result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
+        _someMethodWithAllComments_return_release_handle(__call_result_handle);
+        final _error_value = smoke_PlatformComments_SomeEnum_fromFfi(__error_handle);
+        smoke_PlatformComments_SomeEnum_releaseFfiHandle(__error_handle);
+        throw PlatformComments_SomethingWrongException(_error_value);
+    }
+    final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
+    _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_PlatformComments_toFfi(PlatformComments value) =>
+  _smoke_PlatformComments_copy_handle((value as PlatformComments$Impl).handle);
+PlatformComments smoke_PlatformComments_fromFfi(Pointer<Void> handle) =>
+  PlatformComments$Impl(_smoke_PlatformComments_copy_handle(handle));
+void smoke_PlatformComments_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_PlatformComments_release_handle(handle);
+Pointer<Void> smoke_PlatformComments_toFfi_nullable(PlatformComments value) =>
+  value != null ? smoke_PlatformComments_toFfi(value) : Pointer<Void>.fromAddress(0);
+PlatformComments smoke_PlatformComments_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_PlatformComments_fromFfi(handle) : null;
+void smoke_PlatformComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PlatformComments_release_handle(handle);
+// End of PlatformComments "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/UnicodeComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/UnicodeComments.dart
@@ -4,6 +4,15 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
+abstract class UnicodeComments {
+  void release();
+  /// Süßölgefäß
+  /// @param[input] שלום
+  /// @return товарищ
+  /// @throws ネコ
+  bool someMethodWithAllComments(String input);
+}
+// UnicodeComments "private" section, not exported.
 final _smoke_UnicodeComments_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -28,17 +37,16 @@ final _someMethodWithAllComments_return_has_error = __lib.nativeLibrary.lookupFu
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_has_error');
-class UnicodeComments {
-  final Pointer<Void> _handle;
-  UnicodeComments._(this._handle);
-  void release() => _smoke_UnicodeComments_release_handle(_handle);
-  /// Süßölgefäß
-  /// @param[input] שלום
-  /// @return товарищ
-  /// @throws ネコ
+class UnicodeComments$Impl implements UnicodeComments {
+  final Pointer<Void> handle;
+  UnicodeComments$Impl(this.handle);
+  @override
+  void release() => _smoke_UnicodeComments_release_handle(handle);
+  @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_UnicodeComments_someMethodWithAllComments__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __call_result_handle = _someMethodWithAllComments_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
@@ -56,9 +64,9 @@ class UnicodeComments {
   }
 }
 Pointer<Void> smoke_UnicodeComments_toFfi(UnicodeComments value) =>
-  _smoke_UnicodeComments_copy_handle(value._handle);
+  _smoke_UnicodeComments_copy_handle((value as UnicodeComments$Impl).handle);
 UnicodeComments smoke_UnicodeComments_fromFfi(Pointer<Void> handle) =>
-  UnicodeComments._(_smoke_UnicodeComments_copy_handle(handle));
+  UnicodeComments$Impl(_smoke_UnicodeComments_copy_handle(handle));
 void smoke_UnicodeComments_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_UnicodeComments_release_handle(handle);
 Pointer<Void> smoke_UnicodeComments_toFfi_nullable(UnicodeComments value) =>
@@ -67,3 +75,4 @@ UnicodeComments smoke_UnicodeComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_UnicodeComments_fromFfi(handle) : null;
 void smoke_UnicodeComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_UnicodeComments_release_handle(handle);
+// End of UnicodeComments "private" section.

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/ConstantsInterface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/ConstantsInterface.dart
@@ -2,18 +2,8 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_ConstantsInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ConstantsInterface_copy_handle');
-final _smoke_ConstantsInterface_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_ConstantsInterface_release_handle');
-class ConstantsInterface {
-  final Pointer<Void> _handle;
-  ConstantsInterface._(this._handle);
-  void release() => _smoke_ConstantsInterface_release_handle(_handle);
+abstract class ConstantsInterface {
+  void release();
   static final bool boolConstant = true;
   static final int intConstant = -11;
   static final int uintConstant = 4294967295;
@@ -22,18 +12,6 @@ class ConstantsInterface {
   static final String stringConstant = "Foo bar";
   static final ConstantsInterface_StateEnum enumConstant = ConstantsInterface_StateEnum.on;
 }
-Pointer<Void> smoke_ConstantsInterface_toFfi(ConstantsInterface value) =>
-  _smoke_ConstantsInterface_copy_handle(value._handle);
-ConstantsInterface smoke_ConstantsInterface_fromFfi(Pointer<Void> handle) =>
-  ConstantsInterface._(_smoke_ConstantsInterface_copy_handle(handle));
-void smoke_ConstantsInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ConstantsInterface_release_handle(handle);
-Pointer<Void> smoke_ConstantsInterface_toFfi_nullable(ConstantsInterface value) =>
-  value != null ? smoke_ConstantsInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-ConstantsInterface smoke_ConstantsInterface_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_ConstantsInterface_fromFfi(handle) : null;
-void smoke_ConstantsInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ConstantsInterface_release_handle(handle);
 enum ConstantsInterface_StateEnum {
     off,
     on
@@ -93,3 +71,31 @@ ConstantsInterface_StateEnum smoke_ConstantsInterface_StateEnum_fromFfi_nullable
 void smoke_ConstantsInterface_StateEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ConstantsInterface_StateEnum_release_handle_nullable(handle);
 // End of ConstantsInterface_StateEnum "private" section.
+// ConstantsInterface "private" section, not exported.
+final _smoke_ConstantsInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ConstantsInterface_copy_handle');
+final _smoke_ConstantsInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ConstantsInterface_release_handle');
+class ConstantsInterface$Impl implements ConstantsInterface {
+  final Pointer<Void> handle;
+  ConstantsInterface$Impl(this.handle);
+  @override
+  void release() => _smoke_ConstantsInterface_release_handle(handle);
+}
+Pointer<Void> smoke_ConstantsInterface_toFfi(ConstantsInterface value) =>
+  _smoke_ConstantsInterface_copy_handle((value as ConstantsInterface$Impl).handle);
+ConstantsInterface smoke_ConstantsInterface_fromFfi(Pointer<Void> handle) =>
+  ConstantsInterface$Impl(_smoke_ConstantsInterface_copy_handle(handle));
+void smoke_ConstantsInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_ConstantsInterface_release_handle(handle);
+Pointer<Void> smoke_ConstantsInterface_toFfi_nullable(ConstantsInterface value) =>
+  value != null ? smoke_ConstantsInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+ConstantsInterface smoke_ConstantsInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_ConstantsInterface_fromFfi(handle) : null;
+void smoke_ConstantsInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_ConstantsInterface_release_handle(handle);
+// End of ConstantsInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/StructConstants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/StructConstants.dart
@@ -3,33 +3,11 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_StructConstants_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructConstants_copy_handle');
-final _smoke_StructConstants_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_StructConstants_release_handle');
-class StructConstants {
-  final Pointer<Void> _handle;
-  StructConstants._(this._handle);
-  void release() => _smoke_StructConstants_release_handle(_handle);
+abstract class StructConstants {
+  void release();
   static final StructConstants_SomeStruct structConstant = StructConstants_SomeStruct("bar Buzz", 1.41);
   static final StructConstants_NestingStruct nestingStructConstant = StructConstants_NestingStruct(StructConstants_SomeStruct("nonsense", -2.82));
 }
-Pointer<Void> smoke_StructConstants_toFfi(StructConstants value) =>
-  _smoke_StructConstants_copy_handle(value._handle);
-StructConstants smoke_StructConstants_fromFfi(Pointer<Void> handle) =>
-  StructConstants._(_smoke_StructConstants_copy_handle(handle));
-void smoke_StructConstants_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_StructConstants_release_handle(handle);
-Pointer<Void> smoke_StructConstants_toFfi_nullable(StructConstants value) =>
-  value != null ? smoke_StructConstants_toFfi(value) : Pointer<Void>.fromAddress(0);
-StructConstants smoke_StructConstants_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_StructConstants_fromFfi(handle) : null;
-void smoke_StructConstants_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructConstants_release_handle(handle);
 class StructConstants_SomeStruct {
   String stringField;
   double floatField;
@@ -164,3 +142,31 @@ StructConstants_NestingStruct smoke_StructConstants_NestingStruct_fromFfi_nullab
 void smoke_StructConstants_NestingStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_StructConstants_NestingStruct_release_handle_nullable(handle);
 // End of StructConstants_NestingStruct "private" section.
+// StructConstants "private" section, not exported.
+final _smoke_StructConstants_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructConstants_copy_handle');
+final _smoke_StructConstants_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_StructConstants_release_handle');
+class StructConstants$Impl implements StructConstants {
+  final Pointer<Void> handle;
+  StructConstants$Impl(this.handle);
+  @override
+  void release() => _smoke_StructConstants_release_handle(handle);
+}
+Pointer<Void> smoke_StructConstants_toFfi(StructConstants value) =>
+  _smoke_StructConstants_copy_handle((value as StructConstants$Impl).handle);
+StructConstants smoke_StructConstants_fromFfi(Pointer<Void> handle) =>
+  StructConstants$Impl(_smoke_StructConstants_copy_handle(handle));
+void smoke_StructConstants_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_StructConstants_release_handle(handle);
+Pointer<Void> smoke_StructConstants_toFfi_nullable(StructConstants value) =>
+  value != null ? smoke_StructConstants_toFfi(value) : Pointer<Void>.fromAddress(0);
+StructConstants smoke_StructConstants_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_StructConstants_fromFfi(handle) : null;
+void smoke_StructConstants_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_StructConstants_release_handle(handle);
+// End of StructConstants "private" section.

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/Constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/Constructors.dart
@@ -5,114 +5,13 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_Constructors_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Constructors_copy_handle');
-final _smoke_Constructors_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Constructors_release_handle');
-final _smoke_Constructors_get_type_id = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Constructors_get_type_id');
-final _createFromString_return_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Constructors_create__String_return_release_handle');
-final _createFromString_return_get_result = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Constructors_create__String_return_get_result');
-final _createFromString_return_get_error = __lib.nativeLibrary.lookupFunction<
-    Uint32 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Constructors_create__String_return_get_error');
-final _createFromString_return_has_error = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Constructors_create__String_return_has_error');
-class Constructors {
-  @protected
-  final Pointer<Void> handle;
-  Pointer<Void> get _handle => handle;
-  @protected
-  Constructors(this.handle);
-  void release() => _smoke_Constructors_release_handle(_handle);
-  Constructors.create() : this(_create());
-  Constructors.createFromOther(Constructors other) : this(_createFromOther(other));
-  Constructors.createFromMulti(String foo, int bar) : this(_createFromMulti(foo, bar));
-  Constructors.createFromString(String input) : this(_createFromString(input));
-  Constructors.createFromList(List<double> input) : this(_createFromList(input));
-  static Pointer<Void> _create() {
-    final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Constructors_create');
-    final __result_handle = _create_ffi();
-    return __result_handle;
-  }
-  static Pointer<Void> _createFromOther(Constructors other) {
-    final _createFromOther_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Constructors_create__Constructors');
-    final _other_handle = smoke_Constructors_toFfi(other);
-    final __result_handle = _createFromOther_ffi(_other_handle);
-    smoke_Constructors_releaseFfiHandle(_other_handle);
-    return __result_handle;
-  }
-  static Pointer<Void> _createFromMulti(String foo, int bar) {
-    final _createFromMulti_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Uint64), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Constructors_create__String_ULong');
-    final _foo_handle = String_toFfi(foo);
-    final _bar_handle = (bar);
-    final __result_handle = _createFromMulti_ffi(_foo_handle, _bar_handle);
-    String_releaseFfiHandle(_foo_handle);
-    (_bar_handle);
-    return __result_handle;
-  }
-  static Pointer<Void> _createFromString(String input) {
-    final _createFromString_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Constructors_create__String');
-    final _input_handle = String_toFfi(input);
-    final __call_result_handle = _createFromString_ffi(_input_handle);
-    String_releaseFfiHandle(_input_handle);
-    if (_createFromString_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _createFromString_return_get_error(__call_result_handle);
-        _createFromString_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Constructors_ErrorEnum_fromFfi(__error_handle);
-        smoke_Constructors_ErrorEnum_releaseFfiHandle(__error_handle);
-        throw Constructors_ConstructorExplodedException(_error_value);
-    }
-    final __result_handle = _createFromString_return_get_result(__call_result_handle);
-    _createFromString_return_release_handle(__call_result_handle);
-    return __result_handle;
-  }
-  static Pointer<Void> _createFromList(List<double> input) {
-    final _createFromList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Constructors_create__ListOf_1Double');
-    final _input_handle = ListOf_Double_toFfi(input);
-    final __result_handle = _createFromList_ffi(_input_handle);
-    ListOf_Double_releaseFfiHandle(_input_handle);
-    return __result_handle;
-  }
-}
-Pointer<Void> smoke_Constructors_toFfi(Constructors value) =>
-  _smoke_Constructors_copy_handle(value._handle);
-Constructors smoke_Constructors_fromFfi(Pointer<Void> handle) {
-  final _copied_handle = _smoke_Constructors_copy_handle(handle);
-  final _type_id_handle = _smoke_Constructors_get_type_id(handle);
-  final _type_id = String_fromFfi(_type_id_handle);
-  final result = _type_id.isEmpty
-    ? Constructors(_copied_handle)
-    : __lib.typeRepository[_type_id](_copied_handle);
-  String_releaseFfiHandle(_type_id_handle);
-  return result;
-}
-void smoke_Constructors_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Constructors_release_handle(handle);
-Pointer<Void> smoke_Constructors_toFfi_nullable(Constructors value) =>
-  value != null ? smoke_Constructors_toFfi(value) : Pointer<Void>.fromAddress(0);
-Constructors smoke_Constructors_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_Constructors_fromFfi(handle) : null;
-void smoke_Constructors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Constructors_release_handle(handle);
-// Internal, not exported.
-class Constructors__Factory {
-  static Constructors create(Pointer<Void> handle) => Constructors(handle);
+abstract class Constructors {
+  factory Constructors.create() => Constructors$Impl.create();
+  factory Constructors.createFromOther(Constructors other) => Constructors$Impl.createFromOther(other);
+  factory Constructors.createFromMulti(String foo, int bar) => Constructors$Impl.createFromMulti(foo, bar);
+  factory Constructors.createFromString(String input) => Constructors$Impl.createFromString(input);
+  factory Constructors.createFromList(List<double> input) => Constructors$Impl.createFromList(input);
+  void release();
 }
 enum Constructors_ErrorEnum {
     none,
@@ -177,3 +76,108 @@ class Constructors_ConstructorExplodedException implements Exception {
   final Constructors_ErrorEnum error;
   Constructors_ConstructorExplodedException(this.error);
 }
+// Constructors "private" section, not exported.
+final _smoke_Constructors_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Constructors_copy_handle');
+final _smoke_Constructors_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Constructors_release_handle');
+final _smoke_Constructors_get_type_id = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Constructors_get_type_id');
+final _createFromString_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Constructors_create__String_return_release_handle');
+final _createFromString_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Constructors_create__String_return_get_result');
+final _createFromString_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Constructors_create__String_return_get_error');
+final _createFromString_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Constructors_create__String_return_has_error');
+class Constructors$Impl implements Constructors {
+  final Pointer<Void> handle;
+  Constructors$Impl(this.handle);
+  @override
+  void release() => _smoke_Constructors_release_handle(handle);
+  Constructors$Impl.create() : this(_create());
+  Constructors$Impl.createFromOther(Constructors other) : this(_createFromOther(other));
+  Constructors$Impl.createFromMulti(String foo, int bar) : this(_createFromMulti(foo, bar));
+  Constructors$Impl.createFromString(String input) : this(_createFromString(input));
+  Constructors$Impl.createFromList(List<double> input) : this(_createFromList(input));
+  static Pointer<Void> _create() {
+    final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Constructors_create');
+    final __result_handle = _create_ffi();
+    return __result_handle;
+  }
+  static Pointer<Void> _createFromOther(Constructors other) {
+    final _createFromOther_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Constructors_create__Constructors');
+    final _other_handle = smoke_Constructors_toFfi(other);
+    final __result_handle = _createFromOther_ffi(_other_handle);
+    smoke_Constructors_releaseFfiHandle(_other_handle);
+    return __result_handle;
+  }
+  static Pointer<Void> _createFromMulti(String foo, int bar) {
+    final _createFromMulti_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Uint64), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Constructors_create__String_ULong');
+    final _foo_handle = String_toFfi(foo);
+    final _bar_handle = (bar);
+    final __result_handle = _createFromMulti_ffi(_foo_handle, _bar_handle);
+    String_releaseFfiHandle(_foo_handle);
+    (_bar_handle);
+    return __result_handle;
+  }
+  static Pointer<Void> _createFromString(String input) {
+    final _createFromString_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Constructors_create__String');
+    final _input_handle = String_toFfi(input);
+    final __call_result_handle = _createFromString_ffi(_input_handle);
+    String_releaseFfiHandle(_input_handle);
+    if (_createFromString_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _createFromString_return_get_error(__call_result_handle);
+        _createFromString_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Constructors_ErrorEnum_fromFfi(__error_handle);
+        smoke_Constructors_ErrorEnum_releaseFfiHandle(__error_handle);
+        throw Constructors_ConstructorExplodedException(_error_value);
+    }
+    final __result_handle = _createFromString_return_get_result(__call_result_handle);
+    _createFromString_return_release_handle(__call_result_handle);
+    return __result_handle;
+  }
+  static Pointer<Void> _createFromList(List<double> input) {
+    final _createFromList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Constructors_create__ListOf_1Double');
+    final _input_handle = ListOf_Double_toFfi(input);
+    final __result_handle = _createFromList_ffi(_input_handle);
+    ListOf_Double_releaseFfiHandle(_input_handle);
+    return __result_handle;
+  }
+}
+Pointer<Void> smoke_Constructors_toFfi(Constructors value) =>
+  _smoke_Constructors_copy_handle((value as Constructors$Impl).handle);
+Constructors smoke_Constructors_fromFfi(Pointer<Void> handle) {
+  final _copied_handle = _smoke_Constructors_copy_handle(handle);
+  final _type_id_handle = _smoke_Constructors_get_type_id(handle);
+  final _type_id = String_fromFfi(_type_id_handle);
+  final result = _type_id.isEmpty
+    ? Constructors$Impl(_copied_handle)
+    : __lib.typeRepository[_type_id](_copied_handle);
+  String_releaseFfiHandle(_type_id_handle);
+  return result;
+}
+void smoke_Constructors_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Constructors_release_handle(handle);
+Pointer<Void> smoke_Constructors_toFfi_nullable(Constructors value) =>
+  value != null ? smoke_Constructors_toFfi(value) : Pointer<Void>.fromAddress(0);
+Constructors smoke_Constructors_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_Constructors_fromFfi(handle) : null;
+void smoke_Constructors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Constructors_release_handle(handle);
+// End of Constructors "private" section.

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/Dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/Dates.dart
@@ -3,56 +3,12 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_Dates_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Dates_copy_handle');
-final _smoke_Dates_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Dates_release_handle');
-class Dates {
-  final Pointer<Void> _handle;
-  Dates._(this._handle);
-  void release() => _smoke_Dates_release_handle(_handle);
-  DateTime dateMethod(DateTime input) {
-    final _dateMethod_ffi = __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Uint64), int Function(Pointer<Void>, int)>('library_smoke_Dates_dateMethod__Date');
-    final _input_handle = Date_toFfi(input);
-    final __result_handle = _dateMethod_ffi(_handle, _input_handle);
-    Date_releaseFfiHandle(_input_handle);
-    final _result = Date_fromFfi(__result_handle);
-    Date_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  DateTime get dateProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Dates_dateProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = Date_fromFfi(__result_handle);
-    Date_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set dateProperty(DateTime value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint64), void Function(Pointer<Void>, int)>('library_smoke_Dates_dateProperty_set__Date');
-    final _value_handle = Date_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    Date_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+abstract class Dates {
+  void release();
+  DateTime dateMethod(DateTime input);
+  DateTime get dateProperty;
+  set dateProperty(DateTime value);
 }
-Pointer<Void> smoke_Dates_toFfi(Dates value) =>
-  _smoke_Dates_copy_handle(value._handle);
-Dates smoke_Dates_fromFfi(Pointer<Void> handle) =>
-  Dates._(_smoke_Dates_copy_handle(handle));
-void smoke_Dates_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Dates_release_handle(handle);
-Pointer<Void> smoke_Dates_toFfi_nullable(Dates value) =>
-  value != null ? smoke_Dates_toFfi(value) : Pointer<Void>.fromAddress(0);
-Dates smoke_Dates_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_Dates_fromFfi(handle) : null;
-void smoke_Dates_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Dates_release_handle(handle);
 class Dates_DateStruct {
   DateTime dateField;
   Dates_DateStruct(this.dateField);
@@ -115,3 +71,62 @@ Dates_DateStruct smoke_Dates_DateStruct_fromFfi_nullable(Pointer<Void> handle) {
 void smoke_Dates_DateStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Dates_DateStruct_release_handle_nullable(handle);
 // End of Dates_DateStruct "private" section.
+// Dates "private" section, not exported.
+final _smoke_Dates_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Dates_copy_handle');
+final _smoke_Dates_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Dates_release_handle');
+class Dates$Impl implements Dates {
+  final Pointer<Void> handle;
+  Dates$Impl(this.handle);
+  @override
+  void release() => _smoke_Dates_release_handle(handle);
+  @override
+  DateTime dateMethod(DateTime input) {
+    final _dateMethod_ffi = __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Uint64), int Function(Pointer<Void>, int)>('library_smoke_Dates_dateMethod__Date');
+    final _input_handle = Date_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _dateMethod_ffi(_handle, _input_handle);
+    Date_releaseFfiHandle(_input_handle);
+    final _result = Date_fromFfi(__result_handle);
+    Date_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  DateTime get dateProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Dates_dateProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = Date_fromFfi(__result_handle);
+    Date_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set dateProperty(DateTime value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint64), void Function(Pointer<Void>, int)>('library_smoke_Dates_dateProperty_set__Date');
+    final _value_handle = Date_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Date_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_Dates_toFfi(Dates value) =>
+  _smoke_Dates_copy_handle((value as Dates$Impl).handle);
+Dates smoke_Dates_fromFfi(Pointer<Void> handle) =>
+  Dates$Impl(_smoke_Dates_copy_handle(handle));
+void smoke_Dates_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Dates_release_handle(handle);
+Pointer<Void> smoke_Dates_toFfi_nullable(Dates value) =>
+  value != null ? smoke_Dates_toFfi(value) : Pointer<Void>.fromAddress(0);
+Dates smoke_Dates_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_Dates_fromFfi(handle) : null;
+void smoke_Dates_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Dates_release_handle(handle);
+// End of Dates "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/DefaultValues.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/DefaultValues.dart
@@ -4,40 +4,10 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_DefaultValues_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_copy_handle');
-final _smoke_DefaultValues_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_release_handle');
-class DefaultValues {
-  final Pointer<Void> _handle;
-  DefaultValues._(this._handle);
-  void release() => _smoke_DefaultValues_release_handle(_handle);
-  static DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) {
-    final _processStructWithDefaults_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_DefaultValues_processStructWithDefaults__StructWithDefaults');
-    final _input_handle = smoke_DefaultValues_StructWithDefaults_toFfi(input);
-    final __result_handle = _processStructWithDefaults_ffi(_input_handle);
-    smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_input_handle);
-    final _result = smoke_DefaultValues_StructWithDefaults_fromFfi(__result_handle);
-    smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+abstract class DefaultValues {
+  void release();
+  static DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) => DefaultValues$Impl.processStructWithDefaults(input);
 }
-Pointer<Void> smoke_DefaultValues_toFfi(DefaultValues value) =>
-  _smoke_DefaultValues_copy_handle(value._handle);
-DefaultValues smoke_DefaultValues_fromFfi(Pointer<Void> handle) =>
-  DefaultValues._(_smoke_DefaultValues_copy_handle(handle));
-void smoke_DefaultValues_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_DefaultValues_release_handle(handle);
-Pointer<Void> smoke_DefaultValues_toFfi_nullable(DefaultValues value) =>
-  value != null ? smoke_DefaultValues_toFfi(value) : Pointer<Void>.fromAddress(0);
-DefaultValues smoke_DefaultValues_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_DefaultValues_fromFfi(handle) : null;
-void smoke_DefaultValues_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DefaultValues_release_handle(handle);
 enum DefaultValues_SomeEnum {
     fooValue,
     barValue
@@ -716,3 +686,40 @@ DefaultValues_StructWithTypedefDefaults smoke_DefaultValues_StructWithTypedefDef
 void smoke_DefaultValues_StructWithTypedefDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_DefaultValues_StructWithTypedefDefaults_release_handle_nullable(handle);
 // End of DefaultValues_StructWithTypedefDefaults "private" section.
+// DefaultValues "private" section, not exported.
+final _smoke_DefaultValues_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DefaultValues_copy_handle');
+final _smoke_DefaultValues_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DefaultValues_release_handle');
+class DefaultValues$Impl implements DefaultValues {
+  final Pointer<Void> handle;
+  DefaultValues$Impl(this.handle);
+  @override
+  void release() => _smoke_DefaultValues_release_handle(handle);
+  static DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) {
+    final _processStructWithDefaults_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_DefaultValues_processStructWithDefaults__StructWithDefaults');
+    final _input_handle = smoke_DefaultValues_StructWithDefaults_toFfi(input);
+    final __result_handle = _processStructWithDefaults_ffi(_input_handle);
+    smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_input_handle);
+    final _result = smoke_DefaultValues_StructWithDefaults_fromFfi(__result_handle);
+    smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_DefaultValues_toFfi(DefaultValues value) =>
+  _smoke_DefaultValues_copy_handle((value as DefaultValues$Impl).handle);
+DefaultValues smoke_DefaultValues_fromFfi(Pointer<Void> handle) =>
+  DefaultValues$Impl(_smoke_DefaultValues_copy_handle(handle));
+void smoke_DefaultValues_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_DefaultValues_release_handle(handle);
+Pointer<Void> smoke_DefaultValues_toFfi_nullable(DefaultValues value) =>
+  value != null ? smoke_DefaultValues_toFfi(value) : Pointer<Void>.fromAddress(0);
+DefaultValues smoke_DefaultValues_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_DefaultValues_fromFfi(handle) : null;
+void smoke_DefaultValues_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_DefaultValues_release_handle(handle);
+// End of DefaultValues "private" section.

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/Enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/Enums.dart
@@ -3,78 +3,14 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_Enums_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Enums_copy_handle');
-final _smoke_Enums_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Enums_release_handle');
-class Enums {
-  final Pointer<Void> _handle;
-  Enums._(this._handle);
-  void release() => _smoke_Enums_release_handle(_handle);
-  static Enums_SimpleEnum methodWithEnumeration(Enums_SimpleEnum input) {
-    final _methodWithEnumeration_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Uint32), int Function(int)>('library_smoke_Enums_methodWithEnumeration__SimpleEnum');
-    final _input_handle = smoke_Enums_SimpleEnum_toFfi(input);
-    final __result_handle = _methodWithEnumeration_ffi(_input_handle);
-    smoke_Enums_SimpleEnum_releaseFfiHandle(_input_handle);
-    final _result = smoke_Enums_SimpleEnum_fromFfi(__result_handle);
-    smoke_Enums_SimpleEnum_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static Enums_InternalErrorCode flipEnumValue(Enums_InternalErrorCode input) {
-    final _flipEnumValue_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Uint32), int Function(int)>('library_smoke_Enums_flipEnumValue__InternalErrorCode');
-    final _input_handle = smoke_Enums_InternalErrorCode_toFfi(input);
-    final __result_handle = _flipEnumValue_ffi(_input_handle);
-    smoke_Enums_InternalErrorCode_releaseFfiHandle(_input_handle);
-    final _result = smoke_Enums_InternalErrorCode_fromFfi(__result_handle);
-    smoke_Enums_InternalErrorCode_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static Enums_InternalErrorCode extractEnumFromStruct(Enums_ErrorStruct input) {
-    final _extractEnumFromStruct_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Enums_extractEnumFromStruct__ErrorStruct');
-    final _input_handle = smoke_Enums_ErrorStruct_toFfi(input);
-    final __result_handle = _extractEnumFromStruct_ffi(_input_handle);
-    smoke_Enums_ErrorStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_Enums_InternalErrorCode_fromFfi(__result_handle);
-    smoke_Enums_InternalErrorCode_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static Enums_ErrorStruct createStructWithEnumInside(Enums_InternalErrorCode type, String message) {
-    final _createStructWithEnumInside_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Uint32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Enums_createStructWithEnumInside__InternalErrorCode_String');
-    final _type_handle = smoke_Enums_InternalErrorCode_toFfi(type);
-    final _message_handle = String_toFfi(message);
-    final __result_handle = _createStructWithEnumInside_ffi(_type_handle, _message_handle);
-    smoke_Enums_InternalErrorCode_releaseFfiHandle(_type_handle);
-    String_releaseFfiHandle(_message_handle);
-    final _result = smoke_Enums_ErrorStruct_fromFfi(__result_handle);
-    smoke_Enums_ErrorStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static methodWithExternalEnum(Enums_ExternalEnum input) {
-    final _methodWithExternalEnum_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Uint32), void Function(int)>('library_smoke_Enums_methodWithExternalEnum__External_1Enum');
-    final _input_handle = smoke_Enums_ExternalEnum_toFfi(input);
-    final __result_handle = _methodWithExternalEnum_ffi(_input_handle);
-    smoke_Enums_ExternalEnum_releaseFfiHandle(_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+abstract class Enums {
+  void release();
+  static Enums_SimpleEnum methodWithEnumeration(Enums_SimpleEnum input) => Enums$Impl.methodWithEnumeration(input);
+  static Enums_InternalErrorCode flipEnumValue(Enums_InternalErrorCode input) => Enums$Impl.flipEnumValue(input);
+  static Enums_InternalErrorCode extractEnumFromStruct(Enums_ErrorStruct input) => Enums$Impl.extractEnumFromStruct(input);
+  static Enums_ErrorStruct createStructWithEnumInside(Enums_InternalErrorCode type, String message) => Enums$Impl.createStructWithEnumInside(type, message);
+  static methodWithExternalEnum(Enums_ExternalEnum input) => Enums$Impl.methodWithExternalEnum(input);
 }
-Pointer<Void> smoke_Enums_toFfi(Enums value) =>
-  _smoke_Enums_copy_handle(value._handle);
-Enums smoke_Enums_fromFfi(Pointer<Void> handle) =>
-  Enums._(_smoke_Enums_copy_handle(handle));
-void smoke_Enums_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Enums_release_handle(handle);
-Pointer<Void> smoke_Enums_toFfi_nullable(Enums value) =>
-  value != null ? smoke_Enums_toFfi(value) : Pointer<Void>.fromAddress(0);
-Enums smoke_Enums_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_Enums_fromFfi(handle) : null;
-void smoke_Enums_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Enums_release_handle(handle);
 enum Enums_SimpleEnum {
     first,
     second
@@ -383,3 +319,78 @@ Enums_ErrorStruct smoke_Enums_ErrorStruct_fromFfi_nullable(Pointer<Void> handle)
 void smoke_Enums_ErrorStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Enums_ErrorStruct_release_handle_nullable(handle);
 // End of Enums_ErrorStruct "private" section.
+// Enums "private" section, not exported.
+final _smoke_Enums_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Enums_copy_handle');
+final _smoke_Enums_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Enums_release_handle');
+class Enums$Impl implements Enums {
+  final Pointer<Void> handle;
+  Enums$Impl(this.handle);
+  @override
+  void release() => _smoke_Enums_release_handle(handle);
+  static Enums_SimpleEnum methodWithEnumeration(Enums_SimpleEnum input) {
+    final _methodWithEnumeration_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Uint32), int Function(int)>('library_smoke_Enums_methodWithEnumeration__SimpleEnum');
+    final _input_handle = smoke_Enums_SimpleEnum_toFfi(input);
+    final __result_handle = _methodWithEnumeration_ffi(_input_handle);
+    smoke_Enums_SimpleEnum_releaseFfiHandle(_input_handle);
+    final _result = smoke_Enums_SimpleEnum_fromFfi(__result_handle);
+    smoke_Enums_SimpleEnum_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static Enums_InternalErrorCode flipEnumValue(Enums_InternalErrorCode input) {
+    final _flipEnumValue_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Uint32), int Function(int)>('library_smoke_Enums_flipEnumValue__InternalErrorCode');
+    final _input_handle = smoke_Enums_InternalErrorCode_toFfi(input);
+    final __result_handle = _flipEnumValue_ffi(_input_handle);
+    smoke_Enums_InternalErrorCode_releaseFfiHandle(_input_handle);
+    final _result = smoke_Enums_InternalErrorCode_fromFfi(__result_handle);
+    smoke_Enums_InternalErrorCode_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static Enums_InternalErrorCode extractEnumFromStruct(Enums_ErrorStruct input) {
+    final _extractEnumFromStruct_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Enums_extractEnumFromStruct__ErrorStruct');
+    final _input_handle = smoke_Enums_ErrorStruct_toFfi(input);
+    final __result_handle = _extractEnumFromStruct_ffi(_input_handle);
+    smoke_Enums_ErrorStruct_releaseFfiHandle(_input_handle);
+    final _result = smoke_Enums_InternalErrorCode_fromFfi(__result_handle);
+    smoke_Enums_InternalErrorCode_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static Enums_ErrorStruct createStructWithEnumInside(Enums_InternalErrorCode type, String message) {
+    final _createStructWithEnumInside_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Uint32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Enums_createStructWithEnumInside__InternalErrorCode_String');
+    final _type_handle = smoke_Enums_InternalErrorCode_toFfi(type);
+    final _message_handle = String_toFfi(message);
+    final __result_handle = _createStructWithEnumInside_ffi(_type_handle, _message_handle);
+    smoke_Enums_InternalErrorCode_releaseFfiHandle(_type_handle);
+    String_releaseFfiHandle(_message_handle);
+    final _result = smoke_Enums_ErrorStruct_fromFfi(__result_handle);
+    smoke_Enums_ErrorStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static methodWithExternalEnum(Enums_ExternalEnum input) {
+    final _methodWithExternalEnum_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Uint32), void Function(int)>('library_smoke_Enums_methodWithExternalEnum__External_1Enum');
+    final _input_handle = smoke_Enums_ExternalEnum_toFfi(input);
+    final __result_handle = _methodWithExternalEnum_ffi(_input_handle);
+    smoke_Enums_ExternalEnum_releaseFfiHandle(_input_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_Enums_toFfi(Enums value) =>
+  _smoke_Enums_copy_handle((value as Enums$Impl).handle);
+Enums smoke_Enums_fromFfi(Pointer<Void> handle) =>
+  Enums$Impl(_smoke_Enums_copy_handle(handle));
+void smoke_Enums_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Enums_release_handle(handle);
+Pointer<Void> smoke_Enums_toFfi_nullable(Enums value) =>
+  value != null ? smoke_Enums_toFfi(value) : Pointer<Void>.fromAddress(0);
+Enums smoke_Enums_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_Enums_fromFfi(handle) : null;
+void smoke_Enums_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Enums_release_handle(handle);
+// End of Enums "private" section.

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/Errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/Errors.dart
@@ -5,182 +5,14 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_Errors_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Errors_copy_handle');
-final _smoke_Errors_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Errors_release_handle');
-final _methodWithErrors_return_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrors_return_release_handle');
-final _methodWithErrors_return_get_result = (Pointer) {};
-final _methodWithErrors_return_get_error = __lib.nativeLibrary.lookupFunction<
-    Uint32 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrors_return_get_error');
-final _methodWithErrors_return_has_error = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrors_return_has_error');
-final _methodWithExternalErrors_return_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithExternalErrors_return_release_handle');
-final _methodWithExternalErrors_return_get_result = (Pointer) {};
-final _methodWithExternalErrors_return_get_error = __lib.nativeLibrary.lookupFunction<
-    Uint32 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithExternalErrors_return_get_error');
-final _methodWithExternalErrors_return_has_error = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithExternalErrors_return_has_error');
-final _methodWithErrorsAndReturnValue_return_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_release_handle');
-final _methodWithErrorsAndReturnValue_return_get_result = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_get_result');
-final _methodWithErrorsAndReturnValue_return_get_error = __lib.nativeLibrary.lookupFunction<
-    Uint32 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_get_error');
-final _methodWithErrorsAndReturnValue_return_has_error = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_has_error');
-final _methodWithPayloadError_return_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadError_return_release_handle');
-final _methodWithPayloadError_return_get_result = (Pointer) {};
-final _methodWithPayloadError_return_get_error = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadError_return_get_error');
-final _methodWithPayloadError_return_has_error = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadError_return_has_error');
-final _methodWithPayloadErrorAndReturnValue_return_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_release_handle');
-final _methodWithPayloadErrorAndReturnValue_return_get_result = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_get_result');
-final _methodWithPayloadErrorAndReturnValue_return_get_error = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_get_error');
-final _methodWithPayloadErrorAndReturnValue_return_has_error = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>),
-    int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_has_error');
-class Errors {
-  final Pointer<Void> _handle;
-  Errors._(this._handle);
-  void release() => _smoke_Errors_release_handle(_handle);
-  static methodWithErrors() {
-    final _methodWithErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Errors_methodWithErrors');
-    final __call_result_handle = _methodWithErrors_ffi();
-    if (_methodWithErrors_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithErrors_return_get_error(__call_result_handle);
-        _methodWithErrors_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Errors_InternalErrorCode_fromFfi(__error_handle);
-        smoke_Errors_InternalErrorCode_releaseFfiHandle(__error_handle);
-        throw Errors_InternalException(_error_value);
-    }
-    final __result_handle = _methodWithErrors_return_get_result(__call_result_handle);
-    _methodWithErrors_return_release_handle(__call_result_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  static methodWithExternalErrors() {
-    final _methodWithExternalErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Errors_methodWithExternalErrors');
-    final __call_result_handle = _methodWithExternalErrors_ffi();
-    if (_methodWithExternalErrors_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithExternalErrors_return_get_error(__call_result_handle);
-        _methodWithExternalErrors_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Errors_ExternalErrors_fromFfi(__error_handle);
-        smoke_Errors_ExternalErrors_releaseFfiHandle(__error_handle);
-        throw Errors_ExternalException(_error_value);
-    }
-    final __result_handle = _methodWithExternalErrors_return_get_result(__call_result_handle);
-    _methodWithExternalErrors_return_release_handle(__call_result_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  static String methodWithErrorsAndReturnValue() {
-    final _methodWithErrorsAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Errors_methodWithErrorsAndReturnValue');
-    final __call_result_handle = _methodWithErrorsAndReturnValue_ffi();
-    if (_methodWithErrorsAndReturnValue_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithErrorsAndReturnValue_return_get_error(__call_result_handle);
-        _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Errors_InternalErrorCode_fromFfi(__error_handle);
-        smoke_Errors_InternalErrorCode_releaseFfiHandle(__error_handle);
-        throw Errors_InternalException(_error_value);
-    }
-    final __result_handle = _methodWithErrorsAndReturnValue_return_get_result(__call_result_handle);
-    _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static methodWithPayloadError() {
-    final _methodWithPayloadError_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Errors_methodWithPayloadError');
-    final __call_result_handle = _methodWithPayloadError_ffi();
-    if (_methodWithPayloadError_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithPayloadError_return_get_error(__call_result_handle);
-        _methodWithPayloadError_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Payload_fromFfi(__error_handle);
-        smoke_Payload_releaseFfiHandle(__error_handle);
-        throw WithPayloadException(_error_value);
-    }
-    final __result_handle = _methodWithPayloadError_return_get_result(__call_result_handle);
-    _methodWithPayloadError_return_release_handle(__call_result_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  static String methodWithPayloadErrorAndReturnValue() {
-    final _methodWithPayloadErrorAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Errors_methodWithPayloadErrorAndReturnValue');
-    final __call_result_handle = _methodWithPayloadErrorAndReturnValue_ffi();
-    if (_methodWithPayloadErrorAndReturnValue_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithPayloadErrorAndReturnValue_return_get_error(__call_result_handle);
-        _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Payload_fromFfi(__error_handle);
-        smoke_Payload_releaseFfiHandle(__error_handle);
-        throw WithPayloadException(_error_value);
-    }
-    final __result_handle = _methodWithPayloadErrorAndReturnValue_return_get_result(__call_result_handle);
-    _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+abstract class Errors {
+  void release();
+  static methodWithErrors() => Errors$Impl.methodWithErrors();
+  static methodWithExternalErrors() => Errors$Impl.methodWithExternalErrors();
+  static String methodWithErrorsAndReturnValue() => Errors$Impl.methodWithErrorsAndReturnValue();
+  static methodWithPayloadError() => Errors$Impl.methodWithPayloadError();
+  static String methodWithPayloadErrorAndReturnValue() => Errors$Impl.methodWithPayloadErrorAndReturnValue();
 }
-Pointer<Void> smoke_Errors_toFfi(Errors value) =>
-  _smoke_Errors_copy_handle(value._handle);
-Errors smoke_Errors_fromFfi(Pointer<Void> handle) =>
-  Errors._(_smoke_Errors_copy_handle(handle));
-void smoke_Errors_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Errors_release_handle(handle);
-Pointer<Void> smoke_Errors_toFfi_nullable(Errors value) =>
-  value != null ? smoke_Errors_toFfi(value) : Pointer<Void>.fromAddress(0);
-Errors smoke_Errors_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_Errors_fromFfi(handle) : null;
-void smoke_Errors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Errors_release_handle(handle);
 enum Errors_InternalErrorCode {
     errorNone,
     errorFatal
@@ -314,3 +146,182 @@ class Errors_ExternalException implements Exception {
   final Errors_ExternalErrors error;
   Errors_ExternalException(this.error);
 }
+// Errors "private" section, not exported.
+final _smoke_Errors_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Errors_copy_handle');
+final _smoke_Errors_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Errors_release_handle');
+final _methodWithErrors_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithErrors_return_release_handle');
+final _methodWithErrors_return_get_result = (Pointer) {};
+final _methodWithErrors_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithErrors_return_get_error');
+final _methodWithErrors_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithErrors_return_has_error');
+final _methodWithExternalErrors_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithExternalErrors_return_release_handle');
+final _methodWithExternalErrors_return_get_result = (Pointer) {};
+final _methodWithExternalErrors_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithExternalErrors_return_get_error');
+final _methodWithExternalErrors_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithExternalErrors_return_has_error');
+final _methodWithErrorsAndReturnValue_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_release_handle');
+final _methodWithErrorsAndReturnValue_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_get_result');
+final _methodWithErrorsAndReturnValue_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_get_error');
+final _methodWithErrorsAndReturnValue_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_has_error');
+final _methodWithPayloadError_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithPayloadError_return_release_handle');
+final _methodWithPayloadError_return_get_result = (Pointer) {};
+final _methodWithPayloadError_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithPayloadError_return_get_error');
+final _methodWithPayloadError_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithPayloadError_return_has_error');
+final _methodWithPayloadErrorAndReturnValue_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_release_handle');
+final _methodWithPayloadErrorAndReturnValue_return_get_result = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_get_result');
+final _methodWithPayloadErrorAndReturnValue_return_get_error = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_get_error');
+final _methodWithPayloadErrorAndReturnValue_return_has_error = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_has_error');
+class Errors$Impl implements Errors {
+  final Pointer<Void> handle;
+  Errors$Impl(this.handle);
+  @override
+  void release() => _smoke_Errors_release_handle(handle);
+  static methodWithErrors() {
+    final _methodWithErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Errors_methodWithErrors');
+    final __call_result_handle = _methodWithErrors_ffi();
+    if (_methodWithErrors_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _methodWithErrors_return_get_error(__call_result_handle);
+        _methodWithErrors_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Errors_InternalErrorCode_fromFfi(__error_handle);
+        smoke_Errors_InternalErrorCode_releaseFfiHandle(__error_handle);
+        throw Errors_InternalException(_error_value);
+    }
+    final __result_handle = _methodWithErrors_return_get_result(__call_result_handle);
+    _methodWithErrors_return_release_handle(__call_result_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  static methodWithExternalErrors() {
+    final _methodWithExternalErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Errors_methodWithExternalErrors');
+    final __call_result_handle = _methodWithExternalErrors_ffi();
+    if (_methodWithExternalErrors_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _methodWithExternalErrors_return_get_error(__call_result_handle);
+        _methodWithExternalErrors_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Errors_ExternalErrors_fromFfi(__error_handle);
+        smoke_Errors_ExternalErrors_releaseFfiHandle(__error_handle);
+        throw Errors_ExternalException(_error_value);
+    }
+    final __result_handle = _methodWithExternalErrors_return_get_result(__call_result_handle);
+    _methodWithExternalErrors_return_release_handle(__call_result_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  static String methodWithErrorsAndReturnValue() {
+    final _methodWithErrorsAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Errors_methodWithErrorsAndReturnValue');
+    final __call_result_handle = _methodWithErrorsAndReturnValue_ffi();
+    if (_methodWithErrorsAndReturnValue_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _methodWithErrorsAndReturnValue_return_get_error(__call_result_handle);
+        _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Errors_InternalErrorCode_fromFfi(__error_handle);
+        smoke_Errors_InternalErrorCode_releaseFfiHandle(__error_handle);
+        throw Errors_InternalException(_error_value);
+    }
+    final __result_handle = _methodWithErrorsAndReturnValue_return_get_result(__call_result_handle);
+    _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static methodWithPayloadError() {
+    final _methodWithPayloadError_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Errors_methodWithPayloadError');
+    final __call_result_handle = _methodWithPayloadError_ffi();
+    if (_methodWithPayloadError_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _methodWithPayloadError_return_get_error(__call_result_handle);
+        _methodWithPayloadError_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Payload_fromFfi(__error_handle);
+        smoke_Payload_releaseFfiHandle(__error_handle);
+        throw WithPayloadException(_error_value);
+    }
+    final __result_handle = _methodWithPayloadError_return_get_result(__call_result_handle);
+    _methodWithPayloadError_return_release_handle(__call_result_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  static String methodWithPayloadErrorAndReturnValue() {
+    final _methodWithPayloadErrorAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Errors_methodWithPayloadErrorAndReturnValue');
+    final __call_result_handle = _methodWithPayloadErrorAndReturnValue_ffi();
+    if (_methodWithPayloadErrorAndReturnValue_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _methodWithPayloadErrorAndReturnValue_return_get_error(__call_result_handle);
+        _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
+        final _error_value = smoke_Payload_fromFfi(__error_handle);
+        smoke_Payload_releaseFfiHandle(__error_handle);
+        throw WithPayloadException(_error_value);
+    }
+    final __result_handle = _methodWithPayloadErrorAndReturnValue_return_get_result(__call_result_handle);
+    _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_Errors_toFfi(Errors value) =>
+  _smoke_Errors_copy_handle((value as Errors$Impl).handle);
+Errors smoke_Errors_fromFfi(Pointer<Void> handle) =>
+  Errors$Impl(_smoke_Errors_copy_handle(handle));
+void smoke_Errors_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Errors_release_handle(handle);
+Pointer<Void> smoke_Errors_toFfi_nullable(Errors value) =>
+  value != null ? smoke_Errors_toFfi(value) : Pointer<Void>.fromAddress(0);
+Errors smoke_Errors_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_Errors_fromFfi(handle) : null;
+void smoke_Errors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Errors_release_handle(handle);
+// End of Errors "private" section.

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/ErrorsInterface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/ErrorsInterface.dart
@@ -240,15 +240,15 @@ final _methodWithPayloadErrorAndReturnValue_return_has_error = __lib.nativeLibra
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_has_error');
-class ErrorsInterface__Impl implements ErrorsInterface {
-  Pointer<Void> get _handle => handle;
+class ErrorsInterface$Impl implements ErrorsInterface {
   final Pointer<Void> handle;
-  ErrorsInterface__Impl(this.handle);
+  ErrorsInterface$Impl(this.handle);
   @override
   void release() => _smoke_ErrorsInterface_release_handle(handle);
   @override
   methodWithErrors() {
     final _methodWithErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ErrorsInterface_methodWithErrors');
+    final _handle = this.handle;
     final __call_result_handle = _methodWithErrors_ffi(_handle);
     if (_methodWithErrors_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithErrors_return_get_error(__call_result_handle);
@@ -266,6 +266,7 @@ class ErrorsInterface__Impl implements ErrorsInterface {
   @override
   methodWithExternalErrors() {
     final _methodWithExternalErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ErrorsInterface_methodWithExternalErrors');
+    final _handle = this.handle;
     final __call_result_handle = _methodWithExternalErrors_ffi(_handle);
     if (_methodWithExternalErrors_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithExternalErrors_return_get_error(__call_result_handle);
@@ -283,6 +284,7 @@ class ErrorsInterface__Impl implements ErrorsInterface {
   @override
   String methodWithErrorsAndReturnValue() {
     final _methodWithErrorsAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue');
+    final _handle = this.handle;
     final __call_result_handle = _methodWithErrorsAndReturnValue_ffi(_handle);
     if (_methodWithErrorsAndReturnValue_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithErrorsAndReturnValue_return_get_error(__call_result_handle);
@@ -383,7 +385,7 @@ int _ErrorsInterface_methodWithPayloadErrorAndReturnValue_static(int _token, Poi
   return _error;
 }
 Pointer<Void> smoke_ErrorsInterface_toFfi(ErrorsInterface value) {
-  if (value is ErrorsInterface__Impl) return _smoke_ErrorsInterface_copy_handle(value.handle);
+  if (value is ErrorsInterface$Impl) return _smoke_ErrorsInterface_copy_handle(value.handle);
   final result = _smoke_ErrorsInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -403,7 +405,7 @@ ErrorsInterface smoke_ErrorsInterface_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_ErrorsInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? ErrorsInterface__Impl(_copied_handle)
+    ? ErrorsInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Class.dart
@@ -7,6 +7,14 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
+abstract class Class implements Interface {
+  factory Class() => Class$Impl.constructor();
+  void release();
+  Struct fun(List<Struct> double);
+  Enum get property;
+  set property(Enum value);
+}
+// Class "private" section, not exported.
 final _package_Class_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -35,19 +43,22 @@ final _fun_return_has_error = __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_has_error');
-class Class implements Interface {
-  final Pointer<Void> _handle;
-  Class._(this._handle);
-  void release() => _package_Class_release_handle(_handle);
-  Class() : this._(_constructor());
+class Class$Impl implements Class {
+  final Pointer<Void> handle;
+  Class$Impl(this.handle);
+  @override
+  void release() => _package_Class_release_handle(handle);
+  Class$Impl.constructor() : this(_constructor());
   static Pointer<Void> _constructor() {
     final _constructor_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_package_Class_constructor');
     final __result_handle = _constructor_ffi();
     return __result_handle;
   }
+  @override
   Struct fun(List<Struct> double) {
     final _fun_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_package_Class_fun__ListOf_1package_1Types_1Struct');
     final _double_handle = ListOf_package_Types_Struct_toFfi(double);
+    final _handle = this.handle;
     final __call_result_handle = _fun_ffi(_handle, _double_handle);
     ListOf_package_Types_Struct_releaseFfiHandle(_double_handle);
     if (_fun_return_has_error(__call_result_handle) != 0) {
@@ -63,16 +74,20 @@ class Class implements Interface {
     package_Types_Struct_releaseFfiHandle(__result_handle);
     return _result;
   }
+  @override
   Enum get property {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_package_Class_property_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = package_Types_Enum_fromFfi(__result_handle);
     package_Types_Enum_releaseFfiHandle(__result_handle);
     return _result;
   }
+  @override
   set property(Enum value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint32), void Function(Pointer<Void>, int)>('library_package_Class_property_set__enum');
     final _value_handle = package_Types_Enum_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     package_Types_Enum_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -81,13 +96,13 @@ class Class implements Interface {
   }
 }
 Pointer<Void> package_Class_toFfi(Class value) =>
-  _package_Class_copy_handle(value._handle);
+  _package_Class_copy_handle((value as Class$Impl).handle);
 Class package_Class_fromFfi(Pointer<Void> handle) {
   final _copied_handle = _package_Class_copy_handle(handle);
   final _type_id_handle = _package_Class_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? Class._(_copied_handle)
+    ? Class$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;
@@ -100,7 +115,4 @@ Class package_Class_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? package_Class_fromFfi(handle) : null;
 void package_Class_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _package_Class_release_handle(handle);
-// Internal, not exported.
-class Class__Factory {
-  static Class create(Pointer<Void> handle) => Class._(handle);
-}
+// End of Class "private" section.

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Interface.dart
@@ -29,15 +29,14 @@ final _package_Interface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Interface_get_type_id');
-class Interface__Impl implements Interface {
-  Pointer<Void> get _handle => handle;
+class Interface$Impl implements Interface {
   final Pointer<Void> handle;
-  Interface__Impl(this.handle);
+  Interface$Impl(this.handle);
   @override
   void release() => _package_Interface_release_handle(handle);
 }
 Pointer<Void> package_Interface_toFfi(Interface value) {
-  if (value is Interface__Impl) return _package_Interface_copy_handle(value.handle);
+  if (value is Interface$Impl) return _package_Interface_copy_handle(value.handle);
   final result = _package_Interface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi
@@ -52,7 +51,7 @@ Interface package_Interface_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _package_Interface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? Interface__Impl(_copied_handle)
+    ? Interface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithBasicTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithBasicTypes.dart
@@ -4,133 +4,21 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_GenericTypesWithBasicTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithBasicTypes_copy_handle');
-final _smoke_GenericTypesWithBasicTypes_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithBasicTypes_release_handle');
-class GenericTypesWithBasicTypes {
-  final Pointer<Void> _handle;
-  GenericTypesWithBasicTypes._(this._handle);
-  void release() => _smoke_GenericTypesWithBasicTypes_release_handle(_handle);
-  List<int> methodWithList(List<int> input) {
-    final _methodWithList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithList__ListOf_1Int');
-    final _input_handle = ListOf_Int_toFfi(input);
-    final __result_handle = _methodWithList_ffi(_handle, _input_handle);
-    ListOf_Int_releaseFfiHandle(_input_handle);
-    final _result = ListOf_Int_fromFfi(__result_handle);
-    ListOf_Int_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  Map<int, bool> methodWithMap(Map<int, bool> input) {
-    final _methodWithMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMap__MapOf_1Int_1to_1Boolean');
-    final _input_handle = MapOf_Int_to_Boolean_toFfi(input);
-    final __result_handle = _methodWithMap_ffi(_handle, _input_handle);
-    MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
-    final _result = MapOf_Int_to_Boolean_fromFfi(__result_handle);
-    MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  Set<int> methodWithSet(Set<int> input) {
-    final _methodWithSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSet__SetOf_1Int');
-    final _input_handle = SetOf_Int_toFfi(input);
-    final __result_handle = _methodWithSet_ffi(_handle, _input_handle);
-    SetOf_Int_releaseFfiHandle(_input_handle);
-    final _result = SetOf_Int_fromFfi(__result_handle);
-    SetOf_Int_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  List<String> methodWithListTypeAlias(List<String> input) {
-    final _methodWithListTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias__ListOf_1String');
-    final _input_handle = ListOf_String_toFfi(input);
-    final __result_handle = _methodWithListTypeAlias_ffi(_handle, _input_handle);
-    ListOf_String_releaseFfiHandle(_input_handle);
-    final _result = ListOf_String_fromFfi(__result_handle);
-    ListOf_String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  Map<String, String> methodWithMapTypeAlias(Map<String, String> input) {
-    final _methodWithMapTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias__MapOf_1String_1to_1String');
-    final _input_handle = MapOf_String_to_String_toFfi(input);
-    final __result_handle = _methodWithMapTypeAlias_ffi(_handle, _input_handle);
-    MapOf_String_to_String_releaseFfiHandle(_input_handle);
-    final _result = MapOf_String_to_String_fromFfi(__result_handle);
-    MapOf_String_to_String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  Set<String> methodWithSetTypeAlias(Set<String> input) {
-    final _methodWithSetTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias__SetOf_1String');
-    final _input_handle = SetOf_String_toFfi(input);
-    final __result_handle = _methodWithSetTypeAlias_ffi(_handle, _input_handle);
-    SetOf_String_releaseFfiHandle(_input_handle);
-    final _result = SetOf_String_fromFfi(__result_handle);
-    SetOf_String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  List<double> get listProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_listProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = ListOf_Float_fromFfi(__result_handle);
-    ListOf_Float_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set listProperty(List<double> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_listProperty_set__ListOf_1Float');
-    final _value_handle = ListOf_Float_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    ListOf_Float_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  Map<double, double> get mapProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = MapOf_Float_to_Double_fromFfi(__result_handle);
-    MapOf_Float_to_Double_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set mapProperty(Map<double, double> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_set__MapOf_1Float_1to_1Double');
-    final _value_handle = MapOf_Float_to_Double_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    MapOf_Float_to_Double_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  Set<double> get setProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_setProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = SetOf_Float_fromFfi(__result_handle);
-    SetOf_Float_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set setProperty(Set<double> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_setProperty_set__SetOf_1Float');
-    final _value_handle = SetOf_Float_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    SetOf_Float_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+abstract class GenericTypesWithBasicTypes {
+  void release();
+  List<int> methodWithList(List<int> input);
+  Map<int, bool> methodWithMap(Map<int, bool> input);
+  Set<int> methodWithSet(Set<int> input);
+  List<String> methodWithListTypeAlias(List<String> input);
+  Map<String, String> methodWithMapTypeAlias(Map<String, String> input);
+  Set<String> methodWithSetTypeAlias(Set<String> input);
+  List<double> get listProperty;
+  set listProperty(List<double> value);
+  Map<double, double> get mapProperty;
+  set mapProperty(Map<double, double> value);
+  Set<double> get setProperty;
+  set setProperty(Set<double> value);
 }
-Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi(GenericTypesWithBasicTypes value) =>
-  _smoke_GenericTypesWithBasicTypes_copy_handle(value._handle);
-GenericTypesWithBasicTypes smoke_GenericTypesWithBasicTypes_fromFfi(Pointer<Void> handle) =>
-  GenericTypesWithBasicTypes._(_smoke_GenericTypesWithBasicTypes_copy_handle(handle));
-void smoke_GenericTypesWithBasicTypes_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithBasicTypes_release_handle(handle);
-Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi_nullable(GenericTypesWithBasicTypes value) =>
-  value != null ? smoke_GenericTypesWithBasicTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
-GenericTypesWithBasicTypes smoke_GenericTypesWithBasicTypes_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_GenericTypesWithBasicTypes_fromFfi(handle) : null;
-void smoke_GenericTypesWithBasicTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithBasicTypes_release_handle(handle);
 class GenericTypesWithBasicTypes_StructWithGenerics {
   List<int> numbersList;
   Map<int, String> numbersMap;
@@ -213,3 +101,157 @@ GenericTypesWithBasicTypes_StructWithGenerics smoke_GenericTypesWithBasicTypes_S
 void smoke_GenericTypesWithBasicTypes_StructWithGenerics_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle_nullable(handle);
 // End of GenericTypesWithBasicTypes_StructWithGenerics "private" section.
+// GenericTypesWithBasicTypes "private" section, not exported.
+final _smoke_GenericTypesWithBasicTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_GenericTypesWithBasicTypes_copy_handle');
+final _smoke_GenericTypesWithBasicTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_GenericTypesWithBasicTypes_release_handle');
+class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
+  final Pointer<Void> handle;
+  GenericTypesWithBasicTypes$Impl(this.handle);
+  @override
+  void release() => _smoke_GenericTypesWithBasicTypes_release_handle(handle);
+  @override
+  List<int> methodWithList(List<int> input) {
+    final _methodWithList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithList__ListOf_1Int');
+    final _input_handle = ListOf_Int_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithList_ffi(_handle, _input_handle);
+    ListOf_Int_releaseFfiHandle(_input_handle);
+    final _result = ListOf_Int_fromFfi(__result_handle);
+    ListOf_Int_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  Map<int, bool> methodWithMap(Map<int, bool> input) {
+    final _methodWithMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMap__MapOf_1Int_1to_1Boolean');
+    final _input_handle = MapOf_Int_to_Boolean_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithMap_ffi(_handle, _input_handle);
+    MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
+    final _result = MapOf_Int_to_Boolean_fromFfi(__result_handle);
+    MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  Set<int> methodWithSet(Set<int> input) {
+    final _methodWithSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSet__SetOf_1Int');
+    final _input_handle = SetOf_Int_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithSet_ffi(_handle, _input_handle);
+    SetOf_Int_releaseFfiHandle(_input_handle);
+    final _result = SetOf_Int_fromFfi(__result_handle);
+    SetOf_Int_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  List<String> methodWithListTypeAlias(List<String> input) {
+    final _methodWithListTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias__ListOf_1String');
+    final _input_handle = ListOf_String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithListTypeAlias_ffi(_handle, _input_handle);
+    ListOf_String_releaseFfiHandle(_input_handle);
+    final _result = ListOf_String_fromFfi(__result_handle);
+    ListOf_String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  Map<String, String> methodWithMapTypeAlias(Map<String, String> input) {
+    final _methodWithMapTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias__MapOf_1String_1to_1String');
+    final _input_handle = MapOf_String_to_String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithMapTypeAlias_ffi(_handle, _input_handle);
+    MapOf_String_to_String_releaseFfiHandle(_input_handle);
+    final _result = MapOf_String_to_String_fromFfi(__result_handle);
+    MapOf_String_to_String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  Set<String> methodWithSetTypeAlias(Set<String> input) {
+    final _methodWithSetTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias__SetOf_1String');
+    final _input_handle = SetOf_String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithSetTypeAlias_ffi(_handle, _input_handle);
+    SetOf_String_releaseFfiHandle(_input_handle);
+    final _result = SetOf_String_fromFfi(__result_handle);
+    SetOf_String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  List<double> get listProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_listProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = ListOf_Float_fromFfi(__result_handle);
+    ListOf_Float_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set listProperty(List<double> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_listProperty_set__ListOf_1Float');
+    final _value_handle = ListOf_Float_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    ListOf_Float_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  Map<double, double> get mapProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = MapOf_Float_to_Double_fromFfi(__result_handle);
+    MapOf_Float_to_Double_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set mapProperty(Map<double, double> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_set__MapOf_1Float_1to_1Double');
+    final _value_handle = MapOf_Float_to_Double_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    MapOf_Float_to_Double_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  Set<double> get setProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_setProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = SetOf_Float_fromFfi(__result_handle);
+    SetOf_Float_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set setProperty(Set<double> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_setProperty_set__SetOf_1Float');
+    final _value_handle = SetOf_Float_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    SetOf_Float_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi(GenericTypesWithBasicTypes value) =>
+  _smoke_GenericTypesWithBasicTypes_copy_handle((value as GenericTypesWithBasicTypes$Impl).handle);
+GenericTypesWithBasicTypes smoke_GenericTypesWithBasicTypes_fromFfi(Pointer<Void> handle) =>
+  GenericTypesWithBasicTypes$Impl(_smoke_GenericTypesWithBasicTypes_copy_handle(handle));
+void smoke_GenericTypesWithBasicTypes_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_GenericTypesWithBasicTypes_release_handle(handle);
+Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi_nullable(GenericTypesWithBasicTypes value) =>
+  value != null ? smoke_GenericTypesWithBasicTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
+GenericTypesWithBasicTypes smoke_GenericTypesWithBasicTypes_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_GenericTypesWithBasicTypes_fromFfi(handle) : null;
+void smoke_GenericTypesWithBasicTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_GenericTypesWithBasicTypes_release_handle(handle);
+// End of GenericTypesWithBasicTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithCompoundTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithCompoundTypes.dart
@@ -6,103 +6,17 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_GenericTypesWithCompoundTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_copy_handle');
-final _smoke_GenericTypesWithCompoundTypes_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_release_handle');
-class GenericTypesWithCompoundTypes {
-  final Pointer<Void> _handle;
-  GenericTypesWithCompoundTypes._(this._handle);
-  void release() => _smoke_GenericTypesWithCompoundTypes_release_handle(_handle);
-  List<GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructList(List<GenericTypesWithCompoundTypes_BasicStruct> input) {
-    final _methodWithStructList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct');
-    final _input_handle = ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
-    final __result_handle = _methodWithStructList_ffi(_handle, _input_handle);
-    ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
-    final _result = ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
-    ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  Map<String, GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructMap(Map<String, GenericTypesWithCompoundTypes_BasicStruct> input) {
-    final _methodWithStructMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructMap__MapOf_1String_1to_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct');
-    final _input_handle = MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
-    final __result_handle = _methodWithStructMap_ffi(_handle, _input_handle);
-    MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
-    final _result = MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
-    MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  List<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumList(List<GenericTypesWithCompoundTypes_SomeEnum> input) {
-    final _methodWithEnumList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
-    final _input_handle = ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
-    final __result_handle = _methodWithEnumList_ffi(_handle, _input_handle);
-    ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
-    final _result = ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
-    ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> methodWithEnumMapKey(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> input) {
-    final _methodWithEnumMapKey_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey__MapOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum_1to_1Boolean');
-    final _input_handle = MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(input);
-    final __result_handle = _methodWithEnumMapKey_ffi(_handle, _input_handle);
-    MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(_input_handle);
-    final _result = MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi(__result_handle);
-    MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  Map<int, GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumMapValue(Map<int, GenericTypesWithCompoundTypes_SomeEnum> input) {
-    final _methodWithEnumMapValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue__MapOf_1Int_1to_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
-    final _input_handle = MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
-    final __result_handle = _methodWithEnumMapValue_ffi(_handle, _input_handle);
-    MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
-    final _result = MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
-    MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  Set<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumSet(Set<GenericTypesWithCompoundTypes_SomeEnum> input) {
-    final _methodWithEnumSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumSet__SetOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
-    final _input_handle = SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
-    final __result_handle = _methodWithEnumSet_ffi(_handle, _input_handle);
-    SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
-    final _result = SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
-    SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  List<DummyInterface> methodWithInstancesList(List<DummyClass> input) {
-    final _methodWithInstancesList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesList__ListOf_1smoke_1DummyClass');
-    final _input_handle = ListOf_smoke_DummyClass_toFfi(input);
-    final __result_handle = _methodWithInstancesList_ffi(_handle, _input_handle);
-    ListOf_smoke_DummyClass_releaseFfiHandle(_input_handle);
-    final _result = ListOf_smoke_DummyInterface_fromFfi(__result_handle);
-    ListOf_smoke_DummyInterface_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  Map<int, DummyInterface> methodWithInstancesMap(Map<int, DummyClass> input) {
-    final _methodWithInstancesMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap__MapOf_1Int_1to_1smoke_1DummyClass');
-    final _input_handle = MapOf_Int_to_smoke_DummyClass_toFfi(input);
-    final __result_handle = _methodWithInstancesMap_ffi(_handle, _input_handle);
-    MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(_input_handle);
-    final _result = MapOf_Int_to_smoke_DummyInterface_fromFfi(__result_handle);
-    MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+abstract class GenericTypesWithCompoundTypes {
+  void release();
+  List<GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructList(List<GenericTypesWithCompoundTypes_BasicStruct> input);
+  Map<String, GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructMap(Map<String, GenericTypesWithCompoundTypes_BasicStruct> input);
+  List<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumList(List<GenericTypesWithCompoundTypes_SomeEnum> input);
+  Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> methodWithEnumMapKey(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> input);
+  Map<int, GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumMapValue(Map<int, GenericTypesWithCompoundTypes_SomeEnum> input);
+  Set<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumSet(Set<GenericTypesWithCompoundTypes_SomeEnum> input);
+  List<DummyInterface> methodWithInstancesList(List<DummyClass> input);
+  Map<int, DummyInterface> methodWithInstancesMap(Map<int, DummyClass> input);
 }
-Pointer<Void> smoke_GenericTypesWithCompoundTypes_toFfi(GenericTypesWithCompoundTypes value) =>
-  _smoke_GenericTypesWithCompoundTypes_copy_handle(value._handle);
-GenericTypesWithCompoundTypes smoke_GenericTypesWithCompoundTypes_fromFfi(Pointer<Void> handle) =>
-  GenericTypesWithCompoundTypes._(_smoke_GenericTypesWithCompoundTypes_copy_handle(handle));
-void smoke_GenericTypesWithCompoundTypes_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithCompoundTypes_release_handle(handle);
-Pointer<Void> smoke_GenericTypesWithCompoundTypes_toFfi_nullable(GenericTypesWithCompoundTypes value) =>
-  value != null ? smoke_GenericTypesWithCompoundTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
-GenericTypesWithCompoundTypes smoke_GenericTypesWithCompoundTypes_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_GenericTypesWithCompoundTypes_fromFfi(handle) : null;
-void smoke_GenericTypesWithCompoundTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithCompoundTypes_release_handle(handle);
 enum GenericTypesWithCompoundTypes_SomeEnum {
     foo,
     bar
@@ -345,3 +259,119 @@ GenericTypesWithCompoundTypes_ExternalStruct smoke_GenericTypesWithCompoundTypes
 void smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable(handle);
 // End of GenericTypesWithCompoundTypes_ExternalStruct "private" section.
+// GenericTypesWithCompoundTypes "private" section, not exported.
+final _smoke_GenericTypesWithCompoundTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_GenericTypesWithCompoundTypes_copy_handle');
+final _smoke_GenericTypesWithCompoundTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_GenericTypesWithCompoundTypes_release_handle');
+class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundTypes {
+  final Pointer<Void> handle;
+  GenericTypesWithCompoundTypes$Impl(this.handle);
+  @override
+  void release() => _smoke_GenericTypesWithCompoundTypes_release_handle(handle);
+  @override
+  List<GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructList(List<GenericTypesWithCompoundTypes_BasicStruct> input) {
+    final _methodWithStructList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct');
+    final _input_handle = ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithStructList_ffi(_handle, _input_handle);
+    ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
+    final _result = ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
+    ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  Map<String, GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructMap(Map<String, GenericTypesWithCompoundTypes_BasicStruct> input) {
+    final _methodWithStructMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructMap__MapOf_1String_1to_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct');
+    final _input_handle = MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithStructMap_ffi(_handle, _input_handle);
+    MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
+    final _result = MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
+    MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  List<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumList(List<GenericTypesWithCompoundTypes_SomeEnum> input) {
+    final _methodWithEnumList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
+    final _input_handle = ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithEnumList_ffi(_handle, _input_handle);
+    ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
+    final _result = ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
+    ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> methodWithEnumMapKey(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> input) {
+    final _methodWithEnumMapKey_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey__MapOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum_1to_1Boolean');
+    final _input_handle = MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithEnumMapKey_ffi(_handle, _input_handle);
+    MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(_input_handle);
+    final _result = MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi(__result_handle);
+    MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  Map<int, GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumMapValue(Map<int, GenericTypesWithCompoundTypes_SomeEnum> input) {
+    final _methodWithEnumMapValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue__MapOf_1Int_1to_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
+    final _input_handle = MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithEnumMapValue_ffi(_handle, _input_handle);
+    MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
+    final _result = MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
+    MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  Set<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumSet(Set<GenericTypesWithCompoundTypes_SomeEnum> input) {
+    final _methodWithEnumSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumSet__SetOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
+    final _input_handle = SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithEnumSet_ffi(_handle, _input_handle);
+    SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
+    final _result = SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
+    SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  List<DummyInterface> methodWithInstancesList(List<DummyClass> input) {
+    final _methodWithInstancesList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesList__ListOf_1smoke_1DummyClass');
+    final _input_handle = ListOf_smoke_DummyClass_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithInstancesList_ffi(_handle, _input_handle);
+    ListOf_smoke_DummyClass_releaseFfiHandle(_input_handle);
+    final _result = ListOf_smoke_DummyInterface_fromFfi(__result_handle);
+    ListOf_smoke_DummyInterface_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  Map<int, DummyInterface> methodWithInstancesMap(Map<int, DummyClass> input) {
+    final _methodWithInstancesMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap__MapOf_1Int_1to_1smoke_1DummyClass');
+    final _input_handle = MapOf_Int_to_smoke_DummyClass_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithInstancesMap_ffi(_handle, _input_handle);
+    MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(_input_handle);
+    final _result = MapOf_Int_to_smoke_DummyInterface_fromFfi(__result_handle);
+    MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_GenericTypesWithCompoundTypes_toFfi(GenericTypesWithCompoundTypes value) =>
+  _smoke_GenericTypesWithCompoundTypes_copy_handle((value as GenericTypesWithCompoundTypes$Impl).handle);
+GenericTypesWithCompoundTypes smoke_GenericTypesWithCompoundTypes_fromFfi(Pointer<Void> handle) =>
+  GenericTypesWithCompoundTypes$Impl(_smoke_GenericTypesWithCompoundTypes_copy_handle(handle));
+void smoke_GenericTypesWithCompoundTypes_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_GenericTypesWithCompoundTypes_release_handle(handle);
+Pointer<Void> smoke_GenericTypesWithCompoundTypes_toFfi_nullable(GenericTypesWithCompoundTypes value) =>
+  value != null ? smoke_GenericTypesWithCompoundTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
+GenericTypesWithCompoundTypes smoke_GenericTypesWithCompoundTypes_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_GenericTypesWithCompoundTypes_fromFfi(handle) : null;
+void smoke_GenericTypesWithCompoundTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_GenericTypesWithCompoundTypes_release_handle(handle);
+// End of GenericTypesWithCompoundTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithGenericTypes.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/GenericTypesWithGenericTypes.dart
@@ -4,6 +4,17 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
+abstract class GenericTypesWithGenericTypes {
+  void release();
+  List<List<int>> methodWithListOfLists(List<List<int>> input);
+  Map<Map<int, bool>, bool> methodWithMapOfMaps(Map<int, Map<int, bool>> input);
+  Set<Set<int>> methodWithSetOfSets(Set<Set<int>> input);
+  Map<int, List<int>> methodWithListAndMap(List<Map<int, bool>> input);
+  Set<List<int>> methodWithListAndSet(List<Set<int>> input);
+  Set<Map<int, bool>> methodWithMapAndSet(Map<int, Set<int>> input);
+  Map<List<int>, bool> methodWithMapGenericKeys(Map<Set<int>, bool> input);
+}
+// GenericTypesWithGenericTypes "private" section, not exported.
 final _smoke_GenericTypesWithGenericTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -12,67 +23,82 @@ final _smoke_GenericTypesWithGenericTypes_release_handle = __lib.nativeLibrary.l
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithGenericTypes_release_handle');
-class GenericTypesWithGenericTypes {
-  final Pointer<Void> _handle;
-  GenericTypesWithGenericTypes._(this._handle);
-  void release() => _smoke_GenericTypesWithGenericTypes_release_handle(_handle);
+class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes {
+  final Pointer<Void> handle;
+  GenericTypesWithGenericTypes$Impl(this.handle);
+  @override
+  void release() => _smoke_GenericTypesWithGenericTypes_release_handle(handle);
+  @override
   List<List<int>> methodWithListOfLists(List<List<int>> input) {
     final _methodWithListOfLists_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListOfLists__ListOf_1ListOf_1Int');
     final _input_handle = ListOf_ListOf_Int_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _methodWithListOfLists_ffi(_handle, _input_handle);
     ListOf_ListOf_Int_releaseFfiHandle(_input_handle);
     final _result = ListOf_ListOf_Int_fromFfi(__result_handle);
     ListOf_ListOf_Int_releaseFfiHandle(__result_handle);
     return _result;
   }
+  @override
   Map<Map<int, bool>, bool> methodWithMapOfMaps(Map<int, Map<int, bool>> input) {
     final _methodWithMapOfMaps_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps__MapOf_1Int_1to_1MapOf_1Int_1to_1Boolean');
     final _input_handle = MapOf_Int_to_MapOf_Int_to_Boolean_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _methodWithMapOfMaps_ffi(_handle, _input_handle);
     MapOf_Int_to_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
     final _result = MapOf_MapOf_Int_to_Boolean_to_Boolean_fromFfi(__result_handle);
     MapOf_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(__result_handle);
     return _result;
   }
+  @override
   Set<Set<int>> methodWithSetOfSets(Set<Set<int>> input) {
     final _methodWithSetOfSets_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithSetOfSets__SetOf_1SetOf_1Int');
     final _input_handle = SetOf_SetOf_Int_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _methodWithSetOfSets_ffi(_handle, _input_handle);
     SetOf_SetOf_Int_releaseFfiHandle(_input_handle);
     final _result = SetOf_SetOf_Int_fromFfi(__result_handle);
     SetOf_SetOf_Int_releaseFfiHandle(__result_handle);
     return _result;
   }
+  @override
   Map<int, List<int>> methodWithListAndMap(List<Map<int, bool>> input) {
     final _methodWithListAndMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListAndMap__ListOf_1MapOf_1Int_1to_1Boolean');
     final _input_handle = ListOf_MapOf_Int_to_Boolean_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _methodWithListAndMap_ffi(_handle, _input_handle);
     ListOf_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
     final _result = MapOf_Int_to_ListOf_Int_fromFfi(__result_handle);
     MapOf_Int_to_ListOf_Int_releaseFfiHandle(__result_handle);
     return _result;
   }
+  @override
   Set<List<int>> methodWithListAndSet(List<Set<int>> input) {
     final _methodWithListAndSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListAndSet__ListOf_1SetOf_1Int');
     final _input_handle = ListOf_SetOf_Int_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _methodWithListAndSet_ffi(_handle, _input_handle);
     ListOf_SetOf_Int_releaseFfiHandle(_input_handle);
     final _result = SetOf_ListOf_Int_fromFfi(__result_handle);
     SetOf_ListOf_Int_releaseFfiHandle(__result_handle);
     return _result;
   }
+  @override
   Set<Map<int, bool>> methodWithMapAndSet(Map<int, Set<int>> input) {
     final _methodWithMapAndSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapAndSet__MapOf_1Int_1to_1SetOf_1Int');
     final _input_handle = MapOf_Int_to_SetOf_Int_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _methodWithMapAndSet_ffi(_handle, _input_handle);
     MapOf_Int_to_SetOf_Int_releaseFfiHandle(_input_handle);
     final _result = SetOf_MapOf_Int_to_Boolean_fromFfi(__result_handle);
     SetOf_MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
     return _result;
   }
+  @override
   Map<List<int>, bool> methodWithMapGenericKeys(Map<Set<int>, bool> input) {
     final _methodWithMapGenericKeys_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys__MapOf_1SetOf_1Int_1to_1Boolean');
     final _input_handle = MapOf_SetOf_Int_to_Boolean_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _methodWithMapGenericKeys_ffi(_handle, _input_handle);
     MapOf_SetOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
     final _result = MapOf_ListOf_Int_to_Boolean_fromFfi(__result_handle);
@@ -81,9 +107,9 @@ class GenericTypesWithGenericTypes {
   }
 }
 Pointer<Void> smoke_GenericTypesWithGenericTypes_toFfi(GenericTypesWithGenericTypes value) =>
-  _smoke_GenericTypesWithGenericTypes_copy_handle(value._handle);
+  _smoke_GenericTypesWithGenericTypes_copy_handle((value as GenericTypesWithGenericTypes$Impl).handle);
 GenericTypesWithGenericTypes smoke_GenericTypesWithGenericTypes_fromFfi(Pointer<Void> handle) =>
-  GenericTypesWithGenericTypes._(_smoke_GenericTypesWithGenericTypes_copy_handle(handle));
+  GenericTypesWithGenericTypes$Impl(_smoke_GenericTypesWithGenericTypes_copy_handle(handle));
 void smoke_GenericTypesWithGenericTypes_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_GenericTypesWithGenericTypes_release_handle(handle);
 Pointer<Void> smoke_GenericTypesWithGenericTypes_toFfi_nullable(GenericTypesWithGenericTypes value) =>
@@ -92,3 +118,4 @@ GenericTypesWithGenericTypes smoke_GenericTypesWithGenericTypes_fromFfi_nullable
   handle.address != 0 ? smoke_GenericTypesWithGenericTypes_fromFfi(handle) : null;
 void smoke_GenericTypesWithGenericTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_GenericTypesWithGenericTypes_release_handle(handle);
+// End of GenericTypesWithGenericTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
@@ -8,11 +8,11 @@ import 'package:library/src/smoke/ParentInterface.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 final Map<String, Function> typeRepository = {
-  "smoke_ParentInterface": (handle) => ParentInterface__Impl(handle),
-  "smoke_ChildInterface": (handle) => ChildInterface__Impl(handle),
-  "smoke_ChildClassFromInterface": (handle) => ChildClassFromInterface__Factory.create(handle),
-  "smoke_ParentClass": (handle) => ParentClass(handle),
-  "smoke_ChildClassFromClass": (handle) => ChildClassFromClass__Factory.create(handle),
-  "smoke_InternalParent": (handle) => InternalParent(handle),
-  "smoke_InternalChild": (handle) => InternalChild__Factory.create(handle),
+  "smoke_ParentInterface": (handle) => ParentInterface$Impl(handle),
+  "smoke_ChildInterface": (handle) => ChildInterface$Impl(handle),
+  "smoke_ChildClassFromInterface": (handle) => ChildClassFromInterface$Impl(handle),
+  "smoke_ParentClass": (handle) => ParentClass$Impl(handle),
+  "smoke_ChildClassFromClass": (handle) => ChildClassFromClass$Impl(handle),
+  "smoke_InternalParent": (handle) => InternalParent$Impl(handle),
+  "smoke_InternalChild": (handle) => InternalChild$Impl(handle),
  };

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildClassFromClass.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildClassFromClass.dart
@@ -5,6 +5,11 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
+abstract class ChildClassFromClass implements ParentClass {
+  void release();
+  childClassMethod();
+}
+// ChildClassFromClass "private" section, not exported.
 final _smoke_ChildClassFromClass_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -17,12 +22,14 @@ final _smoke_ChildClassFromClass_get_type_id = __lib.nativeLibrary.lookupFunctio
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildClassFromClass_get_type_id');
-class ChildClassFromClass extends ParentClass {
-  Pointer<Void> get _handle => handle;
-  ChildClassFromClass._(Pointer<Void> handle) : super(handle);
-  void release() => _smoke_ChildClassFromClass_release_handle(_handle);
+class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFromClass {
+  ChildClassFromClass$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() => _smoke_ChildClassFromClass_release_handle(handle);
+  @override
   childClassMethod() {
     final _childClassMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_ChildClassFromClass_childClassMethod');
+    final _handle = this.handle;
     final __result_handle = _childClassMethod_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
@@ -30,13 +37,13 @@ class ChildClassFromClass extends ParentClass {
   }
 }
 Pointer<Void> smoke_ChildClassFromClass_toFfi(ChildClassFromClass value) =>
-  _smoke_ChildClassFromClass_copy_handle(value._handle);
+  _smoke_ChildClassFromClass_copy_handle((value as ChildClassFromClass$Impl).handle);
 ChildClassFromClass smoke_ChildClassFromClass_fromFfi(Pointer<Void> handle) {
   final _copied_handle = _smoke_ChildClassFromClass_copy_handle(handle);
   final _type_id_handle = _smoke_ChildClassFromClass_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? ChildClassFromClass._(_copied_handle)
+    ? ChildClassFromClass$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;
@@ -49,7 +56,4 @@ ChildClassFromClass smoke_ChildClassFromClass_fromFfi_nullable(Pointer<Void> han
   handle.address != 0 ? smoke_ChildClassFromClass_fromFfi(handle) : null;
 void smoke_ChildClassFromClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ChildClassFromClass_release_handle(handle);
-// Internal, not exported.
-class ChildClassFromClass__Factory {
-  static ChildClassFromClass create(Pointer<Void> handle) => ChildClassFromClass._(handle);
-}
+// End of ChildClassFromClass "private" section.

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildClassFromInterface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildClassFromInterface.dart
@@ -5,6 +5,11 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
+abstract class ChildClassFromInterface implements ParentInterface {
+  void release();
+  childClassMethod();
+}
+// ChildClassFromInterface "private" section, not exported.
 final _smoke_ChildClassFromInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -17,12 +22,15 @@ final _smoke_ChildClassFromInterface_get_type_id = __lib.nativeLibrary.lookupFun
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildClassFromInterface_get_type_id');
-class ChildClassFromInterface implements ParentInterface {
-  final Pointer<Void> _handle;
-  ChildClassFromInterface._(this._handle);
-  void release() => _smoke_ChildClassFromInterface_release_handle(_handle);
+class ChildClassFromInterface$Impl implements ChildClassFromInterface {
+  final Pointer<Void> handle;
+  ChildClassFromInterface$Impl(this.handle);
+  @override
+  void release() => _smoke_ChildClassFromInterface_release_handle(handle);
+  @override
   childClassMethod() {
     final _childClassMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_ChildClassFromInterface_childClassMethod');
+    final _handle = this.handle;
     final __result_handle = _childClassMethod_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
@@ -31,6 +39,7 @@ class ChildClassFromInterface implements ParentInterface {
   @override
   rootMethod() {
     final _rootMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_ParentInterface_rootMethod');
+    final _handle = this.handle;
     final __result_handle = _rootMethod_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
@@ -39,14 +48,17 @@ class ChildClassFromInterface implements ParentInterface {
   @override
   String get rootProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = String_fromFfi(__result_handle);
     String_releaseFfiHandle(__result_handle);
     return _result;
   }
+  @override
   set rootProperty(String value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String');
     final _value_handle = String_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     String_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -55,13 +67,13 @@ class ChildClassFromInterface implements ParentInterface {
   }
 }
 Pointer<Void> smoke_ChildClassFromInterface_toFfi(ChildClassFromInterface value) =>
-  _smoke_ChildClassFromInterface_copy_handle(value._handle);
+  _smoke_ChildClassFromInterface_copy_handle((value as ChildClassFromInterface$Impl).handle);
 ChildClassFromInterface smoke_ChildClassFromInterface_fromFfi(Pointer<Void> handle) {
   final _copied_handle = _smoke_ChildClassFromInterface_copy_handle(handle);
   final _type_id_handle = _smoke_ChildClassFromInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? ChildClassFromInterface._(_copied_handle)
+    ? ChildClassFromInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;
@@ -74,7 +86,4 @@ ChildClassFromInterface smoke_ChildClassFromInterface_fromFfi_nullable(Pointer<V
   handle.address != 0 ? smoke_ChildClassFromInterface_fromFfi(handle) : null;
 void smoke_ChildClassFromInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ChildClassFromInterface_release_handle(handle);
-// Internal, not exported.
-class ChildClassFromInterface__Factory {
-  static ChildClassFromInterface create(Pointer<Void> handle) => ChildClassFromInterface._(handle);
-}
+// End of ChildClassFromInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildInterface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildInterface.dart
@@ -31,14 +31,14 @@ final _smoke_ChildInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildInterface_get_type_id');
-class ChildInterface__Impl extends ParentInterface__Impl implements ChildInterface {
-  Pointer<Void> get _handle => handle;
-  ChildInterface__Impl(Pointer<Void> handle) : super(handle);
+class ChildInterface$Impl extends ParentInterface$Impl implements ChildInterface {
+  ChildInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() => _smoke_ChildInterface_release_handle(handle);
   @override
   childMethod() {
     final _childMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_ChildInterface_childMethod');
+    final _handle = this.handle;
     final __result_handle = _childMethod_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
@@ -63,7 +63,7 @@ int _ChildInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
   return 0;
 }
 Pointer<Void> smoke_ChildInterface_toFfi(ChildInterface value) {
-  if (value is ChildInterface__Impl) return _smoke_ChildInterface_copy_handle(value.handle);
+  if (value is ChildInterface$Impl) return _smoke_ChildInterface_copy_handle(value.handle);
   final result = _smoke_ChildInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -82,7 +82,7 @@ ChildInterface smoke_ChildInterface_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_ChildInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? ChildInterface__Impl(_copied_handle)
+    ? ChildInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentClass.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentClass.dart
@@ -4,6 +4,11 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
+abstract class ParentClass {
+  void release();
+  rootMethod();
+}
+// ParentClass "private" section, not exported.
 final _smoke_ParentClass_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -16,15 +21,15 @@ final _smoke_ParentClass_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ParentClass_get_type_id');
-class ParentClass {
-  @protected
+class ParentClass$Impl implements ParentClass {
   final Pointer<Void> handle;
-  Pointer<Void> get _handle => handle;
-  @protected
-  ParentClass(this.handle);
-  void release() => _smoke_ParentClass_release_handle(_handle);
+  ParentClass$Impl(this.handle);
+  @override
+  void release() => _smoke_ParentClass_release_handle(handle);
+  @override
   rootMethod() {
     final _rootMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_ParentClass_rootMethod');
+    final _handle = this.handle;
     final __result_handle = _rootMethod_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
@@ -32,13 +37,13 @@ class ParentClass {
   }
 }
 Pointer<Void> smoke_ParentClass_toFfi(ParentClass value) =>
-  _smoke_ParentClass_copy_handle(value._handle);
+  _smoke_ParentClass_copy_handle((value as ParentClass$Impl).handle);
 ParentClass smoke_ParentClass_fromFfi(Pointer<Void> handle) {
   final _copied_handle = _smoke_ParentClass_copy_handle(handle);
   final _type_id_handle = _smoke_ParentClass_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? ParentClass(_copied_handle)
+    ? ParentClass$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;
@@ -51,7 +56,4 @@ ParentClass smoke_ParentClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ParentClass_fromFfi(handle) : null;
 void smoke_ParentClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ParentClass_release_handle(handle);
-// Internal, not exported.
-class ParentClass__Factory {
-  static ParentClass create(Pointer<Void> handle) => ParentClass(handle);
-}
+// End of ParentClass "private" section.

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentInterface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentInterface.dart
@@ -32,15 +32,15 @@ final _smoke_ParentInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ParentInterface_get_type_id');
-class ParentInterface__Impl implements ParentInterface {
-  Pointer<Void> get _handle => handle;
+class ParentInterface$Impl implements ParentInterface {
   final Pointer<Void> handle;
-  ParentInterface__Impl(this.handle);
+  ParentInterface$Impl(this.handle);
   @override
   void release() => _smoke_ParentInterface_release_handle(handle);
   @override
   rootMethod() {
     final _rootMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_ParentInterface_rootMethod');
+    final _handle = this.handle;
     final __result_handle = _rootMethod_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
@@ -48,6 +48,7 @@ class ParentInterface__Impl implements ParentInterface {
   }
   String get rootProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = String_fromFfi(__result_handle);
     String_releaseFfiHandle(__result_handle);
@@ -56,6 +57,7 @@ class ParentInterface__Impl implements ParentInterface {
   set rootProperty(String value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String');
     final _value_handle = String_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     String_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -77,7 +79,7 @@ int _ParentInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
   return 0;
 }
 Pointer<Void> smoke_ParentInterface_toFfi(ParentInterface value) {
-  if (value is ParentInterface__Impl) return _smoke_ParentInterface_copy_handle(value.handle);
+  if (value is ParentInterface$Impl) return _smoke_ParentInterface_copy_handle(value.handle);
   final result = _smoke_ParentInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -95,7 +97,7 @@ ParentInterface smoke_ParentInterface_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_ParentInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? ParentInterface__Impl(_copied_handle)
+    ? ParentInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalClass.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalClass.dart
@@ -3,47 +3,11 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_ExternalClass_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ExternalClass_copy_handle');
-final _smoke_ExternalClass_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_ExternalClass_release_handle');
-class ExternalClass {
-  final Pointer<Void> _handle;
-  ExternalClass._(this._handle);
-  void release() => _smoke_ExternalClass_release_handle(_handle);
-  someMethod(int someParameter) {
-    final _someMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int8), void Function(Pointer<Void>, int)>('library_smoke_ExternalClass_someMethod__Byte');
-    final _someParameter_handle = (someParameter);
-    final __result_handle = _someMethod_ffi(_handle, _someParameter_handle);
-    (_someParameter_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  String get someProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ExternalClass_someProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+abstract class ExternalClass {
+  void release();
+  someMethod(int someParameter);
+  String get someProperty;
 }
-Pointer<Void> smoke_ExternalClass_toFfi(ExternalClass value) =>
-  _smoke_ExternalClass_copy_handle(value._handle);
-ExternalClass smoke_ExternalClass_fromFfi(Pointer<Void> handle) =>
-  ExternalClass._(_smoke_ExternalClass_copy_handle(handle));
-void smoke_ExternalClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ExternalClass_release_handle(handle);
-Pointer<Void> smoke_ExternalClass_toFfi_nullable(ExternalClass value) =>
-  value != null ? smoke_ExternalClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-ExternalClass smoke_ExternalClass_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_ExternalClass_fromFfi(handle) : null;
-void smoke_ExternalClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExternalClass_release_handle(handle);
 enum ExternalClass_SomeEnum {
     someValue
 }
@@ -158,3 +122,51 @@ ExternalClass_SomeStruct smoke_ExternalClass_SomeStruct_fromFfi_nullable(Pointer
 void smoke_ExternalClass_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ExternalClass_SomeStruct_release_handle_nullable(handle);
 // End of ExternalClass_SomeStruct "private" section.
+// ExternalClass "private" section, not exported.
+final _smoke_ExternalClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_copy_handle');
+final _smoke_ExternalClass_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_release_handle');
+class ExternalClass$Impl implements ExternalClass {
+  final Pointer<Void> handle;
+  ExternalClass$Impl(this.handle);
+  @override
+  void release() => _smoke_ExternalClass_release_handle(handle);
+  @override
+  someMethod(int someParameter) {
+    final _someMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int8), void Function(Pointer<Void>, int)>('library_smoke_ExternalClass_someMethod__Byte');
+    final _someParameter_handle = (someParameter);
+    final _handle = this.handle;
+    final __result_handle = _someMethod_ffi(_handle, _someParameter_handle);
+    (_someParameter_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  String get someProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ExternalClass_someProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_ExternalClass_toFfi(ExternalClass value) =>
+  _smoke_ExternalClass_copy_handle((value as ExternalClass$Impl).handle);
+ExternalClass smoke_ExternalClass_fromFfi(Pointer<Void> handle) =>
+  ExternalClass$Impl(_smoke_ExternalClass_copy_handle(handle));
+void smoke_ExternalClass_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_ExternalClass_release_handle(handle);
+Pointer<Void> smoke_ExternalClass_toFfi_nullable(ExternalClass value) =>
+  value != null ? smoke_ExternalClass_toFfi(value) : Pointer<Void>.fromAddress(0);
+ExternalClass smoke_ExternalClass_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_ExternalClass_fromFfi(handle) : null;
+void smoke_ExternalClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_ExternalClass_release_handle(handle);
+// End of ExternalClass "private" section.

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalInterface.dart
@@ -145,16 +145,16 @@ final _smoke_ExternalInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_get_type_id');
-class ExternalInterface__Impl implements ExternalInterface {
-  Pointer<Void> get _handle => handle;
+class ExternalInterface$Impl implements ExternalInterface {
   final Pointer<Void> handle;
-  ExternalInterface__Impl(this.handle);
+  ExternalInterface$Impl(this.handle);
   @override
   void release() => _smoke_ExternalInterface_release_handle(handle);
   @override
   someMethod(int someParameter) {
     final _someMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int8), void Function(Pointer<Void>, int)>('library_smoke_ExternalInterface_someMethod__Byte');
     final _someParameter_handle = (someParameter);
+    final _handle = this.handle;
     final __result_handle = _someMethod_ffi(_handle, _someParameter_handle);
     (_someParameter_handle);
     final _result = (__result_handle);
@@ -163,6 +163,7 @@ class ExternalInterface__Impl implements ExternalInterface {
   }
   String get someProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ExternalInterface_someProperty_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = String_fromFfi(__result_handle);
     String_releaseFfiHandle(__result_handle);
@@ -179,7 +180,7 @@ int _ExternalInterface_someProperty_get_static(int _token, Pointer<Pointer<Void>
   return 0;
 }
 Pointer<Void> smoke_ExternalInterface_toFfi(ExternalInterface value) {
-  if (value is ExternalInterface__Impl) return _smoke_ExternalInterface_copy_handle(value.handle);
+  if (value is ExternalInterface$Impl) return _smoke_ExternalInterface_copy_handle(value.handle);
   final result = _smoke_ExternalInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -196,7 +197,7 @@ ExternalInterface smoke_ExternalInterface_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_ExternalInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? ExternalInterface__Impl(_copied_handle)
+    ? ExternalInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleClass.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleClass.dart
@@ -3,6 +3,12 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
+abstract class SimpleClass {
+  void release();
+  String getStringValue();
+  SimpleClass useSimpleClass(SimpleClass input);
+}
+// SimpleClass "private" section, not exported.
 final _smoke_SimpleClass_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -11,20 +17,25 @@ final _smoke_SimpleClass_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SimpleClass_release_handle');
-class SimpleClass {
-  final Pointer<Void> _handle;
-  SimpleClass._(this._handle);
-  void release() => _smoke_SimpleClass_release_handle(_handle);
+class SimpleClass$Impl implements SimpleClass {
+  final Pointer<Void> handle;
+  SimpleClass$Impl(this.handle);
+  @override
+  void release() => _smoke_SimpleClass_release_handle(handle);
+  @override
   String getStringValue() {
     final _getStringValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_SimpleClass_getStringValue');
+    final _handle = this.handle;
     final __result_handle = _getStringValue_ffi(_handle);
     final _result = String_fromFfi(__result_handle);
     String_releaseFfiHandle(__result_handle);
     return _result;
   }
+  @override
   SimpleClass useSimpleClass(SimpleClass input) {
     final _useSimpleClass_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_SimpleClass_useSimpleClass__SimpleClass');
     final _input_handle = smoke_SimpleClass_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _useSimpleClass_ffi(_handle, _input_handle);
     smoke_SimpleClass_releaseFfiHandle(_input_handle);
     final _result = smoke_SimpleClass_fromFfi(__result_handle);
@@ -33,9 +44,9 @@ class SimpleClass {
   }
 }
 Pointer<Void> smoke_SimpleClass_toFfi(SimpleClass value) =>
-  _smoke_SimpleClass_copy_handle(value._handle);
+  _smoke_SimpleClass_copy_handle((value as SimpleClass$Impl).handle);
 SimpleClass smoke_SimpleClass_fromFfi(Pointer<Void> handle) =>
-  SimpleClass._(_smoke_SimpleClass_copy_handle(handle));
+  SimpleClass$Impl(_smoke_SimpleClass_copy_handle(handle));
 void smoke_SimpleClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SimpleClass_release_handle(handle);
 Pointer<Void> smoke_SimpleClass_toFfi_nullable(SimpleClass value) =>
@@ -44,3 +55,4 @@ SimpleClass smoke_SimpleClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SimpleClass_fromFfi(handle) : null;
 void smoke_SimpleClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SimpleClass_release_handle(handle);
+// End of SimpleClass "private" section.

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleInterface.dart
@@ -31,15 +31,15 @@ final _smoke_SimpleInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleInterface_get_type_id');
-class SimpleInterface__Impl implements SimpleInterface {
-  Pointer<Void> get _handle => handle;
+class SimpleInterface$Impl implements SimpleInterface {
   final Pointer<Void> handle;
-  SimpleInterface__Impl(this.handle);
+  SimpleInterface$Impl(this.handle);
   @override
   void release() => _smoke_SimpleInterface_release_handle(handle);
   @override
   String getStringValue() {
     final _getStringValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_SimpleInterface_getStringValue');
+    final _handle = this.handle;
     final __result_handle = _getStringValue_ffi(_handle);
     final _result = String_fromFfi(__result_handle);
     String_releaseFfiHandle(__result_handle);
@@ -49,6 +49,7 @@ class SimpleInterface__Impl implements SimpleInterface {
   SimpleInterface useSimpleInterface(SimpleInterface input) {
     final _useSimpleInterface_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_SimpleInterface_useSimpleInterface__SimpleInterface');
     final _input_handle = smoke_SimpleInterface_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _useSimpleInterface_ffi(_handle, _input_handle);
     smoke_SimpleInterface_releaseFfiHandle(_input_handle);
     final _result = smoke_SimpleInterface_fromFfi(__result_handle);
@@ -69,7 +70,7 @@ int _SimpleInterface_useSimpleInterface_static(int _token, Pointer<Void> input, 
   return 0;
 }
 Pointer<Void> smoke_SimpleInterface_toFfi(SimpleInterface value) {
-  if (value is SimpleInterface__Impl) return _smoke_SimpleInterface_copy_handle(value.handle);
+  if (value is SimpleInterface$Impl) return _smoke_SimpleInterface_copy_handle(value.handle);
   final result = _smoke_SimpleInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -86,7 +87,7 @@ SimpleInterface smoke_SimpleInterface_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_SimpleInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? SimpleInterface__Impl(_copied_handle)
+    ? SimpleInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/Lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/Lambdas.dart
@@ -5,53 +5,11 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_Lambdas_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_copy_handle');
-final _smoke_Lambdas_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Lambdas_release_handle');
-class Lambdas {
-  final Pointer<Void> _handle;
-  Lambdas._(this._handle);
-  void release() => _smoke_Lambdas_release_handle(_handle);
-  Lambdas_Producer deconfuse(String value, Lambdas_Confuser confuser) {
-    final _deconfuse_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_deconfuse__String_Confuser');
-    final _value_handle = String_toFfi(value);
-    final _confuser_handle = smoke_Lambdas_Confuser_toFfi(confuser);
-    final __result_handle = _deconfuse_ffi(_handle, _value_handle, _confuser_handle);
-    String_releaseFfiHandle(_value_handle);
-    smoke_Lambdas_Confuser_releaseFfiHandle(_confuser_handle);
-    final _result = smoke_Lambdas_Producer_fromFfi(__result_handle);
-    smoke_Lambdas_Producer_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static Map<int, String> fuse(List<String> items, Lambdas_Indexer callback) {
-    final _fuse_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_fuse__ListOf_1String_Indexer');
-    final _items_handle = ListOf_String_toFfi(items);
-    final _callback_handle = smoke_Lambdas_Indexer_toFfi(callback);
-    final __result_handle = _fuse_ffi(_items_handle, _callback_handle);
-    ListOf_String_releaseFfiHandle(_items_handle);
-    smoke_Lambdas_Indexer_releaseFfiHandle(_callback_handle);
-    final _result = MapOf_Int_to_String_fromFfi(__result_handle);
-    MapOf_Int_to_String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+abstract class Lambdas {
+  void release();
+  Lambdas_Producer deconfuse(String value, Lambdas_Confuser confuser);
+  static Map<int, String> fuse(List<String> items, Lambdas_Indexer callback) => Lambdas$Impl.fuse(items, callback);
 }
-Pointer<Void> smoke_Lambdas_toFfi(Lambdas value) =>
-  _smoke_Lambdas_copy_handle(value._handle);
-Lambdas smoke_Lambdas_fromFfi(Pointer<Void> handle) =>
-  Lambdas._(_smoke_Lambdas_copy_handle(handle));
-void smoke_Lambdas_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Lambdas_release_handle(handle);
-Pointer<Void> smoke_Lambdas_toFfi_nullable(Lambdas value) =>
-  value != null ? smoke_Lambdas_toFfi(value) : Pointer<Void>.fromAddress(0);
-Lambdas smoke_Lambdas_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_Lambdas_fromFfi(handle) : null;
-void smoke_Lambdas_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Lambdas_release_handle(handle);
 typedef Lambdas_Producer = String Function();
 // Lambdas_Producer "private" section, not exported.
 final _smoke_Lambdas_Producer_copy_handle = __lib.nativeLibrary.lookupFunction<
@@ -70,13 +28,14 @@ final _smoke_Lambdas_Producer_get_raw_pointer = __lib.nativeLibrary.lookupFuncti
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('library_smoke_Lambdas_Producer_get_raw_pointer');
-class Lambdas_Producer__Impl {
+class Lambdas_Producer$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
-  Lambdas_Producer__Impl(this.handle);
+  Lambdas_Producer$Impl(this.handle);
   void release() => _smoke_Lambdas_Producer_release_handle(handle);
   String call() {
     final _call_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Lambdas_Producer_call');
+    final _handle = this.handle;
     final __result_handle = _call_ffi(_handle);
     final _result = String_fromFfi(__result_handle);
     String_releaseFfiHandle(__result_handle);
@@ -100,7 +59,7 @@ Pointer<Void> smoke_Lambdas_Producer_toFfi(Lambdas_Producer value) {
 Lambdas_Producer smoke_Lambdas_Producer_fromFfi(Pointer<Void> handle) {
   final instance = __lib.reverseCache[_smoke_Lambdas_Producer_get_raw_pointer(handle)] as Lambdas_Producer;
   if (instance != null) return instance;
-  final _impl = Lambdas_Producer__Impl(_smoke_Lambdas_Producer_copy_handle(handle));
+  final _impl = Lambdas_Producer$Impl(_smoke_Lambdas_Producer_copy_handle(handle));
   return () {
     final _result =_impl.call();
     _impl.release();
@@ -158,14 +117,15 @@ final _smoke_Lambdas_Confuser_get_raw_pointer = __lib.nativeLibrary.lookupFuncti
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('library_smoke_Lambdas_Confuser_get_raw_pointer');
-class Lambdas_Confuser__Impl {
+class Lambdas_Confuser$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
-  Lambdas_Confuser__Impl(this.handle);
+  Lambdas_Confuser$Impl(this.handle);
   void release() => _smoke_Lambdas_Confuser_release_handle(handle);
   Lambdas_Producer call(String p0) {
     final _call_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_Confuser_call__String');
     final _p0_handle = String_toFfi(p0);
+    final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, _p0_handle);
     String_releaseFfiHandle(_p0_handle);
     final _result = smoke_Lambdas_Producer_fromFfi(__result_handle);
@@ -191,7 +151,7 @@ Pointer<Void> smoke_Lambdas_Confuser_toFfi(Lambdas_Confuser value) {
 Lambdas_Confuser smoke_Lambdas_Confuser_fromFfi(Pointer<Void> handle) {
   final instance = __lib.reverseCache[_smoke_Lambdas_Confuser_get_raw_pointer(handle)] as Lambdas_Confuser;
   if (instance != null) return instance;
-  final _impl = Lambdas_Confuser__Impl(_smoke_Lambdas_Confuser_copy_handle(handle));
+  final _impl = Lambdas_Confuser$Impl(_smoke_Lambdas_Confuser_copy_handle(handle));
   return (String p0) {
     final _result =_impl.call(p0);
     _impl.release();
@@ -248,14 +208,15 @@ final _smoke_Lambdas_Consumer_get_raw_pointer = __lib.nativeLibrary.lookupFuncti
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('library_smoke_Lambdas_Consumer_get_raw_pointer');
-class Lambdas_Consumer__Impl {
+class Lambdas_Consumer$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
-  Lambdas_Consumer__Impl(this.handle);
+  Lambdas_Consumer$Impl(this.handle);
   void release() => _smoke_Lambdas_Consumer_release_handle(handle);
   call(String p0) {
     final _call_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_Consumer_call__String');
     final _p0_handle = String_toFfi(p0);
+    final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, _p0_handle);
     String_releaseFfiHandle(_p0_handle);
     final _result = (__result_handle);
@@ -280,7 +241,7 @@ Pointer<Void> smoke_Lambdas_Consumer_toFfi(Lambdas_Consumer value) {
 Lambdas_Consumer smoke_Lambdas_Consumer_fromFfi(Pointer<Void> handle) {
   final instance = __lib.reverseCache[_smoke_Lambdas_Consumer_get_raw_pointer(handle)] as Lambdas_Consumer;
   if (instance != null) return instance;
-  final _impl = Lambdas_Consumer__Impl(_smoke_Lambdas_Consumer_copy_handle(handle));
+  final _impl = Lambdas_Consumer$Impl(_smoke_Lambdas_Consumer_copy_handle(handle));
   return (String p0) {
     final _result =_impl.call(p0);
     _impl.release();
@@ -337,15 +298,16 @@ final _smoke_Lambdas_Indexer_get_raw_pointer = __lib.nativeLibrary.lookupFunctio
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('library_smoke_Lambdas_Indexer_get_raw_pointer');
-class Lambdas_Indexer__Impl {
+class Lambdas_Indexer$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
-  Lambdas_Indexer__Impl(this.handle);
+  Lambdas_Indexer$Impl(this.handle);
   void release() => _smoke_Lambdas_Indexer_release_handle(handle);
   int call(String p0, double p1) {
     final _call_ffi = __lib.nativeLibrary.lookupFunction<Int32 Function(Pointer<Void>, Pointer<Void>, Float), int Function(Pointer<Void>, Pointer<Void>, double)>('library_smoke_Lambdas_Indexer_call__String_Float');
     final _p0_handle = String_toFfi(p0);
     final _p1_handle = (p1);
+    final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, _p0_handle, _p1_handle);
     String_releaseFfiHandle(_p0_handle);
     (_p1_handle);
@@ -373,7 +335,7 @@ Pointer<Void> smoke_Lambdas_Indexer_toFfi(Lambdas_Indexer value) {
 Lambdas_Indexer smoke_Lambdas_Indexer_fromFfi(Pointer<Void> handle) {
   final instance = __lib.reverseCache[_smoke_Lambdas_Indexer_get_raw_pointer(handle)] as Lambdas_Indexer;
   if (instance != null) return instance;
-  final _impl = Lambdas_Indexer__Impl(_smoke_Lambdas_Indexer_copy_handle(handle));
+  final _impl = Lambdas_Indexer$Impl(_smoke_Lambdas_Indexer_copy_handle(handle));
   return (String p0, double p1) {
     final _result =_impl.call(p0, p1);
     _impl.release();
@@ -430,14 +392,15 @@ final _smoke_Lambdas_NullableConfuser_get_raw_pointer = __lib.nativeLibrary.look
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('library_smoke_Lambdas_NullableConfuser_get_raw_pointer');
-class Lambdas_NullableConfuser__Impl {
+class Lambdas_NullableConfuser$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
-  Lambdas_NullableConfuser__Impl(this.handle);
+  Lambdas_NullableConfuser$Impl(this.handle);
   void release() => _smoke_Lambdas_NullableConfuser_release_handle(handle);
   Lambdas_Producer call(String p0) {
     final _call_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_NullableConfuser_call__String');
     final _p0_handle = String_toFfi_nullable(p0);
+    final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, _p0_handle);
     String_releaseFfiHandle_nullable(_p0_handle);
     final _result = smoke_Lambdas_Producer_fromFfi_nullable(__result_handle);
@@ -463,7 +426,7 @@ Pointer<Void> smoke_Lambdas_NullableConfuser_toFfi(Lambdas_NullableConfuser valu
 Lambdas_NullableConfuser smoke_Lambdas_NullableConfuser_fromFfi(Pointer<Void> handle) {
   final instance = __lib.reverseCache[_smoke_Lambdas_NullableConfuser_get_raw_pointer(handle)] as Lambdas_NullableConfuser;
   if (instance != null) return instance;
-  final _impl = Lambdas_NullableConfuser__Impl(_smoke_Lambdas_NullableConfuser_copy_handle(handle));
+  final _impl = Lambdas_NullableConfuser$Impl(_smoke_Lambdas_NullableConfuser_copy_handle(handle));
   return (String p0) {
     final _result =_impl.call(p0);
     _impl.release();
@@ -502,3 +465,55 @@ Lambdas_NullableConfuser smoke_Lambdas_NullableConfuser_fromFfi_nullable(Pointer
 void smoke_Lambdas_NullableConfuser_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Lambdas_NullableConfuser_release_handle_nullable(handle);
 // End of Lambdas_NullableConfuser "private" section.
+// Lambdas "private" section, not exported.
+final _smoke_Lambdas_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Lambdas_copy_handle');
+final _smoke_Lambdas_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Lambdas_release_handle');
+class Lambdas$Impl implements Lambdas {
+  final Pointer<Void> handle;
+  Lambdas$Impl(this.handle);
+  @override
+  void release() => _smoke_Lambdas_release_handle(handle);
+  @override
+  Lambdas_Producer deconfuse(String value, Lambdas_Confuser confuser) {
+    final _deconfuse_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_deconfuse__String_Confuser');
+    final _value_handle = String_toFfi(value);
+    final _confuser_handle = smoke_Lambdas_Confuser_toFfi(confuser);
+    final _handle = this.handle;
+    final __result_handle = _deconfuse_ffi(_handle, _value_handle, _confuser_handle);
+    String_releaseFfiHandle(_value_handle);
+    smoke_Lambdas_Confuser_releaseFfiHandle(_confuser_handle);
+    final _result = smoke_Lambdas_Producer_fromFfi(__result_handle);
+    smoke_Lambdas_Producer_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static Map<int, String> fuse(List<String> items, Lambdas_Indexer callback) {
+    final _fuse_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_fuse__ListOf_1String_Indexer');
+    final _items_handle = ListOf_String_toFfi(items);
+    final _callback_handle = smoke_Lambdas_Indexer_toFfi(callback);
+    final __result_handle = _fuse_ffi(_items_handle, _callback_handle);
+    ListOf_String_releaseFfiHandle(_items_handle);
+    smoke_Lambdas_Indexer_releaseFfiHandle(_callback_handle);
+    final _result = MapOf_Int_to_String_fromFfi(__result_handle);
+    MapOf_Int_to_String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_Lambdas_toFfi(Lambdas value) =>
+  _smoke_Lambdas_copy_handle((value as Lambdas$Impl).handle);
+Lambdas smoke_Lambdas_fromFfi(Pointer<Void> handle) =>
+  Lambdas$Impl(_smoke_Lambdas_copy_handle(handle));
+void smoke_Lambdas_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Lambdas_release_handle(handle);
+Pointer<Void> smoke_Lambdas_toFfi_nullable(Lambdas value) =>
+  value != null ? smoke_Lambdas_toFfi(value) : Pointer<Void>.fromAddress(0);
+Lambdas smoke_Lambdas_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_Lambdas_fromFfi(handle) : null;
+void smoke_Lambdas_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Lambdas_release_handle(handle);
+// End of Lambdas "private" section.

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/LambdasWithStructuredTypes.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/LambdasWithStructuredTypes.dart
@@ -6,49 +6,11 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_LambdasWithStructuredTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_copy_handle');
-final _smoke_LambdasWithStructuredTypes_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_release_handle');
-class LambdasWithStructuredTypes {
-  final Pointer<Void> _handle;
-  LambdasWithStructuredTypes._(this._handle);
-  void release() => _smoke_LambdasWithStructuredTypes_release_handle(_handle);
-  doClassStuff(LambdasWithStructuredTypes_ClassCallback callback) {
-    final _doClassStuff_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doClassStuff__ClassCallback');
-    final _callback_handle = smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(callback);
-    final __result_handle = _doClassStuff_ffi(_handle, _callback_handle);
-    smoke_LambdasWithStructuredTypes_ClassCallback_releaseFfiHandle(_callback_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  doStructStuff(LambdasWithStructuredTypes_StructCallback callback) {
-    final _doStructStuff_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doStructStuff__StructCallback');
-    final _callback_handle = smoke_LambdasWithStructuredTypes_StructCallback_toFfi(callback);
-    final __result_handle = _doStructStuff_ffi(_handle, _callback_handle);
-    smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle(_callback_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+abstract class LambdasWithStructuredTypes {
+  void release();
+  doClassStuff(LambdasWithStructuredTypes_ClassCallback callback);
+  doStructStuff(LambdasWithStructuredTypes_StructCallback callback);
 }
-Pointer<Void> smoke_LambdasWithStructuredTypes_toFfi(LambdasWithStructuredTypes value) =>
-  _smoke_LambdasWithStructuredTypes_copy_handle(value._handle);
-LambdasWithStructuredTypes smoke_LambdasWithStructuredTypes_fromFfi(Pointer<Void> handle) =>
-  LambdasWithStructuredTypes._(_smoke_LambdasWithStructuredTypes_copy_handle(handle));
-void smoke_LambdasWithStructuredTypes_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_LambdasWithStructuredTypes_release_handle(handle);
-Pointer<Void> smoke_LambdasWithStructuredTypes_toFfi_nullable(LambdasWithStructuredTypes value) =>
-  value != null ? smoke_LambdasWithStructuredTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
-LambdasWithStructuredTypes smoke_LambdasWithStructuredTypes_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_LambdasWithStructuredTypes_fromFfi(handle) : null;
-void smoke_LambdasWithStructuredTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_LambdasWithStructuredTypes_release_handle(handle);
 typedef LambdasWithStructuredTypes_ClassCallback = void Function(LambdasInterface);
 // LambdasWithStructuredTypes_ClassCallback "private" section, not exported.
 final _smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle = __lib.nativeLibrary.lookupFunction<
@@ -67,14 +29,15 @@ final _smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer = __lib.na
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('library_smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer');
-class LambdasWithStructuredTypes_ClassCallback__Impl {
+class LambdasWithStructuredTypes_ClassCallback$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
-  LambdasWithStructuredTypes_ClassCallback__Impl(this.handle);
+  LambdasWithStructuredTypes_ClassCallback$Impl(this.handle);
   void release() => _smoke_LambdasWithStructuredTypes_ClassCallback_release_handle(handle);
   call(LambdasInterface p0) {
     final _call_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_ClassCallback_call__LambdasInterface');
     final _p0_handle = smoke_LambdasInterface_toFfi(p0);
+    final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, _p0_handle);
     smoke_LambdasInterface_releaseFfiHandle(_p0_handle);
     final _result = (__result_handle);
@@ -99,7 +62,7 @@ Pointer<Void> smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(LambdasWithSt
 LambdasWithStructuredTypes_ClassCallback smoke_LambdasWithStructuredTypes_ClassCallback_fromFfi(Pointer<Void> handle) {
   final instance = __lib.reverseCache[_smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer(handle)] as LambdasWithStructuredTypes_ClassCallback;
   if (instance != null) return instance;
-  final _impl = LambdasWithStructuredTypes_ClassCallback__Impl(_smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle(handle));
+  final _impl = LambdasWithStructuredTypes_ClassCallback$Impl(_smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle(handle));
   return (LambdasInterface p0) {
     final _result =_impl.call(p0);
     _impl.release();
@@ -156,14 +119,15 @@ final _smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer = __lib.n
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('library_smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer');
-class LambdasWithStructuredTypes_StructCallback__Impl {
+class LambdasWithStructuredTypes_StructCallback$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
-  LambdasWithStructuredTypes_StructCallback__Impl(this.handle);
+  LambdasWithStructuredTypes_StructCallback$Impl(this.handle);
   void release() => _smoke_LambdasWithStructuredTypes_StructCallback_release_handle(handle);
   call(LambdasDeclarationOrder_SomeStruct p0) {
     final _call_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_StructCallback_call__SomeStruct');
     final _p0_handle = smoke_LambdasDeclarationOrder_SomeStruct_toFfi(p0);
+    final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, _p0_handle);
     smoke_LambdasDeclarationOrder_SomeStruct_releaseFfiHandle(_p0_handle);
     final _result = (__result_handle);
@@ -188,7 +152,7 @@ Pointer<Void> smoke_LambdasWithStructuredTypes_StructCallback_toFfi(LambdasWithS
 LambdasWithStructuredTypes_StructCallback smoke_LambdasWithStructuredTypes_StructCallback_fromFfi(Pointer<Void> handle) {
   final instance = __lib.reverseCache[_smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer(handle)] as LambdasWithStructuredTypes_StructCallback;
   if (instance != null) return instance;
-  final _impl = LambdasWithStructuredTypes_StructCallback__Impl(_smoke_LambdasWithStructuredTypes_StructCallback_copy_handle(handle));
+  final _impl = LambdasWithStructuredTypes_StructCallback$Impl(_smoke_LambdasWithStructuredTypes_StructCallback_copy_handle(handle));
   return (LambdasDeclarationOrder_SomeStruct p0) {
     final _result =_impl.call(p0);
     _impl.release();
@@ -227,3 +191,53 @@ LambdasWithStructuredTypes_StructCallback smoke_LambdasWithStructuredTypes_Struc
 void smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_LambdasWithStructuredTypes_StructCallback_release_handle_nullable(handle);
 // End of LambdasWithStructuredTypes_StructCallback "private" section.
+// LambdasWithStructuredTypes "private" section, not exported.
+final _smoke_LambdasWithStructuredTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_LambdasWithStructuredTypes_copy_handle');
+final _smoke_LambdasWithStructuredTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_LambdasWithStructuredTypes_release_handle');
+class LambdasWithStructuredTypes$Impl implements LambdasWithStructuredTypes {
+  final Pointer<Void> handle;
+  LambdasWithStructuredTypes$Impl(this.handle);
+  @override
+  void release() => _smoke_LambdasWithStructuredTypes_release_handle(handle);
+  @override
+  doClassStuff(LambdasWithStructuredTypes_ClassCallback callback) {
+    final _doClassStuff_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doClassStuff__ClassCallback');
+    final _callback_handle = smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(callback);
+    final _handle = this.handle;
+    final __result_handle = _doClassStuff_ffi(_handle, _callback_handle);
+    smoke_LambdasWithStructuredTypes_ClassCallback_releaseFfiHandle(_callback_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  doStructStuff(LambdasWithStructuredTypes_StructCallback callback) {
+    final _doStructStuff_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doStructStuff__StructCallback');
+    final _callback_handle = smoke_LambdasWithStructuredTypes_StructCallback_toFfi(callback);
+    final _handle = this.handle;
+    final __result_handle = _doStructStuff_ffi(_handle, _callback_handle);
+    smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle(_callback_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_LambdasWithStructuredTypes_toFfi(LambdasWithStructuredTypes value) =>
+  _smoke_LambdasWithStructuredTypes_copy_handle((value as LambdasWithStructuredTypes$Impl).handle);
+LambdasWithStructuredTypes smoke_LambdasWithStructuredTypes_fromFfi(Pointer<Void> handle) =>
+  LambdasWithStructuredTypes$Impl(_smoke_LambdasWithStructuredTypes_copy_handle(handle));
+void smoke_LambdasWithStructuredTypes_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_LambdasWithStructuredTypes_release_handle(handle);
+Pointer<Void> smoke_LambdasWithStructuredTypes_toFfi_nullable(LambdasWithStructuredTypes value) =>
+  value != null ? smoke_LambdasWithStructuredTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
+LambdasWithStructuredTypes smoke_LambdasWithStructuredTypes_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_LambdasWithStructuredTypes_fromFfi(handle) : null;
+void smoke_LambdasWithStructuredTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_LambdasWithStructuredTypes_release_handle(handle);
+// End of LambdasWithStructuredTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/StandaloneProducer.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/StandaloneProducer.dart
@@ -22,13 +22,14 @@ final _smoke_StandaloneProducer_get_raw_pointer = __lib.nativeLibrary.lookupFunc
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('library_smoke_StandaloneProducer_get_raw_pointer');
-class StandaloneProducer__Impl {
+class StandaloneProducer$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
-  StandaloneProducer__Impl(this.handle);
+  StandaloneProducer$Impl(this.handle);
   void release() => _smoke_StandaloneProducer_release_handle(handle);
   String call() {
     final _call_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_StandaloneProducer_call');
+    final _handle = this.handle;
     final __result_handle = _call_ffi(_handle);
     final _result = String_fromFfi(__result_handle);
     String_releaseFfiHandle(__result_handle);
@@ -52,7 +53,7 @@ Pointer<Void> smoke_StandaloneProducer_toFfi(StandaloneProducer value) {
 StandaloneProducer smoke_StandaloneProducer_fromFfi(Pointer<Void> handle) {
   final instance = __lib.reverseCache[_smoke_StandaloneProducer_get_raw_pointer(handle)] as StandaloneProducer;
   if (instance != null) return instance;
-  final _impl = StandaloneProducer__Impl(_smoke_StandaloneProducer_copy_handle(handle));
+  final _impl = StandaloneProducer$Impl(_smoke_StandaloneProducer_copy_handle(handle));
   return () {
     final _result =_impl.call();
     _impl.release();

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/CalculatorListener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/CalculatorListener.dart
@@ -99,16 +99,16 @@ final _smoke_CalculatorListener_get_type_id = __lib.nativeLibrary.lookupFunction
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_get_type_id');
-class CalculatorListener__Impl implements CalculatorListener {
-  Pointer<Void> get _handle => handle;
+class CalculatorListener$Impl implements CalculatorListener {
   final Pointer<Void> handle;
-  CalculatorListener__Impl(this.handle);
+  CalculatorListener$Impl(this.handle);
   @override
   void release() => _smoke_CalculatorListener_release_handle(handle);
   @override
   onCalculationResult(double calculationResult) {
     final _onCalculationResult_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Double), void Function(Pointer<Void>, double)>('library_smoke_CalculatorListener_onCalculationResult__Double');
     final _calculationResult_handle = (calculationResult);
+    final _handle = this.handle;
     final __result_handle = _onCalculationResult_ffi(_handle, _calculationResult_handle);
     (_calculationResult_handle);
     final _result = (__result_handle);
@@ -119,6 +119,7 @@ class CalculatorListener__Impl implements CalculatorListener {
   onCalculationResultConst(double calculationResult) {
     final _onCalculationResultConst_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Double), void Function(Pointer<Void>, double)>('library_smoke_CalculatorListener_onCalculationResultConst__Double');
     final _calculationResult_handle = (calculationResult);
+    final _handle = this.handle;
     final __result_handle = _onCalculationResultConst_ffi(_handle, _calculationResult_handle);
     (_calculationResult_handle);
     final _result = (__result_handle);
@@ -129,6 +130,7 @@ class CalculatorListener__Impl implements CalculatorListener {
   onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult) {
     final _onCalculationResultStruct_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultStruct__ResultStruct');
     final _calculationResult_handle = smoke_CalculatorListener_ResultStruct_toFfi(calculationResult);
+    final _handle = this.handle;
     final __result_handle = _onCalculationResultStruct_ffi(_handle, _calculationResult_handle);
     smoke_CalculatorListener_ResultStruct_releaseFfiHandle(_calculationResult_handle);
     final _result = (__result_handle);
@@ -139,6 +141,7 @@ class CalculatorListener__Impl implements CalculatorListener {
   onCalculationResultArray(List<double> calculationResult) {
     final _onCalculationResultArray_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultArray__ListOf_1Double');
     final _calculationResult_handle = ListOf_Double_toFfi(calculationResult);
+    final _handle = this.handle;
     final __result_handle = _onCalculationResultArray_ffi(_handle, _calculationResult_handle);
     ListOf_Double_releaseFfiHandle(_calculationResult_handle);
     final _result = (__result_handle);
@@ -149,6 +152,7 @@ class CalculatorListener__Impl implements CalculatorListener {
   onCalculationResultMap(Map<String, double> calculationResults) {
     final _onCalculationResultMap_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultMap__MapOf_1String_1to_1Double');
     final _calculationResults_handle = MapOf_String_to_Double_toFfi(calculationResults);
+    final _handle = this.handle;
     final __result_handle = _onCalculationResultMap_ffi(_handle, _calculationResults_handle);
     MapOf_String_to_Double_releaseFfiHandle(_calculationResults_handle);
     final _result = (__result_handle);
@@ -159,6 +163,7 @@ class CalculatorListener__Impl implements CalculatorListener {
   onCalculationResultInstance(CalculationResult calculationResult) {
     final _onCalculationResultInstance_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultInstance__CalculationResult');
     final _calculationResult_handle = smoke_CalculationResult_toFfi(calculationResult);
+    final _handle = this.handle;
     final __result_handle = _onCalculationResultInstance_ffi(_handle, _calculationResult_handle);
     smoke_CalculationResult_releaseFfiHandle(_calculationResult_handle);
     final _result = (__result_handle);
@@ -197,7 +202,7 @@ int _CalculatorListener_onCalculationResultInstance_static(int _token, Pointer<V
   return 0;
 }
 Pointer<Void> smoke_CalculatorListener_toFfi(CalculatorListener value) {
-  if (value is CalculatorListener__Impl) return _smoke_CalculatorListener_copy_handle(value.handle);
+  if (value is CalculatorListener$Impl) return _smoke_CalculatorListener_copy_handle(value.handle);
   final result = _smoke_CalculatorListener_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -218,7 +223,7 @@ CalculatorListener smoke_CalculatorListener_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_CalculatorListener_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? CalculatorListener__Impl(_copied_handle)
+    ? CalculatorListener$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenerWithProperties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenerWithProperties.dart
@@ -167,14 +167,14 @@ final _smoke_ListenerWithProperties_get_type_id = __lib.nativeLibrary.lookupFunc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_get_type_id');
-class ListenerWithProperties__Impl implements ListenerWithProperties {
-  Pointer<Void> get _handle => handle;
+class ListenerWithProperties$Impl implements ListenerWithProperties {
   final Pointer<Void> handle;
-  ListenerWithProperties__Impl(this.handle);
+  ListenerWithProperties$Impl(this.handle);
   @override
   void release() => _smoke_ListenerWithProperties_release_handle(handle);
   String get message {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ListenerWithProperties_message_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = String_fromFfi(__result_handle);
     String_releaseFfiHandle(__result_handle);
@@ -183,6 +183,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   set message(String value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_ListenerWithProperties_message_set__String');
     final _value_handle = String_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     String_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -191,6 +192,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   }
   CalculationResult get packedMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ListenerWithProperties_packedMessage_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = smoke_CalculationResult_fromFfi(__result_handle);
     smoke_CalculationResult_releaseFfiHandle(__result_handle);
@@ -199,6 +201,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   set packedMessage(CalculationResult value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_ListenerWithProperties_packedMessage_set__CalculationResult');
     final _value_handle = smoke_CalculationResult_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     smoke_CalculationResult_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -207,6 +210,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   }
   ListenerWithProperties_ResultStruct get structuredMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ListenerWithProperties_structuredMessage_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = smoke_ListenerWithProperties_ResultStruct_fromFfi(__result_handle);
     smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(__result_handle);
@@ -215,6 +219,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   set structuredMessage(ListenerWithProperties_ResultStruct value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_ListenerWithProperties_structuredMessage_set__ResultStruct');
     final _value_handle = smoke_ListenerWithProperties_ResultStruct_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -223,6 +228,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   }
   ListenerWithProperties_ResultEnum get enumeratedMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_ListenerWithProperties_enumeratedMessage_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = smoke_ListenerWithProperties_ResultEnum_fromFfi(__result_handle);
     smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(__result_handle);
@@ -231,6 +237,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   set enumeratedMessage(ListenerWithProperties_ResultEnum value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint32), void Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_set__ResultEnum');
     final _value_handle = smoke_ListenerWithProperties_ResultEnum_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -239,6 +246,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   }
   List<String> get arrayedMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ListenerWithProperties_arrayedMessage_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = ListOf_String_fromFfi(__result_handle);
     ListOf_String_releaseFfiHandle(__result_handle);
@@ -247,6 +255,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   set arrayedMessage(List<String> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_ListenerWithProperties_arrayedMessage_set__ListOf_1String');
     final _value_handle = ListOf_String_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     ListOf_String_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -255,6 +264,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   }
   Map<String, double> get mappedMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ListenerWithProperties_mappedMessage_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = MapOf_String_to_Double_fromFfi(__result_handle);
     MapOf_String_to_Double_releaseFfiHandle(__result_handle);
@@ -263,6 +273,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   set mappedMessage(Map<String, double> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_ListenerWithProperties_mappedMessage_set__MapOf_1String_1to_1Double');
     final _value_handle = MapOf_String_to_Double_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     MapOf_String_to_Double_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -271,6 +282,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   }
   Uint8List get bufferedMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ListenerWithProperties_bufferedMessage_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = Blob_fromFfi(__result_handle);
     Blob_releaseFfiHandle(__result_handle);
@@ -279,6 +291,7 @@ class ListenerWithProperties__Impl implements ListenerWithProperties {
   set bufferedMessage(Uint8List value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_ListenerWithProperties_bufferedMessage_set__Blob');
     final _value_handle = Blob_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     Blob_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -350,7 +363,7 @@ int _ListenerWithProperties_bufferedMessage_set_static(int _token, Pointer<Void>
   return 0;
 }
 Pointer<Void> smoke_ListenerWithProperties_toFfi(ListenerWithProperties value) {
-  if (value is ListenerWithProperties__Impl) return _smoke_ListenerWithProperties_copy_handle(value.handle);
+  if (value is ListenerWithProperties$Impl) return _smoke_ListenerWithProperties_copy_handle(value.handle);
   final result = _smoke_ListenerWithProperties_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -379,7 +392,7 @@ ListenerWithProperties smoke_ListenerWithProperties_fromFfi(Pointer<Void> handle
   final _type_id_handle = _smoke_ListenerWithProperties_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? ListenerWithProperties__Impl(_copied_handle)
+    ? ListenerWithProperties$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenersWithReturnValues.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenersWithReturnValues.dart
@@ -159,15 +159,15 @@ final _smoke_ListenersWithReturnValues_get_type_id = __lib.nativeLibrary.lookupF
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_get_type_id');
-class ListenersWithReturnValues__Impl implements ListenersWithReturnValues {
-  Pointer<Void> get _handle => handle;
+class ListenersWithReturnValues$Impl implements ListenersWithReturnValues {
   final Pointer<Void> handle;
-  ListenersWithReturnValues__Impl(this.handle);
+  ListenersWithReturnValues$Impl(this.handle);
   @override
   void release() => _smoke_ListenersWithReturnValues_release_handle(handle);
   @override
   double fetchDataDouble() {
     final _fetchDataDouble_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>), double Function(Pointer<Void>)>('library_smoke_ListenersWithReturnValues_fetchDataDouble');
+    final _handle = this.handle;
     final __result_handle = _fetchDataDouble_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
@@ -176,6 +176,7 @@ class ListenersWithReturnValues__Impl implements ListenersWithReturnValues {
   @override
   String fetchDataString() {
     final _fetchDataString_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ListenersWithReturnValues_fetchDataString');
+    final _handle = this.handle;
     final __result_handle = _fetchDataString_ffi(_handle);
     final _result = String_fromFfi(__result_handle);
     String_releaseFfiHandle(__result_handle);
@@ -184,6 +185,7 @@ class ListenersWithReturnValues__Impl implements ListenersWithReturnValues {
   @override
   ListenersWithReturnValues_ResultStruct fetchDataStruct() {
     final _fetchDataStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ListenersWithReturnValues_fetchDataStruct');
+    final _handle = this.handle;
     final __result_handle = _fetchDataStruct_ffi(_handle);
     final _result = smoke_ListenersWithReturnValues_ResultStruct_fromFfi(__result_handle);
     smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle(__result_handle);
@@ -192,6 +194,7 @@ class ListenersWithReturnValues__Impl implements ListenersWithReturnValues {
   @override
   ListenersWithReturnValues_ResultEnum fetchDataEnum() {
     final _fetchDataEnum_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_ListenersWithReturnValues_fetchDataEnum');
+    final _handle = this.handle;
     final __result_handle = _fetchDataEnum_ffi(_handle);
     final _result = smoke_ListenersWithReturnValues_ResultEnum_fromFfi(__result_handle);
     smoke_ListenersWithReturnValues_ResultEnum_releaseFfiHandle(__result_handle);
@@ -200,6 +203,7 @@ class ListenersWithReturnValues__Impl implements ListenersWithReturnValues {
   @override
   List<double> fetchDataArray() {
     final _fetchDataArray_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ListenersWithReturnValues_fetchDataArray');
+    final _handle = this.handle;
     final __result_handle = _fetchDataArray_ffi(_handle);
     final _result = ListOf_Double_fromFfi(__result_handle);
     ListOf_Double_releaseFfiHandle(__result_handle);
@@ -208,6 +212,7 @@ class ListenersWithReturnValues__Impl implements ListenersWithReturnValues {
   @override
   Map<String, double> fetchDataMap() {
     final _fetchDataMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ListenersWithReturnValues_fetchDataMap');
+    final _handle = this.handle;
     final __result_handle = _fetchDataMap_ffi(_handle);
     final _result = MapOf_String_to_Double_fromFfi(__result_handle);
     MapOf_String_to_Double_releaseFfiHandle(__result_handle);
@@ -216,6 +221,7 @@ class ListenersWithReturnValues__Impl implements ListenersWithReturnValues {
   @override
   CalculationResult fetchDataInstance() {
     final _fetchDataInstance_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_ListenersWithReturnValues_fetchDataInstance');
+    final _handle = this.handle;
     final __result_handle = _fetchDataInstance_ffi(_handle);
     final _result = smoke_CalculationResult_fromFfi(__result_handle);
     smoke_CalculationResult_releaseFfiHandle(__result_handle);
@@ -259,7 +265,7 @@ int _ListenersWithReturnValues_fetchDataInstance_static(int _token, Pointer<Poin
   return 0;
 }
 Pointer<Void> smoke_ListenersWithReturnValues_toFfi(ListenersWithReturnValues value) {
-  if (value is ListenersWithReturnValues__Impl) return _smoke_ListenersWithReturnValues_copy_handle(value.handle);
+  if (value is ListenersWithReturnValues$Impl) return _smoke_ListenersWithReturnValues_copy_handle(value.handle);
   final result = _smoke_ListenersWithReturnValues_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -281,7 +287,7 @@ ListenersWithReturnValues smoke_ListenersWithReturnValues_fromFfi(Pointer<Void> 
   final _type_id_handle = _smoke_ListenersWithReturnValues_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? ListenersWithReturnValues__Impl(_copied_handle)
+    ? ListenersWithReturnValues$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/MethodOverloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/MethodOverloads.dart
@@ -4,125 +4,19 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_MethodOverloads_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_MethodOverloads_copy_handle');
-final _smoke_MethodOverloads_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_MethodOverloads_release_handle');
-class MethodOverloads {
-  final Pointer<Void> _handle;
-  MethodOverloads._(this._handle);
-  void release() => _smoke_MethodOverloads_release_handle(_handle);
-  bool isBoolean(bool input) {
-    final _isBoolean_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Uint8), int Function(Pointer<Void>, int)>('library_smoke_MethodOverloads_isBoolean__Boolean');
-    final _input_handle = Boolean_toFfi(input);
-    final __result_handle = _isBoolean_ffi(_handle, _input_handle);
-    Boolean_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  bool isBooleanByte(int input) {
-    final _isBooleanByte_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int8), int Function(Pointer<Void>, int)>('library_smoke_MethodOverloads_isBoolean__Byte');
-    final _input_handle = (input);
-    final __result_handle = _isBooleanByte_ffi(_handle, _input_handle);
-    (_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  bool isBooleanString(String input) {
-    final _isBooleanString_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__String');
-    final _input_handle = String_toFfi(input);
-    final __result_handle = _isBooleanString_ffi(_handle, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  bool isBooleanPoint(MethodOverloads_Point input) {
-    final _isBooleanPoint_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Point');
-    final _input_handle = smoke_MethodOverloads_Point_toFfi(input);
-    final __result_handle = _isBooleanPoint_ffi(_handle, _input_handle);
-    smoke_MethodOverloads_Point_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  bool isBooleanMulti(bool input1, int input2, String input3, MethodOverloads_Point input4) {
-    final _isBooleanMulti_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Uint8, Int8, Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, int, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Boolean_Byte_String_Point');
-    final _input1_handle = Boolean_toFfi(input1);
-    final _input2_handle = (input2);
-    final _input3_handle = String_toFfi(input3);
-    final _input4_handle = smoke_MethodOverloads_Point_toFfi(input4);
-    final __result_handle = _isBooleanMulti_ffi(_handle, _input1_handle, _input2_handle, _input3_handle, _input4_handle);
-    Boolean_releaseFfiHandle(_input1_handle);
-    (_input2_handle);
-    String_releaseFfiHandle(_input3_handle);
-    smoke_MethodOverloads_Point_releaseFfiHandle(_input4_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  bool isBooleanStringArray(List<String> input) {
-    final _isBooleanStringArray_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_1String');
-    final _input_handle = ListOf_String_toFfi(input);
-    final __result_handle = _isBooleanStringArray_ffi(_handle, _input_handle);
-    ListOf_String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  bool isBooleanIntArray(List<int> input) {
-    final _isBooleanIntArray_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_1Byte');
-    final _input_handle = ListOf_Byte_toFfi(input);
-    final __result_handle = _isBooleanIntArray_ffi(_handle, _input_handle);
-    ListOf_Byte_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  bool isBooleanConst() {
-    final _isBooleanConst_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean');
-    final __result_handle = _isBooleanConst_ffi(_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  bool isFloatString(String input) {
-    final _isFloatString_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__String');
-    final _input_handle = String_toFfi(input);
-    final __result_handle = _isFloatString_ffi(_handle, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  bool isFloatList(List<int> input) {
-    final _isFloatList_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__ListOf_1Byte');
-    final _input_handle = ListOf_Byte_toFfi(input);
-    final __result_handle = _isFloatList_ffi(_handle, _input_handle);
-    ListOf_Byte_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+abstract class MethodOverloads {
+  void release();
+  bool isBoolean(bool input);
+  bool isBooleanByte(int input);
+  bool isBooleanString(String input);
+  bool isBooleanPoint(MethodOverloads_Point input);
+  bool isBooleanMulti(bool input1, int input2, String input3, MethodOverloads_Point input4);
+  bool isBooleanStringArray(List<String> input);
+  bool isBooleanIntArray(List<int> input);
+  bool isBooleanConst();
+  bool isFloatString(String input);
+  bool isFloatList(List<int> input);
 }
-Pointer<Void> smoke_MethodOverloads_toFfi(MethodOverloads value) =>
-  _smoke_MethodOverloads_copy_handle(value._handle);
-MethodOverloads smoke_MethodOverloads_fromFfi(Pointer<Void> handle) =>
-  MethodOverloads._(_smoke_MethodOverloads_copy_handle(handle));
-void smoke_MethodOverloads_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_MethodOverloads_release_handle(handle);
-Pointer<Void> smoke_MethodOverloads_toFfi_nullable(MethodOverloads value) =>
-  value != null ? smoke_MethodOverloads_toFfi(value) : Pointer<Void>.fromAddress(0);
-MethodOverloads smoke_MethodOverloads_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_MethodOverloads_fromFfi(handle) : null;
-void smoke_MethodOverloads_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_MethodOverloads_release_handle(handle);
 class MethodOverloads_Point {
   double x;
   double y;
@@ -195,3 +89,145 @@ MethodOverloads_Point smoke_MethodOverloads_Point_fromFfi_nullable(Pointer<Void>
 void smoke_MethodOverloads_Point_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_MethodOverloads_Point_release_handle_nullable(handle);
 // End of MethodOverloads_Point "private" section.
+// MethodOverloads "private" section, not exported.
+final _smoke_MethodOverloads_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MethodOverloads_copy_handle');
+final _smoke_MethodOverloads_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MethodOverloads_release_handle');
+class MethodOverloads$Impl implements MethodOverloads {
+  final Pointer<Void> handle;
+  MethodOverloads$Impl(this.handle);
+  @override
+  void release() => _smoke_MethodOverloads_release_handle(handle);
+  @override
+  bool isBoolean(bool input) {
+    final _isBoolean_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Uint8), int Function(Pointer<Void>, int)>('library_smoke_MethodOverloads_isBoolean__Boolean');
+    final _input_handle = Boolean_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _isBoolean_ffi(_handle, _input_handle);
+    Boolean_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool isBooleanByte(int input) {
+    final _isBooleanByte_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int8), int Function(Pointer<Void>, int)>('library_smoke_MethodOverloads_isBoolean__Byte');
+    final _input_handle = (input);
+    final _handle = this.handle;
+    final __result_handle = _isBooleanByte_ffi(_handle, _input_handle);
+    (_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool isBooleanString(String input) {
+    final _isBooleanString_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__String');
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _isBooleanString_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool isBooleanPoint(MethodOverloads_Point input) {
+    final _isBooleanPoint_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Point');
+    final _input_handle = smoke_MethodOverloads_Point_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _isBooleanPoint_ffi(_handle, _input_handle);
+    smoke_MethodOverloads_Point_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool isBooleanMulti(bool input1, int input2, String input3, MethodOverloads_Point input4) {
+    final _isBooleanMulti_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Uint8, Int8, Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, int, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Boolean_Byte_String_Point');
+    final _input1_handle = Boolean_toFfi(input1);
+    final _input2_handle = (input2);
+    final _input3_handle = String_toFfi(input3);
+    final _input4_handle = smoke_MethodOverloads_Point_toFfi(input4);
+    final _handle = this.handle;
+    final __result_handle = _isBooleanMulti_ffi(_handle, _input1_handle, _input2_handle, _input3_handle, _input4_handle);
+    Boolean_releaseFfiHandle(_input1_handle);
+    (_input2_handle);
+    String_releaseFfiHandle(_input3_handle);
+    smoke_MethodOverloads_Point_releaseFfiHandle(_input4_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool isBooleanStringArray(List<String> input) {
+    final _isBooleanStringArray_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_1String');
+    final _input_handle = ListOf_String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _isBooleanStringArray_ffi(_handle, _input_handle);
+    ListOf_String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool isBooleanIntArray(List<int> input) {
+    final _isBooleanIntArray_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_1Byte');
+    final _input_handle = ListOf_Byte_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _isBooleanIntArray_ffi(_handle, _input_handle);
+    ListOf_Byte_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool isBooleanConst() {
+    final _isBooleanConst_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean');
+    final _handle = this.handle;
+    final __result_handle = _isBooleanConst_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool isFloatString(String input) {
+    final _isFloatString_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__String');
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _isFloatString_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  bool isFloatList(List<int> input) {
+    final _isFloatList_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__ListOf_1Byte');
+    final _input_handle = ListOf_Byte_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _isFloatList_ffi(_handle, _input_handle);
+    ListOf_Byte_releaseFfiHandle(_input_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_MethodOverloads_toFfi(MethodOverloads value) =>
+  _smoke_MethodOverloads_copy_handle((value as MethodOverloads$Impl).handle);
+MethodOverloads smoke_MethodOverloads_fromFfi(Pointer<Void> handle) =>
+  MethodOverloads$Impl(_smoke_MethodOverloads_copy_handle(handle));
+void smoke_MethodOverloads_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_MethodOverloads_release_handle(handle);
+Pointer<Void> smoke_MethodOverloads_toFfi_nullable(MethodOverloads value) =>
+  value != null ? smoke_MethodOverloads_toFfi(value) : Pointer<Void>.fromAddress(0);
+MethodOverloads smoke_MethodOverloads_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_MethodOverloads_fromFfi(handle) : null;
+void smoke_MethodOverloads_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_MethodOverloads_release_handle(handle);
+// End of MethodOverloads "private" section.

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/SpecialNames.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/SpecialNames.dart
@@ -3,6 +3,14 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
+abstract class SpecialNames {
+  void release();
+  create();
+  reallyRelease();
+  createProxy();
+  Uppercase();
+}
+// SpecialNames "private" section, not exported.
 final _smoke_SpecialNames_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -11,33 +19,42 @@ final _smoke_SpecialNames_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SpecialNames_release_handle');
-class SpecialNames {
-  final Pointer<Void> _handle;
-  SpecialNames._(this._handle);
-  void release() => _smoke_SpecialNames_release_handle(_handle);
+class SpecialNames$Impl implements SpecialNames {
+  final Pointer<Void> handle;
+  SpecialNames$Impl(this.handle);
+  @override
+  void release() => _smoke_SpecialNames_release_handle(handle);
+  @override
   create() {
     final _create_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_SpecialNames_create');
+    final _handle = this.handle;
     final __result_handle = _create_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
   }
+  @override
   reallyRelease() {
     final _reallyRelease_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_SpecialNames_release');
+    final _handle = this.handle;
     final __result_handle = _reallyRelease_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
   }
+  @override
   createProxy() {
     final _createProxy_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_SpecialNames_createProxy');
+    final _handle = this.handle;
     final __result_handle = _createProxy_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
   }
+  @override
   Uppercase() {
     final _Uppercase_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_SpecialNames_Uppercase');
+    final _handle = this.handle;
     final __result_handle = _Uppercase_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
@@ -45,9 +62,9 @@ class SpecialNames {
   }
 }
 Pointer<Void> smoke_SpecialNames_toFfi(SpecialNames value) =>
-  _smoke_SpecialNames_copy_handle(value._handle);
+  _smoke_SpecialNames_copy_handle((value as SpecialNames$Impl).handle);
 SpecialNames smoke_SpecialNames_fromFfi(Pointer<Void> handle) =>
-  SpecialNames._(_smoke_SpecialNames_copy_handle(handle));
+  SpecialNames$Impl(_smoke_SpecialNames_copy_handle(handle));
 void smoke_SpecialNames_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SpecialNames_release_handle(handle);
 Pointer<Void> smoke_SpecialNames_toFfi_nullable(SpecialNames value) =>
@@ -56,3 +73,4 @@ SpecialNames smoke_SpecialNames_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SpecialNames_fromFfi(handle) : null;
 void smoke_SpecialNames_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SpecialNames_release_handle(handle);
+// End of SpecialNames "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/LevelOne.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/LevelOne.dart
@@ -5,90 +5,16 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_LevelOne_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LevelOne_copy_handle');
-final _smoke_LevelOne_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_LevelOne_release_handle');
-class LevelOne {
-  final Pointer<Void> _handle;
-  LevelOne._(this._handle);
-  void release() => _smoke_LevelOne_release_handle(_handle);
+abstract class LevelOne {
+  void release();
 }
-Pointer<Void> smoke_LevelOne_toFfi(LevelOne value) =>
-  _smoke_LevelOne_copy_handle(value._handle);
-LevelOne smoke_LevelOne_fromFfi(Pointer<Void> handle) =>
-  LevelOne._(_smoke_LevelOne_copy_handle(handle));
-void smoke_LevelOne_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_LevelOne_release_handle(handle);
-Pointer<Void> smoke_LevelOne_toFfi_nullable(LevelOne value) =>
-  value != null ? smoke_LevelOne_toFfi(value) : Pointer<Void>.fromAddress(0);
-LevelOne smoke_LevelOne_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_LevelOne_fromFfi(handle) : null;
-void smoke_LevelOne_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_LevelOne_release_handle(handle);
-final _smoke_LevelOne_LevelTwo_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_copy_handle');
-final _smoke_LevelOne_LevelTwo_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_release_handle');
-class LevelOne_LevelTwo {
-  final Pointer<Void> _handle;
-  LevelOne_LevelTwo._(this._handle);
-  void release() => _smoke_LevelOne_LevelTwo_release_handle(_handle);
+abstract class LevelOne_LevelTwo {
+  void release();
 }
-Pointer<Void> smoke_LevelOne_LevelTwo_toFfi(LevelOne_LevelTwo value) =>
-  _smoke_LevelOne_LevelTwo_copy_handle(value._handle);
-LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi(Pointer<Void> handle) =>
-  LevelOne_LevelTwo._(_smoke_LevelOne_LevelTwo_copy_handle(handle));
-void smoke_LevelOne_LevelTwo_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_LevelOne_LevelTwo_release_handle(handle);
-Pointer<Void> smoke_LevelOne_LevelTwo_toFfi_nullable(LevelOne_LevelTwo value) =>
-  value != null ? smoke_LevelOne_LevelTwo_toFfi(value) : Pointer<Void>.fromAddress(0);
-LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_LevelOne_LevelTwo_fromFfi(handle) : null;
-void smoke_LevelOne_LevelTwo_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_LevelOne_LevelTwo_release_handle(handle);
-final _smoke_LevelOne_LevelTwo_LevelThree_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_copy_handle');
-final _smoke_LevelOne_LevelTwo_LevelThree_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_release_handle');
-class LevelOne_LevelTwo_LevelThree {
-  final Pointer<Void> _handle;
-  LevelOne_LevelTwo_LevelThree._(this._handle);
-  void release() => _smoke_LevelOne_LevelTwo_LevelThree_release_handle(_handle);
-  OuterInterface_InnerClass foo(OuterClass_InnerInterface input) {
-    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_LevelOne_LevelTwo_LevelThree_foo__InnerInterface');
-    final _input_handle = smoke_OuterClass_InnerInterface_toFfi(input);
-    final __result_handle = _foo_ffi(_handle, _input_handle);
-    smoke_OuterClass_InnerInterface_releaseFfiHandle(_input_handle);
-    final _result = smoke_OuterInterface_InnerClass_fromFfi(__result_handle);
-    smoke_OuterInterface_InnerClass_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+abstract class LevelOne_LevelTwo_LevelThree {
+  void release();
+  OuterInterface_InnerClass foo(OuterClass_InnerInterface input);
 }
-Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi(LevelOne_LevelTwo_LevelThree value) =>
-  _smoke_LevelOne_LevelTwo_LevelThree_copy_handle(value._handle);
-LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi(Pointer<Void> handle) =>
-  LevelOne_LevelTwo_LevelThree._(_smoke_LevelOne_LevelTwo_LevelThree_copy_handle(handle));
-void smoke_LevelOne_LevelTwo_LevelThree_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
-Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi_nullable(LevelOne_LevelTwo_LevelThree value) =>
-  value != null ? smoke_LevelOne_LevelTwo_LevelThree_toFfi(value) : Pointer<Void>.fromAddress(0);
-LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_LevelOne_LevelTwo_LevelThree_fromFfi(handle) : null;
-void smoke_LevelOne_LevelTwo_LevelThree_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
 enum LevelOne_LevelTwo_LevelThree_LevelFourEnum {
     none
 }
@@ -211,3 +137,98 @@ LevelOne_LevelTwo_LevelThree_LevelFour smoke_LevelOne_LevelTwo_LevelThree_LevelF
 void smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable(handle);
 // End of LevelOne_LevelTwo_LevelThree_LevelFour "private" section.
+// LevelOne_LevelTwo_LevelThree "private" section, not exported.
+final _smoke_LevelOne_LevelTwo_LevelThree_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_copy_handle');
+final _smoke_LevelOne_LevelTwo_LevelThree_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_release_handle');
+class LevelOne_LevelTwo_LevelThree$Impl implements LevelOne_LevelTwo_LevelThree {
+  final Pointer<Void> handle;
+  LevelOne_LevelTwo_LevelThree$Impl(this.handle);
+  @override
+  void release() => _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
+  @override
+  OuterInterface_InnerClass foo(OuterClass_InnerInterface input) {
+    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_LevelOne_LevelTwo_LevelThree_foo__InnerInterface');
+    final _input_handle = smoke_OuterClass_InnerInterface_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _foo_ffi(_handle, _input_handle);
+    smoke_OuterClass_InnerInterface_releaseFfiHandle(_input_handle);
+    final _result = smoke_OuterInterface_InnerClass_fromFfi(__result_handle);
+    smoke_OuterInterface_InnerClass_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi(LevelOne_LevelTwo_LevelThree value) =>
+  _smoke_LevelOne_LevelTwo_LevelThree_copy_handle((value as LevelOne_LevelTwo_LevelThree$Impl).handle);
+LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi(Pointer<Void> handle) =>
+  LevelOne_LevelTwo_LevelThree$Impl(_smoke_LevelOne_LevelTwo_LevelThree_copy_handle(handle));
+void smoke_LevelOne_LevelTwo_LevelThree_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
+Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi_nullable(LevelOne_LevelTwo_LevelThree value) =>
+  value != null ? smoke_LevelOne_LevelTwo_LevelThree_toFfi(value) : Pointer<Void>.fromAddress(0);
+LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_LevelOne_LevelTwo_LevelThree_fromFfi(handle) : null;
+void smoke_LevelOne_LevelTwo_LevelThree_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
+// End of LevelOne_LevelTwo_LevelThree "private" section.
+// LevelOne_LevelTwo "private" section, not exported.
+final _smoke_LevelOne_LevelTwo_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_LevelOne_LevelTwo_copy_handle');
+final _smoke_LevelOne_LevelTwo_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_LevelOne_LevelTwo_release_handle');
+class LevelOne_LevelTwo$Impl implements LevelOne_LevelTwo {
+  final Pointer<Void> handle;
+  LevelOne_LevelTwo$Impl(this.handle);
+  @override
+  void release() => _smoke_LevelOne_LevelTwo_release_handle(handle);
+}
+Pointer<Void> smoke_LevelOne_LevelTwo_toFfi(LevelOne_LevelTwo value) =>
+  _smoke_LevelOne_LevelTwo_copy_handle((value as LevelOne_LevelTwo$Impl).handle);
+LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi(Pointer<Void> handle) =>
+  LevelOne_LevelTwo$Impl(_smoke_LevelOne_LevelTwo_copy_handle(handle));
+void smoke_LevelOne_LevelTwo_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_LevelOne_LevelTwo_release_handle(handle);
+Pointer<Void> smoke_LevelOne_LevelTwo_toFfi_nullable(LevelOne_LevelTwo value) =>
+  value != null ? smoke_LevelOne_LevelTwo_toFfi(value) : Pointer<Void>.fromAddress(0);
+LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_LevelOne_LevelTwo_fromFfi(handle) : null;
+void smoke_LevelOne_LevelTwo_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_LevelOne_LevelTwo_release_handle(handle);
+// End of LevelOne_LevelTwo "private" section.
+// LevelOne "private" section, not exported.
+final _smoke_LevelOne_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_LevelOne_copy_handle');
+final _smoke_LevelOne_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_LevelOne_release_handle');
+class LevelOne$Impl implements LevelOne {
+  final Pointer<Void> handle;
+  LevelOne$Impl(this.handle);
+  @override
+  void release() => _smoke_LevelOne_release_handle(handle);
+}
+Pointer<Void> smoke_LevelOne_toFfi(LevelOne value) =>
+  _smoke_LevelOne_copy_handle((value as LevelOne$Impl).handle);
+LevelOne smoke_LevelOne_fromFfi(Pointer<Void> handle) =>
+  LevelOne$Impl(_smoke_LevelOne_copy_handle(handle));
+void smoke_LevelOne_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_LevelOne_release_handle(handle);
+Pointer<Void> smoke_LevelOne_toFfi_nullable(LevelOne value) =>
+  value != null ? smoke_LevelOne_toFfi(value) : Pointer<Void>.fromAddress(0);
+LevelOne smoke_LevelOne_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_LevelOne_fromFfi(handle) : null;
+void smoke_LevelOne_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_LevelOne_release_handle(handle);
+// End of LevelOne "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterClass.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterClass.dart
@@ -5,40 +5,15 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_OuterClass_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_OuterClass_copy_handle');
-final _smoke_OuterClass_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_OuterClass_release_handle');
-class OuterClass {
-  final Pointer<Void> _handle;
-  OuterClass._(this._handle);
-  void release() => _smoke_OuterClass_release_handle(_handle);
-  String foo(String input) {
-    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_OuterClass_foo__String');
-    final _input_handle = String_toFfi(input);
-    final __result_handle = _foo_ffi(_handle, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+abstract class OuterClass {
+  void release();
+  String foo(String input);
 }
-Pointer<Void> smoke_OuterClass_toFfi(OuterClass value) =>
-  _smoke_OuterClass_copy_handle(value._handle);
-OuterClass smoke_OuterClass_fromFfi(Pointer<Void> handle) =>
-  OuterClass._(_smoke_OuterClass_copy_handle(handle));
-void smoke_OuterClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_OuterClass_release_handle(handle);
-Pointer<Void> smoke_OuterClass_toFfi_nullable(OuterClass value) =>
-  value != null ? smoke_OuterClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-OuterClass smoke_OuterClass_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_OuterClass_fromFfi(handle) : null;
-void smoke_OuterClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterClass_release_handle(handle);
+abstract class OuterClass_InnerClass {
+  void release();
+  String foo(String input);
+}
+// OuterClass_InnerClass "private" section, not exported.
 final _smoke_OuterClass_InnerClass_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -47,13 +22,16 @@ final _smoke_OuterClass_InnerClass_release_handle = __lib.nativeLibrary.lookupFu
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClass_InnerClass_release_handle');
-class OuterClass_InnerClass {
-  final Pointer<Void> _handle;
-  OuterClass_InnerClass._(this._handle);
-  void release() => _smoke_OuterClass_InnerClass_release_handle(_handle);
+class OuterClass_InnerClass$Impl implements OuterClass_InnerClass {
+  final Pointer<Void> handle;
+  OuterClass_InnerClass$Impl(this.handle);
+  @override
+  void release() => _smoke_OuterClass_InnerClass_release_handle(handle);
+  @override
   String foo(String input) {
     final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_OuterClass_InnerClass_foo__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = String_fromFfi(__result_handle);
@@ -62,9 +40,9 @@ class OuterClass_InnerClass {
   }
 }
 Pointer<Void> smoke_OuterClass_InnerClass_toFfi(OuterClass_InnerClass value) =>
-  _smoke_OuterClass_InnerClass_copy_handle(value._handle);
+  _smoke_OuterClass_InnerClass_copy_handle((value as OuterClass_InnerClass$Impl).handle);
 OuterClass_InnerClass smoke_OuterClass_InnerClass_fromFfi(Pointer<Void> handle) =>
-  OuterClass_InnerClass._(_smoke_OuterClass_InnerClass_copy_handle(handle));
+  OuterClass_InnerClass$Impl(_smoke_OuterClass_InnerClass_copy_handle(handle));
 void smoke_OuterClass_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterClass_InnerClass_release_handle(handle);
 Pointer<Void> smoke_OuterClass_InnerClass_toFfi_nullable(OuterClass_InnerClass value) =>
@@ -73,6 +51,7 @@ OuterClass_InnerClass smoke_OuterClass_InnerClass_fromFfi_nullable(Pointer<Void>
   handle.address != 0 ? smoke_OuterClass_InnerClass_fromFfi(handle) : null;
 void smoke_OuterClass_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterClass_InnerClass_release_handle(handle);
+// End of OuterClass_InnerClass "private" section.
 abstract class OuterClass_InnerInterface {
   void release();
   String foo(String input);
@@ -98,16 +77,16 @@ final _smoke_OuterClass_InnerInterface_get_type_id = __lib.nativeLibrary.lookupF
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClass_InnerInterface_get_type_id');
-class OuterClass_InnerInterface__Impl implements OuterClass_InnerInterface {
-  Pointer<Void> get _handle => handle;
+class OuterClass_InnerInterface$Impl implements OuterClass_InnerInterface {
   final Pointer<Void> handle;
-  OuterClass_InnerInterface__Impl(this.handle);
+  OuterClass_InnerInterface$Impl(this.handle);
   @override
   void release() => _smoke_OuterClass_InnerInterface_release_handle(handle);
   @override
   String foo(String input) {
     final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_OuterClass_InnerInterface_foo__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = String_fromFfi(__result_handle);
@@ -122,7 +101,7 @@ int _OuterClass_InnerInterface_foo_static(int _token, Pointer<Void> input, Point
   return 0;
 }
 Pointer<Void> smoke_OuterClass_InnerInterface_toFfi(OuterClass_InnerInterface value) {
-  if (value is OuterClass_InnerInterface__Impl) return _smoke_OuterClass_InnerInterface_copy_handle(value.handle);
+  if (value is OuterClass_InnerInterface$Impl) return _smoke_OuterClass_InnerInterface_copy_handle(value.handle);
   final result = _smoke_OuterClass_InnerInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -138,7 +117,7 @@ OuterClass_InnerInterface smoke_OuterClass_InnerInterface_fromFfi(Pointer<Void> 
   final _type_id_handle = _smoke_OuterClass_InnerInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? OuterClass_InnerInterface__Impl(_copied_handle)
+    ? OuterClass_InnerInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;
@@ -152,3 +131,42 @@ OuterClass_InnerInterface smoke_OuterClass_InnerInterface_fromFfi_nullable(Point
 void smoke_OuterClass_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterClass_InnerInterface_release_handle(handle);
 // End of OuterClass_InnerInterface "private" section.
+// OuterClass "private" section, not exported.
+final _smoke_OuterClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClass_copy_handle');
+final _smoke_OuterClass_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterClass_release_handle');
+class OuterClass$Impl implements OuterClass {
+  final Pointer<Void> handle;
+  OuterClass$Impl(this.handle);
+  @override
+  void release() => _smoke_OuterClass_release_handle(handle);
+  @override
+  String foo(String input) {
+    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_OuterClass_foo__String');
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _foo_ffi(_handle, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_OuterClass_toFfi(OuterClass value) =>
+  _smoke_OuterClass_copy_handle((value as OuterClass$Impl).handle);
+OuterClass smoke_OuterClass_fromFfi(Pointer<Void> handle) =>
+  OuterClass$Impl(_smoke_OuterClass_copy_handle(handle));
+void smoke_OuterClass_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_OuterClass_release_handle(handle);
+Pointer<Void> smoke_OuterClass_toFfi_nullable(OuterClass value) =>
+  value != null ? smoke_OuterClass_toFfi(value) : Pointer<Void>.fromAddress(0);
+OuterClass smoke_OuterClass_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_OuterClass_fromFfi(handle) : null;
+void smoke_OuterClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_OuterClass_release_handle(handle);
+// End of OuterClass "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterInterface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterInterface.dart
@@ -9,6 +9,11 @@ abstract class OuterInterface {
   void release();
   String foo(String input);
 }
+abstract class OuterInterface_InnerClass {
+  void release();
+  String foo(String input);
+}
+// OuterInterface_InnerClass "private" section, not exported.
 final _smoke_OuterInterface_InnerClass_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -17,13 +22,16 @@ final _smoke_OuterInterface_InnerClass_release_handle = __lib.nativeLibrary.look
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterInterface_InnerClass_release_handle');
-class OuterInterface_InnerClass {
-  final Pointer<Void> _handle;
-  OuterInterface_InnerClass._(this._handle);
-  void release() => _smoke_OuterInterface_InnerClass_release_handle(_handle);
+class OuterInterface_InnerClass$Impl implements OuterInterface_InnerClass {
+  final Pointer<Void> handle;
+  OuterInterface_InnerClass$Impl(this.handle);
+  @override
+  void release() => _smoke_OuterInterface_InnerClass_release_handle(handle);
+  @override
   String foo(String input) {
     final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_OuterInterface_InnerClass_foo__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = String_fromFfi(__result_handle);
@@ -32,9 +40,9 @@ class OuterInterface_InnerClass {
   }
 }
 Pointer<Void> smoke_OuterInterface_InnerClass_toFfi(OuterInterface_InnerClass value) =>
-  _smoke_OuterInterface_InnerClass_copy_handle(value._handle);
+  _smoke_OuterInterface_InnerClass_copy_handle((value as OuterInterface_InnerClass$Impl).handle);
 OuterInterface_InnerClass smoke_OuterInterface_InnerClass_fromFfi(Pointer<Void> handle) =>
-  OuterInterface_InnerClass._(_smoke_OuterInterface_InnerClass_copy_handle(handle));
+  OuterInterface_InnerClass$Impl(_smoke_OuterInterface_InnerClass_copy_handle(handle));
 void smoke_OuterInterface_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterInterface_InnerClass_release_handle(handle);
 Pointer<Void> smoke_OuterInterface_InnerClass_toFfi_nullable(OuterInterface_InnerClass value) =>
@@ -43,6 +51,7 @@ OuterInterface_InnerClass smoke_OuterInterface_InnerClass_fromFfi_nullable(Point
   handle.address != 0 ? smoke_OuterInterface_InnerClass_fromFfi(handle) : null;
 void smoke_OuterInterface_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterInterface_InnerClass_release_handle(handle);
+// End of OuterInterface_InnerClass "private" section.
 abstract class OuterInterface_InnerInterface {
   void release();
   String foo(String input);
@@ -68,16 +77,16 @@ final _smoke_OuterInterface_InnerInterface_get_type_id = __lib.nativeLibrary.loo
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_InnerInterface_get_type_id');
-class OuterInterface_InnerInterface__Impl implements OuterInterface_InnerInterface {
-  Pointer<Void> get _handle => handle;
+class OuterInterface_InnerInterface$Impl implements OuterInterface_InnerInterface {
   final Pointer<Void> handle;
-  OuterInterface_InnerInterface__Impl(this.handle);
+  OuterInterface_InnerInterface$Impl(this.handle);
   @override
   void release() => _smoke_OuterInterface_InnerInterface_release_handle(handle);
   @override
   String foo(String input) {
     final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_OuterInterface_InnerInterface_foo__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = String_fromFfi(__result_handle);
@@ -92,7 +101,7 @@ int _OuterInterface_InnerInterface_foo_static(int _token, Pointer<Void> input, P
   return 0;
 }
 Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi(OuterInterface_InnerInterface value) {
-  if (value is OuterInterface_InnerInterface__Impl) return _smoke_OuterInterface_InnerInterface_copy_handle(value.handle);
+  if (value is OuterInterface_InnerInterface$Impl) return _smoke_OuterInterface_InnerInterface_copy_handle(value.handle);
   final result = _smoke_OuterInterface_InnerInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -108,7 +117,7 @@ OuterInterface_InnerInterface smoke_OuterInterface_InnerInterface_fromFfi(Pointe
   final _type_id_handle = _smoke_OuterInterface_InnerInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? OuterInterface_InnerInterface__Impl(_copied_handle)
+    ? OuterInterface_InnerInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;
@@ -143,16 +152,16 @@ final _smoke_OuterInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_get_type_id');
-class OuterInterface__Impl implements OuterInterface {
-  Pointer<Void> get _handle => handle;
+class OuterInterface$Impl implements OuterInterface {
   final Pointer<Void> handle;
-  OuterInterface__Impl(this.handle);
+  OuterInterface$Impl(this.handle);
   @override
   void release() => _smoke_OuterInterface_release_handle(handle);
   @override
   String foo(String input) {
     final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_OuterInterface_foo__String');
     final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, _input_handle);
     String_releaseFfiHandle(_input_handle);
     final _result = String_fromFfi(__result_handle);
@@ -167,7 +176,7 @@ int _OuterInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<
   return 0;
 }
 Pointer<Void> smoke_OuterInterface_toFfi(OuterInterface value) {
-  if (value is OuterInterface__Impl) return _smoke_OuterInterface_copy_handle(value.handle);
+  if (value is OuterInterface$Impl) return _smoke_OuterInterface_copy_handle(value.handle);
   final result = _smoke_OuterInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -183,7 +192,7 @@ OuterInterface smoke_OuterInterface_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_OuterInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? OuterInterface__Impl(_copied_handle)
+    ? OuterInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/UseFreeTypes.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/UseFreeTypes.dart
@@ -6,6 +6,11 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
+abstract class UseFreeTypes {
+  void release();
+  DateTime doStuff(FreePoint point, FreeEnum mode);
+}
+// UseFreeTypes "private" section, not exported.
 final _smoke_UseFreeTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -30,14 +35,17 @@ final _doStuff_return_has_error = __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_has_error');
-class UseFreeTypes {
-  final Pointer<Void> _handle;
-  UseFreeTypes._(this._handle);
-  void release() => _smoke_UseFreeTypes_release_handle(_handle);
+class UseFreeTypes$Impl implements UseFreeTypes {
+  final Pointer<Void> handle;
+  UseFreeTypes$Impl(this.handle);
+  @override
+  void release() => _smoke_UseFreeTypes_release_handle(handle);
+  @override
   DateTime doStuff(FreePoint point, FreeEnum mode) {
     final _doStuff_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, Pointer<Void>, int)>('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum');
     final _point_handle = smoke_FreePoint_toFfi(point);
     final _mode_handle = smoke_FreeEnum_toFfi(mode);
+    final _handle = this.handle;
     final __call_result_handle = _doStuff_ffi(_handle, _point_handle, _mode_handle);
     smoke_FreePoint_releaseFfiHandle(_point_handle);
     smoke_FreeEnum_releaseFfiHandle(_mode_handle);
@@ -56,9 +64,9 @@ class UseFreeTypes {
   }
 }
 Pointer<Void> smoke_UseFreeTypes_toFfi(UseFreeTypes value) =>
-  _smoke_UseFreeTypes_copy_handle(value._handle);
+  _smoke_UseFreeTypes_copy_handle((value as UseFreeTypes$Impl).handle);
 UseFreeTypes smoke_UseFreeTypes_fromFfi(Pointer<Void> handle) =>
-  UseFreeTypes._(_smoke_UseFreeTypes_copy_handle(handle));
+  UseFreeTypes$Impl(_smoke_UseFreeTypes_copy_handle(handle));
 void smoke_UseFreeTypes_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_UseFreeTypes_release_handle(handle);
 Pointer<Void> smoke_UseFreeTypes_toFfi_nullable(UseFreeTypes value) =>
@@ -67,3 +75,4 @@ UseFreeTypes smoke_UseFreeTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_UseFreeTypes_fromFfi(handle) : null;
 void smoke_UseFreeTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_UseFreeTypes_release_handle(handle);
+// End of UseFreeTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/Nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/Nullable.dart
@@ -5,281 +5,39 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_Nullable_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_copy_handle');
-final _smoke_Nullable_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Nullable_release_handle');
-class Nullable {
-  final Pointer<Void> _handle;
-  Nullable._(this._handle);
-  void release() => _smoke_Nullable_release_handle(_handle);
-  String methodWithString(String input) {
-    final _methodWithString_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithString__String');
-    final _input_handle = String_toFfi_nullable(input);
-    final __result_handle = _methodWithString_ffi(_handle, _input_handle);
-    String_releaseFfiHandle_nullable(_input_handle);
-    final _result = String_fromFfi_nullable(__result_handle);
-    String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  bool methodWithBoolean(bool input) {
-    final _methodWithBoolean_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithBoolean__Boolean');
-    final _input_handle = Boolean_toFfi_nullable(input);
-    final __result_handle = _methodWithBoolean_ffi(_handle, _input_handle);
-    Boolean_releaseFfiHandle_nullable(_input_handle);
-    final _result = Boolean_fromFfi_nullable(__result_handle);
-    Boolean_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  double methodWithDouble(double input) {
-    final _methodWithDouble_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithDouble__Double');
-    final _input_handle = Double_toFfi_nullable(input);
-    final __result_handle = _methodWithDouble_ffi(_handle, _input_handle);
-    Double_releaseFfiHandle_nullable(_input_handle);
-    final _result = Double_fromFfi_nullable(__result_handle);
-    Double_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  int methodWithInt(int input) {
-    final _methodWithInt_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithInt__Long');
-    final _input_handle = Long_toFfi_nullable(input);
-    final __result_handle = _methodWithInt_ffi(_handle, _input_handle);
-    Long_releaseFfiHandle_nullable(_input_handle);
-    final _result = Long_fromFfi_nullable(__result_handle);
-    Long_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  Nullable_SomeStruct methodWithSomeStruct(Nullable_SomeStruct input) {
-    final _methodWithSomeStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeStruct__SomeStruct');
-    final _input_handle = smoke_Nullable_SomeStruct_toFfi_nullable(input);
-    final __result_handle = _methodWithSomeStruct_ffi(_handle, _input_handle);
-    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_input_handle);
-    final _result = smoke_Nullable_SomeStruct_fromFfi_nullable(__result_handle);
-    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  Nullable_SomeEnum methodWithSomeEnum(Nullable_SomeEnum input) {
-    final _methodWithSomeEnum_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeEnum__SomeEnum');
-    final _input_handle = smoke_Nullable_SomeEnum_toFfi_nullable(input);
-    final __result_handle = _methodWithSomeEnum_ffi(_handle, _input_handle);
-    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_input_handle);
-    final _result = smoke_Nullable_SomeEnum_fromFfi_nullable(__result_handle);
-    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  List<String> methodWithSomeArray(List<String> input) {
-    final _methodWithSomeArray_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeArray__ListOf_1String');
-    final _input_handle = ListOf_String_toFfi_nullable(input);
-    final __result_handle = _methodWithSomeArray_ffi(_handle, _input_handle);
-    ListOf_String_releaseFfiHandle_nullable(_input_handle);
-    final _result = ListOf_String_fromFfi_nullable(__result_handle);
-    ListOf_String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  List<String> methodWithInlineArray(List<String> input) {
-    final _methodWithInlineArray_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithInlineArray__ListOf_1String');
-    final _input_handle = ListOf_String_toFfi_nullable(input);
-    final __result_handle = _methodWithInlineArray_ffi(_handle, _input_handle);
-    ListOf_String_releaseFfiHandle_nullable(_input_handle);
-    final _result = ListOf_String_fromFfi_nullable(__result_handle);
-    ListOf_String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  Map<int, String> methodWithSomeMap(Map<int, String> input) {
-    final _methodWithSomeMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeMap__MapOf_1Long_1to_1String');
-    final _input_handle = MapOf_Long_to_String_toFfi_nullable(input);
-    final __result_handle = _methodWithSomeMap_ffi(_handle, _input_handle);
-    MapOf_Long_to_String_releaseFfiHandle_nullable(_input_handle);
-    final _result = MapOf_Long_to_String_fromFfi_nullable(__result_handle);
-    MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  SomeInterface methodWithInstance(SomeInterface input) {
-    final _methodWithInstance_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithInstance__SomeInterface');
-    final _input_handle = smoke_SomeInterface_toFfi_nullable(input);
-    final __result_handle = _methodWithInstance_ffi(_handle, _input_handle);
-    smoke_SomeInterface_releaseFfiHandle_nullable(_input_handle);
-    final _result = smoke_SomeInterface_fromFfi_nullable(__result_handle);
-    smoke_SomeInterface_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  String get stringProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_stringProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = String_fromFfi_nullable(__result_handle);
-    String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  set stringProperty(String value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_stringProperty_set__String');
-    final _value_handle = String_toFfi_nullable(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    String_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  bool get isBoolProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_isBoolProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = Boolean_fromFfi_nullable(__result_handle);
-    Boolean_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  set isBoolProperty(bool value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_isBoolProperty_set__Boolean');
-    final _value_handle = Boolean_toFfi_nullable(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    Boolean_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  double get doubleProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_doubleProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = Double_fromFfi_nullable(__result_handle);
-    Double_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  set doubleProperty(double value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_doubleProperty_set__Double');
-    final _value_handle = Double_toFfi_nullable(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    Double_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  int get intProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_intProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = Long_fromFfi_nullable(__result_handle);
-    Long_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  set intProperty(int value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_intProperty_set__Long');
-    final _value_handle = Long_toFfi_nullable(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    Long_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  Nullable_SomeStruct get structProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_structProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = smoke_Nullable_SomeStruct_fromFfi_nullable(__result_handle);
-    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  set structProperty(Nullable_SomeStruct value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_structProperty_set__SomeStruct');
-    final _value_handle = smoke_Nullable_SomeStruct_toFfi_nullable(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  Nullable_SomeEnum get enumProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_enumProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = smoke_Nullable_SomeEnum_fromFfi_nullable(__result_handle);
-    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  set enumProperty(Nullable_SomeEnum value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_enumProperty_set__SomeEnum');
-    final _value_handle = smoke_Nullable_SomeEnum_toFfi_nullable(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  List<String> get arrayProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_arrayProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = ListOf_String_fromFfi_nullable(__result_handle);
-    ListOf_String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  set arrayProperty(List<String> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_arrayProperty_set__ListOf_1String');
-    final _value_handle = ListOf_String_toFfi_nullable(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    ListOf_String_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  List<String> get inlineArrayProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_inlineArrayProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = ListOf_String_fromFfi_nullable(__result_handle);
-    ListOf_String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  set inlineArrayProperty(List<String> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_inlineArrayProperty_set__ListOf_1String');
-    final _value_handle = ListOf_String_toFfi_nullable(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    ListOf_String_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  Map<int, String> get mapProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_mapProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = MapOf_Long_to_String_fromFfi_nullable(__result_handle);
-    MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  set mapProperty(Map<int, String> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_mapProperty_set__MapOf_1Long_1to_1String');
-    final _value_handle = MapOf_Long_to_String_toFfi_nullable(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    MapOf_Long_to_String_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  SomeInterface get instanceProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_instanceProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = smoke_SomeInterface_fromFfi_nullable(__result_handle);
-    smoke_SomeInterface_releaseFfiHandle_nullable(__result_handle);
-    return _result;
-  }
-  set instanceProperty(SomeInterface value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_instanceProperty_set__SomeInterface');
-    final _value_handle = smoke_SomeInterface_toFfi_nullable(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    smoke_SomeInterface_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+abstract class Nullable {
+  void release();
+  String methodWithString(String input);
+  bool methodWithBoolean(bool input);
+  double methodWithDouble(double input);
+  int methodWithInt(int input);
+  Nullable_SomeStruct methodWithSomeStruct(Nullable_SomeStruct input);
+  Nullable_SomeEnum methodWithSomeEnum(Nullable_SomeEnum input);
+  List<String> methodWithSomeArray(List<String> input);
+  List<String> methodWithInlineArray(List<String> input);
+  Map<int, String> methodWithSomeMap(Map<int, String> input);
+  SomeInterface methodWithInstance(SomeInterface input);
+  String get stringProperty;
+  set stringProperty(String value);
+  bool get isBoolProperty;
+  set isBoolProperty(bool value);
+  double get doubleProperty;
+  set doubleProperty(double value);
+  int get intProperty;
+  set intProperty(int value);
+  Nullable_SomeStruct get structProperty;
+  set structProperty(Nullable_SomeStruct value);
+  Nullable_SomeEnum get enumProperty;
+  set enumProperty(Nullable_SomeEnum value);
+  List<String> get arrayProperty;
+  set arrayProperty(List<String> value);
+  List<String> get inlineArrayProperty;
+  set inlineArrayProperty(List<String> value);
+  Map<int, String> get mapProperty;
+  set mapProperty(Map<int, String> value);
+  SomeInterface get instanceProperty;
+  set instanceProperty(SomeInterface value);
 }
-Pointer<Void> smoke_Nullable_toFfi(Nullable value) =>
-  _smoke_Nullable_copy_handle(value._handle);
-Nullable smoke_Nullable_fromFfi(Pointer<Void> handle) =>
-  Nullable._(_smoke_Nullable_copy_handle(handle));
-void smoke_Nullable_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Nullable_release_handle(handle);
-Pointer<Void> smoke_Nullable_toFfi_nullable(Nullable value) =>
-  value != null ? smoke_Nullable_toFfi(value) : Pointer<Void>.fromAddress(0);
-Nullable smoke_Nullable_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_Nullable_fromFfi(handle) : null;
-void smoke_Nullable_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Nullable_release_handle(handle);
 enum Nullable_SomeEnum {
     on,
     off
@@ -675,3 +433,341 @@ Nullable_NullableIntsStruct smoke_Nullable_NullableIntsStruct_fromFfi_nullable(P
 void smoke_Nullable_NullableIntsStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Nullable_NullableIntsStruct_release_handle_nullable(handle);
 // End of Nullable_NullableIntsStruct "private" section.
+// Nullable "private" section, not exported.
+final _smoke_Nullable_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Nullable_copy_handle');
+final _smoke_Nullable_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Nullable_release_handle');
+class Nullable$Impl implements Nullable {
+  final Pointer<Void> handle;
+  Nullable$Impl(this.handle);
+  @override
+  void release() => _smoke_Nullable_release_handle(handle);
+  @override
+  String methodWithString(String input) {
+    final _methodWithString_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithString__String');
+    final _input_handle = String_toFfi_nullable(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithString_ffi(_handle, _input_handle);
+    String_releaseFfiHandle_nullable(_input_handle);
+    final _result = String_fromFfi_nullable(__result_handle);
+    String_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  bool methodWithBoolean(bool input) {
+    final _methodWithBoolean_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithBoolean__Boolean');
+    final _input_handle = Boolean_toFfi_nullable(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithBoolean_ffi(_handle, _input_handle);
+    Boolean_releaseFfiHandle_nullable(_input_handle);
+    final _result = Boolean_fromFfi_nullable(__result_handle);
+    Boolean_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  double methodWithDouble(double input) {
+    final _methodWithDouble_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithDouble__Double');
+    final _input_handle = Double_toFfi_nullable(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithDouble_ffi(_handle, _input_handle);
+    Double_releaseFfiHandle_nullable(_input_handle);
+    final _result = Double_fromFfi_nullable(__result_handle);
+    Double_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  int methodWithInt(int input) {
+    final _methodWithInt_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithInt__Long');
+    final _input_handle = Long_toFfi_nullable(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithInt_ffi(_handle, _input_handle);
+    Long_releaseFfiHandle_nullable(_input_handle);
+    final _result = Long_fromFfi_nullable(__result_handle);
+    Long_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  Nullable_SomeStruct methodWithSomeStruct(Nullable_SomeStruct input) {
+    final _methodWithSomeStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeStruct__SomeStruct');
+    final _input_handle = smoke_Nullable_SomeStruct_toFfi_nullable(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithSomeStruct_ffi(_handle, _input_handle);
+    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_input_handle);
+    final _result = smoke_Nullable_SomeStruct_fromFfi_nullable(__result_handle);
+    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  Nullable_SomeEnum methodWithSomeEnum(Nullable_SomeEnum input) {
+    final _methodWithSomeEnum_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeEnum__SomeEnum');
+    final _input_handle = smoke_Nullable_SomeEnum_toFfi_nullable(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithSomeEnum_ffi(_handle, _input_handle);
+    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_input_handle);
+    final _result = smoke_Nullable_SomeEnum_fromFfi_nullable(__result_handle);
+    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  List<String> methodWithSomeArray(List<String> input) {
+    final _methodWithSomeArray_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeArray__ListOf_1String');
+    final _input_handle = ListOf_String_toFfi_nullable(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithSomeArray_ffi(_handle, _input_handle);
+    ListOf_String_releaseFfiHandle_nullable(_input_handle);
+    final _result = ListOf_String_fromFfi_nullable(__result_handle);
+    ListOf_String_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  List<String> methodWithInlineArray(List<String> input) {
+    final _methodWithInlineArray_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithInlineArray__ListOf_1String');
+    final _input_handle = ListOf_String_toFfi_nullable(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithInlineArray_ffi(_handle, _input_handle);
+    ListOf_String_releaseFfiHandle_nullable(_input_handle);
+    final _result = ListOf_String_fromFfi_nullable(__result_handle);
+    ListOf_String_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  Map<int, String> methodWithSomeMap(Map<int, String> input) {
+    final _methodWithSomeMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeMap__MapOf_1Long_1to_1String');
+    final _input_handle = MapOf_Long_to_String_toFfi_nullable(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithSomeMap_ffi(_handle, _input_handle);
+    MapOf_Long_to_String_releaseFfiHandle_nullable(_input_handle);
+    final _result = MapOf_Long_to_String_fromFfi_nullable(__result_handle);
+    MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  SomeInterface methodWithInstance(SomeInterface input) {
+    final _methodWithInstance_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_methodWithInstance__SomeInterface');
+    final _input_handle = smoke_SomeInterface_toFfi_nullable(input);
+    final _handle = this.handle;
+    final __result_handle = _methodWithInstance_ffi(_handle, _input_handle);
+    smoke_SomeInterface_releaseFfiHandle_nullable(_input_handle);
+    final _result = smoke_SomeInterface_fromFfi_nullable(__result_handle);
+    smoke_SomeInterface_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  String get stringProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_stringProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = String_fromFfi_nullable(__result_handle);
+    String_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  set stringProperty(String value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_stringProperty_set__String');
+    final _value_handle = String_toFfi_nullable(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    String_releaseFfiHandle_nullable(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  bool get isBoolProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_isBoolProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = Boolean_fromFfi_nullable(__result_handle);
+    Boolean_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  set isBoolProperty(bool value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_isBoolProperty_set__Boolean');
+    final _value_handle = Boolean_toFfi_nullable(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Boolean_releaseFfiHandle_nullable(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  double get doubleProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_doubleProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = Double_fromFfi_nullable(__result_handle);
+    Double_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  set doubleProperty(double value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_doubleProperty_set__Double');
+    final _value_handle = Double_toFfi_nullable(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Double_releaseFfiHandle_nullable(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  int get intProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_intProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = Long_fromFfi_nullable(__result_handle);
+    Long_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  set intProperty(int value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_intProperty_set__Long');
+    final _value_handle = Long_toFfi_nullable(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Long_releaseFfiHandle_nullable(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  Nullable_SomeStruct get structProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_structProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = smoke_Nullable_SomeStruct_fromFfi_nullable(__result_handle);
+    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  set structProperty(Nullable_SomeStruct value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_structProperty_set__SomeStruct');
+    final _value_handle = smoke_Nullable_SomeStruct_toFfi_nullable(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  Nullable_SomeEnum get enumProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_enumProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = smoke_Nullable_SomeEnum_fromFfi_nullable(__result_handle);
+    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  set enumProperty(Nullable_SomeEnum value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_enumProperty_set__SomeEnum');
+    final _value_handle = smoke_Nullable_SomeEnum_toFfi_nullable(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  List<String> get arrayProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_arrayProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = ListOf_String_fromFfi_nullable(__result_handle);
+    ListOf_String_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  set arrayProperty(List<String> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_arrayProperty_set__ListOf_1String');
+    final _value_handle = ListOf_String_toFfi_nullable(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    ListOf_String_releaseFfiHandle_nullable(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  List<String> get inlineArrayProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_inlineArrayProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = ListOf_String_fromFfi_nullable(__result_handle);
+    ListOf_String_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  set inlineArrayProperty(List<String> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_inlineArrayProperty_set__ListOf_1String');
+    final _value_handle = ListOf_String_toFfi_nullable(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    ListOf_String_releaseFfiHandle_nullable(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  Map<int, String> get mapProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_mapProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = MapOf_Long_to_String_fromFfi_nullable(__result_handle);
+    MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  set mapProperty(Map<int, String> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_mapProperty_set__MapOf_1Long_1to_1String');
+    final _value_handle = MapOf_Long_to_String_toFfi_nullable(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    MapOf_Long_to_String_releaseFfiHandle_nullable(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  SomeInterface get instanceProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Nullable_instanceProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = smoke_SomeInterface_fromFfi_nullable(__result_handle);
+    smoke_SomeInterface_releaseFfiHandle_nullable(__result_handle);
+    return _result;
+  }
+  @override
+  set instanceProperty(SomeInterface value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Nullable_instanceProperty_set__SomeInterface');
+    final _value_handle = smoke_SomeInterface_toFfi_nullable(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    smoke_SomeInterface_releaseFfiHandle_nullable(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_Nullable_toFfi(Nullable value) =>
+  _smoke_Nullable_copy_handle((value as Nullable$Impl).handle);
+Nullable smoke_Nullable_fromFfi(Pointer<Void> handle) =>
+  Nullable$Impl(_smoke_Nullable_copy_handle(handle));
+void smoke_Nullable_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Nullable_release_handle(handle);
+Pointer<Void> smoke_Nullable_toFfi_nullable(Nullable value) =>
+  value != null ? smoke_Nullable_toFfi(value) : Pointer<Void>.fromAddress(0);
+Nullable smoke_Nullable_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_Nullable_fromFfi(handle) : null;
+void smoke_Nullable_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Nullable_release_handle(handle);
+// End of Nullable "private" section.

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/NestedPackages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/NestedPackages.dart
@@ -3,40 +3,10 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_off_NestedPackages_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_off_NestedPackages_copy_handle');
-final _smoke_off_NestedPackages_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_off_NestedPackages_release_handle');
-class NestedPackages {
-  final Pointer<Void> _handle;
-  NestedPackages._(this._handle);
-  void release() => _smoke_off_NestedPackages_release_handle(_handle);
-  static NestedPackages_SomeStruct basicMethod(NestedPackages_SomeStruct input) {
-    final _basicMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_off_NestedPackages_basicMethod__SomeStruct');
-    final _input_handle = smoke_off_NestedPackages_SomeStruct_toFfi(input);
-    final __result_handle = _basicMethod_ffi(_input_handle);
-    smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_off_NestedPackages_SomeStruct_fromFfi(__result_handle);
-    smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+abstract class NestedPackages {
+  void release();
+  static NestedPackages_SomeStruct basicMethod(NestedPackages_SomeStruct input) => NestedPackages$Impl.basicMethod(input);
 }
-Pointer<Void> smoke_off_NestedPackages_toFfi(NestedPackages value) =>
-  _smoke_off_NestedPackages_copy_handle(value._handle);
-NestedPackages smoke_off_NestedPackages_fromFfi(Pointer<Void> handle) =>
-  NestedPackages._(_smoke_off_NestedPackages_copy_handle(handle));
-void smoke_off_NestedPackages_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_off_NestedPackages_release_handle(handle);
-Pointer<Void> smoke_off_NestedPackages_toFfi_nullable(NestedPackages value) =>
-  value != null ? smoke_off_NestedPackages_toFfi(value) : Pointer<Void>.fromAddress(0);
-NestedPackages smoke_off_NestedPackages_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_off_NestedPackages_fromFfi(handle) : null;
-void smoke_off_NestedPackages_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_off_NestedPackages_release_handle(handle);
 class NestedPackages_SomeStruct {
   String someField;
   NestedPackages_SomeStruct(this.someField);
@@ -99,3 +69,40 @@ NestedPackages_SomeStruct smoke_off_NestedPackages_SomeStruct_fromFfi_nullable(P
 void smoke_off_NestedPackages_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_off_NestedPackages_SomeStruct_release_handle_nullable(handle);
 // End of NestedPackages_SomeStruct "private" section.
+// NestedPackages "private" section, not exported.
+final _smoke_off_NestedPackages_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_off_NestedPackages_copy_handle');
+final _smoke_off_NestedPackages_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_off_NestedPackages_release_handle');
+class NestedPackages$Impl implements NestedPackages {
+  final Pointer<Void> handle;
+  NestedPackages$Impl(this.handle);
+  @override
+  void release() => _smoke_off_NestedPackages_release_handle(handle);
+  static NestedPackages_SomeStruct basicMethod(NestedPackages_SomeStruct input) {
+    final _basicMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_off_NestedPackages_basicMethod__SomeStruct');
+    final _input_handle = smoke_off_NestedPackages_SomeStruct_toFfi(input);
+    final __result_handle = _basicMethod_ffi(_input_handle);
+    smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(_input_handle);
+    final _result = smoke_off_NestedPackages_SomeStruct_fromFfi(__result_handle);
+    smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_off_NestedPackages_toFfi(NestedPackages value) =>
+  _smoke_off_NestedPackages_copy_handle((value as NestedPackages$Impl).handle);
+NestedPackages smoke_off_NestedPackages_fromFfi(Pointer<Void> handle) =>
+  NestedPackages$Impl(_smoke_off_NestedPackages_copy_handle(handle));
+void smoke_off_NestedPackages_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_off_NestedPackages_release_handle(handle);
+Pointer<Void> smoke_off_NestedPackages_toFfi_nullable(NestedPackages value) =>
+  value != null ? smoke_off_NestedPackages_toFfi(value) : Pointer<Void>.fromAddress(0);
+NestedPackages smoke_off_NestedPackages_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_off_NestedPackages_fromFfi(handle) : null;
+void smoke_off_NestedPackages_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_off_NestedPackages_release_handle(handle);
+// End of NestedPackages "private" section.

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeInterface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeInterface.dart
@@ -4,6 +4,14 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
+abstract class weeInterface {
+  factory weeInterface(String makeParameter) => weeInterface$Impl.make(makeParameter);
+  void release();
+  weeStruct WeeMethod(String WeeParameter);
+  int get WEE_PROPERTY;
+  set WEE_PROPERTY(int value);
+}
+// weeInterface "private" section, not exported.
 final _smoke_PlatformNamesInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -12,14 +20,17 @@ final _smoke_PlatformNamesInterface_release_handle = __lib.nativeLibrary.lookupF
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformNamesInterface_release_handle');
-class weeInterface {
-  final Pointer<Void> _handle;
-  weeInterface._(this._handle);
-  void release() => _smoke_PlatformNamesInterface_release_handle(_handle);
-  weeInterface(String makeParameter) : this._(_make(makeParameter));
+class weeInterface$Impl implements weeInterface {
+  final Pointer<Void> handle;
+  weeInterface$Impl(this.handle);
+  @override
+  void release() => _smoke_PlatformNamesInterface_release_handle(handle);
+  weeInterface$Impl.make(String makeParameter) : this(_make(makeParameter));
+  @override
   weeStruct WeeMethod(String WeeParameter) {
     final _WeeMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_PlatformNamesInterface_basicMethod__String');
     final _WeeParameter_handle = String_toFfi(WeeParameter);
+    final _handle = this.handle;
     final __result_handle = _WeeMethod_ffi(_handle, _WeeParameter_handle);
     String_releaseFfiHandle(_WeeParameter_handle);
     final _result = smoke_PlatformNames_BasicStruct_fromFfi(__result_handle);
@@ -33,16 +44,20 @@ class weeInterface {
     String_releaseFfiHandle(_makeParameter_handle);
     return __result_handle;
   }
+  @override
   int get WEE_PROPERTY {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_PlatformNamesInterface_basicProperty_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = (__result_handle);
     (__result_handle);
     return _result;
   }
+  @override
   set WEE_PROPERTY(int value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint32), void Function(Pointer<Void>, int)>('library_smoke_PlatformNamesInterface_basicProperty_set__UInt');
     final _value_handle = (value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     (_value_handle);
     final _result = (__result_handle);
@@ -51,9 +66,9 @@ class weeInterface {
   }
 }
 Pointer<Void> smoke_PlatformNamesInterface_toFfi(weeInterface value) =>
-  _smoke_PlatformNamesInterface_copy_handle(value._handle);
+  _smoke_PlatformNamesInterface_copy_handle((value as weeInterface$Impl).handle);
 weeInterface smoke_PlatformNamesInterface_fromFfi(Pointer<Void> handle) =>
-  weeInterface._(_smoke_PlatformNamesInterface_copy_handle(handle));
+  weeInterface$Impl(_smoke_PlatformNamesInterface_copy_handle(handle));
 void smoke_PlatformNamesInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_PlatformNamesInterface_release_handle(handle);
 Pointer<Void> smoke_PlatformNamesInterface_toFfi_nullable(weeInterface value) =>
@@ -62,3 +77,4 @@ weeInterface smoke_PlatformNamesInterface_fromFfi_nullable(Pointer<Void> handle)
   handle.address != 0 ? smoke_PlatformNamesInterface_fromFfi(handle) : null;
 void smoke_PlatformNamesInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_PlatformNamesInterface_release_handle(handle);
+// End of weeInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeListener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeListener.dart
@@ -30,16 +30,16 @@ final _smoke_PlatformNamesListener_get_type_id = __lib.nativeLibrary.lookupFunct
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNamesListener_get_type_id');
-class weeListener__Impl implements weeListener {
-  Pointer<Void> get _handle => handle;
+class weeListener$Impl implements weeListener {
   final Pointer<Void> handle;
-  weeListener__Impl(this.handle);
+  weeListener$Impl(this.handle);
   @override
   void release() => _smoke_PlatformNamesListener_release_handle(handle);
   @override
   WeeMethod(String WeeParameter) {
     final _WeeMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_PlatformNamesListener_basicMethod__String');
     final _WeeParameter_handle = String_toFfi(WeeParameter);
+    final _handle = this.handle;
     final __result_handle = _WeeMethod_ffi(_handle, _WeeParameter_handle);
     String_releaseFfiHandle(_WeeParameter_handle);
     final _result = (__result_handle);
@@ -53,7 +53,7 @@ int _weeListener_WeeMethod_static(int _token, Pointer<Void> WeeParameter) {
   return 0;
 }
 Pointer<Void> smoke_PlatformNamesListener_toFfi(weeListener value) {
-  if (value is weeListener__Impl) return _smoke_PlatformNamesListener_copy_handle(value.handle);
+  if (value is weeListener$Impl) return _smoke_PlatformNamesListener_copy_handle(value.handle);
   final result = _smoke_PlatformNamesListener_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -69,7 +69,7 @@ weeListener smoke_PlatformNamesListener_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_PlatformNamesListener_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? weeListener__Impl(_copied_handle)
+    ? weeListener$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/Properties.dart
@@ -6,173 +6,27 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_Properties_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Properties_copy_handle');
-final _smoke_Properties_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Properties_release_handle');
-class Properties {
-  final Pointer<Void> _handle;
-  Properties._(this._handle);
-  void release() => _smoke_Properties_release_handle(_handle);
-  int get builtInTypeProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Properties_builtInTypeProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  set builtInTypeProperty(int value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint32), void Function(Pointer<Void>, int)>('library_smoke_Properties_builtInTypeProperty_set__UInt');
-    final _value_handle = (value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    (_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  double get readonlyProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>), double Function(Pointer<Void>)>('library_smoke_Properties_readonlyProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  Properties_ExampleStruct get structProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Properties_structProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = smoke_Properties_ExampleStruct_fromFfi(__result_handle);
-    smoke_Properties_ExampleStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set structProperty(Properties_ExampleStruct value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Properties_structProperty_set__ExampleStruct');
-    final _value_handle = smoke_Properties_ExampleStruct_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    smoke_Properties_ExampleStruct_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  List<String> get arrayProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Properties_arrayProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = ListOf_String_fromFfi(__result_handle);
-    ListOf_String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set arrayProperty(List<String> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Properties_arrayProperty_set__ListOf_1String');
-    final _value_handle = ListOf_String_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    ListOf_String_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  Properties_InternalErrorCode get complexTypeProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Properties_complexTypeProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = smoke_Properties_InternalErrorCode_fromFfi(__result_handle);
-    smoke_Properties_InternalErrorCode_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set complexTypeProperty(Properties_InternalErrorCode value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint32), void Function(Pointer<Void>, int)>('library_smoke_Properties_complexTypeProperty_set__InternalErrorCode');
-    final _value_handle = smoke_Properties_InternalErrorCode_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    smoke_Properties_InternalErrorCode_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  Uint8List get byteBufferProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Properties_byteBufferProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = Blob_fromFfi(__result_handle);
-    Blob_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set byteBufferProperty(Uint8List value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Properties_byteBufferProperty_set__Blob');
-    final _value_handle = Blob_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    Blob_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  PropertiesInterface get instanceProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Properties_instanceProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = smoke_PropertiesInterface_fromFfi(__result_handle);
-    smoke_PropertiesInterface_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set instanceProperty(PropertiesInterface value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Properties_instanceProperty_set__PropertiesInterface');
-    final _value_handle = smoke_PropertiesInterface_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    smoke_PropertiesInterface_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  bool get isBooleanProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Properties_isBooleanProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set isBooleanProperty(bool value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint8), void Function(Pointer<Void>, int)>('library_smoke_Properties_isBooleanProperty_set__Boolean');
-    final _value_handle = Boolean_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    Boolean_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  static String get staticProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Properties_staticProperty_get');
-    final __result_handle = _get_ffi();
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static set staticProperty(String value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_Properties_staticProperty_set__String');
-    final _value_handle = String_toFfi(value);
-    final __result_handle = _set_ffi(_value_handle);
-    String_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  static Properties_ExampleStruct get staticReadonlyProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Properties_staticReadonlyProperty_get');
-    final __result_handle = _get_ffi();
-    final _result = smoke_Properties_ExampleStruct_fromFfi(__result_handle);
-    smoke_Properties_ExampleStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+abstract class Properties {
+  void release();
+  int get builtInTypeProperty;
+  set builtInTypeProperty(int value);
+  double get readonlyProperty;
+  Properties_ExampleStruct get structProperty;
+  set structProperty(Properties_ExampleStruct value);
+  List<String> get arrayProperty;
+  set arrayProperty(List<String> value);
+  Properties_InternalErrorCode get complexTypeProperty;
+  set complexTypeProperty(Properties_InternalErrorCode value);
+  Uint8List get byteBufferProperty;
+  set byteBufferProperty(Uint8List value);
+  PropertiesInterface get instanceProperty;
+  set instanceProperty(PropertiesInterface value);
+  bool get isBooleanProperty;
+  set isBooleanProperty(bool value);
+  static String get staticProperty => Properties$Impl.staticProperty;
+  static set staticProperty(String value) { Properties$Impl.staticProperty = value; }
+  static Properties_ExampleStruct get staticReadonlyProperty => Properties$Impl.staticReadonlyProperty;
 }
-Pointer<Void> smoke_Properties_toFfi(Properties value) =>
-  _smoke_Properties_copy_handle(value._handle);
-Properties smoke_Properties_fromFfi(Pointer<Void> handle) =>
-  Properties._(_smoke_Properties_copy_handle(handle));
-void smoke_Properties_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Properties_release_handle(handle);
-Pointer<Void> smoke_Properties_toFfi_nullable(Properties value) =>
-  value != null ? smoke_Properties_toFfi(value) : Pointer<Void>.fromAddress(0);
-Properties smoke_Properties_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_Properties_fromFfi(handle) : null;
-void smoke_Properties_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Properties_release_handle(handle);
 enum Properties_InternalErrorCode {
     errorNone,
     errorFatal
@@ -294,3 +148,203 @@ Properties_ExampleStruct smoke_Properties_ExampleStruct_fromFfi_nullable(Pointer
 void smoke_Properties_ExampleStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Properties_ExampleStruct_release_handle_nullable(handle);
 // End of Properties_ExampleStruct "private" section.
+// Properties "private" section, not exported.
+final _smoke_Properties_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Properties_copy_handle');
+final _smoke_Properties_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Properties_release_handle');
+class Properties$Impl implements Properties {
+  final Pointer<Void> handle;
+  Properties$Impl(this.handle);
+  @override
+  void release() => _smoke_Properties_release_handle(handle);
+  @override
+  int get builtInTypeProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Properties_builtInTypeProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  set builtInTypeProperty(int value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint32), void Function(Pointer<Void>, int)>('library_smoke_Properties_builtInTypeProperty_set__UInt');
+    final _value_handle = (value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    (_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  double get readonlyProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>), double Function(Pointer<Void>)>('library_smoke_Properties_readonlyProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  Properties_ExampleStruct get structProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Properties_structProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = smoke_Properties_ExampleStruct_fromFfi(__result_handle);
+    smoke_Properties_ExampleStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set structProperty(Properties_ExampleStruct value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Properties_structProperty_set__ExampleStruct');
+    final _value_handle = smoke_Properties_ExampleStruct_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    smoke_Properties_ExampleStruct_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  List<String> get arrayProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Properties_arrayProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = ListOf_String_fromFfi(__result_handle);
+    ListOf_String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set arrayProperty(List<String> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Properties_arrayProperty_set__ListOf_1String');
+    final _value_handle = ListOf_String_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    ListOf_String_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  Properties_InternalErrorCode get complexTypeProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Properties_complexTypeProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = smoke_Properties_InternalErrorCode_fromFfi(__result_handle);
+    smoke_Properties_InternalErrorCode_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set complexTypeProperty(Properties_InternalErrorCode value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint32), void Function(Pointer<Void>, int)>('library_smoke_Properties_complexTypeProperty_set__InternalErrorCode');
+    final _value_handle = smoke_Properties_InternalErrorCode_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    smoke_Properties_InternalErrorCode_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  Uint8List get byteBufferProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Properties_byteBufferProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = Blob_fromFfi(__result_handle);
+    Blob_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set byteBufferProperty(Uint8List value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Properties_byteBufferProperty_set__Blob');
+    final _value_handle = Blob_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Blob_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  PropertiesInterface get instanceProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Properties_instanceProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = smoke_PropertiesInterface_fromFfi(__result_handle);
+    smoke_PropertiesInterface_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set instanceProperty(PropertiesInterface value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_Properties_instanceProperty_set__PropertiesInterface');
+    final _value_handle = smoke_PropertiesInterface_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    smoke_PropertiesInterface_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  bool get isBooleanProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>), int Function(Pointer<Void>)>('library_smoke_Properties_isBooleanProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = Boolean_fromFfi(__result_handle);
+    Boolean_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set isBooleanProperty(bool value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Uint8), void Function(Pointer<Void>, int)>('library_smoke_Properties_isBooleanProperty_set__Boolean');
+    final _value_handle = Boolean_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    Boolean_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  static String get staticProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Properties_staticProperty_get');
+    final __result_handle = _get_ffi();
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static set staticProperty(String value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>), void Function(Pointer<Void>)>('library_smoke_Properties_staticProperty_set__String');
+    final _value_handle = String_toFfi(value);
+    final __result_handle = _set_ffi(_value_handle);
+    String_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  static Properties_ExampleStruct get staticReadonlyProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Properties_staticReadonlyProperty_get');
+    final __result_handle = _get_ffi();
+    final _result = smoke_Properties_ExampleStruct_fromFfi(__result_handle);
+    smoke_Properties_ExampleStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_Properties_toFfi(Properties value) =>
+  _smoke_Properties_copy_handle((value as Properties$Impl).handle);
+Properties smoke_Properties_fromFfi(Pointer<Void> handle) =>
+  Properties$Impl(_smoke_Properties_copy_handle(handle));
+void smoke_Properties_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Properties_release_handle(handle);
+Pointer<Void> smoke_Properties_toFfi_nullable(Properties value) =>
+  value != null ? smoke_Properties_toFfi(value) : Pointer<Void>.fromAddress(0);
+Properties smoke_Properties_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_Properties_fromFfi(handle) : null;
+void smoke_Properties_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Properties_release_handle(handle);
+// End of Properties "private" section.

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/PropertiesInterface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/PropertiesInterface.dart
@@ -93,14 +93,14 @@ final _smoke_PropertiesInterface_get_type_id = __lib.nativeLibrary.lookupFunctio
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_get_type_id');
-class PropertiesInterface__Impl implements PropertiesInterface {
-  Pointer<Void> get _handle => handle;
+class PropertiesInterface$Impl implements PropertiesInterface {
   final Pointer<Void> handle;
-  PropertiesInterface__Impl(this.handle);
+  PropertiesInterface$Impl(this.handle);
   @override
   void release() => _smoke_PropertiesInterface_release_handle(handle);
   PropertiesInterface_ExampleStruct get structProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_PropertiesInterface_structProperty_get');
+    final _handle = this.handle;
     final __result_handle = _get_ffi(_handle);
     final _result = smoke_PropertiesInterface_ExampleStruct_fromFfi(__result_handle);
     smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(__result_handle);
@@ -109,6 +109,7 @@ class PropertiesInterface__Impl implements PropertiesInterface {
   set structProperty(PropertiesInterface_ExampleStruct value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_PropertiesInterface_structProperty_set__ExampleStruct');
     final _value_handle = smoke_PropertiesInterface_ExampleStruct_toFfi(value);
+    final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, _value_handle);
     smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(_value_handle);
     final _result = (__result_handle);
@@ -126,7 +127,7 @@ int _PropertiesInterface_structProperty_set_static(int _token, Pointer<Void> _va
   return 0;
 }
 Pointer<Void> smoke_PropertiesInterface_toFfi(PropertiesInterface value) {
-  if (value is PropertiesInterface__Impl) return _smoke_PropertiesInterface_copy_handle(value.handle);
+  if (value is PropertiesInterface$Impl) return _smoke_PropertiesInterface_copy_handle(value.handle);
   final result = _smoke_PropertiesInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi,
@@ -143,7 +144,7 @@ PropertiesInterface smoke_PropertiesInterface_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_PropertiesInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? PropertiesInterface__Impl(_copied_handle)
+    ? PropertiesInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/Structs.dart
@@ -6,90 +6,16 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_Structs_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_copy_handle');
-final _smoke_Structs_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_Structs_release_handle');
-class Structs {
-  final Pointer<Void> _handle;
-  Structs._(this._handle);
-  void release() => _smoke_Structs_release_handle(_handle);
-  static Structs_Point swapPointCoordinates(Structs_Point input) {
-    final _swapPointCoordinates_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Structs_swapPointCoordinates__Point');
-    final _input_handle = smoke_Structs_Point_toFfi(input);
-    final __result_handle = _swapPointCoordinates_ffi(_input_handle);
-    smoke_Structs_Point_releaseFfiHandle(_input_handle);
-    final _result = smoke_Structs_Point_fromFfi(__result_handle);
-    smoke_Structs_Point_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static Structs_AllTypesStruct returnAllTypesStruct(Structs_AllTypesStruct input) {
-    final _returnAllTypesStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Structs_returnAllTypesStruct__AllTypesStruct');
-    final _input_handle = smoke_Structs_AllTypesStruct_toFfi(input);
-    final __result_handle = _returnAllTypesStruct_ffi(_input_handle);
-    smoke_Structs_AllTypesStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_Structs_AllTypesStruct_fromFfi(__result_handle);
-    smoke_Structs_AllTypesStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static Structs_ExternalStruct getExternalStruct() {
-    final _getExternalStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Structs_getExternalStruct');
-    final __result_handle = _getExternalStruct_ffi();
-    final _result = smoke_Structs_ExternalStruct_fromFfi(__result_handle);
-    smoke_Structs_ExternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static Structs_AnotherExternalStruct getAnotherExternalStruct() {
-    final _getAnotherExternalStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Structs_getAnotherExternalStruct');
-    final __result_handle = _getAnotherExternalStruct_ffi();
-    final _result = smoke_Structs_AnotherExternalStruct_fromFfi(__result_handle);
-    smoke_Structs_AnotherExternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static Structs_YetAnotherExternalStruct getYetAnotherExternalStruct() {
-    final _getYetAnotherExternalStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Structs_getYetAnotherExternalStruct');
-    final __result_handle = _getYetAnotherExternalStruct_ffi();
-    final _result = smoke_Structs_YetAnotherExternalStruct_fromFfi(__result_handle);
-    smoke_Structs_YetAnotherExternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static Point createPoint(double x, double y) {
-    final _createPoint_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Double, Double), Pointer<Void> Function(double, double)>('library_smoke_Structs_createPoint__Double_Double');
-    final _x_handle = (x);
-    final _y_handle = (y);
-    final __result_handle = _createPoint_ffi(_x_handle, _y_handle);
-    (_x_handle);
-    (_y_handle);
-    final _result = smoke_TypeCollection_Point_fromFfi(__result_handle);
-    smoke_TypeCollection_Point_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static AllTypesStruct modifyAllTypesStruct(AllTypesStruct input) {
-    final _modifyAllTypesStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Structs_modifyAllTypesStruct__AllTypesStruct');
-    final _input_handle = smoke_TypeCollection_AllTypesStruct_toFfi(input);
-    final __result_handle = _modifyAllTypesStruct_ffi(_input_handle);
-    smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_TypeCollection_AllTypesStruct_fromFfi(__result_handle);
-    smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
+abstract class Structs {
+  void release();
+  static Structs_Point swapPointCoordinates(Structs_Point input) => Structs$Impl.swapPointCoordinates(input);
+  static Structs_AllTypesStruct returnAllTypesStruct(Structs_AllTypesStruct input) => Structs$Impl.returnAllTypesStruct(input);
+  static Structs_ExternalStruct getExternalStruct() => Structs$Impl.getExternalStruct();
+  static Structs_AnotherExternalStruct getAnotherExternalStruct() => Structs$Impl.getAnotherExternalStruct();
+  static Structs_YetAnotherExternalStruct getYetAnotherExternalStruct() => Structs$Impl.getYetAnotherExternalStruct();
+  static Point createPoint(double x, double y) => Structs$Impl.createPoint(x, y);
+  static AllTypesStruct modifyAllTypesStruct(AllTypesStruct input) => Structs$Impl.modifyAllTypesStruct(input);
 }
-Pointer<Void> smoke_Structs_toFfi(Structs value) =>
-  _smoke_Structs_copy_handle(value._handle);
-Structs smoke_Structs_fromFfi(Pointer<Void> handle) =>
-  Structs._(_smoke_Structs_copy_handle(handle));
-void smoke_Structs_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Structs_release_handle(handle);
-Pointer<Void> smoke_Structs_toFfi_nullable(Structs value) =>
-  value != null ? smoke_Structs_toFfi(value) : Pointer<Void>.fromAddress(0);
-Structs smoke_Structs_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_Structs_fromFfi(handle) : null;
-void smoke_Structs_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_release_handle(handle);
 enum Structs_FooBar {
     foo,
     bar
@@ -1011,3 +937,90 @@ Structs_MutableStructWithCppAccessors smoke_Structs_MutableStructWithCppAccessor
 void smoke_Structs_MutableStructWithCppAccessors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Structs_MutableStructWithCppAccessors_release_handle_nullable(handle);
 // End of Structs_MutableStructWithCppAccessors "private" section.
+// Structs "private" section, not exported.
+final _smoke_Structs_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Structs_copy_handle');
+final _smoke_Structs_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Structs_release_handle');
+class Structs$Impl implements Structs {
+  final Pointer<Void> handle;
+  Structs$Impl(this.handle);
+  @override
+  void release() => _smoke_Structs_release_handle(handle);
+  static Structs_Point swapPointCoordinates(Structs_Point input) {
+    final _swapPointCoordinates_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Structs_swapPointCoordinates__Point');
+    final _input_handle = smoke_Structs_Point_toFfi(input);
+    final __result_handle = _swapPointCoordinates_ffi(_input_handle);
+    smoke_Structs_Point_releaseFfiHandle(_input_handle);
+    final _result = smoke_Structs_Point_fromFfi(__result_handle);
+    smoke_Structs_Point_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static Structs_AllTypesStruct returnAllTypesStruct(Structs_AllTypesStruct input) {
+    final _returnAllTypesStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Structs_returnAllTypesStruct__AllTypesStruct');
+    final _input_handle = smoke_Structs_AllTypesStruct_toFfi(input);
+    final __result_handle = _returnAllTypesStruct_ffi(_input_handle);
+    smoke_Structs_AllTypesStruct_releaseFfiHandle(_input_handle);
+    final _result = smoke_Structs_AllTypesStruct_fromFfi(__result_handle);
+    smoke_Structs_AllTypesStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static Structs_ExternalStruct getExternalStruct() {
+    final _getExternalStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Structs_getExternalStruct');
+    final __result_handle = _getExternalStruct_ffi();
+    final _result = smoke_Structs_ExternalStruct_fromFfi(__result_handle);
+    smoke_Structs_ExternalStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static Structs_AnotherExternalStruct getAnotherExternalStruct() {
+    final _getAnotherExternalStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Structs_getAnotherExternalStruct');
+    final __result_handle = _getAnotherExternalStruct_ffi();
+    final _result = smoke_Structs_AnotherExternalStruct_fromFfi(__result_handle);
+    smoke_Structs_AnotherExternalStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static Structs_YetAnotherExternalStruct getYetAnotherExternalStruct() {
+    final _getYetAnotherExternalStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Structs_getYetAnotherExternalStruct');
+    final __result_handle = _getYetAnotherExternalStruct_ffi();
+    final _result = smoke_Structs_YetAnotherExternalStruct_fromFfi(__result_handle);
+    smoke_Structs_YetAnotherExternalStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static Point createPoint(double x, double y) {
+    final _createPoint_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Double, Double), Pointer<Void> Function(double, double)>('library_smoke_Structs_createPoint__Double_Double');
+    final _x_handle = (x);
+    final _y_handle = (y);
+    final __result_handle = _createPoint_ffi(_x_handle, _y_handle);
+    (_x_handle);
+    (_y_handle);
+    final _result = smoke_TypeCollection_Point_fromFfi(__result_handle);
+    smoke_TypeCollection_Point_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static AllTypesStruct modifyAllTypesStruct(AllTypesStruct input) {
+    final _modifyAllTypesStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Structs_modifyAllTypesStruct__AllTypesStruct');
+    final _input_handle = smoke_TypeCollection_AllTypesStruct_toFfi(input);
+    final __result_handle = _modifyAllTypesStruct_ffi(_input_handle);
+    smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(_input_handle);
+    final _result = smoke_TypeCollection_AllTypesStruct_fromFfi(__result_handle);
+    smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_Structs_toFfi(Structs value) =>
+  _smoke_Structs_copy_handle((value as Structs$Impl).handle);
+Structs smoke_Structs_fromFfi(Pointer<Void> handle) =>
+  Structs$Impl(_smoke_Structs_copy_handle(handle));
+void smoke_Structs_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Structs_release_handle(handle);
+Pointer<Void> smoke_Structs_toFfi_nullable(Structs value) =>
+  value != null ? smoke_Structs_toFfi(value) : Pointer<Void>.fromAddress(0);
+Structs smoke_Structs_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_Structs_fromFfi(handle) : null;
+void smoke_Structs_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Structs_release_handle(handle);
+// End of Structs "private" section.

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/TypeDefs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/TypeDefs.dart
@@ -5,101 +5,17 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_TypeDefs_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_copy_handle');
-final _smoke_TypeDefs_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_release_handle');
-class TypeDefs {
-  final Pointer<Void> _handle;
-  TypeDefs._(this._handle);
-  void release() => _smoke_TypeDefs_release_handle(_handle);
-  static double methodWithPrimitiveTypeDef(double input) {
-    final _methodWithPrimitiveTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Double), double Function(double)>('library_smoke_TypeDefs_methodWithPrimitiveTypeDef__Double');
-    final _input_handle = (input);
-    final __result_handle = _methodWithPrimitiveTypeDef_ffi(_input_handle);
-    (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  static List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) {
-    final _methodWithComplexTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_TypeDefs_methodWithComplexTypeDef__ListOf_1smoke_1TypeDefs_1TestStruct');
-    final _input_handle = ListOf_smoke_TypeDefs_TestStruct_toFfi(input);
-    final __result_handle = _methodWithComplexTypeDef_ffi(_input_handle);
-    ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
-    final _result = ListOf_smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
-    ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static double returnNestedIntTypeDef(double input) {
-    final _returnNestedIntTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Double), double Function(double)>('library_smoke_TypeDefs_returnNestedIntTypeDef__Double');
-    final _input_handle = (input);
-    final __result_handle = _returnNestedIntTypeDef_ffi(_input_handle);
-    (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  static TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) {
-    final _returnTestStructTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_TypeDefs_returnTestStructTypeDef__TestStruct');
-    final _input_handle = smoke_TypeDefs_TestStruct_toFfi(input);
-    final __result_handle = _returnTestStructTypeDef_ffi(_input_handle);
-    smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
-    smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static TypeDefs_TestStruct returnNestedStructTypeDef(TypeDefs_TestStruct input) {
-    final _returnNestedStructTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_TypeDefs_returnNestedStructTypeDef__TestStruct');
-    final _input_handle = smoke_TypeDefs_TestStruct_toFfi(input);
-    final __result_handle = _returnNestedStructTypeDef_ffi(_input_handle);
-    smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
-    smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  static Point returnTypeDefPointFromTypeCollection(Point input) {
-    final _returnTypeDefPointFromTypeCollection_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_TypeDefs_returnTypeDefPointFromTypeCollection__Point');
-    final _input_handle = smoke_TypeCollection_Point_toFfi(input);
-    final __result_handle = _returnTypeDefPointFromTypeCollection_ffi(_input_handle);
-    smoke_TypeCollection_Point_releaseFfiHandle(_input_handle);
-    final _result = smoke_TypeCollection_Point_fromFfi(__result_handle);
-    smoke_TypeCollection_Point_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  List<double> get primitiveTypeProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_TypeDefs_primitiveTypeProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = ListOf_Double_fromFfi(__result_handle);
-    ListOf_Double_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set primitiveTypeProperty(List<double> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_TypeDefs_primitiveTypeProperty_set__ListOf_1Double');
-    final _value_handle = ListOf_Double_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    ListOf_Double_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+abstract class TypeDefs {
+  void release();
+  static double methodWithPrimitiveTypeDef(double input) => TypeDefs$Impl.methodWithPrimitiveTypeDef(input);
+  static List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) => TypeDefs$Impl.methodWithComplexTypeDef(input);
+  static double returnNestedIntTypeDef(double input) => TypeDefs$Impl.returnNestedIntTypeDef(input);
+  static TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) => TypeDefs$Impl.returnTestStructTypeDef(input);
+  static TypeDefs_TestStruct returnNestedStructTypeDef(TypeDefs_TestStruct input) => TypeDefs$Impl.returnNestedStructTypeDef(input);
+  static Point returnTypeDefPointFromTypeCollection(Point input) => TypeDefs$Impl.returnTypeDefPointFromTypeCollection(input);
+  List<double> get primitiveTypeProperty;
+  set primitiveTypeProperty(List<double> value);
 }
-Pointer<Void> smoke_TypeDefs_toFfi(TypeDefs value) =>
-  _smoke_TypeDefs_copy_handle(value._handle);
-TypeDefs smoke_TypeDefs_fromFfi(Pointer<Void> handle) =>
-  TypeDefs._(_smoke_TypeDefs_copy_handle(handle));
-void smoke_TypeDefs_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_TypeDefs_release_handle(handle);
-Pointer<Void> smoke_TypeDefs_toFfi_nullable(TypeDefs value) =>
-  value != null ? smoke_TypeDefs_toFfi(value) : Pointer<Void>.fromAddress(0);
-TypeDefs smoke_TypeDefs_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_TypeDefs_fromFfi(handle) : null;
-void smoke_TypeDefs_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_TypeDefs_release_handle(handle);
 class TypeDefs_StructHavingAliasFieldDefinedBelow {
   double field;
   TypeDefs_StructHavingAliasFieldDefinedBelow(this.field);
@@ -224,3 +140,105 @@ TypeDefs_TestStruct smoke_TypeDefs_TestStruct_fromFfi_nullable(Pointer<Void> han
 void smoke_TypeDefs_TestStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_TypeDefs_TestStruct_release_handle_nullable(handle);
 // End of TypeDefs_TestStruct "private" section.
+// TypeDefs "private" section, not exported.
+final _smoke_TypeDefs_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypeDefs_copy_handle');
+final _smoke_TypeDefs_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypeDefs_release_handle');
+class TypeDefs$Impl implements TypeDefs {
+  final Pointer<Void> handle;
+  TypeDefs$Impl(this.handle);
+  @override
+  void release() => _smoke_TypeDefs_release_handle(handle);
+  static double methodWithPrimitiveTypeDef(double input) {
+    final _methodWithPrimitiveTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Double), double Function(double)>('library_smoke_TypeDefs_methodWithPrimitiveTypeDef__Double');
+    final _input_handle = (input);
+    final __result_handle = _methodWithPrimitiveTypeDef_ffi(_input_handle);
+    (_input_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  static List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) {
+    final _methodWithComplexTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_TypeDefs_methodWithComplexTypeDef__ListOf_1smoke_1TypeDefs_1TestStruct');
+    final _input_handle = ListOf_smoke_TypeDefs_TestStruct_toFfi(input);
+    final __result_handle = _methodWithComplexTypeDef_ffi(_input_handle);
+    ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
+    final _result = ListOf_smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
+    ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static double returnNestedIntTypeDef(double input) {
+    final _returnNestedIntTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Double), double Function(double)>('library_smoke_TypeDefs_returnNestedIntTypeDef__Double');
+    final _input_handle = (input);
+    final __result_handle = _returnNestedIntTypeDef_ffi(_input_handle);
+    (_input_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  static TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) {
+    final _returnTestStructTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_TypeDefs_returnTestStructTypeDef__TestStruct');
+    final _input_handle = smoke_TypeDefs_TestStruct_toFfi(input);
+    final __result_handle = _returnTestStructTypeDef_ffi(_input_handle);
+    smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
+    final _result = smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
+    smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static TypeDefs_TestStruct returnNestedStructTypeDef(TypeDefs_TestStruct input) {
+    final _returnNestedStructTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_TypeDefs_returnNestedStructTypeDef__TestStruct');
+    final _input_handle = smoke_TypeDefs_TestStruct_toFfi(input);
+    final __result_handle = _returnNestedStructTypeDef_ffi(_input_handle);
+    smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
+    final _result = smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
+    smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  static Point returnTypeDefPointFromTypeCollection(Point input) {
+    final _returnTypeDefPointFromTypeCollection_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_TypeDefs_returnTypeDefPointFromTypeCollection__Point');
+    final _input_handle = smoke_TypeCollection_Point_toFfi(input);
+    final __result_handle = _returnTypeDefPointFromTypeCollection_ffi(_input_handle);
+    smoke_TypeCollection_Point_releaseFfiHandle(_input_handle);
+    final _result = smoke_TypeCollection_Point_fromFfi(__result_handle);
+    smoke_TypeCollection_Point_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  List<double> get primitiveTypeProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_TypeDefs_primitiveTypeProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = ListOf_Double_fromFfi(__result_handle);
+    ListOf_Double_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set primitiveTypeProperty(List<double> value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_TypeDefs_primitiveTypeProperty_set__ListOf_1Double');
+    final _value_handle = ListOf_Double_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    ListOf_Double_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_TypeDefs_toFfi(TypeDefs value) =>
+  _smoke_TypeDefs_copy_handle((value as TypeDefs$Impl).handle);
+TypeDefs smoke_TypeDefs_fromFfi(Pointer<Void> handle) =>
+  TypeDefs$Impl(_smoke_TypeDefs_copy_handle(handle));
+void smoke_TypeDefs_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_TypeDefs_release_handle(handle);
+Pointer<Void> smoke_TypeDefs_toFfi_nullable(TypeDefs value) =>
+  value != null ? smoke_TypeDefs_toFfi(value) : Pointer<Void>.fromAddress(0);
+TypeDefs smoke_TypeDefs_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_TypeDefs_fromFfi(handle) : null;
+void smoke_TypeDefs_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_TypeDefs_release_handle(handle);
+// End of TypeDefs "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalClass.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalClass.dart
@@ -2,6 +2,10 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
+abstract class InternalClass {
+  void release();
+}
+// InternalClass "private" section, not exported.
 final _smoke_InternalClass_copy_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -10,15 +14,16 @@ final _smoke_InternalClass_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClass_release_handle');
-class InternalClass {
-  final Pointer<Void> _handle;
-  InternalClass._(this._handle);
-  void release() => _smoke_InternalClass_release_handle(_handle);
+class InternalClass$Impl implements InternalClass {
+  final Pointer<Void> handle;
+  InternalClass$Impl(this.handle);
+  @override
+  void release() => _smoke_InternalClass_release_handle(handle);
 }
 Pointer<Void> smoke_InternalClass_toFfi(InternalClass value) =>
-  _smoke_InternalClass_copy_handle(value._handle);
+  _smoke_InternalClass_copy_handle((value as InternalClass$Impl).handle);
 InternalClass smoke_InternalClass_fromFfi(Pointer<Void> handle) =>
-  InternalClass._(_smoke_InternalClass_copy_handle(handle));
+  InternalClass$Impl(_smoke_InternalClass_copy_handle(handle));
 void smoke_InternalClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_InternalClass_release_handle(handle);
 Pointer<Void> smoke_InternalClass_toFfi_nullable(InternalClass value) =>
@@ -27,3 +32,4 @@ InternalClass smoke_InternalClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InternalClass_fromFfi(handle) : null;
 void smoke_InternalClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_InternalClass_release_handle(handle);
+// End of InternalClass "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalInterface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalInterface.dart
@@ -29,15 +29,14 @@ final _smoke_InternalInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InternalInterface_get_type_id');
-class InternalInterface__Impl implements InternalInterface {
-  Pointer<Void> get _handle => handle;
+class InternalInterface$Impl implements InternalInterface {
   final Pointer<Void> handle;
-  InternalInterface__Impl(this.handle);
+  InternalInterface$Impl(this.handle);
   @override
   void release() => _smoke_InternalInterface_release_handle(handle);
 }
 Pointer<Void> smoke_InternalInterface_toFfi(InternalInterface value) {
-  if (value is InternalInterface__Impl) return _smoke_InternalInterface_copy_handle(value.handle);
+  if (value is InternalInterface$Impl) return _smoke_InternalInterface_copy_handle(value.handle);
   final result = _smoke_InternalInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi
@@ -52,7 +51,7 @@ InternalInterface smoke_InternalInterface_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_InternalInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? InternalInterface__Impl(_copied_handle)
+    ? InternalInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicClass.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicClass.dart
@@ -3,72 +3,14 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _smoke_PublicClass_copy_handle = __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_copy_handle');
-final _smoke_PublicClass_release_handle = __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_PublicClass_release_handle');
-class PublicClass {
-  final Pointer<Void> _handle;
-  PublicClass._(this._handle);
-  void release() => _smoke_PublicClass_release_handle(_handle);
-  PublicClass_InternalStruct _internalMethod(PublicClass_InternalStruct input) {
-    final _internalMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_PublicClass_internalMethod__InternalStruct');
-    final _input_handle = smoke_PublicClass_InternalStruct_toFfi(input);
-    final __result_handle = _internalMethod_ffi(_handle, _input_handle);
-    smoke_PublicClass_InternalStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_PublicClass_InternalStruct_fromFfi(__result_handle);
-    smoke_PublicClass_InternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  PublicClass_InternalStruct get _internalStructProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_PublicClass_internalStructProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = smoke_PublicClass_InternalStruct_fromFfi(__result_handle);
-    smoke_PublicClass_InternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set _internalStructProperty(PublicClass_InternalStruct value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_PublicClass_internalStructProperty_set__InternalStruct');
-    final _value_handle = smoke_PublicClass_InternalStruct_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    smoke_PublicClass_InternalStruct_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
-  String get internalSetterProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_PublicClass_internalSetterProperty_get');
-    final __result_handle = _get_ffi(_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
-  }
-  set _internalSetterProperty(String value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_PublicClass_internalSetterProperty_set__String');
-    final _value_handle = String_toFfi(value);
-    final __result_handle = _set_ffi(_handle, _value_handle);
-    String_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
-  }
+abstract class PublicClass {
+  void release();
+  PublicClass_InternalStruct _internalMethod(PublicClass_InternalStruct input);
+  PublicClass_InternalStruct get _internalStructProperty;
+  set _internalStructProperty(PublicClass_InternalStruct value);
+  String get internalSetterProperty;
+  set _internalSetterProperty(String value);
 }
-Pointer<Void> smoke_PublicClass_toFfi(PublicClass value) =>
-  _smoke_PublicClass_copy_handle(value._handle);
-PublicClass smoke_PublicClass_fromFfi(Pointer<Void> handle) =>
-  PublicClass._(_smoke_PublicClass_copy_handle(handle));
-void smoke_PublicClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_PublicClass_release_handle(handle);
-Pointer<Void> smoke_PublicClass_toFfi_nullable(PublicClass value) =>
-  value != null ? smoke_PublicClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-PublicClass smoke_PublicClass_fromFfi_nullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smoke_PublicClass_fromFfi(handle) : null;
-void smoke_PublicClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PublicClass_release_handle(handle);
 enum PublicClass_InternalEnum {
     foo,
     bar
@@ -326,3 +268,82 @@ PublicClass_PublicStructWithInternalDefaults smoke_PublicClass_PublicStructWithI
 void smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle_nullable(handle);
 // End of PublicClass_PublicStructWithInternalDefaults "private" section.
+// PublicClass "private" section, not exported.
+final _smoke_PublicClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicClass_copy_handle');
+final _smoke_PublicClass_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PublicClass_release_handle');
+class PublicClass$Impl implements PublicClass {
+  final Pointer<Void> handle;
+  PublicClass$Impl(this.handle);
+  @override
+  void release() => _smoke_PublicClass_release_handle(handle);
+  @override
+  PublicClass_InternalStruct _internalMethod(PublicClass_InternalStruct input) {
+    final _internalMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, Pointer<Void>)>('library_smoke_PublicClass_internalMethod__InternalStruct');
+    final _input_handle = smoke_PublicClass_InternalStruct_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _internalMethod_ffi(_handle, _input_handle);
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(_input_handle);
+    final _result = smoke_PublicClass_InternalStruct_fromFfi(__result_handle);
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  PublicClass_InternalStruct get _internalStructProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_PublicClass_internalStructProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = smoke_PublicClass_InternalStruct_fromFfi(__result_handle);
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set _internalStructProperty(PublicClass_InternalStruct value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_PublicClass_internalStructProperty_set__InternalStruct');
+    final _value_handle = smoke_PublicClass_InternalStruct_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+  @override
+  String get internalSetterProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_PublicClass_internalSetterProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle);
+    final _result = String_fromFfi(__result_handle);
+    String_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  set _internalSetterProperty(String value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, Pointer<Void>)>('library_smoke_PublicClass_internalSetterProperty_set__String');
+    final _value_handle = String_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, _value_handle);
+    String_releaseFfiHandle(_value_handle);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_PublicClass_toFfi(PublicClass value) =>
+  _smoke_PublicClass_copy_handle((value as PublicClass$Impl).handle);
+PublicClass smoke_PublicClass_fromFfi(Pointer<Void> handle) =>
+  PublicClass$Impl(_smoke_PublicClass_copy_handle(handle));
+void smoke_PublicClass_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_PublicClass_release_handle(handle);
+Pointer<Void> smoke_PublicClass_toFfi_nullable(PublicClass value) =>
+  value != null ? smoke_PublicClass_toFfi(value) : Pointer<Void>.fromAddress(0);
+PublicClass smoke_PublicClass_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_PublicClass_fromFfi(handle) : null;
+void smoke_PublicClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_PublicClass_release_handle(handle);
+// End of PublicClass "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicInterface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicInterface.dart
@@ -92,15 +92,14 @@ final _smoke_PublicInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_get_type_id');
-class PublicInterface__Impl implements PublicInterface {
-  Pointer<Void> get _handle => handle;
+class PublicInterface$Impl implements PublicInterface {
   final Pointer<Void> handle;
-  PublicInterface__Impl(this.handle);
+  PublicInterface$Impl(this.handle);
   @override
   void release() => _smoke_PublicInterface_release_handle(handle);
 }
 Pointer<Void> smoke_PublicInterface_toFfi(PublicInterface value) {
-  if (value is PublicInterface__Impl) return _smoke_PublicInterface_copy_handle(value.handle);
+  if (value is PublicInterface$Impl) return _smoke_PublicInterface_copy_handle(value.handle);
   final result = _smoke_PublicInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.uncacheObjectFfi
@@ -115,7 +114,7 @@ PublicInterface smoke_PublicInterface_fromFfi(Pointer<Void> handle) {
   final _type_id_handle = _smoke_PublicInterface_get_type_id(handle);
   final _type_id = String_fromFfi(_type_id_handle);
   final result = _type_id.isEmpty
-    ? PublicInterface__Impl(_copied_handle)
+    ? PublicInterface$Impl(_copied_handle)
     : __lib.typeRepository[_type_id](_copied_handle);
   String_releaseFfiHandle(_type_id_handle);
   return result;


### PR DESCRIPTION
Updated Dart templates to expose IDL-defined classes as abstract classes
with factory constructors. This allows hiding the implementation details
("handle" field and the internal constructor that initializes it) that
were visible before due to lack of "internal" visibility in Dart.

Updated smoke tests accordingly. Functional tests were not updated since
there is no change in functionality.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>