### PR TITLE
Add support for "default" (nameless) constructors in Dart.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for explicitly specifying "default" (nameless) constructors for Dart.
+
 ## 6.3.4
 Release date: 2020-03-18
 ### Bug fixes:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -429,6 +429,7 @@ deprecated, takes a string literal value as a deprecation message.
 * **@Dart**: marks an element with Dart-specific properties:
   * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in Dart.
   This is the default property for this attribute.
+  * **Default**: marks a constructor as a "default" (nameless) in Dart.
 * **@Cpp**: marks an element with C++-specific properties:
   * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in C++.
   This is the default property for this attribute.

--- a/examples/libhello/lime/test/MethodOverloads.lime
+++ b/examples/libhello/lime/test/MethodOverloads.lime
@@ -78,22 +78,32 @@ interface SpecialNames {
 }
 
 open class ConstructorOverloads {
+    @Dart(Default)
     constructor create()
-    @Dart("createFromString")
+    @Dart("fromString")
     constructor create(
         input: String
     )
-    @Dart("createFromBoolean")
+    @Dart("fromBoolean")
     constructor create(
         input: Boolean
     )
-    @Dart("createFromMulti")
+    @Dart("fromMulti")
     constructor create(
         stringInput: String,
         booleanInput: Boolean
     )
-    @Dart("createFromList")
+    @Dart("fromList")
     constructor create(
         input: List<Double>
     )
+}
+
+struct StructConstructorOverloads {
+    stringField: String
+
+    @Dart("empty")
+    constructor create()
+    @Dart(Default)
+    constructor create(input: String)
 }

--- a/examples/libhello/src/test/MethodOverloads.cpp
+++ b/examples/libhello/src/test/MethodOverloads.cpp
@@ -20,6 +20,7 @@
 
 #include "test/ConstructorOverloads.h"
 #include "test/MethodOverloads.h"
+#include "test/StructConstructorOverloads.h"
 
 namespace test
 {
@@ -114,6 +115,18 @@ std::shared_ptr< ConstructorOverloads >
 ConstructorOverloads::create( const std::vector< double >& input )
 {
     return std::make_shared< ConstructorOverloadsImpl >( );
+}
+
+StructConstructorOverloads
+StructConstructorOverloads::create()
+{
+    return StructConstructorOverloads("");
+}
+
+StructConstructorOverloads
+StructConstructorOverloads::create(const std::string& input)
+{
+    return StructConstructorOverloads(input);
 }
 
 }  // namespace test

--- a/examples/platforms/dart/test/MethodOverloads_test.dart
+++ b/examples/platforms/dart/test/MethodOverloads_test.dart
@@ -70,4 +70,28 @@ void main() {
 
     expect(result, isFalse);
   });
+  _testSuite.test("Call default class constructor", () {
+    final result = ConstructorOverloads();
+
+    expect(result, isNotNull);
+
+    result.release();
+  });
+  _testSuite.test("Call overloaded class constructor", () {
+    final result = ConstructorOverloads.fromString("foo");
+
+    expect(result, isNotNull);
+
+    result.release();
+  });
+  _testSuite.test("Call default struct constructor", () {
+    final result = StructConstructorOverloads("foo");
+
+    expect(result.stringField, "foo");
+  });
+  _testSuite.test("Call overloaded struct constructor", () {
+    final result = StructConstructorOverloads.empty();
+
+    expect(result.stringField, "");
+  });
 }

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -22,7 +22,8 @@
 abstract class {{resolveName}} {{#if parent}}implements {{resolveName parent}} {{/if}}{
 {{#set parent=this}}{{#constructors}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
-  factory {{resolveName parent}}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}({{!!
+  factory {{resolveName parent}}{{#unlessHasAttribute this "Dart" "Default"}}{{!!
+  }}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}{{/unlessHasAttribute}}({{!!
   }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
   }}){{>dartImplRedirect}};
 {{/constructors}}{{/set}}

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -114,7 +114,9 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveN
 
 // End of {{resolveName}} "private" section.{{!!
 
-}}{{+dartConstructor}}{{resolveName parent}}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}({{!!
+}}{{+dartConstructor}}{{resolveName parent}}{{#unlessHasAttribute this "Dart" "Default"}}{{!!
+}}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}{{!!
+}}{{/unlessHasAttribute}}({{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) : {{!!
 }}this._copy(_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}));
 {{/dartConstructor}}{{!!

--- a/gluecodium/src/test/resources/smoke/constructors/input/Constructors.lime
+++ b/gluecodium/src/test/resources/smoke/constructors/input/Constructors.lime
@@ -23,17 +23,18 @@ open class Constructors {
         CRASHED
     }
 
+    @Dart(Default)
     constructor create()
-    @Dart("createFromOther")
+    @Dart("fromOther")
     constructor create(other: Constructors)
-    @Dart("createFromMulti")
+    @Dart("fromMulti")
     constructor create(
         foo: String,
         bar: ULong
     )
-    @Dart("createFromString")
+    @Dart("fromString")
     constructor create(input: String) throws ConstructorExploded
-    @Dart("createFromList")
+    @Dart("fromList")
     constructor create(input: List<Double>)
 
     exception ConstructorExploded(ErrorEnum)

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/Constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/Constructors.dart
@@ -6,11 +6,11 @@ import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
 abstract class Constructors {
-  factory Constructors.create() => Constructors$Impl.create();
-  factory Constructors.createFromOther(Constructors other) => Constructors$Impl.createFromOther(other);
-  factory Constructors.createFromMulti(String foo, int bar) => Constructors$Impl.createFromMulti(foo, bar);
-  factory Constructors.createFromString(String input) => Constructors$Impl.createFromString(input);
-  factory Constructors.createFromList(List<double> input) => Constructors$Impl.createFromList(input);
+  factory Constructors() => Constructors$Impl.create();
+  factory Constructors.fromOther(Constructors other) => Constructors$Impl.fromOther(other);
+  factory Constructors.fromMulti(String foo, int bar) => Constructors$Impl.fromMulti(foo, bar);
+  factory Constructors.fromString(String input) => Constructors$Impl.fromString(input);
+  factory Constructors.fromList(List<double> input) => Constructors$Impl.fromList(input);
   void release();
 }
 enum Constructors_ErrorEnum {
@@ -89,19 +89,19 @@ final _smoke_Constructors_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Constructors_get_type_id');
-final _createFromString_return_release_handle = __lib.nativeLibrary.lookupFunction<
+final _fromString_return_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_release_handle');
-final _createFromString_return_get_result = __lib.nativeLibrary.lookupFunction<
+final _fromString_return_get_result = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_get_result');
-final _createFromString_return_get_error = __lib.nativeLibrary.lookupFunction<
+final _fromString_return_get_error = __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_get_error');
-final _createFromString_return_has_error = __lib.nativeLibrary.lookupFunction<
+final _fromString_return_has_error = __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_has_error');
@@ -111,51 +111,51 @@ class Constructors$Impl implements Constructors {
   @override
   void release() => _smoke_Constructors_release_handle(handle);
   Constructors$Impl.create() : this(_create());
-  Constructors$Impl.createFromOther(Constructors other) : this(_createFromOther(other));
-  Constructors$Impl.createFromMulti(String foo, int bar) : this(_createFromMulti(foo, bar));
-  Constructors$Impl.createFromString(String input) : this(_createFromString(input));
-  Constructors$Impl.createFromList(List<double> input) : this(_createFromList(input));
+  Constructors$Impl.fromOther(Constructors other) : this(_fromOther(other));
+  Constructors$Impl.fromMulti(String foo, int bar) : this(_fromMulti(foo, bar));
+  Constructors$Impl.fromString(String input) : this(_fromString(input));
+  Constructors$Impl.fromList(List<double> input) : this(_fromList(input));
   static Pointer<Void> _create() {
     final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(), Pointer<Void> Function()>('library_smoke_Constructors_create');
     final __result_handle = _create_ffi();
     return __result_handle;
   }
-  static Pointer<Void> _createFromOther(Constructors other) {
-    final _createFromOther_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Constructors_create__Constructors');
+  static Pointer<Void> _fromOther(Constructors other) {
+    final _fromOther_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Constructors_create__Constructors');
     final _other_handle = smoke_Constructors_toFfi(other);
-    final __result_handle = _createFromOther_ffi(_other_handle);
+    final __result_handle = _fromOther_ffi(_other_handle);
     smoke_Constructors_releaseFfiHandle(_other_handle);
     return __result_handle;
   }
-  static Pointer<Void> _createFromMulti(String foo, int bar) {
-    final _createFromMulti_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Uint64), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Constructors_create__String_ULong');
+  static Pointer<Void> _fromMulti(String foo, int bar) {
+    final _fromMulti_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Uint64), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Constructors_create__String_ULong');
     final _foo_handle = String_toFfi(foo);
     final _bar_handle = (bar);
-    final __result_handle = _createFromMulti_ffi(_foo_handle, _bar_handle);
+    final __result_handle = _fromMulti_ffi(_foo_handle, _bar_handle);
     String_releaseFfiHandle(_foo_handle);
     (_bar_handle);
     return __result_handle;
   }
-  static Pointer<Void> _createFromString(String input) {
-    final _createFromString_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Constructors_create__String');
+  static Pointer<Void> _fromString(String input) {
+    final _fromString_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Constructors_create__String');
     final _input_handle = String_toFfi(input);
-    final __call_result_handle = _createFromString_ffi(_input_handle);
+    final __call_result_handle = _fromString_ffi(_input_handle);
     String_releaseFfiHandle(_input_handle);
-    if (_createFromString_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _createFromString_return_get_error(__call_result_handle);
-        _createFromString_return_release_handle(__call_result_handle);
+    if (_fromString_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _fromString_return_get_error(__call_result_handle);
+        _fromString_return_release_handle(__call_result_handle);
         final _error_value = smoke_Constructors_ErrorEnum_fromFfi(__error_handle);
         smoke_Constructors_ErrorEnum_releaseFfiHandle(__error_handle);
         throw Constructors_ConstructorExplodedException(_error_value);
     }
-    final __result_handle = _createFromString_return_get_result(__call_result_handle);
-    _createFromString_return_release_handle(__call_result_handle);
+    final __result_handle = _fromString_return_get_result(__call_result_handle);
+    _fromString_return_release_handle(__call_result_handle);
     return __result_handle;
   }
-  static Pointer<Void> _createFromList(List<double> input) {
-    final _createFromList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Constructors_create__ListOf_1Double');
+  static Pointer<Void> _fromList(List<double> input) {
+    final _fromList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_Constructors_create__ListOf_1Double');
     final _input_handle = ListOf_Double_toFfi(input);
-    final __result_handle = _createFromList_ffi(_input_handle);
+    final __result_handle = _fromList_ffi(_input_handle);
     ListOf_Double_releaseFfiHandle(_input_handle);
     return __result_handle;
   }

--- a/gluecodium/src/test/resources/smoke/constructors/output/lime/smoke/Constructors.lime
+++ b/gluecodium/src/test/resources/smoke/constructors/output/lime/smoke/Constructors.lime
@@ -5,21 +5,22 @@ open class Constructors {
         CRASHED
     }
     exception ConstructorExploded(ErrorEnum)
+    @Dart(Default)
     constructor create()
-    @Dart("createFromOther")
+    @Dart("fromOther")
     constructor create(
         other: Constructors
     )
-    @Dart("createFromMulti")
+    @Dart("fromMulti")
     constructor create(
         foo: String,
         bar: ULong
     )
-    @Dart("createFromString")
+    @Dart("fromString")
     constructor create(
         input: String
     ) throws ConstructorExploded
-    @Dart("createFromList")
+    @Dart("fromList")
     constructor create(
         input: List<Double>
     )

--- a/gluecodium/src/test/resources/smoke/structs/input/StructsWithMethods.lime
+++ b/gluecodium/src/test/resources/smoke/structs/input/StructsWithMethods.lime
@@ -37,10 +37,12 @@ types StructsWithMethods {
             y: Double
         ): Boolean
 
+        @Dart(Default)
         constructor create(
             x: Double,
             y: Double
         )
+        @Dart("copy")
         constructor create(other: Vector) throws ValidationUtils.Validation
     }
 }
@@ -59,7 +61,9 @@ class StructsWithMethodsInterface {
             z: Double
         ): Boolean
 
+        @Dart(Default)
         constructor create(input: String)
+        @Dart("copy")
         constructor create(other: Vector3) throws ValidationUtils.Validation
     }
 

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/StructsWithMethods.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/StructsWithMethods.dart
@@ -4,19 +4,19 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_init.dart' as __lib;
-final _create_return_release_handle = __lib.nativeLibrary.lookupFunction<
+final _copy_return_release_handle = __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create__Vector_return_release_handle');
-final _create_return_get_result = __lib.nativeLibrary.lookupFunction<
+final _copy_return_get_result = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create__Vector_return_get_result');
-final _create_return_get_error = __lib.nativeLibrary.lookupFunction<
+final _copy_return_get_error = __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create__Vector_return_get_error');
-final _create_return_has_error = __lib.nativeLibrary.lookupFunction<
+final _copy_return_has_error = __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create__Vector_return_has_error');
@@ -25,8 +25,8 @@ class Vector {
   double y;
   Vector._(this.x, this.y);
   Vector._copy(Vector _other) : this._(_other.x, _other.y);
-  Vector.create(double x, double y) : this._copy(_create(x, y));
-  Vector.create(Vector other) : this._copy(_create(other));
+  Vector(double x, double y) : this._copy(_create(x, y));
+  Vector.copy(Vector other) : this._copy(_copy(other));
   double distanceTo(Vector other) {
     final _distanceTo_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Pointer<Void>), double Function(Pointer<Void>, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_distanceTo__Vector');
     final _other_handle = smoke_StructsWithMethods_Vector_toFfi(other);
@@ -71,20 +71,20 @@ class Vector {
     smoke_StructsWithMethods_Vector_releaseFfiHandle(__result_handle);
     return _result;
   }
-  static Vector _create(Vector other) {
-    final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_create__Vector');
+  static Vector _copy(Vector other) {
+    final _copy_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>), Pointer<Void> Function(Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_create__Vector');
     final _other_handle = smoke_StructsWithMethods_Vector_toFfi(other);
-    final __call_result_handle = _create_ffi(_other_handle);
+    final __call_result_handle = _copy_ffi(_other_handle);
     smoke_StructsWithMethods_Vector_releaseFfiHandle(_other_handle);
-    if (_create_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _create_return_get_error(__call_result_handle);
-        _create_return_release_handle(__call_result_handle);
+    if (_copy_return_has_error(__call_result_handle) != 0) {
+        final __error_handle = _copy_return_get_error(__call_result_handle);
+        _copy_return_release_handle(__call_result_handle);
         final _error_value = smoke_ValidationUtils_ValidationErrorCode_fromFfi(__error_handle);
         smoke_ValidationUtils_ValidationErrorCode_releaseFfiHandle(__error_handle);
         throw ValidationException(_error_value);
     }
-    final __result_handle = _create_return_get_result(__call_result_handle);
-    _create_return_release_handle(__call_result_handle);
+    final __result_handle = _copy_return_get_result(__call_result_handle);
+    _copy_return_release_handle(__call_result_handle);
     final _result = smoke_StructsWithMethods_Vector_fromFfi(__result_handle);
     smoke_StructsWithMethods_Vector_releaseFfiHandle(__result_handle);
     return _result;

--- a/gluecodium/src/test/resources/smoke/structs/output/lime/smoke/StructsWithMethods.lime
+++ b/gluecodium/src/test/resources/smoke/structs/output/lime/smoke/StructsWithMethods.lime
@@ -14,10 +14,12 @@ types StructsWithMethods {
             x: Double,
             y: Double
         ): Boolean
+        @Dart(Default)
         constructor create(
             x: Double,
             y: Double
         )
+        @Dart("copy")
         constructor create(
             other: Vector
         ) throws Validation

--- a/gluecodium/src/test/resources/smoke/structs/output/lime/smoke/StructsWithMethodsInterface.lime
+++ b/gluecodium/src/test/resources/smoke/structs/output/lime/smoke/StructsWithMethodsInterface.lime
@@ -16,9 +16,11 @@ class StructsWithMethodsInterface {
             y: Double,
             z: Double
         ): Boolean
+        @Dart(Default)
         constructor create(
             input: String
         )
+        @Dart("copy")
         constructor create(
             other: Vector3
         ) throws Validation

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -579,6 +579,8 @@ internal class AntlrLimeModelBuilder(
             "FunctionName" -> LimeAttributeValueType.FUNCTION_NAME
             "Label" -> LimeAttributeValueType.LABEL
             "ObjC" -> LimeAttributeValueType.OBJC
+            "Message" -> LimeAttributeValueType.MESSAGE
+            "Default" -> LimeAttributeValueType.DEFAULT
             "ExternalType" -> LimeAttributeValueType.EXTERNAL_TYPE
             "ExternalName" -> LimeAttributeValueType.EXTERNAL_NAME
             "ExternalGetter" -> LimeAttributeValueType.EXTERNAL_GETTER

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
@@ -29,6 +29,7 @@ enum class LimeAttributeValueType(private val tag: String) {
     LABEL("Label"),
     OBJC("ObjC"),
     MESSAGE("Message"),
+    DEFAULT("Default"),
     EXTERNAL_TYPE("ExternalType"),
     EXTERNAL_NAME("ExternalName"),
     EXTERNAL_GETTER("ExternalGetter"),


### PR DESCRIPTION
Added parser support and template support for marking class and struct
constructors as @Dart(Default). This forces the marked constructor to be
generated as a nameless constructor in Dart. This usage is only
meaningful in case of several overloaded constructors: if there's only
one constructor it will be generated nameless by default.

Added smoke and functional tests as appropriate.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>