### PR TITLE
Resolve documentation links to types from "aux" IDLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Gluecodium project Release Notes
 
 ## Unreleased
+### Bug fixes:
+  * Documentation links to elements declared in "auxiliary" IDL sources are now resolved correctly
+    in the generated C++, Java, and Swift code.
 ### Breaking changes:
   * Added validation against name clashes between property declarations in IDL files.
 

--- a/gluecodium/src/test/java/com/here/gluecodium/AcceptanceTestBase.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/AcceptanceTestBase.kt
@@ -65,6 +65,7 @@ abstract class AcceptanceTestBase protected constructor(
 
     protected fun runTest() {
         val inputDirectory = File(featureDirectory, FEATURE_INPUT_FOLDER)
+        val auxDirectory = File(featureDirectory, FEATURE_AUX_FOLDER)
         val outputDirectory = File(featureDirectory, FEATURE_OUTPUT_FOLDER)
 
         val referenceFiles = GENERATOR_DIRECTORIES[generatorName]!!
@@ -74,7 +75,8 @@ abstract class AcceptanceTestBase protected constructor(
 
         assumeFalse("No reference files were found", referenceFiles.isEmpty())
 
-        val limeModel = LOADER.loadModel(listOf(inputDirectory.toString()), emptyList())
+        val limeModel =
+            LOADER.loadModel(listOf(inputDirectory.toString()), listOf(auxDirectory.toString()))
         assertTrue(gluecodium.executeGenerator(generatorName, limeModel, HashMap()))
 
         val generatedContents = results.associateBy({ it.targetFile.path }, { it.content })
@@ -100,6 +102,7 @@ abstract class AcceptanceTestBase protected constructor(
 
     companion object {
         internal const val FEATURE_INPUT_FOLDER = "input"
+        private const val FEATURE_AUX_FOLDER = "aux"
         private const val FEATURE_OUTPUT_FOLDER = "output"
         private const val IGNORE_PREFIX = "ignore"
         private val GENERATOR_NAMES = listOf(

--- a/gluecodium/src/test/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuiteTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuiteTest.kt
@@ -35,7 +35,7 @@ class SwiftGeneratorSuiteTest {
 
     @Test
     fun generatedFilesContainStaticFiles() {
-        val generatedFiles = suite.generate(LimeModel(emptyMap(), emptyList(), emptyMap()))
+        val generatedFiles = suite.generate(LimeModel(emptyMap(), emptyList()))
 
         assertTrue(
             generatedFiles.toString() + " must contain all " + SwiftGenerator.STATIC_FILES,

--- a/gluecodium/src/test/resources/smoke/comments/aux/AuxClass.lime
+++ b/gluecodium/src/test/resources/smoke/comments/aux/AuxClass.lime
@@ -1,0 +1,21 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+class AuxClass {
+}

--- a/gluecodium/src/test/resources/smoke/comments/aux/AuxStruct.lime
+++ b/gluecodium/src/test/resources/smoke/comments/aux/AuxStruct.lime
@@ -1,0 +1,22 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package fire
+
+struct AuxStruct {
+    auxField: String
+}

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -169,6 +169,8 @@ class CommentsLinks {
     // * top level enum: [CommentsTypeCollection.TypeCollectionEnum]
     // * top level enum item: [CommentsTypeCollection.TypeCollectionEnum.item]
     // * error: [comments.SomethingWrong]
+    // * type from aux sources, same package: [AuxClass]
+    // * type from aux sources, different package: [fire.AuxStruct]
     //
     // Not working for Java:
     // * typedef: [comments.Usefulness]

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
@@ -60,6 +60,8 @@ public final class CommentsLinks extends NativeBase {
      * <li>top level enum: {@link com.example.smoke.TypeCollectionEnum}</li>
      * <li>top level enum item: {@link com.example.smoke.TypeCollectionEnum#ITEM}</li>
      * <li>error: {@link com.example.smoke.Comments.SomethingWrongException}</li>
+     * <li>type from aux sources, same package: {@link com.example.smoke.AuxClass}</li>
+     * <li>type from aux sources, different package: {@link com.example.fire.AuxStruct}</li>
      * </ul>
      * <p>Not working for Java:</p>
      * <ul>

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
@@ -59,6 +59,8 @@ public:
      * * top level enum: ::smoke::TypeCollectionEnum
      * * top level enum item: ::smoke::TypeCollectionEnum::ITEM
      * * error: ::smoke::Comments::SomeEnum
+     * * type from aux sources, same package: ::smoke::AuxClass
+     * * type from aux sources, different package: ::fire::AuxStruct
      *
      * Not working for Java:
      * * typedef: ::smoke::Comments::Usefulness

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
@@ -30,6 +30,8 @@ abstract class CommentsLinks {
   /// * top level enum: [TypeCollectionEnum]
   /// * top level enum item: [item]
   /// * error: [Comments_SomethingWrongException]
+  /// * type from aux sources, same package: [AuxClass]
+  /// * type from aux sources, different package: [AuxStruct]
   ///
   /// Not working for Java:
   /// * typedef: [bool]

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
@@ -33,6 +33,8 @@ class CommentsLinks {
     // * top level enum: [CommentsTypeCollection.TypeCollectionEnum]
     // * top level enum item: [CommentsTypeCollection.TypeCollectionEnum.item]
     // * error: [comments.SomethingWrong]
+    // * type from aux sources, same package: [AuxClass]
+    // * type from aux sources, different package: [fire.AuxStruct]
     //
     // Not working for Java:
     // * typedef: [comments.Usefulness]

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
@@ -50,6 +50,8 @@ public class CommentsLinks {
     /// * top level enum: `TypeCollectionEnum`
     /// * top level enum item: `TypeCollectionEnum.item`
     /// * error: `Comments.SomethingWrongError`
+    /// * type from aux sources, same package: `AuxClass`
+    /// * type from aux sources, different package: `AuxStruct`
     ///
     /// Not working for Java:
     /// * typedef: `Comments.Usefulness`

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeModel.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeModel.kt
@@ -22,5 +22,6 @@ package com.here.gluecodium.model.lime
 class LimeModel(
     val referenceMap: Map<String, LimeElement>,
     val topElements: List<LimeNamedElement>,
+    val auxiliaryElements: List<LimeNamedElement> = emptyList(),
     val fileNameMap: Map<String, String> = emptyMap()
 )


### PR DESCRIPTION
Updated LimeModel class to also contains elements from "aux" IDL
sources, in a separate fields.

Updated C++, Java and Swift generators to correctly process
documentation links to these "aux" elements. Dart generator does not
require any changes as it processed these correctly already.

Added smoke tests.

Resolves: #221
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>