### PR TITLE
Add traversal of lambdas to LimeTypeRefsValidator class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed compilation issue in Dart for internal constructors.
+  * Fixed validation for type references in lambda IDL declarations.
+  * Fixed compilation issue in Dart for collection type references in lambdas.
 
 ## 6.4.5
 Release date: 2020-04-01

--- a/examples/libhello/lime/test/Arrays.lime
+++ b/examples/libhello/lime/test/Arrays.lime
@@ -218,3 +218,7 @@ class CountDispenser {
     }
     static fun countCharacters(input: List<NameDispenser.Holder>): List<Holder>
 }
+
+class AnotherDummyClass {}
+
+lambda LambdaWithClassGenerics = (List<AnotherDummyClass>?) -> List<AnotherDummyClass>

--- a/gluecodium/src/test/resources/smoke/generic_types/input/GenericTypes.lime
+++ b/gluecodium/src/test/resources/smoke/generic_types/input/GenericTypes.lime
@@ -85,3 +85,7 @@ class GenericTypesWithCompoundTypes {
 class DummyClass {}
 
 interface DummyInterface {}
+
+class AnotherDummyClass {}
+
+lambda LambdaWithClassGenerics = (List<AnotherDummyClass>?) -> List<AnotherDummyClass>

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/GenericCollections.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/GenericCollections.cpp
@@ -4,11 +4,13 @@
 #include "alien/FooStruct.h"
 #include "cbridge/include/GenericCollections.h"
 #include "cbridge/include/StringHandle.h"
+#include "cbridge/include/smoke/cbridge_AnotherDummyClass.h"
 #include "cbridge/include/smoke/cbridge_DummyClass.h"
 #include "cbridge/include/smoke/cbridge_DummyInterface.h"
 #include "cbridge/include/smoke/cbridge_GenericTypesWithCompoundTypes.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "gluecodium/Optional.h"
+#include "smoke/AnotherDummyClass.h"
 #include "smoke/DummyClass.h"
 #include "smoke/DummyInterface.h"
 #include "smoke/GenericTypesWithCompoundTypes.h"
@@ -209,6 +211,33 @@ void foobar_ArrayOf_foobar_SetOf__Int_release_optional_handle(_baseRef handle) {
 }
 _baseRef foobar_ArrayOf_foobar_SetOf__Int_unwrap_optional_handle(_baseRef handle) {
     return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<std::unordered_set<int32_t>>>*>( handle ) );
+}
+_baseRef foobar_ArrayOf_smoke_AnotherDummyClass_create_handle() {
+    return reinterpret_cast<_baseRef>( new std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>( ) );
+}
+_baseRef foobar_ArrayOf_smoke_AnotherDummyClass_copy_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( new std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>( *reinterpret_cast<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>*>( handle ) ) );
+}
+void foobar_ArrayOf_smoke_AnotherDummyClass_release_handle(_baseRef handle) {
+    delete reinterpret_cast<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>*>( handle );
+}
+uint64_t foobar_ArrayOf_smoke_AnotherDummyClass_count(_baseRef handle) {
+    return Conversion<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>::toCpp( handle ).size( );
+}
+_baseRef foobar_ArrayOf_smoke_AnotherDummyClass_get( _baseRef handle, uint64_t index ) { return Conversion<std::shared_ptr<::smoke::AnotherDummyClass>>::referenceBaseRef(Conversion<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>::toCpp( handle )[index]);
+}
+void foobar_ArrayOf_smoke_AnotherDummyClass_append( _baseRef handle, _baseRef item )
+{
+Conversion<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>::toCpp(handle).push_back(Conversion<std::shared_ptr<::smoke::AnotherDummyClass>>::toCpp(item));
+}
+_baseRef foobar_ArrayOf_smoke_AnotherDummyClass_create_optional_handle() {
+    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>( std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>( ) ) );
+}
+void foobar_ArrayOf_smoke_AnotherDummyClass_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>*>( handle );
+}
+_baseRef foobar_ArrayOf_smoke_AnotherDummyClass_unwrap_optional_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf_smoke_DummyClass_create_handle() {
     return reinterpret_cast<_baseRef>( new std::vector<std::shared_ptr<::smoke::DummyClass>>( ) );

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/ffi/GenericTypesConversion.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/ffi/GenericTypesConversion.cpp
@@ -5,6 +5,7 @@
 #include "gluecodium/UnorderedMapHash.h"
 #include "gluecodium/UnorderedSetHash.h"
 #include "gluecodium/VectorHash.h"
+#include "smoke/AnotherDummyClass.h"
 #include "smoke/DummyClass.h"
 #include "smoke/DummyInterface.h"
 #include "smoke/GenericTypesWithCompoundTypes.h"
@@ -437,6 +438,66 @@ library_foobar_ListOf_foobar_SetOf_Int_get_value_nullable(FfiOpaqueHandle handle
 {
     return gluecodium::ffi::Conversion<std::vector<std::unordered_set<int32_t>>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::vector<std::unordered_set<int32_t>>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_foobar_ListOf_smoke_AnotherDummyClass_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>());
+}
+void
+library_foobar_ListOf_smoke_AnotherDummyClass_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>*>(handle);
+}
+void
+library_foobar_ListOf_smoke_AnotherDummyClass_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+    reinterpret_cast<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>*>(handle)->push_back(
+        gluecodium::ffi::Conversion<std::shared_ptr<::smoke::AnotherDummyClass>>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_foobar_ListOf_smoke_AnotherDummyClass_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>::iterator(
+        reinterpret_cast<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>*>(handle)->begin()
+    ));
+}
+void
+library_foobar_ListOf_smoke_AnotherDummyClass_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>::iterator*>(iterator_handle);
+}
+bool
+library_foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>*>(handle)->end();
+}
+void
+library_foobar_ListOf_smoke_AnotherDummyClass_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_foobar_ListOf_smoke_AnotherDummyClass_iterator_get(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::shared_ptr<::smoke::AnotherDummyClass>>::toFfi(
+        **reinterpret_cast<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>::iterator*>(iterator_handle)
+    );
+}
+FfiOpaqueHandle
+library_foobar_ListOf_smoke_AnotherDummyClass_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>(
+            gluecodium::ffi::Conversion<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>::toCpp(value)
+        )
+    );
+}
+void
+library_foobar_ListOf_smoke_AnotherDummyClass_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>*>(handle);
+}
+FfiOpaqueHandle
+library_foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>*>(handle)
     );
 }
 FfiOpaqueHandle

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/GenericTypes__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/GenericTypes__conversion.dart
@@ -1,5 +1,6 @@
 import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/GenericTypes__conversion.dart';
+import 'package:library/src/smoke/AnotherDummyClass.dart';
 import 'package:library/src/smoke/DummyClass.dart';
 import 'package:library/src/smoke/DummyInterface.dart';
 import 'package:library/src/smoke/GenericTypesWithCompoundTypes.dart';
@@ -580,6 +581,88 @@ List<Set<int>> foobar_ListOf_foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> han
 }
 void foobar_ListOf_foobar_SetOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_foobar_SetOf_Int_release_handle_nullable(handle);
+final _foobar_ListOf_smoke_AnotherDummyClass_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_foobar_ListOf_smoke_AnotherDummyClass_create_handle');
+final _foobar_ListOf_smoke_AnotherDummyClass_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_foobar_ListOf_smoke_AnotherDummyClass_release_handle');
+final _foobar_ListOf_smoke_AnotherDummyClass_insert = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Pointer<Void>),
+    void Function(Pointer<Void>, Pointer<Void>)
+  >('library_foobar_ListOf_smoke_AnotherDummyClass_insert');
+final _foobar_ListOf_smoke_AnotherDummyClass_iterator = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_foobar_ListOf_smoke_AnotherDummyClass_iterator');
+final _foobar_ListOf_smoke_AnotherDummyClass_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_release_handle');
+final _foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid');
+final _foobar_ListOf_smoke_AnotherDummyClass_iterator_increment = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_increment');
+final _foobar_ListOf_smoke_AnotherDummyClass_iterator_get = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_get');
+Pointer<Void> foobar_ListOf_smoke_AnotherDummyClass_toFfi(List<AnotherDummyClass> value) {
+  final _result = _foobar_ListOf_smoke_AnotherDummyClass_create_handle();
+  for (final element in value) {
+    final _element_handle = smoke_AnotherDummyClass_toFfi(element);
+    _foobar_ListOf_smoke_AnotherDummyClass_insert(_result, _element_handle);
+    smoke_AnotherDummyClass_releaseFfiHandle(_element_handle);
+  }
+  return _result;
+}
+List<AnotherDummyClass> foobar_ListOf_smoke_AnotherDummyClass_fromFfi(Pointer<Void> handle) {
+  final result = List<AnotherDummyClass>();
+  final _iterator_handle = _foobar_ListOf_smoke_AnotherDummyClass_iterator(handle);
+  while (_foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _element_handle = _foobar_ListOf_smoke_AnotherDummyClass_iterator_get(_iterator_handle);
+    result.add(smoke_AnotherDummyClass_fromFfi(_element_handle));
+    smoke_AnotherDummyClass_releaseFfiHandle(_element_handle);
+    _foobar_ListOf_smoke_AnotherDummyClass_iterator_increment(_iterator_handle);
+  }
+  _foobar_ListOf_smoke_AnotherDummyClass_iterator_release_handle(_iterator_handle);
+  return result;
+}
+void foobar_ListOf_smoke_AnotherDummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_AnotherDummyClass_release_handle(handle);
+final _foobar_ListOf_smoke_AnotherDummyClass_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_foobar_ListOf_smoke_AnotherDummyClass_create_handle_nullable');
+final _foobar_ListOf_smoke_AnotherDummyClass_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_foobar_ListOf_smoke_AnotherDummyClass_release_handle_nullable');
+final _foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable');
+Pointer<Void> foobar_ListOf_smoke_AnotherDummyClass_toFfi_nullable(List<AnotherDummyClass> value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = foobar_ListOf_smoke_AnotherDummyClass_toFfi(value);
+  final result = _foobar_ListOf_smoke_AnotherDummyClass_create_handle_nullable(_handle);
+  foobar_ListOf_smoke_AnotherDummyClass_releaseFfiHandle(_handle);
+  return result;
+}
+List<AnotherDummyClass> foobar_ListOf_smoke_AnotherDummyClass_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable(handle);
+  final result = foobar_ListOf_smoke_AnotherDummyClass_fromFfi(_handle);
+  foobar_ListOf_smoke_AnotherDummyClass_releaseFfiHandle(_handle);
+  return result;
+}
+void foobar_ListOf_smoke_AnotherDummyClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _foobar_ListOf_smoke_AnotherDummyClass_release_handle_nullable(handle);
 final _foobar_ListOf_smoke_DummyClass_create_handle = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/Collections.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/Collections.swift
@@ -1,6 +1,58 @@
 //
 //
 import Foundation
+internal func foobar_copyFromCType(_ handle: _baseRef) -> [AnotherDummyClass] {
+    var result: [AnotherDummyClass] = []
+    let count = foobar_ArrayOf_smoke_AnotherDummyClass_count(handle)
+    for idx in 0..<count {
+        result.append(AnotherDummyClass_copyFromCType(foobar_ArrayOf_smoke_AnotherDummyClass_get(handle, idx)))
+    }
+    return result
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> [AnotherDummyClass] {
+    defer {
+        foobar_ArrayOf_smoke_AnotherDummyClass_release_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyToCType(_ swiftArray: [AnotherDummyClass]) -> RefHolder {
+    let handle = foobar_ArrayOf_smoke_AnotherDummyClass_create_handle()
+    for item in swiftArray {
+        let value = moveToCType(item)
+        foobar_ArrayOf_smoke_AnotherDummyClass_append(handle, value.ref)
+    }
+    return RefHolder(handle)
+}
+internal func foobar_moveToCType(_ swiftArray: [AnotherDummyClass]) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftArray).ref, release: foobar_ArrayOf_smoke_AnotherDummyClass_release_handle)
+}
+internal func foobar_copyToCType(_ swiftArray: [AnotherDummyClass]?) -> RefHolder {
+    guard let swiftArray = swiftArray else {
+        return RefHolder(0)
+    }
+    let optionalHandle = foobar_ArrayOf_smoke_AnotherDummyClass_create_optional_handle()
+    let handle = foobar_ArrayOf_smoke_AnotherDummyClass_unwrap_optional_handle(optionalHandle)
+    for item in swiftArray {
+        foobar_ArrayOf_smoke_AnotherDummyClass_append(handle, moveToCType(item).ref)
+    }
+    return RefHolder(optionalHandle)
+}
+internal func foobar_moveToCType(_ swiftType: [AnotherDummyClass]?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: foobar_ArrayOf_smoke_AnotherDummyClass_release_optional_handle)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> [AnotherDummyClass]? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = foobar_ArrayOf_smoke_AnotherDummyClass_unwrap_optional_handle(handle)
+    return foobar_copyFromCType(unwrappedHandle) as [AnotherDummyClass]
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> [AnotherDummyClass]? {
+    defer {
+        foobar_ArrayOf_smoke_AnotherDummyClass_release_optional_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
 internal func foobar_copyFromCType(_ handle: _baseRef) -> [DummyClass] {
     var result: [DummyClass] = []
     let count = foobar_ArrayOf_smoke_DummyClass_count(handle)

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeTypeRefsVisitor.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeTypeRefsVisitor.kt
@@ -22,6 +22,7 @@ package com.here.gluecodium.common
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeException
 import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeTypeAlias
@@ -31,8 +32,10 @@ import com.here.gluecodium.model.lime.LimeTypedElement
 abstract class LimeTypeRefsVisitor<T> {
     protected fun traverseModel(limeModel: LimeModel): List<T> {
         val allElements = limeModel.referenceMap.values
+        val allFunctions = allElements.filterIsInstance<LimeFunction>() +
+            allElements.filterIsInstance<LimeLambda>().map { it.asFunction() }
         return allElements.filterIsInstance<LimeTypedElement>().map { visitTypeRef(it, it.typeRef) } +
-            allElements.filterIsInstance<LimeFunction>().flatMap {
+            allFunctions.flatMap {
                 listOf(visitTypeRef(it, it.returnType.typeRef), visitTypeRef(it, it.thrownType?.typeRef))
             } +
             allElements.filterIsInstance<LimeContainerWithInheritance>().map { visitTypeRef(it, it.parent) } +


### PR DESCRIPTION
Traversal of type references in lambdas was erroneously missing from
LimeTypeRefsValidator class. This lead to two groups of issues:
1. Type references in lambdas being erroneously omitted from any
validation.
2. Collection types used exclusively in lambdas (i.e. if not used
outside of lambdas anywhere) failed to compile in Dart.

Added smoke and functional tests as appropriate.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>