### PR TITLE
Make Dart join infix configurable in name rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Gluecodium project Release Notes
 
 ## Unreleased
+### Features:
+  * Added support for configuring name-joining infix for Dart naming rules.
 ### Bug fixes:
   * Fixed reference resolution for Dart documentation comments.
 

--- a/cmake/modules/gluecodium/gluecodium/Generate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/Generate.cmake
@@ -92,7 +92,8 @@ function(apigen_generate)
       OUTPUT_DIR
       COMMON_OUTPUT_DIR
       BUILD_OUTPUT_DIR
-      DART_LIBRARY_NAME)
+      DART_LIBRARY_NAME
+      DART_NAMERULES)
   set(multiValueArgs LIME_SOURCES FRANCA_SOURCES)
   cmake_parse_arguments(apigen_generate "${options}" "${oneValueArgs}"
                       "${multiValueArgs}" ${ARGN})
@@ -155,6 +156,7 @@ function(apigen_generate)
   _apigen_parse_path_option(-cppnamerules CPP_NAMERULES)
   _apigen_parse_path_option(-javanamerules JAVA_NAMERULES)
   _apigen_parse_path_option(-swiftnamerules SWIFT_NAMERULES)
+  _apigen_parse_path_option(-dartnamerules DART_NAMERULES)
   _apigen_parse_path_option(-commonoutput COMMON_OUTPUT_DIR)
   _apigen_parse_option(-libraryname DART_LIBRARY_NAME)
   _apigen_parse_option(-internalprefix INTERNAL_PREFIX)

--- a/docs/naming_conventions.md
+++ b/docs/naming_conventions.md
@@ -53,6 +53,7 @@ These are all supported name types in the name config file are:
 | `setter`      | Setter name for an property (only Java, C++)
 | `getter`      | Getter name for an property (only Java, C++)
 | `error`       | Exception/Error name (only Java, Swift)
+| `join`        | Joining of compound names (only Dart, only `join.infix`)
 
 If one of the properties is not set in the custom rules, the default is applied.
 
@@ -170,6 +171,12 @@ in the IDL file leads to a compile-time error. This can be resolved manually at 
 specifying alternative names for these conflicting methods through marking them with
 `@Dart("<method-name>")` attribute in the IDL definition.
 
+### Nested types
+Since Dart language has no concept of nested type declarations, the types that are declared nested
+in IDL have compound names in Dart. The infix used to concatenate the names of the outer type and
+the inner type to form the compound name is controlled through `join.infix` name rule. The default
+infix is `_`. An empty infix is considered valid, if specified.
+
 ### Default namerules/dart.properties
 ```
 field=lowerCamelCase
@@ -182,5 +189,6 @@ property.prefix.boolean=is
 type=UpperCamelCase
 error=UpperCamelCase
 error.suffix=Exception
+join.infix=_
 
 ```

--- a/examples/config/dart.properties
+++ b/examples/config/dart.properties
@@ -8,4 +8,4 @@ property.prefix.boolean=is
 type=UpperCamelCase
 error=UpperCamelCase
 error.suffix=Exception
-join.infix=_
+join.infix=

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -417,6 +417,7 @@ apigen_generate(TARGET hello
         CPP_INTERNAL_NAMESPACE lorem_ipsum.test
         INTERNAL_PREFIX "libhello_"
         DART_LIBRARY_NAME "hello"
+        DART_NAMERULES "${CMAKE_CURRENT_SOURCE_DIR}/../config/dart.properties"
         COPYRIGHT_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/../config/COPYRIGHT"
         VERBOSE)
 apigen_target_include_directories(hello)

--- a/examples/platforms/dart/test/Blobs_test.dart
+++ b/examples/platforms/dart/test/Blobs_test.dart
@@ -39,14 +39,14 @@ void main() {
   });
   _testSuite.test("methodWithByteBufferInStruct() empty list", () {
     final result = ArraysByteBuffer.methodWithByteBufferInStruct(
-        ArraysByteBuffer_StructWithByteBuffer(Uint8List(0))
+        ArraysByteBufferStructWithByteBuffer(Uint8List(0))
     );
 
     expect(result.image, isEmpty);
   });
   _testSuite.test("methodWithBymethodWithByteBufferInStructteBuffer() reverses list", () {
     final result = ArraysByteBuffer.methodWithByteBufferInStruct(
-        ArraysByteBuffer_StructWithByteBuffer(Uint8List.fromList([0, 42, 255]))
+        ArraysByteBufferStructWithByteBuffer(Uint8List.fromList([0, 42, 255]))
     );
 
     expect(result.image, Uint8List.fromList([255, 42, 0]));

--- a/examples/platforms/dart/test/Defaults_test.dart
+++ b/examples/platforms/dart/test/Defaults_test.dart
@@ -26,28 +26,28 @@ final _testSuite = TestSuite("Defaults");
 
 void main() {
   _testSuite.test("Check defaults", () {
-    final result = new Defaults_StructWithDefaults.withDefaults();
+    final result = new DefaultsStructWithDefaults.withDefaults();
 
     expect(result.intField, 42);
     expect(result.uintField, 4294967295);
     expect(result.floatField, 3.14);
     expect(result.boolField, true);
     expect(result.stringField, "some string");
-    expect(result.enumField, Defaults_SomeEnum.barValue);
+    expect(result.enumField, DefaultsSomeEnum.barValue);
   });
   _testSuite.test("Check defaults immutable", () {
     final result =
-        new Defaults_ImmutableStructWithDefaults.withDefaults(77, true);
+        new DefaultsImmutableStructWithDefaults.withDefaults(77, true);
 
     expect(result.intField, 42);
     expect(result.uintField, 77);
     expect(result.floatField, 3.14);
     expect(result.boolField, true);
     expect(result.stringField, "some string");
-    expect(result.enumField, Defaults_SomeEnum.barValue);
+    expect(result.enumField, DefaultsSomeEnum.barValue);
   });
   _testSuite.test("Check special defaults", () {
-    final result = new Defaults_StructWithSpecialDefaults.withDefaults();
+    final result = new DefaultsStructWithSpecialDefaults.withDefaults();
 
     expect(result.floatNanField, isNaN);
     expect(result.floatInfinityField, double.infinity);
@@ -57,7 +57,7 @@ void main() {
     expect(result.doubleNegativeInfinityField, double.negativeInfinity);
   });
   _testSuite.test("Check empty defaults", () {
-    final result = new Defaults_StructWithEmptyDefaults.withDefaults();
+    final result = new DefaultsStructWithEmptyDefaults.withDefaults();
 
     expect(result.intsField, isEmpty);
     expect(result.floatsField, isEmpty);
@@ -66,12 +66,12 @@ void main() {
     expect(result.setTypeField, isEmpty);
   });
   _testSuite.test("Check initializer defaults", () {
-    final result = new Defaults_StructWithInitializerDefaults.withDefaults();
+    final result = new DefaultsStructWithInitializerDefaults.withDefaults();
 
     expect(result.intsField, [4, -2, 42]);
     expect(result.floatsField, [3.14, double.negativeInfinity]);
     expect(result.mapField, {1: "foo", 42: "bar"});
-    expect(result.structField.enumField, Defaults_ExternalEnum.oneValue);
+    expect(result.structField.enumField, DefaultsExternalEnum.oneValue);
     expect(result.setTypeField, {"foo", "bar"});
   });
 }

--- a/examples/platforms/dart/test/Enums_test.dart
+++ b/examples/platforms/dart/test/Enums_test.dart
@@ -26,41 +26,41 @@ final _testSuite = TestSuite("Enums");
 
 void main() {
   _testSuite.test("Flip enum to zero", () {
-    final errorEnum = Enums_InternalError.errorFatal;
+    final errorEnum = EnumsInternalError.errorFatal;
 
     final result = Enums.flipEnumValue(errorEnum);
 
-    expect(result, equals(Enums_InternalError.errorNone));
+    expect(result, equals(EnumsInternalError.errorNone));
   });
   _testSuite.test("Flip enum from zero", () {
-    final errorEnum = Enums_InternalError.errorNone;
+    final errorEnum = EnumsInternalError.errorNone;
 
     final result = Enums.flipEnumValue(errorEnum);
 
-    expect(result, equals(Enums_InternalError.errorFatal));
+    expect(result, equals(EnumsInternalError.errorFatal));
   });
   _testSuite.test("Extract enum from struct to zero", () {
-    final input = Enums_ErrorStruct(Enums_InternalError.errorFatal, "");
+    final input = EnumsErrorStruct(EnumsInternalError.errorFatal, "");
 
     final result = Enums.extractEnumFromStruct(input);
 
-    expect(result, equals(Enums_InternalError.errorNone));
+    expect(result, equals(EnumsInternalError.errorNone));
   });
   _testSuite.test("Extract enum from struct from zero", () {
-    final input = Enums_ErrorStruct(Enums_InternalError.errorNone, "");
+    final input = EnumsErrorStruct(EnumsInternalError.errorNone, "");
 
     final result = Enums.extractEnumFromStruct(input);
 
-    expect(result, equals(Enums_InternalError.errorFatal));
+    expect(result, equals(EnumsInternalError.errorFatal));
   });
   _testSuite.test("Create struct with enum inside to zero", () {
-    final result = Enums.createStructWithEnumInside(Enums_InternalError.errorFatal, "");
+    final result = Enums.createStructWithEnumInside(EnumsInternalError.errorFatal, "");
 
-    expect(result.type, equals(Enums_InternalError.errorNone));
+    expect(result.type, equals(EnumsInternalError.errorNone));
   });
   _testSuite.test("Create struct with enum inside from zero", () {
-    final result = Enums.createStructWithEnumInside(Enums_InternalError.errorNone, "");
+    final result = Enums.createStructWithEnumInside(EnumsInternalError.errorNone, "");
 
-    expect(result.type, equals(Enums_InternalError.errorFatal));
+    expect(result.type, equals(EnumsInternalError.errorFatal));
   });
 }

--- a/examples/platforms/dart/test/Exceptions_test.dart
+++ b/examples/platforms/dart/test/Exceptions_test.dart
@@ -27,23 +27,23 @@ final _testSuite = TestSuite("Exceptions");
 
 void main() {
   _testSuite.test("methodWithError() throws", () {
-    Errors_InternalException exception = null;
+    ErrorsInternalException exception = null;
 
     try {
       Errors.methodWithError(true);
-    } on Errors_InternalException catch(e) {
+    } on ErrorsInternalException catch(e) {
       exception = e;
     }
 
     expect(exception, isNotNull);
-    expect(exception.error, Errors_InternalErrorCode.crashed);
+    expect(exception.error, ErrorsInternalErrorCode.crashed);
   });
   _testSuite.test("methodWithError() does not throw", () {
-    Errors_InternalException exception = null;
+    ErrorsInternalException exception = null;
 
     try {
       Errors.methodWithError(false);
-    } on Errors_InternalException catch(e) {
+    } on ErrorsInternalException catch(e) {
       exception = e;
     }
 
@@ -51,25 +51,25 @@ void main() {
   });
   _testSuite.test("methodWithErrorAndString() throws", () {
     String result = null;
-    AdditionalErrors_ExternalException exception = null;
+    AdditionalErrorsExternalException exception = null;
 
     try {
       result = Errors.methodWithErrorAndString(true);
-    } on AdditionalErrors_ExternalException catch(e) {
+    } on AdditionalErrorsExternalException catch(e) {
       exception = e;
     }
 
     expect(result, isNull);
     expect(exception, isNotNull);
-    expect(exception.error, AdditionalErrors_ExternalErrorCode.failed);
+    expect(exception.error, AdditionalErrorsExternalErrorCode.failed);
   });
   _testSuite.test("methodWithErrorAndString() does not throw", () {
     String result = null;
-    AdditionalErrors_ExternalException exception = null;
+    AdditionalErrorsExternalException exception = null;
 
     try {
       result = Errors.methodWithErrorAndString(false);
-    } on AdditionalErrors_ExternalException catch(e) {
+    } on AdditionalErrorsExternalException catch(e) {
       exception = e;
     }
 
@@ -77,23 +77,23 @@ void main() {
     expect(exception, isNull);
   });
   _testSuite.test("methodWithExternalError() throws", () {
-    Errors_ExternalException exception = null;
+    ErrorsExternalException exception = null;
 
     try {
       Errors.methodWithExternalError(true);
-    } on Errors_ExternalException catch(e) {
+    } on ErrorsExternalException catch(e) {
       exception = e;
     }
 
     expect(exception, isNotNull);
-    expect(exception.error, Errors_ExternalErrorCode.boom);
+    expect(exception.error, ErrorsExternalErrorCode.boom);
   });
   _testSuite.test("methodWithExternalError() does not throw", () {
-    Errors_ExternalException exception = null;
+    ErrorsExternalException exception = null;
 
     try {
       Errors.methodWithExternalError(false);
-    } on Errors_ExternalException catch(e) {
+    } on ErrorsExternalException catch(e) {
       exception = e;
     }
 
@@ -153,25 +153,25 @@ void main() {
   });
   _testSuite.test("Throwing constructor throws", () {
     ThrowingConstructor result = null;
-    ThrowingConstructor_SomeException exception = null;
+    ThrowingConstructorSomeException exception = null;
 
     try {
       result = new ThrowingConstructor(1.0);
-    } on ThrowingConstructor_SomeException catch(e) {
+    } on ThrowingConstructorSomeException catch(e) {
       exception = e;
     }
 
     expect(result, isNull);
     expect(exception, isNotNull);
-    expect(exception.error, ThrowingConstructor_ErrorEnum.crashed);
+    expect(exception.error, ThrowingConstructorErrorEnum.crashed);
   });
   _testSuite.test("Throwing constructor does not throw", () {
     ThrowingConstructor result = null;
-    ThrowingConstructor_SomeException exception = null;
+    ThrowingConstructorSomeException exception = null;
 
     try {
       result = new ThrowingConstructor(0.0);
-    } on ThrowingConstructor_SomeException catch(e) {
+    } on ThrowingConstructorSomeException catch(e) {
       exception = e;
     }
 

--- a/examples/platforms/dart/test/ExternalTypes_test.dart
+++ b/examples/platforms/dart/test/ExternalTypes_test.dart
@@ -29,7 +29,7 @@ void main() {
   _testSuite.test("Use external struct", () {
     final externalStruct =
       ExternalStruct("foo", "bar", [7, 11], AnotherExternalStruct(42));
-    final input = UseExternalTypes_StructWithExternalTypes(
+    final input = UseExternalTypesStructWithExternalTypes(
         externalStruct, ExternalEnum.bar);
 
     final result = UseExternalTypes.extractExternalStruct(input);
@@ -42,7 +42,7 @@ void main() {
   _testSuite.test("Use external enum", () {
     final externalStruct =
       ExternalStruct("foo", "bar", [7, 11], AnotherExternalStruct(42));
-    final input = UseExternalTypes_StructWithExternalTypes(
+    final input = UseExternalTypesStructWithExternalTypes(
         externalStruct, ExternalEnum.bar);
 
     final result = UseExternalTypes.extractExternalEnum(input);

--- a/examples/platforms/dart/test/Lambdas_test.dart
+++ b/examples/platforms/dart/test/Lambdas_test.dart
@@ -60,7 +60,7 @@ void main() {
   });
   _testSuite.test("Call Dart lambda in struct in C++", () {
     final capturedDelimiter = ">.<";
-    final holder = Lambdas_LambdaHolder(
+    final holder = LambdasLambdaHolder(
         (String s1, String s2) => s1 + capturedDelimiter + s2);
 
     final result = Lambdas.concatenateInStruct("foo", "bar", holder);

--- a/examples/platforms/dart/test/ListenersWithAttributes_test.dart
+++ b/examples/platforms/dart/test/ListenersWithAttributes_test.dart
@@ -42,11 +42,11 @@ class TestListener implements ListenerWithAttributes {
   MessageBox boxedMessage = null;
 
   @override
-  ListenerWithReturn_MessageStruct structuredMessage = null;
+  ListenerWithReturnMessageStruct structuredMessage = null;
 
   @override
-  ListenerWithReturn_MessageEnum enumeratedMessage =
-      ListenerWithReturn_MessageEnum.no;
+  ListenerWithReturnMessageEnum enumeratedMessage =
+      ListenerWithReturnMessageEnum.no;
 
   @override
   List<String> arrayedMessage = ["Doesn't work"];

--- a/examples/platforms/dart/test/ListenersWithErrors_test.dart
+++ b/examples/platforms/dart/test/ListenersWithErrors_test.dart
@@ -50,12 +50,12 @@ class ThrowingListener extends ErrorsInInterface {
 
   @override
   String getMessage() {
-    throw AdditionalErrors_ExternalException(AdditionalErrors_ExternalErrorCode.failed);
+    throw AdditionalErrorsExternalException(AdditionalErrorsExternalErrorCode.failed);
   }
 
   @override
   void setMessage(String value) {
-    throw AdditionalErrors_ExternalException(AdditionalErrors_ExternalErrorCode.failed);
+    throw AdditionalErrorsExternalException(AdditionalErrorsExternalErrorCode.failed);
   }
 
   @override
@@ -87,32 +87,32 @@ void main() {
     expect(result, "Works");
   });
   _testSuite.test("getMessage() error rethrown", () {
-    AdditionalErrors_ExternalException exception = null;
+    AdditionalErrorsExternalException exception = null;
     final ErrorsInInterface listener = ThrowingListener();
 
     try {
       messenger.getMessage(listener);
-    } on AdditionalErrors_ExternalException catch(e) {
+    } on AdditionalErrorsExternalException catch(e) {
       exception = e;
     }
 
     expect(exception, isNotNull);
-    expect(exception.error, AdditionalErrors_ExternalErrorCode.failed);
+    expect(exception.error, AdditionalErrorsExternalErrorCode.failed);
 
     listener.release();
   });
   _testSuite.test("setMessage() error rethrown", () {
-    AdditionalErrors_ExternalException exception = null;
+    AdditionalErrorsExternalException exception = null;
     final ErrorsInInterface listener = ThrowingListener();
 
     try {
       messenger.setMessage(listener, "Foo");
-    } on AdditionalErrors_ExternalException catch(e) {
+    } on AdditionalErrorsExternalException catch(e) {
       exception = e;
     }
 
     expect(exception, isNotNull);
-    expect(exception.error, AdditionalErrors_ExternalErrorCode.failed);
+    expect(exception.error, AdditionalErrorsExternalErrorCode.failed);
 
     listener.release();
   });

--- a/examples/platforms/dart/test/ListenersWithReturnValues_test.dart
+++ b/examples/platforms/dart/test/ListenersWithReturnValues_test.dart
@@ -42,12 +42,12 @@ class TestListener extends ListenerWithReturn {
   MessageBox getBoxedMessage() => MessageBox();
 
   @override
-  ListenerWithReturn_MessageStruct getStructuredMessage() =>
-    ListenerWithReturn_MessageStruct("Works");
+  ListenerWithReturnMessageStruct getStructuredMessage() =>
+    ListenerWithReturnMessageStruct("Works");
 
   @override
-  ListenerWithReturn_MessageEnum getEnumeratedMessage() =>
-    ListenerWithReturn_MessageEnum.yes;
+  ListenerWithReturnMessageEnum getEnumeratedMessage() =>
+    ListenerWithReturnMessageEnum.yes;
 
   @override
   List<String> getArrayedMessage() => ["Works"];

--- a/examples/platforms/dart/test/Listeners_test.dart
+++ b/examples/platforms/dart/test/Listeners_test.dart
@@ -32,7 +32,7 @@ class MessageListener extends StringListener {
   void onConstMessage(String message) {}
 
   @override
-  void onStructMessage(StringListener_StringStruct message) {}
+  void onStructMessage(StringListenerStringStruct message) {}
 }
 
 class RouteImpl extends Route {

--- a/examples/platforms/dart/test/Lists_test.dart
+++ b/examples/platforms/dart/test/Lists_test.dart
@@ -112,7 +112,7 @@ void main() {
     expect(result, equals([false, true, true]));
   });
   _testSuite.test("Reverse Struct list", () {
-    final input = [Arrays_BasicStruct(-4.2), Arrays_BasicStruct(3.1)];
+    final input = [ArraysBasicStruct(-4.2), ArraysBasicStruct(3.1)];
 
     final result = Arrays.reverseStructArray(input);
 

--- a/examples/platforms/dart/test/Maps_test.dart
+++ b/examples/platforms/dart/test/Maps_test.dart
@@ -47,7 +47,7 @@ void main() {
     expect(result, equals({31: ["FOO"], 42: ["BAR"]}));
   });
   _testSuite.test("Map to Struct round trip", () {
-    final input = {31: Maps_SomeStruct("foo"), 42: Maps_SomeStruct("bar")};
+    final input = {31: MapsSomeStruct("foo"), 42: MapsSomeStruct("bar")};
 
     final result = Maps.methodWithMapToStruct(input);
 
@@ -55,14 +55,14 @@ void main() {
     expect(result[42].value, equals("BAR"));
   });
   _testSuite.test("Empty nested Map round trip", () {
-    final input = <int, Map<int, Maps_SomeStruct>>{};
+    final input = <int, Map<int, MapsSomeStruct>>{};
 
     final result = Maps.methodWithNestedMap(input);
 
     expect(result, isEmpty);
   });
   _testSuite.test("Nested map round trip", () {
-    final input = {31: {77: Maps_SomeStruct("foo")}, 42: {199: Maps_SomeStruct("bar")}};
+    final input = {31: {77: MapsSomeStruct("foo")}, 42: {199: MapsSomeStruct("bar")}};
 
     final result = Maps.methodWithNestedMap(input);
 
@@ -70,26 +70,26 @@ void main() {
     expect(result[42][199].value, equals("BAR"));
   });
   _testSuite.test("Empty Map in Struct round trip", () {
-    final input = Maps_StructWithMap({});
+    final input = MapsStructWithMap({});
 
     final result = Maps.methodWithStructWithMap(input);
 
     expect(result.errorMapping, isEmpty);
   });
   _testSuite.test("Map in Struct round trip", () {
-    final input = Maps_StructWithMap({31: "foo", 42: "bar"});
+    final input = MapsStructWithMap({31: "foo", 42: "bar"});
 
     final result = Maps.methodWithStructWithMap(input);
 
     expect(result.errorMapping, equals({31: "FOO", 42: "BAR"}));
   });
   _testSuite.test("Map with Enum keys round trip", () {
-    final input = {Maps_SomeEnum.fooValue: "foo", Maps_SomeEnum.barValue: "bar"};
+    final input = {MapsSomeEnum.fooValue: "foo", MapsSomeEnum.barValue: "bar"};
 
     final result = Maps.methodWithEnumToStringMap(input);
 
     expect(result, equals(
-        {Maps_SomeEnum.fooValue: "FOO", Maps_SomeEnum.barValue: "BAR"}
+        {MapsSomeEnum.fooValue: "FOO", MapsSomeEnum.barValue: "BAR"}
     ));
   });
   _testSuite.test("Map with Instances round trip", () {

--- a/examples/platforms/dart/test/MethodOverloads_test.dart
+++ b/examples/platforms/dart/test/MethodOverloads_test.dart
@@ -41,12 +41,12 @@ void main() {
     expect(result, isFalse);
   });
   _testSuite.test("Call isBoolean() with Point", () {
-    final result = MethodOverloads.isBooleanPoint(MethodOverloads_Point(0, 0));
+    final result = MethodOverloads.isBooleanPoint(MethodOverloadsPoint(0, 0));
 
     expect(result, isFalse);
   });
   _testSuite.test("Call isBoolean() with Everything", () {
-    final result = MethodOverloads.isBooleanMulti(false, 42, "nonsense", MethodOverloads_Point(0, 0));
+    final result = MethodOverloads.isBooleanMulti(false, 42, "nonsense", MethodOverloadsPoint(0, 0));
 
     expect(result, isFalse);
   });

--- a/examples/platforms/dart/test/Nullable_test.dart
+++ b/examples/platforms/dart/test/Nullable_test.dart
@@ -35,7 +35,7 @@ void main() {
   });
 
   _testSuite.test("Struct with nullable fields defaults", () {
-    final result = new NullableInterface_NullableStruct.withDefaults();
+    final result = new NullableInterfaceNullableStruct.withDefaults();
 
     expect(result.stringField, isNull);
     expect(result.boolField, isNull);
@@ -48,7 +48,7 @@ void main() {
     expect(result.blobField, isNull);
   });
   _testSuite.test("Struct with nullable fields round trip with nulls", () {
-    final input = new NullableInterface_NullableStruct.withDefaults();
+    final input = new NullableInterfaceNullableStruct.withDefaults();
 
     final result = instance.methodWithNullableStruct(input);
 
@@ -63,12 +63,12 @@ void main() {
     expect(result.blobField, isNull);
   });
   _testSuite.test("Struct with nullable fields round trip with zeroes", () {
-    final input = new NullableInterface_NullableStruct(
+    final input = new NullableInterfaceNullableStruct(
       "",
       false,
       0.0,
-      NullableInterface_SomeStruct(""),
-      NullableInterface_SomeEnum.off,
+      NullableInterfaceSomeStruct(""),
+      NullableInterfaceSomeEnum.off,
       [],
       [],
       {},
@@ -81,19 +81,19 @@ void main() {
     expect(result.boolField, isFalse);
     expect(result.doubleField, 0.0);
     expect(result.structField.stringField, "");
-    expect(result.enumField, NullableInterface_SomeEnum.off);
+    expect(result.enumField, NullableInterfaceSomeEnum.off);
     expect(result.arrayField, isEmpty);
     expect(result.inlineArrayField, isEmpty);
     expect(result.mapField, isEmpty);
     expect(result.blobField, isEmpty);
   });
   _testSuite.test("Struct with nullable fields round trip with non-zeroes", () {
-    final input = new NullableInterface_NullableStruct(
+    final input = new NullableInterfaceNullableStruct(
       "Foo",
       true,
       3.14,
-      NullableInterface_SomeStruct("Bar"),
-      NullableInterface_SomeEnum.on,
+      NullableInterfaceSomeStruct("Bar"),
+      NullableInterfaceSomeEnum.on,
       ["Baz"],
       ["Fizz"],
       {7: "Wheez"},
@@ -106,14 +106,14 @@ void main() {
     expect(result.boolField, isTrue);
     expect(result.doubleField, 3.14);
     expect(result.structField.stringField, "Bar");
-    expect(result.enumField, NullableInterface_SomeEnum.on);
+    expect(result.enumField, NullableInterfaceSomeEnum.on);
     expect(result.arrayField, ["Baz"]);
     expect(result.inlineArrayField, ["Fizz"]);
     expect(result.mapField, {7: "Wheez"});
     expect(result.blobField, Uint8List.fromList([42]));
   });
   _testSuite.test("Nullable int struct defaults", () {
-    final result = new NullableInterface_NullableIntsStruct.withDefaults();
+    final result = new NullableInterfaceNullableIntsStruct.withDefaults();
 
     expect(result.int8Field, isNull);
     expect(result.int16Field, isNull);
@@ -125,7 +125,7 @@ void main() {
     expect(result.uint64Field, isNull);
   });
   _testSuite.test("Nullable int struct round trip with nulls", () {
-    final input = new NullableInterface_NullableIntsStruct.withDefaults();
+    final input = new NullableInterfaceNullableIntsStruct.withDefaults();
 
     final result = instance.methodWithNullableIntsStruct(input);
 
@@ -140,7 +140,7 @@ void main() {
   });
   _testSuite.test("Nullable int struct round trip with zeroes", () {
     final input =
-      new NullableInterface_NullableIntsStruct(0, 0, 0, 0, 0, 0, 0, 0);
+      new NullableInterfaceNullableIntsStruct(0, 0, 0, 0, 0, 0, 0, 0);
 
     final result = instance.methodWithNullableIntsStruct(input);
 
@@ -154,7 +154,7 @@ void main() {
     expect(result.uint64Field, 0);
   });
   _testSuite.test("Nullable int struct round trip with non-zeroes", () {
-    final input = new NullableInterface_NullableIntsStruct(
+    final input = new NullableInterfaceNullableIntsStruct(
         42, -71, -1337, -3735928559, 71, 1337, 2735718543, 3735928559);
 
     final result = instance.methodWithNullableIntsStruct(input);
@@ -235,13 +235,13 @@ void main() {
   });
   _testSuite.test("Nullable Struct round trip with zero", () {
     final result =
-        instance.methodWithSomeStruct(NullableInterface_SomeStruct(""));
+        instance.methodWithSomeStruct(NullableInterfaceSomeStruct(""));
 
     expect(result.stringField, "");
   });
   _testSuite.test("Nullable Struct round trip with non-zero", () {
     final result =
-        instance.methodWithSomeStruct(NullableInterface_SomeStruct("Foo"));
+        instance.methodWithSomeStruct(NullableInterfaceSomeStruct("Foo"));
 
     expect(result.stringField, "Foo");
   });
@@ -251,14 +251,14 @@ void main() {
     expect(result, isNull);
   });
   _testSuite.test("Nullable Enum round trip with zero", () {
-    final result = instance.methodWithSomeEnum(NullableInterface_SomeEnum.off);
+    final result = instance.methodWithSomeEnum(NullableInterfaceSomeEnum.off);
 
-    expect(result, NullableInterface_SomeEnum.off);
+    expect(result, NullableInterfaceSomeEnum.off);
   });
   _testSuite.test("Nullable Enum round trip with non-zero", () {
-    final result = instance.methodWithSomeEnum(NullableInterface_SomeEnum.on);
+    final result = instance.methodWithSomeEnum(NullableInterfaceSomeEnum.on);
 
-    expect(result, NullableInterface_SomeEnum.on);
+    expect(result, NullableInterfaceSomeEnum.on);
   });
   _testSuite.test("Nullable List round trip with null", () {
     final result = instance.methodWithSomeArray(null);

--- a/examples/platforms/dart/test/PlainDataStructuresImmutable_test.dart
+++ b/examples/platforms/dart/test/PlainDataStructuresImmutable_test.dart
@@ -26,8 +26,8 @@ final _testSuite = TestSuite("PlainDataStructuresImmutable");
 
 void main() {
   _testSuite.test("All types immutable struct round trip", () {
-    final input = PlainDataStructuresImmutable_AllTypesImmutableStruct(-1, 2, -3, 4, -5,
-        6, -7, 8, -9, 10, "foo", true, PlainDataStructuresImmutable_Point(-11, 12));
+    final input = PlainDataStructuresImmutableAllTypesImmutableStruct(-1, 2, -3, 4, -5,
+        6, -7, 8, -9, 10, "foo", true, PlainDataStructuresImmutablePoint(-11, 12));
 
     final result = PlainDataStructuresImmutable.immutableStructRoundTrip(input);
 
@@ -47,10 +47,10 @@ void main() {
     expect(result.pointField.y, equals(12));
   });
   _testSuite.test("Nested immutable struct round trip", () {
-    final input = PlainDataStructuresImmutable_NestingImmutableStruct(
-        PlainDataStructuresImmutable_AllTypesImmutableStruct(
+    final input = PlainDataStructuresImmutableNestingImmutableStruct(
+        PlainDataStructuresImmutableAllTypesImmutableStruct(
             -1, 2, -3, 4, -5, 6, -7, 8, -9, 10, "foo", true,
-            PlainDataStructuresImmutable_Point(-11, 12)
+            PlainDataStructuresImmutablePoint(-11, 12)
         )
     );
 
@@ -73,7 +73,7 @@ void main() {
   });
   _testSuite.test("Immutable struct with accessprs round trip", () {
     final input =
-        PlainDataStructuresImmutable_ImmutableStructWithCppAccessors("foo");
+        PlainDataStructuresImmutableImmutableStructWithCppAccessors("foo");
 
     final result = PlainDataStructuresImmutable.immutableStructWithAccessorsRoundTrip(input);
 

--- a/examples/platforms/dart/test/PlainDataStructures_test.dart
+++ b/examples/platforms/dart/test/PlainDataStructures_test.dart
@@ -32,7 +32,7 @@ void main() {
     expect(result.y, equals(2.0));
   });
   _testSuite.test("Manipulate simple data structure", () {
-    final input = PlainDataStructures_Point(1.0, 2.0);
+    final input = PlainDataStructuresPoint(1.0, 2.0);
 
     final result = PlainDataStructures.swapPointCoordinates(input);
 
@@ -40,8 +40,8 @@ void main() {
     expect(result.y, equals(1.0));
   });
   _testSuite.test("Create nested data structure with multiple params", () {
-    final input1 = PlainDataStructures_Point(1.0, 2.0);
-    final input2 = PlainDataStructures_Point(3.0, 4.0);
+    final input1 = PlainDataStructuresPoint(1.0, 2.0);
+    final input2 = PlainDataStructuresPoint(3.0, 4.0);
 
     final result = PlainDataStructures.createLine(input1, input2);
 
@@ -51,8 +51,8 @@ void main() {
     expect(result.b.y, equals(4.0));
   });
   _testSuite.test("All types zeros round trip", () {
-    final input = PlainDataStructures_AllTypesStruct(0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, "", false, PlainDataStructures_Point(0, 0));
+    final input = PlainDataStructuresAllTypesStruct(0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, "", false, PlainDataStructuresPoint(0, 0));
 
     final result = PlainDataStructures.returnAllTypesStruct(input);
 
@@ -72,8 +72,8 @@ void main() {
     expect(result.pointField.y, equals(0));
   });
   _testSuite.test("All types non-zeros round trip", () {
-    final input = PlainDataStructures_AllTypesStruct(-1, 2, -3, 4, -5,
-        6, -7, 8, -9, 10, "foo", true, PlainDataStructures_Point(-11, 12));
+    final input = PlainDataStructuresAllTypesStruct(-1, 2, -3, 4, -5,
+        6, -7, 8, -9, 10, "foo", true, PlainDataStructuresPoint(-11, 12));
 
     final result = PlainDataStructures.returnAllTypesStruct(input);
 

--- a/examples/platforms/dart/test/Properties_test.dart
+++ b/examples/platforms/dart/test/Properties_test.dart
@@ -47,7 +47,7 @@ void main() {
     expect(result, inInclusiveRange(3.14 - epsilon, 3.14 + epsilon));
   });
   _testSuite.test("Struct type Property round trip", () {
-    attributes.structAttribute = Attributes_ExampleStruct(2.71, []);
+    attributes.structAttribute = AttributesExampleStruct(2.71, []);
 
     final result = attributes.structAttribute;
 

--- a/examples/platforms/dart/test/Sets_test.dart
+++ b/examples/platforms/dart/test/Sets_test.dart
@@ -40,14 +40,14 @@ void main() {
     expect(result, equals(input));
   });
   _testSuite.test("Empty Enum set round trip", () {
-    final input = <SetType_SomeEnum>{};
+    final input = <SetTypeSomeEnum>{};
 
     final result = SetType.enumSetRoundTrip(input);
 
     expect(result, isEmpty);
   });
   _testSuite.test("Enum set round trip", () {
-    final input = <SetType_SomeEnum>{SetType_SomeEnum.on};
+    final input = <SetTypeSomeEnum>{SetTypeSomeEnum.on};
 
     final result = SetType.enumSetRoundTrip(input);
 

--- a/examples/platforms/dart/test/StructsWithConstants_test.dart
+++ b/examples/platforms/dart/test/StructsWithConstants_test.dart
@@ -31,7 +31,7 @@ void main() {
     expect(result, "Nonsense");
   });
   _testSuite.test("MultiRoute default description", () {
-    final result = StructsWithConstantsInterface_MultiRoute.defaultDescription;
+    final result = StructsWithConstantsInterfaceMultiRoute.defaultDescription;
 
     expect(result, "Foo");
   });

--- a/examples/platforms/dart/test/StructsWithMethods_test.dart
+++ b/examples/platforms/dart/test/StructsWithMethods_test.dart
@@ -26,7 +26,7 @@ final _testSuite = TestSuite("StructsWithMethods");
 
 void main() {
   final vector = Vector.create(1, 2);
-  final vector3 = StructsWithMethodsInterface_Vector3.create(1, 2, 3);
+  final vector3 = StructsWithMethodsInterfaceVector3.create(1, 2, 3);
 
   _testSuite.test("Vector distance to self", () {
     final result = vector.distanceTo(vector);
@@ -99,7 +99,7 @@ void main() {
     expect(result, 0.0);
   });
   _testSuite.test("Vector3 distance to other", () {
-    final input = StructsWithMethodsInterface_Vector3.create(-4, -5, 6);
+    final input = StructsWithMethodsInterfaceVector3.create(-4, -5, 6);
 
     final result = vector3.distanceTo(input);
 
@@ -114,7 +114,7 @@ void main() {
     expect(result.z, 6.0);
   });
   _testSuite.test("Vector3 add other", () {
-    final input = StructsWithMethodsInterface_Vector3.create(-4, -7, -10);
+    final input = StructsWithMethodsInterfaceVector3.create(-4, -7, -10);
 
     final result = vector3.add(input);
 
@@ -123,22 +123,22 @@ void main() {
     expect(result.z, -7.0);
   });
   _testSuite.test("Vector3 validate passes", () {
-    final result = StructsWithMethodsInterface_Vector3.validate(1, 2, 3);
+    final result = StructsWithMethodsInterfaceVector3.validate(1, 2, 3);
 
     expect(result, isTrue);
   });
   _testSuite.test("Vector3 validate fails", () {
     final result =
-      StructsWithMethodsInterface_Vector3.validate(1, double.nan, 3);
+      StructsWithMethodsInterfaceVector3.validate(1, double.nan, 3);
 
     expect(result, isFalse);
   });
   _testSuite.test("Vector3 copy constructor does not throw", () {
-    StructsWithMethodsInterface_Vector3 result = null;
+    StructsWithMethodsInterfaceVector3 result = null;
     ValidationException exception = null;
 
     try {
-      result = new StructsWithMethodsInterface_Vector3.createCopy(vector3);
+      result = new StructsWithMethodsInterfaceVector3.createCopy(vector3);
     } on ValidationException catch(e) {
       exception = e;
     }
@@ -149,12 +149,12 @@ void main() {
     expect(result.z, 3);
   });
   _testSuite.test("Vector3 copy constructor throws", () {
-    StructsWithMethodsInterface_Vector3 result = null;
+    StructsWithMethodsInterfaceVector3 result = null;
     ValidationException exception = null;
 
     try {
-      result = new StructsWithMethodsInterface_Vector3.createCopy(
-          new StructsWithMethodsInterface_Vector3.create(1, double.nan, 3)
+      result = new StructsWithMethodsInterfaceVector3.createCopy(
+          new StructsWithMethodsInterfaceVector3.create(1, double.nan, 3)
       );
     } on ValidationException catch(e) {
       exception = e;

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/NameRuleSet.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/NameRuleSet.kt
@@ -29,7 +29,8 @@ class NameRuleSet(
     val getPropertyName: (String, Boolean) -> String = ignore2(::illegal),
     val getSetterName: (name: String) -> String = ::illegal,
     val getGetterName: (name: String, Boolean) -> String = ignore2(::illegal),
-    val getErrorName: (name: String) -> String = ::illegal
+    val getErrorName: (name: String) -> String = ::illegal,
+    val joinInfix: String? = null
 ) {
     companion object {
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/NameRuleSetLoader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/NameRuleSetLoader.kt
@@ -37,10 +37,11 @@ private object NameRuleSetLoader {
             getPropertyName = getNameRuleBooleanPrefix(config, NameTypes.Property),
             getSetterName = getNameRule(config, NameTypes.Setter),
             getGetterName = getNameRuleBooleanPrefix(config, NameTypes.Getter),
-            getErrorName = getNameRule(config, NameTypes.Error)
+            getErrorName = getNameRule(config, NameTypes.Error),
+            joinInfix = getInfix(config, NameTypes.Join)
     )
 
-    @Suppress("EnumEntryName")
+    @Suppress("EnumEntryName", "unused")
     enum class NameFormat(val apply: (String) -> String, val joinApply: (List<String?>) -> String) {
         UPPER_SNAKE_CASE(NameHelper::toUpperSnakeCase, NameHelper::joinToUpperSnakeCase),
         lower_snake_case(NameHelper::toLowerSnakeCase, NameHelper::joinToLowerSnakeCase),
@@ -58,7 +59,8 @@ private object NameRuleSetLoader {
         Property,
         Setter,
         Getter,
-        Error
+        Error,
+        Join
     }
 
     private fun getNameRuleBooleanPrefix(config: Configuration, nameType: NameTypes): (String, Boolean) -> String {
@@ -101,6 +103,13 @@ private object NameRuleSetLoader {
             val formatting = config[formattingKey]
             return { formatting.joinApply(listOf(prefix, it, suffix)) }
         } else return config[formattingKey].apply
+    }
+
+    @Suppress("SameParameterValue")
+    private fun getInfix(config: Configuration, nameType: NameTypes): String? {
+        val key = nameType.toString().toLowerCase()
+        val infixKey = Key("$key.infix", stringType)
+        return config.getOrNull(infixKey)
     }
 }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -54,6 +54,7 @@ internal class DartNameResolver(
 ) : NameResolver {
 
     private val commentsProcessor = DartCommentsProcessor()
+    private val joinInfix = nameRules.ruleSet.joinInfix ?: ""
     private val limeToDartNames = buildPathMap()
 
     override fun resolveName(element: Any): String =
@@ -80,7 +81,7 @@ internal class DartNameResolver(
 
     private fun resolveVisibility(limeVisibility: LimeVisibility) =
         when (limeVisibility) {
-            LimeVisibility.INTERNAL -> "internal_"
+            LimeVisibility.INTERNAL -> "internal$joinInfix"
             else -> ""
         }
 
@@ -162,7 +163,7 @@ internal class DartNameResolver(
             null -> listOf(typeName)
             is LimeTypesCollection -> listOf(typeName)
             else -> listOf(resolveName(parentType), typeName)
-        }.joinToString("_")
+        }.joinToString(joinInfix)
     }
 
     private fun getPlatformName(element: LimeNamedElement) =


### PR DESCRIPTION
Added joinInfix property to NameRuleSet. Updated DartNameResolver to use
it for concatenation of names instead of a hard-coded underscore.

Updated functional tests to have a non-default joinInfix.

Resolves: #261
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>