### PR TITLE
Added support for including method signature in doc links.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Features:
   * Added support for `@Cpp(CString)` IDL attribute that marks a function parameter of `String` type
     to accept `const char*` in C++ generated code.
+  * Added support for including method signature when adding a documentation reference link in IDL.
 
 ## 6.4.9
 Release date: 2020-04-07

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppModelBuilder.kt
@@ -321,7 +321,9 @@ class CppModelBuilder(
             qualifiers = getterQualifiers
         )
         storeNamedResult(limeProperty, getterMethod)
-        referenceMap["${limeProperty.fullName}.get"] = getterMethod
+        val getterKey = "${limeProperty.fullName}.get"
+        referenceMap[getterKey] = getterMethod
+        reverseReferenceMap[getterMethod] = getterKey
 
         val limeSetter = limeProperty.setter
         if (limeSetter != null) {
@@ -344,7 +346,9 @@ class CppModelBuilder(
                 qualifiers = setterQualifiers
             )
             storeResult(setterMethod)
-            referenceMap["${limeProperty.fullName}.set"] = setterMethod
+            val setterKey = "${limeProperty.fullName}.set"
+            referenceMap[setterKey] = setterMethod
+            reverseReferenceMap[setterMethod] = setterKey
         }
 
         closeContext()

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -29,6 +29,7 @@ import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 import com.here.gluecodium.model.lime.LimeComment
 import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeGenericType
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
@@ -189,6 +190,14 @@ internal class DartNameResolver(
             .filterIsInstance<LimeNamedElement>()
             .associateBy({ it.fullName }, { resolveFullName(it) })
             .toMutableMap()
+
+        val functions = limeReferenceMap.values.filterIsInstance<LimeFunction>()
+        result += functions.associateBy({ it.path.withSuffix("").toString() }, { resolveName(it) })
+        result += functions.associateBy(
+            { function -> function.path.withSuffix("").toString() + function.parameters
+                .joinToString(prefix = "(", postfix = ")") { it.typeRef.toString() } },
+            { resolveName(it) }
+        )
 
         val properties = limeReferenceMap.values.filterIsInstance<LimeProperty>()
         result += properties.associateBy({ it.fullName + ".get" }, { resolveName(it) })

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaModelBuilder.kt
@@ -298,7 +298,9 @@ class JavaModelBuilder(
         addDeprecatedAnnotationIfNeeded(getterMethod)
 
         storeNamedResult(limeProperty, getterMethod)
-        referenceMap["${limeProperty.fullName}.get"] = getterMethod
+        val getterKey = "${limeProperty.fullName}.get"
+        referenceMap[getterKey] = getterMethod
+        reverseReferenceMap[getterMethod] = getterKey
 
         val limeSetter = limeProperty.setter
         if (limeSetter != null) {
@@ -319,7 +321,9 @@ class JavaModelBuilder(
             addDeprecatedAnnotationIfNeeded(setterMethod)
 
             storeResult(setterMethod)
-            referenceMap["${limeProperty.fullName}.set"] = setterMethod
+            val setterKey = "${limeProperty.fullName}.set"
+            referenceMap[setterKey] = setterMethod
+            reverseReferenceMap[setterMethod] = setterKey
         }
 
         closeContext()

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JavaModel.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JavaModel.kt
@@ -24,11 +24,13 @@ import com.here.gluecodium.model.jni.JniContainer
 
 class JavaModel(
     val referenceMap: Map<String, JavaElement> = emptyMap(),
+    val reverseReferenceMap: Map<JavaElement, String> = emptyMap(),
     val javaElements: List<JavaElement> = emptyList(),
     val jniContainers: List<JniContainer> = emptyList()
 ) {
     fun merge(other: JavaModel) = JavaModel(
         referenceMap + other.referenceMap,
+        reverseReferenceMap + other.reverseReferenceMap,
         javaElements + other.javaElements,
         jniContainers + other.jniContainers
     )

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGenerator.kt
@@ -104,7 +104,12 @@ class JniGenerator(
             wrapInContainer(it, jniToLimeMap, includeResolver)
         }
 
-        return JavaModel(javaBuilder.referenceMap, javaBuilder.finalResults, jniResults)
+        return JavaModel(
+            javaBuilder.referenceMap,
+            javaBuilder.reverseReferenceMap,
+            javaBuilder.finalResults,
+            jniResults
+        )
     }
 
     private fun wrapInContainer(

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -62,6 +62,7 @@ class SwiftGenerator(
 
         return SwiftModel(
             modelBuilder.referenceMap,
+            modelBuilder.reverseReferenceMap,
             modelBuilder.finalResults.mapNotNull { wrapInFile(it, rootElement) }
         )
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModel.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModel.kt
@@ -22,8 +22,14 @@ package com.here.gluecodium.generator.swift
 import com.here.gluecodium.model.swift.SwiftFile
 import com.here.gluecodium.model.swift.SwiftModelElement
 
-class SwiftModel(val referenceMap: Map<String, SwiftModelElement>, val containers: List<SwiftFile>) {
-    fun merge(model: SwiftModel): SwiftModel {
-        return SwiftModel(referenceMap + model.referenceMap, containers + model.containers)
-    }
+class SwiftModel(
+    val referenceMap: Map<String, SwiftModelElement> = emptyMap(),
+    val reverseReferenceMap: Map<SwiftModelElement, String> = emptyMap(),
+    val containers: List<SwiftFile> = emptyList()
+) {
+    fun merge(model: SwiftModel) = SwiftModel(
+        referenceMap + model.referenceMap,
+        reverseReferenceMap + model.reverseReferenceMap,
+        containers + model.containers
+    )
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
@@ -97,6 +97,7 @@ open class JavaGeneratorSuite protected constructor(
         processCommentLinks(
             combinedModel.javaElements,
             combinedModel.referenceMap + auxNameMapping,
+            combinedModel.reverseReferenceMap,
             limeModel
         )
 
@@ -134,13 +135,12 @@ open class JavaGeneratorSuite protected constructor(
     private fun processCommentLinks(
         javaModel: List<JavaElement>,
         referenceMap: Map<String, JavaElement>,
+        elementToLimeName: Map<JavaElement, String>,
         limeModel: LimeModel
     ) {
         val elementToJavaName = mutableMapOf<JavaElement, String>()
         referenceMap.values.forEach { resolveFullName(it, "", elementToJavaName) }
-
         val limeToJavaName = referenceMap.mapValues { elementToJavaName[it.value] ?: "" }
-        val elementToLimeName = referenceMap.entries.associate { it.value to it.key }
 
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
         javaModel

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/common/CommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/common/CommentsProcessor.kt
@@ -45,7 +45,7 @@ abstract class CommentsProcessor(private val renderer: IRender) {
         val path = limeFullName.split(".")
 
         val linkRefHandler = VisitHandler(LinkRef::class.java) {
-            val reference = it.reference.toString()
+            val reference = it.reference.toString().replace(" ", "")
             for (i in path.size downTo 0) {
                 val child = (path.take(i) + reference).joinToString(".")
                 val element = limeToLanguage[child]

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuite.kt
@@ -68,13 +68,13 @@ class SwiftGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
             internalPrefix = internalPrefix
         )
         val swiftModel =
-            limeModel.topElements.fold(SwiftModel(emptyMap(), emptyList())) { model, rootElement ->
+            limeModel.topElements.fold(SwiftModel()) { model, rootElement ->
                 model.merge(swiftGenerator.generateModel(rootElement))
             }
         // Build name mapping for auxiliary model
         val auxGenerator = SwiftGenerator(limeReferenceMap, swiftNameRules, internalPrefix)
         val auxModel =
-            limeModel.auxiliaryElements.fold(SwiftModel(emptyMap(), emptyList())) { model, rootElement ->
+            limeModel.auxiliaryElements.fold(SwiftModel()) { model, rootElement ->
                 model.merge(auxGenerator.generateModel(rootElement))
             }
 
@@ -93,12 +93,11 @@ class SwiftGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
 
         val limeToSwiftName = (swiftModel.referenceMap + auxModel.referenceMap)
             .mapValues { elementToSwiftName[it.value] ?: "" }
-        val elementToLimeName = swiftModel.referenceMap.entries.associate { it.value to it.key }
 
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
         swiftModel.containers.flatMap { it.allElementsRecursive }
             .filterIsInstance<SwiftModelElement>()
-            .forEach { processElementComments(it, elementToLimeName, limeToSwiftName, limeLogger) }
+            .forEach { processElementComments(it, swiftModel.reverseReferenceMap, limeToSwiftName, limeLogger) }
 
         return swiftModel.containers.filter { it.childElements.isNotEmpty() }.map {
             GeneratedFile(

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -162,6 +162,8 @@ class CommentsLinks {
     // * property setter: [comments.SomeProperty.set]
     // * property getter: [comments.SomeProperty.get]
     // * method: [comments.someMethodWithAllComments]
+    // * method with signature: [comments.oneParameterCommentOnly(String, String)]
+    // * method with signature with no spaces: [comments.oneParameterCommentOnly(String,String)]
     // * parameter: [inputParameter]
     // * top level constant: [CommentsTypeCollection.TypeCollectionConstant]
     // * top level struct: [CommentsTypeCollection.TypeCollectionStruct]

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
@@ -53,6 +53,8 @@ public final class CommentsLinks extends NativeBase {
      * <li>property setter: {@link com.example.smoke.Comments#setSomeProperty}</li>
      * <li>property getter: {@link com.example.smoke.Comments#isSomeProperty}</li>
      * <li>method: {@link com.example.smoke.Comments#someMethodWithAllComments}</li>
+     * <li>method with signature: {@link com.example.smoke.Comments#oneParameterCommentOnly}</li>
+     * <li>method with signature with no spaces: {@link com.example.smoke.Comments#oneParameterCommentOnly}</li>
      * <li>parameter: {@link com.example.smoke.CommentsLinks#randomMethod#inputParameter}</li>
      * <li>top level constant: {@link com.example.smoke.CommentsTypeCollection#TYPE_COLLECTION_CONSTANT}</li>
      * <li>top level struct: {@link com.example.smoke.TypeCollectionStruct}</li>

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
@@ -52,6 +52,8 @@ public:
      * * property setter: ::smoke::Comments::set_some_property
      * * property getter: ::smoke::Comments::is_some_property
      * * method: ::smoke::Comments::some_method_with_all_comments
+     * * method with signature: ::smoke::Comments::one_parameter_comment_only
+     * * method with signature with no spaces: ::smoke::Comments::one_parameter_comment_only
      * * parameter: input_parameter
      * * top level constant: ::smoke::TYPE_COLLECTION_CONSTANT
      * * top level struct: ::smoke::TypeCollectionStruct

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
@@ -3,10 +3,9 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
-/// The nested types like [random_method] don't need full name prefix, but it's
+/// The nested types like [randomMethod] don't need full name prefix, but it's
 /// possible to references other interfaces like [CommentsInterface] or other members
-/// [comments.someMethodWithAllComments].
+/// [someMethodWithAllComments].
 ///
 /// Weblinks are not modified like this [example] or [www.example.com].
 ///
@@ -22,7 +21,9 @@ abstract class CommentsLinks {
   /// * property: [Comments.isSomeProperty]
   /// * property setter: [isSomeProperty]
   /// * property getter: [isSomeProperty]
-  /// * method: [comments.someMethodWithAllComments]
+  /// * method: [someMethodWithAllComments]
+  /// * method with signature: [comments.oneParameterCommentOnly(String, String)]
+  /// * method with signature with no spaces: [comments.oneParameterCommentOnly(String,String)]
   /// * parameter: [inputParameter]
   /// * top level constant: [CommentsTypeCollection.typeCollectionConstant]
   /// * top level struct: [TypeCollectionStruct]

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
@@ -26,6 +26,8 @@ class CommentsLinks {
     // * property setter: [comments.SomeProperty.set]
     // * property getter: [comments.SomeProperty.get]
     // * method: [comments.someMethodWithAllComments]
+    // * method with signature: [comments.oneParameterCommentOnly(String, String)]
+    // * method with signature with no spaces: [comments.oneParameterCommentOnly(String,String)]
     // * parameter: [inputParameter]
     // * top level constant: [CommentsTypeCollection.TypeCollectionConstant]
     // * top level struct: [CommentsTypeCollection.TypeCollectionStruct]

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
@@ -43,6 +43,8 @@ public class CommentsLinks {
     /// * property setter: `Comments.isSomeProperty`
     /// * property getter: `Comments.isSomeProperty`
     /// * method: `Comments.someMethodWithAllComments(...)`
+    /// * method with signature: `Comments.oneParameterCommentOnly(...)`
+    /// * method with signature with no spaces: `Comments.oneParameterCommentOnly(...)`
     /// * parameter: `CommentsLinks.randomMethod(...).inputParameter`
     /// * top level constant: `CommentsTypeCollection.typeCollectionConstant`
     /// * top level struct: `TypeCollectionStruct`


### PR DESCRIPTION
Updated AbstractLimeBasedModelBuilder class and its usages to support
referring to methods by name + signature (e.g. foo(String, Boolean)) in
documentation comment links. This enables distinguishing between
different method overloads of the same name (although the target
language generators cannot make this distinction yet, see #227).

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>