### PR TITLE
Add support for C strings in C++ generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for `@Cpp(CString)` IDL attribute that marks a function parameter of `String` type
+    to accept `const char*` in C++ generated code.
+
 ## 6.4.9
 Release date: 2020-04-07
 ### Features:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -440,6 +440,8 @@ deprecated, takes a string literal value as a deprecation message.
   * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in C++.
   This is the default property for this attribute.
   * **Const**: marks a function with a `const` qualifier in C++ generated code.
+  * **CString**: marks a function parameter of `String` type to accept `const char*` in C++ (in
+  addition to usual `std::string`). This produces one additional overload for the function.
   * **Accessors**: marks a struct to have accessor functions generated for fields and to generate
   struct fields as "private" in C++ generated code. Intended for use with `@Immutable` attribute.
   * **ExternalType** **=** **"**_HeaderPaths_**"**: marks a class, interface, struct type or

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -69,9 +69,11 @@ endfunction()
 feature(Strings cpp android swift dart SOURCES
     src/hello/HelloWorld.cpp
     src/test/StaticStringMethods.cpp
+    src/test/StringsWithCstring.cpp
 
     lime/hello/HelloWorld.lime
     lime/test/StaticStringMethods.lime
+    lime/test/StringsWithCstring.lime
 )
 
 feature(MethodOverloading cpp android swift dart SOURCES

--- a/examples/libhello/lime/test/StringsWithCstring.lime
+++ b/examples/libhello/lime/test/StringsWithCstring.lime
@@ -1,0 +1,23 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+class StringsWithCstring {
+    // Method that takes a C string as input and returns an std::string it as output.
+    static fun returnInputString(@Cpp(CString) inputString: String): String
+}

--- a/examples/libhello/src/test/StringsWithCstring.cpp
+++ b/examples/libhello/src/test/StringsWithCstring.cpp
@@ -1,0 +1,35 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/StringsWithCstring.h"
+
+namespace test
+{
+std::string
+StringsWithCstring::return_input_string(const std::string& input_string) {
+    return input_string;
+}
+
+std::string
+StringsWithCstring::return_input_string(const char* input_string) {
+    return return_input_string(std::string(input_string));
+}
+
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/model/cpp/CppMethod.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/cpp/CppMethod.kt
@@ -37,8 +37,6 @@ class CppMethod(
 ) : CppElementWithComment(name, fullyQualifiedName, comment = comment) {
 
     enum class Specifier(private val text: String) {
-        EXPLICIT("explicit"),
-        INLINE("inline"),
         STATIC("static"),
         VIRTUAL("virtual");
 
@@ -47,7 +45,6 @@ class CppMethod(
 
     enum class Qualifier(private val text: String) {
         CONST("const"),
-        OVERRIDE("override"),
         PURE_VIRTUAL("= 0");
 
         override fun toString() = text
@@ -66,7 +63,11 @@ class CppMethod(
     override val childElements
         get() = listOf(returnType) + parameters
 
-    fun copy(specifiers: Set<Specifier>? = null, qualifiers: Set<Qualifier>? = null) =
+    fun copy(
+        parameters: List<CppParameter>? = null,
+        specifiers: Set<Specifier>? = null,
+        qualifiers: Set<Qualifier>? = null
+    ) =
         CppMethod(
             name,
             fullyQualifiedName,
@@ -76,7 +77,7 @@ class CppMethod(
             errorType,
             errorComment,
             isNotNull,
-            parameters,
+            parameters ?: this.parameters,
             specifiers ?: this.specifiers,
             qualifiers ?: this.qualifiers
         )

--- a/gluecodium/src/main/java/com/here/gluecodium/model/cpp/CppParameter.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/cpp/CppParameter.kt
@@ -29,4 +29,6 @@ class CppParameter(
         get() = listOf(type)
 
     fun hasComment() = isNotNull || !comment.isEmpty
+
+    fun copy(type: CppTypeRef? = null) = CppParameter(name, type ?: this.type, isNotNull)
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/model/cpp/CppPrimitiveTypeRef.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/cpp/CppPrimitiveTypeRef.kt
@@ -24,8 +24,9 @@ import com.here.gluecodium.model.common.Include
 
 class CppPrimitiveTypeRef private constructor(
     name: String,
-    includes: List<Include> = emptyList()
-) : CppTypeRef(name, includes, refersToValueType = true) {
+    includes: List<Include> = emptyList(),
+    refersToConstType: Boolean = false
+) : CppTypeRef(name, includes, refersToValueType = true, refersToConstType = refersToConstType) {
 
     companion object {
         private val intIncludes = listOf(CppLibraryIncludes.INT_TYPES)
@@ -35,6 +36,7 @@ class CppPrimitiveTypeRef private constructor(
         val FLOAT = CppPrimitiveTypeRef("float")
         val DOUBLE = CppPrimitiveTypeRef("double")
         val CHAR = CppPrimitiveTypeRef("char")
+        val CSTRING = CppPrimitiveTypeRef("const char*", refersToConstType = true)
         val INT8 = CppPrimitiveTypeRef("int8_t", intIncludes)
         val INT16 = CppPrimitiveTypeRef("int16_t", intIncludes)
         val INT32 = CppPrimitiveTypeRef("int32_t", intIncludes)

--- a/gluecodium/src/main/java/com/here/gluecodium/model/cpp/CppTypeRef.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/cpp/CppTypeRef.kt
@@ -24,7 +24,8 @@ import com.here.gluecodium.model.common.Include
 abstract class CppTypeRef(
     typeName: String,
     includes: List<Include>,
-    val refersToValueType: Boolean = false
+    val refersToValueType: Boolean = false,
+    val refersToConstType: Boolean = false
 ) : CppElementWithIncludes(typeName, typeName, includes) {
 
     open val actualType: CppTypeRef

--- a/gluecodium/src/main/resources/templates/cpp/CppMethodParameterType.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppMethodParameterType.mustache
@@ -18,4 +18,4 @@
   ! License-Filename: LICENSE
   !
   !}}
-const {{#type}}{{name}}{{^refersToValueType}}&{{/refersToValueType}}{{/type}}
+{{#type}}{{#unless refersToConstType}}const {{/unless}}{{name}}{{#unless refersToValueType}}&{{/unless}}{{/type}}

--- a/gluecodium/src/test/resources/smoke/basic_types/input/StringsWithCString.lime
+++ b/gluecodium/src/test/resources/smoke/basic_types/input/StringsWithCString.lime
@@ -1,0 +1,23 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+class StringsWithCstring {
+    // Method that takes a C string as input and returns an std::string it as output.
+    static fun returnInputString(@Cpp(CString) inputString: String): String
+}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/StringsWithCstring.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/StringsWithCstring.h
@@ -1,0 +1,27 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT StringsWithCstring {
+public:
+    StringsWithCstring();
+    virtual ~StringsWithCstring() = 0;
+public:
+    /**
+     * Method that takes a C string as input and returns an std::string it as output.
+     * \param[in] input_string
+     * \return
+     */
+    static ::std::string return_input_string( const char* input_string );
+    /**
+     * Method that takes a C string as input and returns an std::string it as output.
+     * \param[in] input_string
+     * \return
+     */
+    static ::std::string return_input_string( const ::std::string& input_string );
+};
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -68,6 +68,7 @@ internal object AntlrLimeConverter {
             "Accessors" -> LimeAttributeValueType.ACCESSORS
             "Builder" -> LimeAttributeValueType.BUILDER
             "Const" -> LimeAttributeValueType.CONST
+            "CString" -> LimeAttributeValueType.CSTRING
             "Extension" -> LimeAttributeValueType.EXTENSION
             "FunctionName" -> LimeAttributeValueType.FUNCTION_NAME
             "Label" -> LimeAttributeValueType.LABEL

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
@@ -24,6 +24,7 @@ enum class LimeAttributeValueType(private val tag: String) {
     ACCESSORS("Accessors"),
     BUILDER("Builder"),
     CONST("Const"),
+    CSTRING("CString"),
     EXTENSION("Extension"),
     FUNCTION_NAME("FunctionName"),
     LABEL("Label"),


### PR DESCRIPTION
Added new LimeIDL attribute `@Cpp(CString)`. This attribute marks a String
function parameter in IDL have a `const char*` overload in C++.

Updated C++ generator and templates to support this.

Added smoke and functional tests.

Resolves: #268
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>