### PR TITLE
Fix Dart conversion issue for enums with explicit and implicit values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Added support for `@Cpp(CString)` IDL attribute that marks a function parameter of `String` type
     to accept `const char*` in C++ generated code.
   * Added support for including method signature when adding a documentation reference link in IDL.
+### Bug fixes:
+  * Fixed Dart conversion issue for enumerations with mixed explicit and implicit values.
 
 ## 6.4.9
 Release date: 2020-04-07

--- a/examples/libhello/lime/test/Enums.lime
+++ b/examples/libhello/lime/test/Enums.lime
@@ -47,4 +47,10 @@ class Enums {
         // input message
         message: String
     ): /* Output struct with enum and string */ ErrorStruct
+    static fun flipEnumStartsWithOne(input: EnumStartsWithOne): EnumStartsWithOne
+}
+
+enum EnumStartsWithOne {
+    FIRST = 1,
+    SECOND
 }

--- a/examples/libhello/src/test/Enums.cpp
+++ b/examples/libhello/src/test/Enums.cpp
@@ -51,4 +51,12 @@ Enums::create_struct_with_enum_inside( const ::test::Enums::InternalError type,
 {
     return {flip_enum( type ), message};
 }
+
+test::EnumStartsWithOne
+Enums::flip_enum_starts_with_one(const test::EnumStartsWithOne input)
+{
+    return input == test::EnumStartsWithOne::FIRST
+        ? test::EnumStartsWithOne::SECOND
+        : test::EnumStartsWithOne::FIRST;
+}
 }  // namespace test

--- a/examples/platforms/dart/test/Enums_test.dart
+++ b/examples/platforms/dart/test/Enums_test.dart
@@ -63,4 +63,11 @@ void main() {
 
     expect(result.type, equals(EnumsInternalError.errorFatal));
   });
+  _testSuite.test("Flip enum that starts with 1", () {
+    final input = EnumStartsWithOne.second;
+
+    final result = Enums.flipEnumStartsWithOne(input);
+
+    expect(result, EnumStartsWithOne.first);
+  });
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/modelbuilder/LimeTreeWalker.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/modelbuilder/LimeTreeWalker.kt
@@ -94,7 +94,7 @@ class LimeTreeWalker(builders: Collection<LimeBasedModelBuilder>) :
     }
 
     private fun walkChildNodes(limeEnumerator: LimeEnumerator) {
-        walk(limeEnumerator.value)
+        walk(limeEnumerator.explicitValue)
     }
 
     private fun walkChildNodes(limeConstant: LimeConstant) {

--- a/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
@@ -31,7 +31,7 @@ int {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
   switch (value) {
 {{#set parent=this}}{{#enumerators}}
   case {{resolveName parent}}.{{resolveName}}:
-    return {{>enumeratorValue}};
+    return {{value}};
   break;
 {{/enumerators}}{{/set}}
   default:
@@ -42,7 +42,7 @@ int {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(int handle) {
   switch (handle) {
 {{#set parent=this}}{{#enumerators}}
-  case {{>enumeratorValue}}:
+  case {{value}}:
     return {{resolveName parent}}.{{resolveName}};
   break;
 {{/enumerators}}{{/set}}
@@ -55,6 +55,4 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(int handle) {}
 
 {{>dart/DartNullableTypeConversion}}
 
-// End of {{resolveName}} "private" section.{{!!
-
-}}{{+enumeratorValue}}{{#value}}{{.}}{{/value}}{{^value}}{{iter.position}}{{/value}}{{/enumeratorValue}}
+// End of {{resolveName}} "private" section.

--- a/gluecodium/src/main/resources/templates/lime/LimeEnumerator.mustache
+++ b/gluecodium/src/main/resources/templates/lime/LimeEnumerator.mustache
@@ -19,4 +19,4 @@
   !
   !}}
 {{>lime/LimeDocumentation}}
-{{escapedName}}{{#value}} = {{this}}{{/value}}{{#if iter.hasNext}},{{/if}}
+{{escapedName}}{{#explicitValue}} = {{this}}{{/explicitValue}}{{#if iter.hasNext}},{{/if}}

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/common/modelbuilder/LimeTreeWalkerTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/common/modelbuilder/LimeTreeWalkerTest.kt
@@ -64,7 +64,7 @@ class LimeTreeWalkerTest {
     )
     private val limeTypeDef = LimeTypeAlias(EMPTY_PATH, typeRef = limeTypeDefTypeRef)
     private val limeEnumeratorValue = LimeValue.Literal(LimeLazyTypeRef("", emptyMap()), "bar")
-    private val limeEnumerator = LimeEnumerator(EMPTY_PATH, value = limeEnumeratorValue)
+    private val limeEnumerator = LimeEnumerator(EMPTY_PATH, explicitValue = limeEnumeratorValue)
     private val limeEnumeration = LimeEnumeration(EMPTY_PATH, enumerators = listOf(limeEnumerator))
     private val limeFieldValue = LimeValue.Literal(limeValueTypeRef, "foo")
     private val limeField = LimeField(

--- a/gluecodium/src/test/resources/smoke/enums/input/Enums.lime
+++ b/gluecodium/src/test/resources/smoke/enums/input/Enums.lime
@@ -65,3 +65,7 @@ types EnumsInTypeCollection {
     }
 }
 
+enum EnumStartsWithOne {
+    FIRST = 1,
+    SECOND
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/EnumStartsWithOne.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/EnumStartsWithOne.dart
@@ -1,0 +1,63 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+enum EnumStartsWithOne {
+    first,
+    second
+}
+// EnumStartsWithOne "private" section, not exported.
+int smoke_EnumStartsWithOne_toFfi(EnumStartsWithOne value) {
+  switch (value) {
+  case EnumStartsWithOne.first:
+    return 1;
+  break;
+  case EnumStartsWithOne.second:
+    return 2;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for EnumStartsWithOne enum.");
+  }
+}
+EnumStartsWithOne smoke_EnumStartsWithOne_fromFfi(int handle) {
+  switch (handle) {
+  case 1:
+    return EnumStartsWithOne.first;
+  break;
+  case 2:
+    return EnumStartsWithOne.second;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for EnumStartsWithOne enum.");
+  }
+}
+void smoke_EnumStartsWithOne_releaseFfiHandle(int handle) {}
+final _smoke_EnumStartsWithOne_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_EnumStartsWithOne_create_handle_nullable');
+final _smoke_EnumStartsWithOne_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_EnumStartsWithOne_release_handle_nullable');
+final _smoke_EnumStartsWithOne_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_EnumStartsWithOne_get_value_nullable');
+Pointer<Void> smoke_EnumStartsWithOne_toFfi_nullable(EnumStartsWithOne value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_EnumStartsWithOne_toFfi(value);
+  final result = _smoke_EnumStartsWithOne_create_handle_nullable(_handle);
+  smoke_EnumStartsWithOne_releaseFfiHandle(_handle);
+  return result;
+}
+EnumStartsWithOne smoke_EnumStartsWithOne_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_EnumStartsWithOne_get_value_nullable(handle);
+  final result = smoke_EnumStartsWithOne_fromFfi(_handle);
+  smoke_EnumStartsWithOne_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_EnumStartsWithOne_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_EnumStartsWithOne_release_handle_nullable(handle);
+// End of EnumStartsWithOne "private" section.

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -400,11 +400,19 @@ internal class AntlrLimeModelBuilder(
     }
 
     override fun exitEnumerator(ctx: LimeParser.EnumeratorContext) {
+        val siblings =
+            parentContext?.previousResults?.filterIsInstance<LimeEnumerator>() ?: emptyList()
+        val computedValue = siblings.lastOrNull()
+            ?.let { it.value as? LimeValue.Literal }
+            ?.value?.toIntOrNull()
+            ?.let { LimeValue.Literal(LimeBasicTypeRef.INT, (it + 1).toString()) }
+            ?: LimeValue.ZERO
         val limeElement = LimeEnumerator(
             path = currentPath,
             comment = parseStructuredComment(ctx.docComment(), ctx).description,
             attributes = AntlrLimeConverter.convertAnnotations(ctx.annotation()),
-            value = ctx.literalConstant()?.let { convertLiteralConstant(LimeBasicTypeRef.INT, it) }
+            computedValue = computedValue,
+            explicitValue = ctx.literalConstant()?.let { convertLiteralConstant(LimeBasicTypeRef.INT, it) }
         )
 
         storeResultAndPopStacks(limeElement)

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeEnumerator.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeEnumerator.kt
@@ -23,5 +23,8 @@ class LimeEnumerator(
     path: LimePath,
     comment: LimeComment = LimeComment(),
     attributes: LimeAttributes? = null,
-    val value: LimeValue? = null
-) : LimeNamedElement(path = path, comment = comment, attributes = attributes)
+    computedValue: LimeValue = LimeValue.ZERO,
+    val explicitValue: LimeValue? = null
+) : LimeNamedElement(path = path, comment = comment, attributes = attributes) {
+    val value = explicitValue ?: computedValue
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeValue.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeValue.kt
@@ -102,4 +102,8 @@ sealed class LimeValue(val typeRef: LimeTypeRef) : LimeElement() {
 
     open val escapedValue
         get() = toString()
+
+    companion object {
+        val ZERO = Literal(LimeBasicTypeRef.INT, "0")
+    }
 }


### PR DESCRIPTION
Updated LimeEnumerator class to carry both explicit value (IDL
user-assigned) and computed value (previous enumerator value + 1, or 0
for the first enumerator).

Updated Dart template for enums to use computed value if explicit value
is not specified. This fixes a run-time conversion issue for enums with
a mix of explicit and implicit enumerator values.

Added smoke and functional tests.

Resolves: #279
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>