### PR TITLE
Generate correct documentation links for method overloads

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -195,7 +195,7 @@ internal class DartNameResolver(
         result += functions.associateBy({ it.path.withSuffix("").toString() }, { resolveName(it) })
         result += functions.associateBy(
             { function -> function.path.withSuffix("").toString() + function.parameters
-                .joinToString(prefix = "(", postfix = ")") { it.typeRef.toString() } },
+                .joinToString(prefix = "(", postfix = ")", separator = ",") { it.typeRef.toString() } },
             { resolveName(it) }
         )
 

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -186,6 +186,13 @@ class CommentsLinks {
     // @throws May or may not throw [comments.SomethingWrong]
     fun random_method(inputParameter: comments.SomeEnum): comments.SomeEnum throws comments.SomethingWrong
 
+    // Links to method overloads:
+    // * other one: [random_method(SomeEnum)]
+    // * this one: [random_method(String, Boolean)]
+    // * ambiguous one: [random_method]
+    @Dart("randomMethod2")
+    fun random_method(text: String, flag: Boolean)
+
     // Links also work in:
     // @constructor constructor comments [comments.SomeStruct]
     struct RandomStruct {

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
@@ -5,7 +5,7 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
 /**
- * <p>The nested types like {@link com.example.smoke.CommentsLinks#randomMethod} don't need full name prefix, but it's
+ * <p>The nested types like {@link com.example.smoke.CommentsLinks#randomMethod(String, boolean)} don't need full name prefix, but it's
  * possible to references other interfaces like {@link com.example.smoke.CommentsInterface} or other members
  * {@link com.example.smoke.Comments#someMethodWithAllComments}.</p>
  * <p>Weblinks are not modified like this <a href="http://example.com">example</a> or [www.example.com].</p>
@@ -80,4 +80,15 @@ public final class CommentsLinks extends NativeBase {
      */
     @NonNull
     public native Comments.SomeEnum randomMethod(@NonNull final Comments.SomeEnum inputParameter) throws Comments.SomethingWrongException;
+    /**
+     * <p>Links to method overloads:</p>
+     * <ul>
+     * <li>other one: {@link com.example.smoke.CommentsLinks#randomMethod(Comments.SomeEnum)}</li>
+     * <li>this one: {@link com.example.smoke.CommentsLinks#randomMethod(String, boolean)}</li>
+     * <li>ambiguous one: {@link com.example.smoke.CommentsLinks#randomMethod(String, boolean)}</li>
+     * </ul>
+     * @param text
+     * @param flag
+     */
+    public native void randomMethod(@NonNull final String text, final boolean flag);
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
@@ -6,10 +6,11 @@
 #include "gluecodium/Export.h"
 #include "gluecodium/Return.h"
 #include "smoke/Comments.h"
+#include <string>
 #include <system_error>
 namespace smoke {
 /**
- * The nested types like ::smoke::CommentsLinks::random_method don't need full name prefix, but it's
+ * The nested types like ::smoke::CommentsLinks::random_method(const ::std::string&, const bool) don't need full name prefix, but it's
  * possible to references other interfaces like ::smoke::CommentsInterface or other members
  * ::smoke::Comments::some_method_with_all_comments.
  *
@@ -75,5 +76,14 @@ public:
      * \retval ::smoke::Comments::SomeEnum May or may not throw ::smoke::Comments::SomeEnum
      */
     virtual ::gluecodium::Return< ::smoke::Comments::SomeEnum, ::std::error_code > random_method( const ::smoke::Comments::SomeEnum input_parameter ) = 0;
+    /**
+     * Links to method overloads:
+     * * other one: ::smoke::CommentsLinks::random_method(const ::smoke::Comments::SomeEnum)
+     * * this one: ::smoke::CommentsLinks::random_method(const ::std::string&, const bool)
+     * * ambiguous one: ::smoke::CommentsLinks::random_method(const ::std::string&, const bool)
+     * \param[in] text
+     * \param[in] flag
+     */
+    virtual void random_method( const ::std::string& text, const bool flag ) = 0;
 };
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
@@ -1,9 +1,10 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
 import 'package:library/src/smoke/Comments.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-/// The nested types like [randomMethod] don't need full name prefix, but it's
+/// The nested types like [randomMethod2] don't need full name prefix, but it's
 /// possible to references other interfaces like [CommentsInterface] or other members
 /// [someMethodWithAllComments].
 ///
@@ -22,8 +23,8 @@ abstract class CommentsLinks {
   /// * property setter: [isSomeProperty]
   /// * property getter: [isSomeProperty]
   /// * method: [someMethodWithAllComments]
-  /// * method with signature: [comments.oneParameterCommentOnly(String, String)]
-  /// * method with signature with no spaces: [comments.oneParameterCommentOnly(String,String)]
+  /// * method with signature: [oneParameterCommentOnly]
+  /// * method with signature with no spaces: [oneParameterCommentOnly]
   /// * parameter: [inputParameter]
   /// * top level constant: [CommentsTypeCollection.typeCollectionConstant]
   /// * top level struct: [TypeCollectionStruct]
@@ -44,6 +45,11 @@ abstract class CommentsLinks {
   /// @return Sometimes returns [Comments_SomeEnum.useful]
   /// @throws May or may not throw [Comments_SomethingWrongException]
   Comments_SomeEnum randomMethod(Comments_SomeEnum inputParameter);
+  /// Links to method overloads:
+  /// * other one: [randomMethod]
+  /// * this one: [randomMethod2]
+  /// * ambiguous one: [randomMethod2]
+  randomMethod2(String text, bool flag);
 }
 /// Links also work in:
 class CommentsLinks_RandomStruct {
@@ -157,6 +163,19 @@ class CommentsLinks$Impl implements CommentsLinks {
     _randomMethod_return_release_handle(__call_result_handle);
     final _result = smoke_Comments_SomeEnum_fromFfi(__result_handle);
     smoke_Comments_SomeEnum_releaseFfiHandle(__result_handle);
+    return _result;
+  }
+  @override
+  randomMethod2(String text, bool flag) {
+    final _randomMethod2_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_CommentsLinks_randomMethod__String_Boolean');
+    final _text_handle = String_toFfi(text);
+    final _flag_handle = Boolean_toFfi(flag);
+    final _handle = this.handle;
+    final __result_handle = _randomMethod2_ffi(_handle, __lib.LibraryContext.isolateId, _text_handle, _flag_handle);
+    String_releaseFfiHandle(_text_handle);
+    Boolean_releaseFfiHandle(_flag_handle);
+    final _result = (__result_handle);
+    (__result_handle);
     return _result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
@@ -50,4 +50,13 @@ class CommentsLinks {
     fun random_method(
         inputParameter: SomeEnum
     ): SomeEnum throws SomethingWrong
+    // Links to method overloads:
+    // * other one: [random_method(SomeEnum)]
+    // * this one: [random_method(String, Boolean)]
+    // * ambiguous one: [random_method]
+    @Dart("randomMethod2")
+    fun random_method(
+        text: String,
+        flag: Boolean
+    )
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
@@ -1,7 +1,7 @@
 //
 //
 import Foundation
-/// The nested types like `CommentsLinks.randomMethod(...)` don't need full name prefix, but it's
+/// The nested types like `CommentsLinks.randomMethod(String, Bool)` don't need full name prefix, but it's
 /// possible to references other interfaces like `CommentsInterface` or other members
 /// `Comments.someMethodWithAllComments(...)`.
 ///
@@ -45,7 +45,7 @@ public class CommentsLinks {
     /// * method: `Comments.someMethodWithAllComments(...)`
     /// * method with signature: `Comments.oneParameterCommentOnly(...)`
     /// * method with signature with no spaces: `Comments.oneParameterCommentOnly(...)`
-    /// * parameter: `CommentsLinks.randomMethod(...).inputParameter`
+    /// * parameter: `CommentsLinks.randomMethod(Comments.SomeEnum).inputParameter`
     /// * top level constant: `CommentsTypeCollection.typeCollectionConstant`
     /// * top level struct: `TypeCollectionStruct`
     /// * top level struct field: `TypeCollectionStruct.field`
@@ -66,12 +66,24 @@ public class CommentsLinks {
     /// - Throws: `Comments.SomethingWrongError` May or may not throw `Comments.SomethingWrongError`
     public func randomMethod(inputParameter: Comments.SomeEnum) throws -> Comments.SomeEnum {
         let c_inputParameter = moveToCType(inputParameter)
-        let RESULT = smoke_CommentsLinks_randomMethod(self.c_instance, c_inputParameter.ref)
+        let RESULT = smoke_CommentsLinks_randomMethod_SomeEnum(self.c_instance, c_inputParameter.ref)
         if (!RESULT.has_value) {
             throw moveFromCType(RESULT.error_value) as Comments.SomethingWrongError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
+    }
+    /// Links to method overloads:
+    /// * other one: `CommentsLinks.randomMethod(Comments.SomeEnum)`
+    /// * this one: `CommentsLinks.randomMethod(String, Bool)`
+    /// * ambiguous one: `CommentsLinks.randomMethod(String, Bool)`
+    /// - Parameters:
+    ///   - text:
+    ///   - flag:
+    public func randomMethod(text: String, flag: Bool) -> Void {
+        let c_text = moveToCType(text)
+        let c_flag = moveToCType(flag)
+        return moveFromCType(smoke_CommentsLinks_randomMethod_String_Boolean(self.c_instance, c_text.ref, c_flag.ref))
     }
 }
 internal func getRef(_ ref: CommentsLinks?, owning: Bool = true) -> RefHolder {


### PR DESCRIPTION
Updated C++, Java, and Swift generators to append method signature to
documentation links for methods that are overloaded. Dart generator was
not updated as there are no overloaded methods in Dart language.

Added smoke tests.

Resolves: #227
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>