### PR TITLE
Add delegator pattern for interfaces in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Added support for `Skip` platform-specific attribute in IDL (e.g. `@Java(Skip)`, `@Swift(Skip)`,
     or `@Dart(Skip)`). Elements marked with this attribute will be omitted in that platform's
     generated code. This attribute is not supported for C++.
+  * Added support for creating an interface implementation directly from a set of lambdas in Dart.
 
 ## 6.5.0
 Release date: 2020-04-16

--- a/examples/libhello/lime/test/Interfaces.lime
+++ b/examples/libhello/lime/test/Interfaces.lime
@@ -61,3 +61,7 @@ class InterfacesFactory {
     static fun createNestedInterfaceOne(): NestedInterfaceOne
     static fun createNestedInterfaceTwo(): NestedInterfaceTwo
 }
+
+interface InterfaceWithProperty {
+    property stringProperty: String
+}

--- a/examples/platforms/dart/test/Interfaces_test.dart
+++ b/examples/platforms/dart/test/Interfaces_test.dart
@@ -123,4 +123,28 @@ void main() {
     result1.release();
     result2.release();
   });
+  _testSuite.test("Delegator with functions", () {
+    String stringValue;
+    final delegator = SimpleInterfaceOne.fromLambdas(
+      lambda_setStringValue: (value) { stringValue = value; },
+      lambda_getStringValue: () => stringValue
+    );
+
+    delegator.setStringValue("foo");
+    final result = delegator.getStringValue();
+
+    expect(result, "foo");
+  });
+  _testSuite.test("Delegator with property", () {
+    String stringValue;
+    final delegator = InterfaceWithProperty.fromLambdas(
+      lambda_stringProperty_set: (value) { stringValue = value; },
+      lambda_stringProperty_get: () => stringValue
+    );
+
+    delegator.stringProperty = "foo";
+    final result = delegator.stringProperty;
+
+    expect(result, "foo");
+  });
 }

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -19,8 +19,33 @@
   !
   !}}
 {{>dart/DartDocumentation}}
-abstract class {{resolveName}} {{!!
-}}{{#if parent}}implements {{resolveName parent}} {{/if}}{
+abstract class {{resolveName}} {{#if parent}}implements {{resolveName parent}} {{/if}}{
+{{#if inheritedFunctions functions inheritedProperties properties logic="or"}}
+  {{resolveName}}() {}
+
+  factory {{resolveName}}.fromLambdas({
+{{#each inheritedFunctions functions}}
+    @required {{>dart/DartLambdaType}} lambda_{{resolveName}}{{#if iter.hasNext}},
+{{/if}}{{/each}}{{#if inheritedFunctions functions logic="or"}}{{#if inheritedProperties properties logic="or"}},
+{{/if}}{{/if}}{{#each inheritedProperties properties}}{{#set property=this}}{{#getter}}
+    @required {{>dart/DartLambdaType}} lambda_{{resolveName property}}_get{{#if setter}},
+{{/if}}{{/getter}}{{#setter}}
+    @required {{>dart/DartLambdaType}} lambda_{{resolveName property}}_set{{/setter}}{{#if iter.hasNext}},
+{{/if}}{{/set}}{{/each}}
+
+  }) => {{resolveName}}$Lambdas(
+{{#each inheritedFunctions functions}}
+    lambda_{{resolveName}}{{#if iter.hasNext}},
+{{/if}}{{/each}}{{#if inheritedFunctions functions logic="or"}}{{#if inheritedProperties properties logic="or"}},
+{{/if}}{{/if}}{{#each inheritedProperties properties}}{{#set property=this}}{{#getter}}
+    lambda_{{resolveName property}}_get{{#if setter}},
+{{/if}}{{/getter}}{{#setter}}
+    lambda_{{resolveName property}}_set{{/setter}}{{#if iter.hasNext}},
+{{/if}}{{/set}}{{/each}}
+
+  );
+{{/if}}
+
   void release() {}
 
 {{#set isInClass=true}}{{#constants}}
@@ -81,7 +106,70 @@ final _{{resolveName "Ffi"}}_get_type_id = __lib.nativeLibrary.lookupFunction<
 {{>dart/DartFunctionException}}
 
 {{/functions}}{{!!
-}}class {{resolveName}}$Impl {{#if parent}}extends {{resolveName parent}}$Impl {{/if}}implements {{resolveName}} {
+}}{{#if inheritedFunctions functions inheritedProperties properties logic="or"}}
+class {{resolveName}}$Lambdas {{#if parent}}extends {{resolveName parent}}$Lambdas {{/if}}implements {{resolveName}} {
+{{#functions}}
+  {{>dart/DartLambdaType}} lambda_{{resolveName}};
+{{/functions}}
+{{#properties}}{{#set property=this}}
+{{#getter}}  {{>dart/DartLambdaType}} lambda_{{resolveName property}}_get;
+{{/getter}}{{!!
+}}{{#setter}}  {{>dart/DartLambdaType}} lambda_{{resolveName property}}_set;
+{{/setter}}
+{{/set}}{{/properties}}
+
+  {{resolveName}}$Lambdas(
+{{#each inheritedFunctions functions}}
+    {{>dart/DartLambdaType}} lambda_{{resolveName}}{{#if iter.hasNext}},
+{{/if}}{{/each}}{{#if inheritedFunctions functions logic="or"}}{{#if inheritedProperties properties logic="or"}},
+{{/if}}{{/if}}{{#each inheritedProperties properties}}{{#set property=this}}{{#getter}}
+    {{>dart/DartLambdaType}} lambda_{{resolveName property}}_get{{#if setter}},
+{{/if}}{{/getter}}{{#setter}}
+    {{>dart/DartLambdaType}} lambda_{{resolveName property}}_set{{/setter}}{{#if iter.hasNext}},
+{{/if}}{{/set}}{{/each}}
+
+  ){{#if parent}} : super(
+{{#inheritedFunctions}}
+    lambda_{{resolveName}}{{#if iter.hasNext}},
+{{/if}}{{/inheritedFunctions}}{{#if inheritedFunctions inheritedProperties}},
+{{/if}}{{#inheritedProperties}}{{#set property=this}}{{#getter}}
+    lambda_{{resolveName property}}_get{{#if setter}},
+{{/if}}{{/getter}}{{#setter}}
+    lambda_{{resolveName property}}_set{{/setter}}{{#if iter.hasNext}},
+{{/if}}{{/set}}{{/inheritedProperties}}
+
+  ){{/if}} {
+{{#functions}}
+    this.lambda_{{resolveName}} = lambda_{{resolveName}};
+{{/functions}}
+{{#properties}}{{#set property=this}}
+    this.lambda_{{resolveName property}}_get = lambda_{{resolveName property}}_get;
+{{#setter}}    this.lambda_{{resolveName property}}_set = lambda_{{resolveName property}}_set;
+{{/setter}}
+{{/set}}{{/properties}}
+
+  }
+
+  @override
+  void release() {}
+
+{{#functions}}
+  @override
+  {{>dart/DartFunctionSignature}} =>
+    lambda_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
+{{/functions}}
+{{#properties}}
+  @override
+  {{resolveName typeRef}} get {{resolveName visibility}}{{resolveName}} => lambda_{{resolveName}}_get();
+{{#if setter}}
+  @override
+  set {{resolveName visibility}}{{resolveName}}({{resolveName typeRef}} value) => lambda_{{resolveName}}_set(value);
+{{/if}}
+{{/properties}}
+}
+{{/if}}
+
+class {{resolveName}}$Impl {{#if parent}}extends {{resolveName parent}}$Impl {{/if}}implements {{resolveName}} {
   {{#if parent}}{{resolveName}}$Impl(Pointer<Void> handle) : super(handle);{{/if}}{{!!
   }}{{#unless parent}}final Pointer<Void> handle;
   {{resolveName}}$Impl(this.handle);{{/unless}}

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -19,8 +19,7 @@
   !
   !}}
 {{>dart/DartDocumentation}}
-typedef {{resolveName}} = {{resolveName returnType.typeRef}} Function({{!!
-}}{{#parameters}}{{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
+typedef {{resolveName}} = {{>dart/DartLambdaType}};
 
 // {{resolveName}} "private" section, not exported.
 

--- a/gluecodium/src/main/resources/templates/dart/DartLambdaType.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambdaType.mustache
@@ -1,0 +1,21 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{resolveName returnType.typeRef}} Function({{#parameters}}{{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{/parameters}})

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsInterface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsInterface.dart
@@ -5,9 +5,36 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 /// This is some very useful interface.
 abstract class CommentsInterface {
+  CommentsInterface() {}
+  factory CommentsInterface.fromLambdas({
+    @required bool Function(String) lambda_someMethodWithAllComments,
+    @required bool Function(String) lambda_someMethodWithInputComments,
+    @required bool Function(String) lambda_someMethodWithOutputComments,
+    @required bool Function(String) lambda_someMethodWithNoComments,
+    @required void Function(String) lambda_someMethodWithoutReturnTypeWithAllComments,
+    @required void Function(String) lambda_someMethodWithoutReturnTypeWithNoComments,
+    @required bool Function() lambda_someMethodWithoutInputParametersWithAllComments,
+    @required bool Function() lambda_someMethodWithoutInputParametersWithNoComments,
+    @required void Function() lambda_someMethodWithNothing,
+    @required void Function() lambda_someMethodWithoutReturnTypeOrInputParameters,
+    @required bool Function() lambda_isSomeProperty_get,
+    @required void Function(bool) lambda_isSomeProperty_set
+  }) => CommentsInterface$Lambdas(
+    lambda_someMethodWithAllComments,
+    lambda_someMethodWithInputComments,
+    lambda_someMethodWithOutputComments,
+    lambda_someMethodWithNoComments,
+    lambda_someMethodWithoutReturnTypeWithAllComments,
+    lambda_someMethodWithoutReturnTypeWithNoComments,
+    lambda_someMethodWithoutInputParametersWithAllComments,
+    lambda_someMethodWithoutInputParametersWithNoComments,
+    lambda_someMethodWithNothing,
+    lambda_someMethodWithoutReturnTypeOrInputParameters,
+    lambda_isSomeProperty_get,
+    lambda_isSomeProperty_set
+  );
   void release() {}
   /// This is some very useful constant.
   static final bool veryUseful = true;
@@ -188,6 +215,83 @@ final _smoke_CommentsInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_get_type_id');
+class CommentsInterface$Lambdas implements CommentsInterface {
+  bool Function(String) lambda_someMethodWithAllComments;
+  bool Function(String) lambda_someMethodWithInputComments;
+  bool Function(String) lambda_someMethodWithOutputComments;
+  bool Function(String) lambda_someMethodWithNoComments;
+  void Function(String) lambda_someMethodWithoutReturnTypeWithAllComments;
+  void Function(String) lambda_someMethodWithoutReturnTypeWithNoComments;
+  bool Function() lambda_someMethodWithoutInputParametersWithAllComments;
+  bool Function() lambda_someMethodWithoutInputParametersWithNoComments;
+  void Function() lambda_someMethodWithNothing;
+  void Function() lambda_someMethodWithoutReturnTypeOrInputParameters;
+  bool Function() lambda_isSomeProperty_get;
+  void Function(bool) lambda_isSomeProperty_set;
+  CommentsInterface$Lambdas(
+    bool Function(String) lambda_someMethodWithAllComments,
+    bool Function(String) lambda_someMethodWithInputComments,
+    bool Function(String) lambda_someMethodWithOutputComments,
+    bool Function(String) lambda_someMethodWithNoComments,
+    void Function(String) lambda_someMethodWithoutReturnTypeWithAllComments,
+    void Function(String) lambda_someMethodWithoutReturnTypeWithNoComments,
+    bool Function() lambda_someMethodWithoutInputParametersWithAllComments,
+    bool Function() lambda_someMethodWithoutInputParametersWithNoComments,
+    void Function() lambda_someMethodWithNothing,
+    void Function() lambda_someMethodWithoutReturnTypeOrInputParameters,
+    bool Function() lambda_isSomeProperty_get,
+    void Function(bool) lambda_isSomeProperty_set
+  ) {
+    this.lambda_someMethodWithAllComments = lambda_someMethodWithAllComments;
+    this.lambda_someMethodWithInputComments = lambda_someMethodWithInputComments;
+    this.lambda_someMethodWithOutputComments = lambda_someMethodWithOutputComments;
+    this.lambda_someMethodWithNoComments = lambda_someMethodWithNoComments;
+    this.lambda_someMethodWithoutReturnTypeWithAllComments = lambda_someMethodWithoutReturnTypeWithAllComments;
+    this.lambda_someMethodWithoutReturnTypeWithNoComments = lambda_someMethodWithoutReturnTypeWithNoComments;
+    this.lambda_someMethodWithoutInputParametersWithAllComments = lambda_someMethodWithoutInputParametersWithAllComments;
+    this.lambda_someMethodWithoutInputParametersWithNoComments = lambda_someMethodWithoutInputParametersWithNoComments;
+    this.lambda_someMethodWithNothing = lambda_someMethodWithNothing;
+    this.lambda_someMethodWithoutReturnTypeOrInputParameters = lambda_someMethodWithoutReturnTypeOrInputParameters;
+    this.lambda_isSomeProperty_get = lambda_isSomeProperty_get;
+    this.lambda_isSomeProperty_set = lambda_isSomeProperty_set;
+  }
+  @override
+  void release() {}
+  @override
+  bool someMethodWithAllComments(String input) =>
+    lambda_someMethodWithAllComments(input);
+  @override
+  bool someMethodWithInputComments(String input) =>
+    lambda_someMethodWithInputComments(input);
+  @override
+  bool someMethodWithOutputComments(String input) =>
+    lambda_someMethodWithOutputComments(input);
+  @override
+  bool someMethodWithNoComments(String input) =>
+    lambda_someMethodWithNoComments(input);
+  @override
+  someMethodWithoutReturnTypeWithAllComments(String input) =>
+    lambda_someMethodWithoutReturnTypeWithAllComments(input);
+  @override
+  someMethodWithoutReturnTypeWithNoComments(String input) =>
+    lambda_someMethodWithoutReturnTypeWithNoComments(input);
+  @override
+  bool someMethodWithoutInputParametersWithAllComments() =>
+    lambda_someMethodWithoutInputParametersWithAllComments();
+  @override
+  bool someMethodWithoutInputParametersWithNoComments() =>
+    lambda_someMethodWithoutInputParametersWithNoComments();
+  @override
+  someMethodWithNothing() =>
+    lambda_someMethodWithNothing();
+  @override
+  someMethodWithoutReturnTypeOrInputParameters() =>
+    lambda_someMethodWithoutReturnTypeOrInputParameters();
+  @override
+  bool get isSomeProperty => lambda_isSomeProperty_get();
+  @override
+  set isSomeProperty(bool value) => lambda_isSomeProperty_set(value);
+}
 class CommentsInterface$Impl implements CommentsInterface {
   final Pointer<Void> handle;
   CommentsInterface$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationComments.dart
@@ -5,10 +5,19 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 /// This is some very useful interface.
 @Deprecated("Unfortunately, this interface is deprecated. Use [comments] instead.")
 abstract class DeprecationComments {
+  DeprecationComments() {}
+  factory DeprecationComments.fromLambdas({
+    @required bool Function(String) lambda_someMethodWithAllComments,
+    @required bool Function() lambda_isSomeProperty_get,
+    @required void Function(bool) lambda_isSomeProperty_set
+  }) => DeprecationComments$Lambdas(
+    lambda_someMethodWithAllComments,
+    lambda_isSomeProperty_get,
+    lambda_isSomeProperty_set
+  );
   void release() {}
   /// This is some very useful constant.
   @Deprecated("Unfortunately, this constant is deprecated. Use [comments.VeryUseful] instead.")
@@ -178,6 +187,29 @@ final _smoke_DeprecationComments_get_type_id = __lib.nativeLibrary.lookupFunctio
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_get_type_id');
+class DeprecationComments$Lambdas implements DeprecationComments {
+  bool Function(String) lambda_someMethodWithAllComments;
+  bool Function() lambda_isSomeProperty_get;
+  void Function(bool) lambda_isSomeProperty_set;
+  DeprecationComments$Lambdas(
+    bool Function(String) lambda_someMethodWithAllComments,
+    bool Function() lambda_isSomeProperty_get,
+    void Function(bool) lambda_isSomeProperty_set
+  ) {
+    this.lambda_someMethodWithAllComments = lambda_someMethodWithAllComments;
+    this.lambda_isSomeProperty_get = lambda_isSomeProperty_get;
+    this.lambda_isSomeProperty_set = lambda_isSomeProperty_set;
+  }
+  @override
+  void release() {}
+  @override
+  bool someMethodWithAllComments(String input) =>
+    lambda_someMethodWithAllComments(input);
+  @override
+  bool get isSomeProperty => lambda_isSomeProperty_get();
+  @override
+  set isSomeProperty(bool value) => lambda_isSomeProperty_set(value);
+}
 class DeprecationComments$Impl implements DeprecationComments {
   final Pointer<Void> handle;
   DeprecationComments$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationCommentsOnly.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationCommentsOnly.dart
@@ -5,9 +5,18 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 @Deprecated("Unfortunately, this interface is deprecated.")
 abstract class DeprecationCommentsOnly {
+  DeprecationCommentsOnly() {}
+  factory DeprecationCommentsOnly.fromLambdas({
+    @required bool Function(String) lambda_someMethodWithAllComments,
+    @required bool Function() lambda_isSomeProperty_get,
+    @required void Function(bool) lambda_isSomeProperty_set
+  }) => DeprecationCommentsOnly$Lambdas(
+    lambda_someMethodWithAllComments,
+    lambda_isSomeProperty_get,
+    lambda_isSomeProperty_set
+  );
   void release() {}
   @Deprecated("Unfortunately, this constant is deprecated.")
   static final bool veryUseful = true;
@@ -159,6 +168,29 @@ final _smoke_DeprecationCommentsOnly_get_type_id = __lib.nativeLibrary.lookupFun
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_get_type_id');
+class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
+  bool Function(String) lambda_someMethodWithAllComments;
+  bool Function() lambda_isSomeProperty_get;
+  void Function(bool) lambda_isSomeProperty_set;
+  DeprecationCommentsOnly$Lambdas(
+    bool Function(String) lambda_someMethodWithAllComments,
+    bool Function() lambda_isSomeProperty_get,
+    void Function(bool) lambda_isSomeProperty_set
+  ) {
+    this.lambda_someMethodWithAllComments = lambda_someMethodWithAllComments;
+    this.lambda_isSomeProperty_get = lambda_isSomeProperty_get;
+    this.lambda_isSomeProperty_set = lambda_isSomeProperty_set;
+  }
+  @override
+  void release() {}
+  @override
+  bool someMethodWithAllComments(String input) =>
+    lambda_someMethodWithAllComments(input);
+  @override
+  bool get isSomeProperty => lambda_isSomeProperty_get();
+  @override
+  set isSomeProperty(bool value) => lambda_isSomeProperty_set(value);
+}
 class DeprecationCommentsOnly$Impl implements DeprecationCommentsOnly {
   final Pointer<Void> handle;
   DeprecationCommentsOnly$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/ErrorsInterface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/ErrorsInterface.dart
@@ -7,8 +7,21 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 abstract class ErrorsInterface {
+  ErrorsInterface() {}
+  factory ErrorsInterface.fromLambdas({
+    @required void Function() lambda_methodWithErrors,
+    @required void Function() lambda_methodWithExternalErrors,
+    @required String Function() lambda_methodWithErrorsAndReturnValue,
+    @required void Function() lambda_methodWithPayloadError,
+    @required String Function() lambda_methodWithPayloadErrorAndReturnValue
+  }) => ErrorsInterface$Lambdas(
+    lambda_methodWithErrors,
+    lambda_methodWithExternalErrors,
+    lambda_methodWithErrorsAndReturnValue,
+    lambda_methodWithPayloadError,
+    lambda_methodWithPayloadErrorAndReturnValue
+  );
   void release() {}
   methodWithErrors();
   methodWithExternalErrors();
@@ -241,6 +254,43 @@ final _methodWithPayloadErrorAndReturnValue_return_has_error = __lib.nativeLibra
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_has_error');
+class ErrorsInterface$Lambdas implements ErrorsInterface {
+  void Function() lambda_methodWithErrors;
+  void Function() lambda_methodWithExternalErrors;
+  String Function() lambda_methodWithErrorsAndReturnValue;
+  void Function() lambda_methodWithPayloadError;
+  String Function() lambda_methodWithPayloadErrorAndReturnValue;
+  ErrorsInterface$Lambdas(
+    void Function() lambda_methodWithErrors,
+    void Function() lambda_methodWithExternalErrors,
+    String Function() lambda_methodWithErrorsAndReturnValue,
+    void Function() lambda_methodWithPayloadError,
+    String Function() lambda_methodWithPayloadErrorAndReturnValue
+  ) {
+    this.lambda_methodWithErrors = lambda_methodWithErrors;
+    this.lambda_methodWithExternalErrors = lambda_methodWithExternalErrors;
+    this.lambda_methodWithErrorsAndReturnValue = lambda_methodWithErrorsAndReturnValue;
+    this.lambda_methodWithPayloadError = lambda_methodWithPayloadError;
+    this.lambda_methodWithPayloadErrorAndReturnValue = lambda_methodWithPayloadErrorAndReturnValue;
+  }
+  @override
+  void release() {}
+  @override
+  methodWithErrors() =>
+    lambda_methodWithErrors();
+  @override
+  methodWithExternalErrors() =>
+    lambda_methodWithExternalErrors();
+  @override
+  String methodWithErrorsAndReturnValue() =>
+    lambda_methodWithErrorsAndReturnValue();
+  @override
+  static methodWithPayloadError() =>
+    lambda_methodWithPayloadError();
+  @override
+  static String methodWithPayloadErrorAndReturnValue() =>
+    lambda_methodWithPayloadErrorAndReturnValue();
+}
 class ErrorsInterface$Impl implements ErrorsInterface {
   final Pointer<Void> handle;
   ErrorsInterface$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildInterface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ChildInterface.dart
@@ -6,8 +6,19 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 abstract class ChildInterface implements ParentInterface {
+  ChildInterface() {}
+  factory ChildInterface.fromLambdas({
+    @required void Function() lambda_rootMethod,
+    @required void Function() lambda_childMethod,
+    @required String Function() lambda_rootProperty_get,
+    @required void Function(String) lambda_rootProperty_set
+  }) => ChildInterface$Lambdas(
+    lambda_rootMethod,
+    lambda_childMethod,
+    lambda_rootProperty_get,
+    lambda_rootProperty_set
+  );
   void release() {}
   childMethod();
 }
@@ -32,6 +43,26 @@ final _smoke_ChildInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildInterface_get_type_id');
+class ChildInterface$Lambdas extends ParentInterface$Lambdas implements ChildInterface {
+  void Function() lambda_childMethod;
+  ChildInterface$Lambdas(
+    void Function() lambda_rootMethod,
+    void Function() lambda_childMethod,
+    String Function() lambda_rootProperty_get,
+    void Function(String) lambda_rootProperty_set
+  ) : super(
+    lambda_rootMethod,
+    lambda_rootProperty_get,
+    lambda_rootProperty_set
+  ) {
+    this.lambda_childMethod = lambda_childMethod;
+  }
+  @override
+  void release() {}
+  @override
+  childMethod() =>
+    lambda_childMethod();
+}
 class ChildInterface$Impl extends ParentInterface$Impl implements ChildInterface {
   ChildInterface$Impl(Pointer<Void> handle) : super(handle);
   @override

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentInterface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/ParentInterface.dart
@@ -5,8 +5,17 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 abstract class ParentInterface {
+  ParentInterface() {}
+  factory ParentInterface.fromLambdas({
+    @required void Function() lambda_rootMethod,
+    @required String Function() lambda_rootProperty_get,
+    @required void Function(String) lambda_rootProperty_set
+  }) => ParentInterface$Lambdas(
+    lambda_rootMethod,
+    lambda_rootProperty_get,
+    lambda_rootProperty_set
+  );
   void release() {}
   rootMethod();
   String get rootProperty;
@@ -33,6 +42,29 @@ final _smoke_ParentInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ParentInterface_get_type_id');
+class ParentInterface$Lambdas implements ParentInterface {
+  void Function() lambda_rootMethod;
+  String Function() lambda_rootProperty_get;
+  void Function(String) lambda_rootProperty_set;
+  ParentInterface$Lambdas(
+    void Function() lambda_rootMethod,
+    String Function() lambda_rootProperty_get,
+    void Function(String) lambda_rootProperty_set
+  ) {
+    this.lambda_rootMethod = lambda_rootMethod;
+    this.lambda_rootProperty_get = lambda_rootProperty_get;
+    this.lambda_rootProperty_set = lambda_rootProperty_set;
+  }
+  @override
+  void release() {}
+  @override
+  rootMethod() =>
+    lambda_rootMethod();
+  @override
+  String get rootProperty => lambda_rootProperty_get();
+  @override
+  set rootProperty(String value) => lambda_rootProperty_set(value);
+}
 class ParentInterface$Impl implements ParentInterface {
   final Pointer<Void> handle;
   ParentInterface$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/ExternalInterface.dart
@@ -5,8 +5,15 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 abstract class ExternalInterface {
+  ExternalInterface() {}
+  factory ExternalInterface.fromLambdas({
+    @required void Function(int) lambda_someMethod,
+    @required String Function() lambda_someProperty_get
+  }) => ExternalInterface$Lambdas(
+    lambda_someMethod,
+    lambda_someProperty_get
+  );
   void release() {}
   someMethod(int someParameter);
   String get someProperty;
@@ -146,6 +153,24 @@ final _smoke_ExternalInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_get_type_id');
+class ExternalInterface$Lambdas implements ExternalInterface {
+  void Function(int) lambda_someMethod;
+  String Function() lambda_someProperty_get;
+  ExternalInterface$Lambdas(
+    void Function(int) lambda_someMethod,
+    String Function() lambda_someProperty_get
+  ) {
+    this.lambda_someMethod = lambda_someMethod;
+    this.lambda_someProperty_get = lambda_someProperty_get;
+  }
+  @override
+  void release() {}
+  @override
+  someMethod(int someParameter) =>
+    lambda_someMethod(someParameter);
+  @override
+  String get someProperty => lambda_someProperty_get();
+}
 class ExternalInterface$Impl implements ExternalInterface {
   final Pointer<Void> handle;
   ExternalInterface$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleInterface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/SimpleInterface.dart
@@ -5,8 +5,15 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 abstract class SimpleInterface {
+  SimpleInterface() {}
+  factory SimpleInterface.fromLambdas({
+    @required String Function() lambda_getStringValue,
+    @required SimpleInterface Function(SimpleInterface) lambda_useSimpleInterface
+  }) => SimpleInterface$Lambdas(
+    lambda_getStringValue,
+    lambda_useSimpleInterface
+  );
   void release() {}
   String getStringValue();
   SimpleInterface useSimpleInterface(SimpleInterface input);
@@ -32,6 +39,25 @@ final _smoke_SimpleInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleInterface_get_type_id');
+class SimpleInterface$Lambdas implements SimpleInterface {
+  String Function() lambda_getStringValue;
+  SimpleInterface Function(SimpleInterface) lambda_useSimpleInterface;
+  SimpleInterface$Lambdas(
+    String Function() lambda_getStringValue,
+    SimpleInterface Function(SimpleInterface) lambda_useSimpleInterface
+  ) {
+    this.lambda_getStringValue = lambda_getStringValue;
+    this.lambda_useSimpleInterface = lambda_useSimpleInterface;
+  }
+  @override
+  void release() {}
+  @override
+  String getStringValue() =>
+    lambda_getStringValue();
+  @override
+  SimpleInterface useSimpleInterface(SimpleInterface input) =>
+    lambda_useSimpleInterface(input);
+}
 class SimpleInterface$Impl implements SimpleInterface {
   final Pointer<Void> handle;
   SimpleInterface$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/CalculatorListener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/CalculatorListener.dart
@@ -7,8 +7,23 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 abstract class CalculatorListener {
+  CalculatorListener() {}
+  factory CalculatorListener.fromLambdas({
+    @required void Function(double) lambda_onCalculationResult,
+    @required void Function(double) lambda_onCalculationResultConst,
+    @required void Function(CalculatorListener_ResultStruct) lambda_onCalculationResultStruct,
+    @required void Function(List<double>) lambda_onCalculationResultArray,
+    @required void Function(Map<String, double>) lambda_onCalculationResultMap,
+    @required void Function(CalculationResult) lambda_onCalculationResultInstance
+  }) => CalculatorListener$Lambdas(
+    lambda_onCalculationResult,
+    lambda_onCalculationResultConst,
+    lambda_onCalculationResultStruct,
+    lambda_onCalculationResultArray,
+    lambda_onCalculationResultMap,
+    lambda_onCalculationResultInstance
+  );
   void release() {}
   onCalculationResult(double calculationResult);
   onCalculationResultConst(double calculationResult);
@@ -100,6 +115,49 @@ final _smoke_CalculatorListener_get_type_id = __lib.nativeLibrary.lookupFunction
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_get_type_id');
+class CalculatorListener$Lambdas implements CalculatorListener {
+  void Function(double) lambda_onCalculationResult;
+  void Function(double) lambda_onCalculationResultConst;
+  void Function(CalculatorListener_ResultStruct) lambda_onCalculationResultStruct;
+  void Function(List<double>) lambda_onCalculationResultArray;
+  void Function(Map<String, double>) lambda_onCalculationResultMap;
+  void Function(CalculationResult) lambda_onCalculationResultInstance;
+  CalculatorListener$Lambdas(
+    void Function(double) lambda_onCalculationResult,
+    void Function(double) lambda_onCalculationResultConst,
+    void Function(CalculatorListener_ResultStruct) lambda_onCalculationResultStruct,
+    void Function(List<double>) lambda_onCalculationResultArray,
+    void Function(Map<String, double>) lambda_onCalculationResultMap,
+    void Function(CalculationResult) lambda_onCalculationResultInstance
+  ) {
+    this.lambda_onCalculationResult = lambda_onCalculationResult;
+    this.lambda_onCalculationResultConst = lambda_onCalculationResultConst;
+    this.lambda_onCalculationResultStruct = lambda_onCalculationResultStruct;
+    this.lambda_onCalculationResultArray = lambda_onCalculationResultArray;
+    this.lambda_onCalculationResultMap = lambda_onCalculationResultMap;
+    this.lambda_onCalculationResultInstance = lambda_onCalculationResultInstance;
+  }
+  @override
+  void release() {}
+  @override
+  onCalculationResult(double calculationResult) =>
+    lambda_onCalculationResult(calculationResult);
+  @override
+  onCalculationResultConst(double calculationResult) =>
+    lambda_onCalculationResultConst(calculationResult);
+  @override
+  onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult) =>
+    lambda_onCalculationResultStruct(calculationResult);
+  @override
+  onCalculationResultArray(List<double> calculationResult) =>
+    lambda_onCalculationResultArray(calculationResult);
+  @override
+  onCalculationResultMap(Map<String, double> calculationResults) =>
+    lambda_onCalculationResultMap(calculationResults);
+  @override
+  onCalculationResultInstance(CalculationResult calculationResult) =>
+    lambda_onCalculationResultInstance(calculationResult);
+}
 class CalculatorListener$Impl implements CalculatorListener {
   final Pointer<Void> handle;
   CalculatorListener$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenerWithProperties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenerWithProperties.dart
@@ -8,8 +8,39 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 abstract class ListenerWithProperties {
+  ListenerWithProperties() {}
+  factory ListenerWithProperties.fromLambdas({
+    @required String Function() lambda_message_get,
+    @required void Function(String) lambda_message_set,
+    @required CalculationResult Function() lambda_packedMessage_get,
+    @required void Function(CalculationResult) lambda_packedMessage_set,
+    @required ListenerWithProperties_ResultStruct Function() lambda_structuredMessage_get,
+    @required void Function(ListenerWithProperties_ResultStruct) lambda_structuredMessage_set,
+    @required ListenerWithProperties_ResultEnum Function() lambda_enumeratedMessage_get,
+    @required void Function(ListenerWithProperties_ResultEnum) lambda_enumeratedMessage_set,
+    @required List<String> Function() lambda_arrayedMessage_get,
+    @required void Function(List<String>) lambda_arrayedMessage_set,
+    @required Map<String, double> Function() lambda_mappedMessage_get,
+    @required void Function(Map<String, double>) lambda_mappedMessage_set,
+    @required Uint8List Function() lambda_bufferedMessage_get,
+    @required void Function(Uint8List) lambda_bufferedMessage_set
+  }) => ListenerWithProperties$Lambdas(
+    lambda_message_get,
+    lambda_message_set,
+    lambda_packedMessage_get,
+    lambda_packedMessage_set,
+    lambda_structuredMessage_get,
+    lambda_structuredMessage_set,
+    lambda_enumeratedMessage_get,
+    lambda_enumeratedMessage_set,
+    lambda_arrayedMessage_get,
+    lambda_arrayedMessage_set,
+    lambda_mappedMessage_get,
+    lambda_mappedMessage_set,
+    lambda_bufferedMessage_get,
+    lambda_bufferedMessage_set
+  );
   void release() {}
   String get message;
   set message(String value);
@@ -168,6 +199,83 @@ final _smoke_ListenerWithProperties_get_type_id = __lib.nativeLibrary.lookupFunc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_get_type_id');
+class ListenerWithProperties$Lambdas implements ListenerWithProperties {
+  String Function() lambda_message_get;
+  void Function(String) lambda_message_set;
+  CalculationResult Function() lambda_packedMessage_get;
+  void Function(CalculationResult) lambda_packedMessage_set;
+  ListenerWithProperties_ResultStruct Function() lambda_structuredMessage_get;
+  void Function(ListenerWithProperties_ResultStruct) lambda_structuredMessage_set;
+  ListenerWithProperties_ResultEnum Function() lambda_enumeratedMessage_get;
+  void Function(ListenerWithProperties_ResultEnum) lambda_enumeratedMessage_set;
+  List<String> Function() lambda_arrayedMessage_get;
+  void Function(List<String>) lambda_arrayedMessage_set;
+  Map<String, double> Function() lambda_mappedMessage_get;
+  void Function(Map<String, double>) lambda_mappedMessage_set;
+  Uint8List Function() lambda_bufferedMessage_get;
+  void Function(Uint8List) lambda_bufferedMessage_set;
+  ListenerWithProperties$Lambdas(
+    String Function() lambda_message_get,
+    void Function(String) lambda_message_set,
+    CalculationResult Function() lambda_packedMessage_get,
+    void Function(CalculationResult) lambda_packedMessage_set,
+    ListenerWithProperties_ResultStruct Function() lambda_structuredMessage_get,
+    void Function(ListenerWithProperties_ResultStruct) lambda_structuredMessage_set,
+    ListenerWithProperties_ResultEnum Function() lambda_enumeratedMessage_get,
+    void Function(ListenerWithProperties_ResultEnum) lambda_enumeratedMessage_set,
+    List<String> Function() lambda_arrayedMessage_get,
+    void Function(List<String>) lambda_arrayedMessage_set,
+    Map<String, double> Function() lambda_mappedMessage_get,
+    void Function(Map<String, double>) lambda_mappedMessage_set,
+    Uint8List Function() lambda_bufferedMessage_get,
+    void Function(Uint8List) lambda_bufferedMessage_set
+  ) {
+    this.lambda_message_get = lambda_message_get;
+    this.lambda_message_set = lambda_message_set;
+    this.lambda_packedMessage_get = lambda_packedMessage_get;
+    this.lambda_packedMessage_set = lambda_packedMessage_set;
+    this.lambda_structuredMessage_get = lambda_structuredMessage_get;
+    this.lambda_structuredMessage_set = lambda_structuredMessage_set;
+    this.lambda_enumeratedMessage_get = lambda_enumeratedMessage_get;
+    this.lambda_enumeratedMessage_set = lambda_enumeratedMessage_set;
+    this.lambda_arrayedMessage_get = lambda_arrayedMessage_get;
+    this.lambda_arrayedMessage_set = lambda_arrayedMessage_set;
+    this.lambda_mappedMessage_get = lambda_mappedMessage_get;
+    this.lambda_mappedMessage_set = lambda_mappedMessage_set;
+    this.lambda_bufferedMessage_get = lambda_bufferedMessage_get;
+    this.lambda_bufferedMessage_set = lambda_bufferedMessage_set;
+  }
+  @override
+  void release() {}
+  @override
+  String get message => lambda_message_get();
+  @override
+  set message(String value) => lambda_message_set(value);
+  @override
+  CalculationResult get packedMessage => lambda_packedMessage_get();
+  @override
+  set packedMessage(CalculationResult value) => lambda_packedMessage_set(value);
+  @override
+  ListenerWithProperties_ResultStruct get structuredMessage => lambda_structuredMessage_get();
+  @override
+  set structuredMessage(ListenerWithProperties_ResultStruct value) => lambda_structuredMessage_set(value);
+  @override
+  ListenerWithProperties_ResultEnum get enumeratedMessage => lambda_enumeratedMessage_get();
+  @override
+  set enumeratedMessage(ListenerWithProperties_ResultEnum value) => lambda_enumeratedMessage_set(value);
+  @override
+  List<String> get arrayedMessage => lambda_arrayedMessage_get();
+  @override
+  set arrayedMessage(List<String> value) => lambda_arrayedMessage_set(value);
+  @override
+  Map<String, double> get mappedMessage => lambda_mappedMessage_get();
+  @override
+  set mappedMessage(Map<String, double> value) => lambda_mappedMessage_set(value);
+  @override
+  Uint8List get bufferedMessage => lambda_bufferedMessage_get();
+  @override
+  set bufferedMessage(Uint8List value) => lambda_bufferedMessage_set(value);
+}
 class ListenerWithProperties$Impl implements ListenerWithProperties {
   final Pointer<Void> handle;
   ListenerWithProperties$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenersWithReturnValues.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/ListenersWithReturnValues.dart
@@ -7,8 +7,25 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 abstract class ListenersWithReturnValues {
+  ListenersWithReturnValues() {}
+  factory ListenersWithReturnValues.fromLambdas({
+    @required double Function() lambda_fetchDataDouble,
+    @required String Function() lambda_fetchDataString,
+    @required ListenersWithReturnValues_ResultStruct Function() lambda_fetchDataStruct,
+    @required ListenersWithReturnValues_ResultEnum Function() lambda_fetchDataEnum,
+    @required List<double> Function() lambda_fetchDataArray,
+    @required Map<String, double> Function() lambda_fetchDataMap,
+    @required CalculationResult Function() lambda_fetchDataInstance
+  }) => ListenersWithReturnValues$Lambdas(
+    lambda_fetchDataDouble,
+    lambda_fetchDataString,
+    lambda_fetchDataStruct,
+    lambda_fetchDataEnum,
+    lambda_fetchDataArray,
+    lambda_fetchDataMap,
+    lambda_fetchDataInstance
+  );
   void release() {}
   double fetchDataDouble();
   String fetchDataString();
@@ -160,6 +177,55 @@ final _smoke_ListenersWithReturnValues_get_type_id = __lib.nativeLibrary.lookupF
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_get_type_id');
+class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
+  double Function() lambda_fetchDataDouble;
+  String Function() lambda_fetchDataString;
+  ListenersWithReturnValues_ResultStruct Function() lambda_fetchDataStruct;
+  ListenersWithReturnValues_ResultEnum Function() lambda_fetchDataEnum;
+  List<double> Function() lambda_fetchDataArray;
+  Map<String, double> Function() lambda_fetchDataMap;
+  CalculationResult Function() lambda_fetchDataInstance;
+  ListenersWithReturnValues$Lambdas(
+    double Function() lambda_fetchDataDouble,
+    String Function() lambda_fetchDataString,
+    ListenersWithReturnValues_ResultStruct Function() lambda_fetchDataStruct,
+    ListenersWithReturnValues_ResultEnum Function() lambda_fetchDataEnum,
+    List<double> Function() lambda_fetchDataArray,
+    Map<String, double> Function() lambda_fetchDataMap,
+    CalculationResult Function() lambda_fetchDataInstance
+  ) {
+    this.lambda_fetchDataDouble = lambda_fetchDataDouble;
+    this.lambda_fetchDataString = lambda_fetchDataString;
+    this.lambda_fetchDataStruct = lambda_fetchDataStruct;
+    this.lambda_fetchDataEnum = lambda_fetchDataEnum;
+    this.lambda_fetchDataArray = lambda_fetchDataArray;
+    this.lambda_fetchDataMap = lambda_fetchDataMap;
+    this.lambda_fetchDataInstance = lambda_fetchDataInstance;
+  }
+  @override
+  void release() {}
+  @override
+  double fetchDataDouble() =>
+    lambda_fetchDataDouble();
+  @override
+  String fetchDataString() =>
+    lambda_fetchDataString();
+  @override
+  ListenersWithReturnValues_ResultStruct fetchDataStruct() =>
+    lambda_fetchDataStruct();
+  @override
+  ListenersWithReturnValues_ResultEnum fetchDataEnum() =>
+    lambda_fetchDataEnum();
+  @override
+  List<double> fetchDataArray() =>
+    lambda_fetchDataArray();
+  @override
+  Map<String, double> fetchDataMap() =>
+    lambda_fetchDataMap();
+  @override
+  CalculationResult fetchDataInstance() =>
+    lambda_fetchDataInstance();
+}
 class ListenersWithReturnValues$Impl implements ListenersWithReturnValues {
   final Pointer<Void> handle;
   ListenersWithReturnValues$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterClass.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterClass.dart
@@ -5,7 +5,6 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 abstract class OuterClass {
   void release();
   String foo(String input);
@@ -54,6 +53,12 @@ void smoke_OuterClass_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle)
   _smoke_OuterClass_InnerClass_release_handle(handle);
 // End of OuterClass_InnerClass "private" section.
 abstract class OuterClass_InnerInterface {
+  OuterClass_InnerInterface() {}
+  factory OuterClass_InnerInterface.fromLambdas({
+    @required String Function(String) lambda_foo
+  }) => OuterClass_InnerInterface$Lambdas(
+    lambda_foo
+  );
   void release() {}
   String foo(String input);
 }
@@ -78,6 +83,19 @@ final _smoke_OuterClass_InnerInterface_get_type_id = __lib.nativeLibrary.lookupF
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClass_InnerInterface_get_type_id');
+class OuterClass_InnerInterface$Lambdas implements OuterClass_InnerInterface {
+  String Function(String) lambda_foo;
+  OuterClass_InnerInterface$Lambdas(
+    String Function(String) lambda_foo
+  ) {
+    this.lambda_foo = lambda_foo;
+  }
+  @override
+  void release() {}
+  @override
+  String foo(String input) =>
+    lambda_foo(input);
+}
 class OuterClass_InnerInterface$Impl implements OuterClass_InnerInterface {
   final Pointer<Void> handle;
   OuterClass_InnerInterface$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterInterface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/OuterInterface.dart
@@ -5,8 +5,13 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 abstract class OuterInterface {
+  OuterInterface() {}
+  factory OuterInterface.fromLambdas({
+    @required String Function(String) lambda_foo
+  }) => OuterInterface$Lambdas(
+    lambda_foo
+  );
   void release() {}
   String foo(String input);
 }
@@ -54,6 +59,12 @@ void smoke_OuterInterface_InnerClass_releaseFfiHandle_nullable(Pointer<Void> han
   _smoke_OuterInterface_InnerClass_release_handle(handle);
 // End of OuterInterface_InnerClass "private" section.
 abstract class OuterInterface_InnerInterface {
+  OuterInterface_InnerInterface() {}
+  factory OuterInterface_InnerInterface.fromLambdas({
+    @required String Function(String) lambda_foo
+  }) => OuterInterface_InnerInterface$Lambdas(
+    lambda_foo
+  );
   void release() {}
   String foo(String input);
 }
@@ -78,6 +89,19 @@ final _smoke_OuterInterface_InnerInterface_get_type_id = __lib.nativeLibrary.loo
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_InnerInterface_get_type_id');
+class OuterInterface_InnerInterface$Lambdas implements OuterInterface_InnerInterface {
+  String Function(String) lambda_foo;
+  OuterInterface_InnerInterface$Lambdas(
+    String Function(String) lambda_foo
+  ) {
+    this.lambda_foo = lambda_foo;
+  }
+  @override
+  void release() {}
+  @override
+  String foo(String input) =>
+    lambda_foo(input);
+}
 class OuterInterface_InnerInterface$Impl implements OuterInterface_InnerInterface {
   final Pointer<Void> handle;
   OuterInterface_InnerInterface$Impl(this.handle);
@@ -155,6 +179,19 @@ final _smoke_OuterInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_get_type_id');
+class OuterInterface$Lambdas implements OuterInterface {
+  String Function(String) lambda_foo;
+  OuterInterface$Lambdas(
+    String Function(String) lambda_foo
+  ) {
+    this.lambda_foo = lambda_foo;
+  }
+  @override
+  void release() {}
+  @override
+  String foo(String input) =>
+    lambda_foo(input);
+}
 class OuterInterface$Impl implements OuterInterface {
   final Pointer<Void> handle;
   OuterInterface$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeListener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeListener.dart
@@ -5,8 +5,13 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 abstract class weeListener {
+  weeListener() {}
+  factory weeListener.fromLambdas({
+    @required void Function(String) lambda_WeeMethod
+  }) => weeListener$Lambdas(
+    lambda_WeeMethod
+  );
   void release() {}
   WeeMethod(String WeeParameter);
 }
@@ -31,6 +36,19 @@ final _smoke_PlatformNamesListener_get_type_id = __lib.nativeLibrary.lookupFunct
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNamesListener_get_type_id');
+class weeListener$Lambdas implements weeListener {
+  void Function(String) lambda_WeeMethod;
+  weeListener$Lambdas(
+    void Function(String) lambda_WeeMethod
+  ) {
+    this.lambda_WeeMethod = lambda_WeeMethod;
+  }
+  @override
+  void release() {}
+  @override
+  WeeMethod(String WeeParameter) =>
+    lambda_WeeMethod(WeeParameter);
+}
 class weeListener$Impl implements weeListener {
   final Pointer<Void> handle;
   weeListener$Impl(this.handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/PropertiesInterface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/PropertiesInterface.dart
@@ -5,8 +5,15 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 abstract class PropertiesInterface {
+  PropertiesInterface() {}
+  factory PropertiesInterface.fromLambdas({
+    @required PropertiesInterface_ExampleStruct Function() lambda_structProperty_get,
+    @required void Function(PropertiesInterface_ExampleStruct) lambda_structProperty_set
+  }) => PropertiesInterface$Lambdas(
+    lambda_structProperty_get,
+    lambda_structProperty_set
+  );
   void release() {}
   PropertiesInterface_ExampleStruct get structProperty;
   set structProperty(PropertiesInterface_ExampleStruct value);
@@ -94,6 +101,23 @@ final _smoke_PropertiesInterface_get_type_id = __lib.nativeLibrary.lookupFunctio
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_get_type_id');
+class PropertiesInterface$Lambdas implements PropertiesInterface {
+  PropertiesInterface_ExampleStruct Function() lambda_structProperty_get;
+  void Function(PropertiesInterface_ExampleStruct) lambda_structProperty_set;
+  PropertiesInterface$Lambdas(
+    PropertiesInterface_ExampleStruct Function() lambda_structProperty_get,
+    void Function(PropertiesInterface_ExampleStruct) lambda_structProperty_set
+  ) {
+    this.lambda_structProperty_get = lambda_structProperty_get;
+    this.lambda_structProperty_set = lambda_structProperty_set;
+  }
+  @override
+  void release() {}
+  @override
+  PropertiesInterface_ExampleStruct get structProperty => lambda_structProperty_get();
+  @override
+  set structProperty(PropertiesInterface_ExampleStruct value) => lambda_structProperty_set(value);
+}
 class PropertiesInterface$Impl implements PropertiesInterface {
   final Pointer<Void> handle;
   PropertiesInterface$Impl(this.handle);


### PR DESCRIPTION
Updated template for interfaces in Dart to include a "delegator"
implementation of the interface: a class that implements the interface
by taking lambdas as constructor parameters, with lambdas signatures
matching those of interface's functions and property accessors.

Added functional tests. Updated smoke tests.

Resolves: #135
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>