### PR TITLE
Add `-werror` command line parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
     or `@Dart(Skip)`). Elements marked with this attribute will be omitted in that platform's
     generated code. This attribute is not supported for C++.
   * Added support for creating an interface implementation directly from a set of lambdas in Dart.
+  * Added `-werror` command line parameter to support elevating specific validation warnings to
+    errors. Current supported warning types are `DocLinks` and `DartOverloads`.
 
 ## 6.5.0
 Release date: 2020-04-16

--- a/cmake/modules/gluecodium/gluecodium/Generate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/Generate.cmake
@@ -94,7 +94,7 @@ function(apigen_generate)
       BUILD_OUTPUT_DIR
       DART_LIBRARY_NAME
       DART_NAMERULES)
-  set(multiValueArgs LIME_SOURCES FRANCA_SOURCES)
+  set(multiValueArgs LIME_SOURCES FRANCA_SOURCES WERROR)
   cmake_parse_arguments(apigen_generate "${options}" "${oneValueArgs}"
                       "${multiValueArgs}" ${ARGN})
   list(APPEND apigen_generate_LIME_SOURCES ${apigen_generate_FRANCA_SOURCES})
@@ -145,6 +145,9 @@ function(apigen_generate)
       set(input "${CMAKE_CURRENT_SOURCE_DIR}/${input}")
     endif()
     string(APPEND APIGEN_GLUECODIUM_ARGS " -input \"${input}\"")
+  endforeach()
+  foreach(werror ${apigen_generate_WERROR})
+    string(APPEND APIGEN_GLUECODIUM_ARGS " -werror ${werror}")
   endforeach()
   _apigen_parse_option(--android-merge-manifest ANDROID_MERGE_MANIFEST)
   _apigen_parse_option(-javapackage JAVA_PACKAGE)

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -176,6 +176,7 @@ class Gluecodium(
         var cppExport: String = DEFAULT_CPP_EXPORT_MACRO_NAME,
         var internalPrefix: String? = null,
         var libraryName: String = "library",
+        var werror: Set<String> = emptySet(),
         var cppNameRules: Configuration = ConfigurationProperties.fromResource(
             Gluecodium::class.java,
             "/namerules/cpp.properties"
@@ -192,7 +193,12 @@ class Gluecodium(
             Gluecodium::class.java,
             "/namerules/dart.properties"
         )
-    )
+    ) {
+        companion object {
+            const val WARNING_DOC_LINKS = "DocLinks"
+            const val WARNING_DART_OVERLOADS = "DartOverloads"
+        }
+    }
 
     companion object {
         private val LOGGER = Logger.getLogger(Gluecodium::class.java.name)

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -106,6 +106,13 @@ object OptionReader {
         addOption("cppexport", true, "C++ export macro name for explicit symbol exporting.")
         addOption("internalprefix", true, "Name prefix for internal conversion functions in Swift.")
         addOption("libraryname", true, "Name of the generated library for some generators (e.g. Dart).")
+        addOption(
+            "werror",
+            "warning-as-error",
+            true,
+            "Treat the specified validation warning type as an error. Possible values: " +
+                "${Gluecodium.Options.WARNING_DOC_LINKS}, ${Gluecodium.Options.WARNING_DART_OVERLOADS}."
+        )
         addOption("cppnamerules", true, "C++ name rules property file.")
         addOption("javanamerules", true, "Java name rules property file.")
         addOption("swiftnamerules", true, "Swift name rules property file.")
@@ -165,6 +172,7 @@ object OptionReader {
         getStringValue("cppexport")?.let { options.cppExport = it }
         getStringValue("internalprefix")?.let { options.internalPrefix = it }
         getStringValue("libraryname")?.let { options.libraryName = it }
+        getStringListValue("werror")?.let { options.werror = it.toSet() }
 
         options.cppNameRules = readConfigFile(getStringValue("cppnamerules"), options.cppNameRules)
         options.javaNameRules =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartCommentsProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 HERE Europe B.V.
+ * Copyright (C) 2016-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,25 +17,20 @@
  * License-Filename: LICENSE
  */
 
-package com.here.gluecodium.platform.swift
+package com.here.gluecodium.generator.dart
 
 import com.here.gluecodium.platform.common.CommentsProcessor
 import com.vladsch.flexmark.ast.LinkRef
 import com.vladsch.flexmark.formatter.Formatter
 import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
 
-/**
- * Parse markdown comments and process links
- */
-class SwiftCommentsProcessor(werror: Boolean) :
+internal class DartCommentsProcessor(werror: Boolean) :
     CommentsProcessor(Formatter.builder().build(), werror) {
 
     override fun processLink(linkNode: LinkRef, linkReference: String) {
         linkNode.reference = BasedSequenceImpl.of(linkReference)
-        linkNode.referenceOpeningMarker = BasedSequenceImpl.of("`")
-        linkNode.referenceClosingMarker = BasedSequenceImpl.of("`")
+        linkNode.referenceOpeningMarker = BasedSequenceImpl.of("[")
+        linkNode.referenceClosingMarker = BasedSequenceImpl.of("]")
         linkNode.firstChild.unlink()
     }
-
-    override val nullReference = "nil"
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -43,18 +43,14 @@ import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeTypesCollection
 import com.here.gluecodium.model.lime.LimeValue
 import com.here.gluecodium.model.lime.LimeVisibility
-import com.here.gluecodium.platform.common.CommentsProcessor
-import com.vladsch.flexmark.ast.LinkRef
-import com.vladsch.flexmark.formatter.Formatter
-import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
 
 internal class DartNameResolver(
     private val limeReferenceMap: Map<String, LimeElement>,
     private val nameRules: NameRules,
-    private val limeLogger: LimeLogger
+    private val limeLogger: LimeLogger,
+    private val commentsProcessor: DartCommentsProcessor
 ) : NameResolver {
 
-    private val commentsProcessor = DartCommentsProcessor()
     private val joinInfix = nameRules.ruleSet.joinInfix ?: ""
     private val limeToDartNames = buildPathMap()
 
@@ -204,14 +200,5 @@ internal class DartNameResolver(
         result += properties.filter { it.setter != null }.associateBy({ it.fullName + ".set" }, { resolveName(it) })
 
         return result
-    }
-
-    private class DartCommentsProcessor : CommentsProcessor(Formatter.builder().build()) {
-        override fun processLink(linkNode: LinkRef, linkReference: String) {
-            linkNode.reference = BasedSequenceImpl.of(linkReference)
-            linkNode.referenceOpeningMarker = BasedSequenceImpl.of("[")
-            linkNode.referenceClosingMarker = BasedSequenceImpl.of("]")
-            linkNode.firstChild.unlink()
-        }
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaDocProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaDocProcessor.kt
@@ -27,7 +27,9 @@ import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
 /**
  * Parse markdown comments and output JavaDoc
  */
-class JavaDocProcessor : CommentsProcessor(HtmlRenderer.builder().build()) {
+class JavaDocProcessor(werror: Boolean) :
+    CommentsProcessor(HtmlRenderer.builder().build(), werror) {
+
     override fun processLink(linkNode: LinkRef, linkReference: String) {
         linkNode.chars = BasedSequenceImpl.of("{@link $linkReference}")
         linkNode.firstChild.unlink()

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
@@ -20,6 +20,7 @@
 package com.here.gluecodium.platform.android
 
 import com.here.gluecodium.Gluecodium
+import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.generator.androidmanifest.AndroidManifestGenerator
 import com.here.gluecodium.generator.common.GeneratedFile
@@ -57,7 +58,8 @@ open class JavaGeneratorSuite protected constructor(
     private val internalPackage = options.javaInternalPackages
     private val internalNamespace = options.cppInternalNamespace
     private val rootNamespace = options.cppRootNamespace
-    private val commentsProcessor = JavaDocProcessor()
+    private val commentsProcessor =
+        JavaDocProcessor(options.werror.contains(Gluecodium.Options.WARNING_DOC_LINKS))
     private val cppNameRules =
         CppNameRules(rootNamespace, nameRuleSetFromConfig(options.cppNameRules))
     private val javaNameRules = JavaNameRules(nameRuleSetFromConfig(options.javaNameRules))
@@ -105,6 +107,10 @@ open class JavaGeneratorSuite protected constructor(
             combinedModel.reverseReferenceMap,
             limeModel
         )
+
+        if (commentsProcessor.hasError) {
+            throw GluecodiumExecutionException("Validation errors found, see log for details.")
+        }
 
         val javaTemplates = JavaTemplates(generatorName)
         val javaFiles = javaTemplates.generateFiles(combinedModel.javaElements).toMutableList()

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/baseapi/DoxygenCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/baseapi/DoxygenCommentsProcessor.kt
@@ -24,7 +24,9 @@ import com.vladsch.flexmark.ast.LinkRef
 import com.vladsch.flexmark.formatter.Formatter
 import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
 
-class DoxygenCommentsProcessor : CommentsProcessor(Formatter.builder().build()) {
+class DoxygenCommentsProcessor(werror: Boolean) :
+    CommentsProcessor(Formatter.builder().build(), werror) {
+
     override fun processLink(linkNode: LinkRef, linkReference: String) {
         linkNode.reference = BasedSequenceImpl.of(linkReference)
         // Doxygen documentation claims that \link classname Alternative title \endlink is the

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/dart/DartOverloadsValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/dart/DartOverloadsValidatorTest.kt
@@ -58,7 +58,7 @@ class DartOverloadsValidatorTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        validator = DartOverloadsValidator(nameResolver, mockk(relaxed = true))
+        validator = DartOverloadsValidator(nameResolver, mockk(relaxed = true), true)
     }
 
     @Test

--- a/gluecodium/src/test/java/com/here/gluecodium/model/common/JavaDocProcessorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/model/common/JavaDocProcessorTest.kt
@@ -31,7 +31,7 @@ import org.junit.runners.JUnit4
 class JavaDocProcessorTest {
     private val limeLogger =
         LimeLogger(Logger.getLogger(JavaDocProcessorTest::class.java.name), emptyMap())
-    private val commentsProcessor = JavaDocProcessor()
+    private val commentsProcessor = JavaDocProcessor(false)
 
     @Test
     fun simple() {

--- a/lime-loader/src/main/java/com/here/gluecodium/validator/LimeImportsValidator.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/validator/LimeImportsValidator.kt
@@ -37,7 +37,7 @@ internal class LimeImportsValidator(private val logger: LimeLogger) {
         referenceMap: Map<String, LimeElement>
     ): Boolean {
         val unresolvedImports = imports.filterNot { referenceMap.containsKey(it.toString()) }
-        unresolvedImports.forEach { logger.error(fileName, "import '$it' cannot be resolved") }
+        unresolvedImports.forEach { logger.errorWithFileName(fileName, "import '$it' cannot be resolved") }
         return unresolvedImports.isEmpty()
     }
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeLogger.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeLogger.kt
@@ -31,7 +31,10 @@ class LimeLogger(
     fun error(limeElement: LimeNamedElement, message: String) =
         log(Level.SEVERE, getFileName(limeElement), limeElement.fullName, message)
 
-    fun error(fileName: String, message: String) =
+    fun error(elementName: String, message: String) =
+        log(Level.SEVERE, getFileName(elementName), elementName, message)
+
+    fun errorWithFileName(fileName: String, message: String) =
         log(Level.SEVERE, fileName, null, message)
 
     fun warning(limeElement: LimeNamedElement, message: String) =


### PR DESCRIPTION
Added `-werror` command line parameter to support elevating specific
validation warnings to errors. Current supported warning types are
`DocLinks` and `DartOverloads`.

Resolves: #232
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>