### PR TITLE
Add support for @Equatable interfaces in Java

### DIFF
--- a/examples/platforms/android/app/src/test/java/com/here/android/test/EquatableTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/EquatableTest.java
@@ -401,6 +401,24 @@ public final class EquatableTest {
     assertFalse(PointerEquatableClass.areEqual(oneStruct, otherStruct));
   }
 
+  @Test
+  public void equatableInterfaceEquals() {
+    EquatableInterface oneInterface = EquatableInterfaceFactory.createEquatableInterface("foo");
+    EquatableInterface otherInterface = EquatableInterfaceFactory.createEquatableInterface("foo");
+
+    assertEquals(oneInterface, otherInterface);
+    assertEquals(oneInterface.hashCode(), otherInterface.hashCode());
+  }
+
+  @Test
+  public void equatableInterfaceNotEquals() {
+    EquatableInterface oneInterface = EquatableInterfaceFactory.createEquatableInterface("foo");
+    EquatableInterface otherInterface = EquatableInterfaceFactory.createEquatableInterface("bar");
+
+    assertNotEquals(oneInterface, otherInterface);
+    assertNotEquals(oneInterface.hashCode(), otherInterface.hashCode());
+  }
+
   private static EquatableStruct createEquatableStruct() {
 
     Map<Integer, String> someMap = new HashMap<>();

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaModelBuilder.kt
@@ -414,7 +414,7 @@ class JavaModelBuilder(
     }
 
     private fun createJavaImplementationClass(
-        limeContainer: LimeContainerWithInheritance,
+        limeInterface: LimeInterface,
         javaInterface: JavaInterface,
         extendedClass: JavaTypeRef
     ): JavaClass {
@@ -425,14 +425,15 @@ class JavaModelBuilder(
             it.visibility = JavaVisibility.PUBLIC
         }
 
-        val implClassName = nameRules.getImplementationClassName(limeContainer)
+        val implClassName = nameRules.getImplementationClassName(limeInterface)
         val javaClass = JavaClass(
             name = implClassName,
-            classNames = nameResolver.getClassNames(limeContainer).dropLast(1) + implClassName,
+            classNames = nameResolver.getClassNames(limeInterface).dropLast(1) + implClassName,
             extendedClass = extendedClass,
             methods = classMethods,
             isImplClass = true,
-            needsDisposer = nativeBase == extendedClass
+            needsDisposer = nativeBase == extendedClass,
+            hasNativeEquatable = limeInterface.attributes.have(LimeAttributeType.EQUATABLE)
         )
         javaClass.visibility = JavaVisibility.PACKAGE
         javaClass.javaPackage = rootPackage
@@ -531,7 +532,7 @@ class JavaModelBuilder(
     private fun createComments(limeLambdaParameter: LimeLambdaParameter) =
         Comments(
             limeLambdaParameter.comment.getFor(PLATFORM_TAG),
-            limeLambdaParameter.attributes?.get(DEPRECATED, MESSAGE)
+            limeLambdaParameter.attributes.get(DEPRECATED, MESSAGE)
         )
 
     companion object {

--- a/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniContainer.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniContainer.kt
@@ -50,8 +50,7 @@ class JniContainer(
     val enums: MutableList<JniEnum> = mutableListOf()
     val includes: MutableSet<Include> = LinkedHashSet()
     @Suppress("unused")
-    val hasNativeEquatable =
-        containerType == ContainerType.CLASS && (isEquatable || isPointerEquatable)
+    val hasNativeEquatable = isEquatable || isPointerEquatable
     @Suppress("unused")
     val fullJavaName = (javaPackage.packageNames + javaNames.joinToString("$")).joinToString("/")
     @Suppress("unused")

--- a/gluecodium/src/test/resources/smoke/equatable/output/android/com/example/smoke/EquatableInterfaceImpl.java
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android/com/example/smoke/EquatableInterfaceImpl.java
@@ -1,0 +1,20 @@
+/*
+ *
+ */
+package com.example.smoke;
+import com.example.NativeBase;
+class EquatableInterfaceImpl extends NativeBase implements EquatableInterface {
+    protected EquatableInterfaceImpl(final long nativeHandle) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+    private static native void disposeNativeHandle(long nativeHandle);
+    @Override
+    public native boolean equals(Object rhs);
+    @Override
+    public native int hashCode();
+}

--- a/gluecodium/src/test/resources/smoke/equatable/output/android/jni/com_example_smoke_EquatableInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android/jni/com_example_smoke_EquatableInterfaceImpl.cpp
@@ -1,0 +1,49 @@
+/*
+ *
+ */
+#include "com_example_smoke_EquatableInterfaceImpl.h"
+#include "com_example_smoke_EquatableInterface__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+extern "C" {
+JNIEXPORT void JNICALL
+Java_com_example_smoke_EquatableInterfaceImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    delete reinterpret_cast<std::shared_ptr<::smoke::EquatableInterface>*> (_jpointerRef);
+}
+jboolean
+Java_com_example_smoke_EquatableInterfaceImpl_equals(JNIEnv* _jenv, jobject _jinstance, jobject jrhs)
+{
+    if (_jinstance == nullptr || jrhs == nullptr) {
+        return _jinstance == jrhs;
+    }
+    auto& jclass = ::gluecodium::jni::get_cached_native_base_class();
+    if (!_jenv->IsInstanceOf(jrhs, jclass.get())) {
+        return false;
+    }
+    auto lhs = reinterpret_cast<std::shared_ptr<::smoke::EquatableInterface>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto rhs = reinterpret_cast<std::shared_ptr<::smoke::EquatableInterface>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jrhs),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    return **lhs == **rhs;
+}
+jint
+Java_com_example_smoke_EquatableInterfaceImpl_hashCode(JNIEnv* _jenv, jobject _jinstance){
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::EquatableInterface>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    return ::gluecodium::hash<std::shared_ptr<::smoke::EquatableInterface> >()(*pInstanceSharedPointer);
+}
+}


### PR DESCRIPTION
Updated JavaModelBuilder and JNI model to supported @Equatable
interfaces in Java.

Added smoke and functional tests. Since the generated code for interface
impl-classes and regular classes is identical for Java generator, no
changes to Mustache templates is necessary.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>