### PR TITLE
Add support for @Equatable interfaces in Swift

### DIFF
--- a/examples/libhello/lime/test/Equatable.lime
+++ b/examples/libhello/lime/test/Equatable.lime
@@ -180,6 +180,6 @@ interface EquatableInterface {
     property name: String { get }
 }
 
-internal class EquatableInterfaceFactory {
+class EquatableInterfaceFactory {
     static fun createEquatableInterface(name: String): EquatableInterface
 }

--- a/examples/platforms/ios/Tests/testTests/EquatableInstancesTests.swift
+++ b/examples/platforms/ios/Tests/testTests/EquatableInstancesTests.swift
@@ -222,6 +222,27 @@ class EquatableInstancesTests: XCTestCase {
         XCTAssertEqual(hash(oneStruct), hash(otherStruct))
     }
 
+    func testInterfacesAreEqual() {
+        let one = EquatableInterfaceFactory.createEquatableInterface(name: "one")
+        let other = EquatableInterfaceFactory.createEquatableInterface(name: "one")
+
+        XCTAssertTrue(one == other)
+    }
+
+    func testInterfacesAreUnequal() {
+        let one = EquatableInterfaceFactory.createEquatableInterface(name: "one")
+        let other = EquatableInterfaceFactory.createEquatableInterface(name: "other")
+
+        XCTAssertFalse(one == other)
+    }
+
+    class EquatableInterfaceFoo: EquatableInterface {
+        init(name: String) {
+            self.name = name
+        }
+        let name: String
+    }
+
     func hash<H>(_ value: H) -> Int where H: Hashable {
         var hasher = Hasher()
         value.hash(into: &hasher)
@@ -244,6 +265,8 @@ class EquatableInstancesTests: XCTestCase {
         ("testNilUnequalInstancesInStruct", testNilUnequalInstancesInStruct),
         ("testNilEqualInstancesInStruct", testNilEqualInstancesInStruct),
         ("testNilPointerEqualInstancesInStruct", testNilPointerEqualInstancesInStruct),
-        ("testNilPointerUnequalInstancesInStruct", testNilPointerUnequalInstancesInStruct)
+        ("testNilPointerUnequalInstancesInStruct", testNilPointerUnequalInstancesInStruct),
+        ("testInterfacesAreEqual", testInterfacesAreEqual),
+        ("testInterfacesAreUnequal", testInterfacesAreUnequal)
     ]
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
@@ -162,6 +162,7 @@ class SwiftModelBuilder(
             nameSpace = limeContainer.path.head.joinToString("_"),
             cInstance = CBridgeNameRules.getInterfaceName(limeContainer),
             functionTableName = CBridgeNameRules.getFunctionTableName(limeContainer),
+            hasEquatableType = limeContainer.attributes.have(LimeAttributeType.EQUATABLE),
             isObjcInterface = limeContainer.attributes.have(SWIFT, LimeAttributeValueType.OBJC),
             hasTypeRepository = true
         )

--- a/gluecodium/src/main/resources/templates/swift/ClassConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ClassConversion.mustache
@@ -44,9 +44,17 @@ extension {{implName}}: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }{{/useParentCInstance}}{{!!
 
-}}{{#hasEquatableType}}
-extension {{name}}: Hashable {
-    public static func == (lhs: {{name}}, rhs: {{name}}) -> Bool {
+}}{{#if hasEquatableType}}
+{{#if isInterface}}
+public func ==(lhs: {{name}}, rhs: {{name}}) -> Bool {
+    guard let lhsImpl = lhs as? {{implName}} else { return lhs === rhs }
+    guard let rhsImpl = rhs as? {{implName}} else { return lhs === rhs }
+    return lhsImpl == rhsImpl
+}
+
+{{/if}}
+extension {{implName}}: Hashable {
+    public static func == (lhs: {{implName}}, rhs: {{implName}}) -> Bool {
         return {{cInstance}}_equal(lhs.c_handle, rhs.c_handle)
     }
 
@@ -54,7 +62,7 @@ extension {{name}}: Hashable {
         hasher.combine({{cInstance}}_hash(c_handle))
     }
 }
-{{/hasEquatableType}}
+{{/if}}
 
 internal func {{mangledName}}copyFromCType(_ handle: _baseRef) -> {{name}} {
 {{#if isInterface}}

--- a/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableInterface.cpp
@@ -1,0 +1,59 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_EquatableInterface.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "cbridge_internal/include/CachedProxyBase.h"
+#include "cbridge_internal/include/TypeInitRepository.h"
+#include "gluecodium/Optional.h"
+#include "gluecodium/TypeRepository.h"
+#include "smoke/EquatableInterface.h"
+#include <memory>
+#include <new>
+void smoke_EquatableInterface_release_handle(_baseRef handle) {
+    delete get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle);
+}
+_baseRef smoke_EquatableInterface_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)))
+        : 0;
+}
+extern "C" {
+extern void* _CBridgeInitsmoke_EquatableInterface(_baseRef handle);
+}
+namespace {
+struct smoke_EquatableInterfaceRegisterInit {
+    smoke_EquatableInterfaceRegisterInit() {
+        get_init_repository().add_init("smoke_EquatableInterface", &_CBridgeInitsmoke_EquatableInterface);
+    }
+} s_smoke_EquatableInterface_register_init;
+}
+void* smoke_EquatableInterface_get_typed(_baseRef handle) {
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::EquatableInterface>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get());
+    auto init_function = get_init_repository().get_init(real_type_id);
+    return init_function ? init_function(handle) : _CBridgeInitsmoke_EquatableInterface(handle);
+}
+bool smoke_EquatableInterface_equal(_baseRef lhs, _baseRef rhs) {
+    return **get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(lhs) == **get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(rhs);
+}
+uint64_t smoke_EquatableInterface_hash(_baseRef handle) {
+    return ::gluecodium::hash<std::shared_ptr<::smoke::EquatableInterface>::element_type>()(**get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle));
+}
+class smoke_EquatableInterfaceProxy : public std::shared_ptr<::smoke::EquatableInterface>::element_type, public CachedProxyBase<smoke_EquatableInterfaceProxy> {
+public:
+    smoke_EquatableInterfaceProxy(smoke_EquatableInterface_FunctionTable&& functions)
+     : mFunctions(std::move(functions))
+    {
+    }
+    virtual ~smoke_EquatableInterfaceProxy() {
+        mFunctions.release(mFunctions.swift_pointer);
+    }
+private:
+    smoke_EquatableInterface_FunctionTable mFunctions;
+};
+_baseRef smoke_EquatableInterface_create_proxy(smoke_EquatableInterface_FunctionTable functionTable) {
+    auto proxy = smoke_EquatableInterfaceProxy::get_proxy(std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::EquatableInterface>(proxy)) : 0;
+}
+const void* smoke_EquatableInterface_get_swift_object_from_cache(_baseRef handle) {
+    return handle ? smoke_EquatableInterfaceProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get()) : nullptr;
+}

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableInterface.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableInterface.swift
@@ -1,0 +1,105 @@
+//
+//
+import Foundation
+public protocol EquatableInterface : AnyObject {
+}
+internal class _EquatableInterface: EquatableInterface {
+    let c_instance : _baseRef
+    init(cEquatableInterface: _baseRef) {
+        guard cEquatableInterface != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cEquatableInterface
+    }
+    deinit {
+        smoke_EquatableInterface_release_handle(c_instance)
+    }
+}
+@_cdecl("_CBridgeInitsmoke_EquatableInterface")
+internal func _CBridgeInitsmoke_EquatableInterface(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _EquatableInterface(cEquatableInterface: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: EquatableInterface?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_EquatableInterface_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_EquatableInterface_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_EquatableInterface_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    let proxy = smoke_EquatableInterface_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_EquatableInterface_release_handle) : RefHolder(proxy)
+}
+extension _EquatableInterface: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+public func ==(lhs: EquatableInterface, rhs: EquatableInterface) -> Bool {
+    guard let lhsImpl = lhs as? _EquatableInterface else { return lhs === rhs }
+    guard let rhsImpl = rhs as? _EquatableInterface else { return lhs === rhs }
+    return lhsImpl == rhsImpl
+}
+extension _EquatableInterface: Hashable {
+    public static func == (lhs: _EquatableInterface, rhs: _EquatableInterface) -> Bool {
+        return smoke_EquatableInterface_equal(lhs.c_handle, rhs.c_handle)
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(smoke_EquatableInterface_hash(c_handle))
+    }
+}
+internal func EquatableInterface_copyFromCType(_ handle: _baseRef) -> EquatableInterface {
+    if let swift_pointer = smoke_EquatableInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_EquatableInterface_get_typed(smoke_EquatableInterface_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? EquatableInterface {
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func EquatableInterface_moveFromCType(_ handle: _baseRef) -> EquatableInterface {
+    if let swift_pointer = smoke_EquatableInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableInterface {
+        smoke_EquatableInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_EquatableInterface_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? EquatableInterface {
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func EquatableInterface_copyFromCType(_ handle: _baseRef) -> EquatableInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return EquatableInterface_moveFromCType(handle) as EquatableInterface
+}
+internal func EquatableInterface_moveFromCType(_ handle: _baseRef) -> EquatableInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return EquatableInterface_moveFromCType(handle) as EquatableInterface
+}
+internal func copyToCType(_ swiftClass: EquatableInterface) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: EquatableInterface) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: EquatableInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: EquatableInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}


### PR DESCRIPTION
Updated SwiftModelBuilder and Swift templates to support @Equatable
interfaces in Swift.

Added smoke and functional tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>