### PR TITLE
Add support for @Equatable interfaces in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Added support for creating an interface implementation directly from a set of lambdas in Dart.
   * Added `-werror` command line parameter to support elevating specific validation warnings to
     errors. Current supported warning types are `DocLinks` and `DartOverloads`.
+  * Added support for @Equatable attribute on interface declarations in IDL.
 
 ## 6.5.0
 Release date: 2020-04-16

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -409,7 +409,7 @@ behavior specific to a single output language.
 
 Here's the list of currently supported attributes:
 * **@Immutable**: marks a struct type as immutable.
-* **@Equatable**: marks a struct type or a class as equatable.
+* **@Equatable**: marks a struct type, a class, or an interface as equatable.
 * **@PointerEquatable**: marks a class as equatable by reference (pointer). This is an interim tool
 for manually ensuring referential equality (automatic referential equality is planned, but not
 implemented yet, see issue #46). Please note that this attribute is not supported for interfaces.

--- a/examples/platforms/dart/test/EquatableClasses_test.dart
+++ b/examples/platforms/dart/test/EquatableClasses_test.dart
@@ -56,7 +56,7 @@ void main() {
     one.release();
     other.release();
   });
-  _testSuite.test("Pointer equatable class equals to self", () {
+  _testSuite.test("Equatable class equals to self", () {
     final one = EquatableClass("one");
 
     final result = one == one;
@@ -65,7 +65,7 @@ void main() {
 
     one.release();
   });
-  _testSuite.test("Pointer equatable class equals", () {
+  _testSuite.test("Equatable class equals", () {
     final one = EquatableClass("one");
     final other = EquatableClass("one");
 
@@ -76,9 +76,31 @@ void main() {
     one.release();
     other.release();
   });
-  _testSuite.test("Pointer equatable class not equals", () {
+  _testSuite.test("Equatable class not equals", () {
     final one = EquatableClass("one");
     final other = EquatableClass("two");
+
+    final result = one == other;
+
+    expect(result, isFalse);
+
+    one.release();
+    other.release();
+  });
+  _testSuite.test("Equatable interface equals", () {
+    final one = EquatableInterfaceFactory.createEquatableInterface("one");
+    final other = EquatableInterfaceFactory.createEquatableInterface("one");
+
+    final result = one == other;
+
+    expect(result, isTrue);
+
+    one.release();
+    other.release();
+  });
+  _testSuite.test("Equatable interface not equals", () {
+    final one = EquatableInterfaceFactory.createEquatableInterface("one");
+    final other = EquatableInterfaceFactory.createEquatableInterface("two");
 
     final result = one == other;
 

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -71,8 +71,8 @@ final _{{resolveName "Ffi"}}_release_handle = __lib.nativeLibrary.lookupFunction
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle');
-{{#ifHasAttribute "Equatable"}}{{>dartFfiEqualityFunction}}{{/ifHasAttribute}}{{!!
-}}{{#ifHasAttribute "PointerEquatable"}}{{>dartFfiEqualityFunction}}{{/ifHasAttribute}}
+{{#ifHasAttribute "Equatable"}}{{>dart/DartFfiEqualityFunction}}{{/ifHasAttribute}}{{!!
+}}{{#ifHasAttribute "PointerEquatable"}}{{>dart/DartFfiEqualityFunction}}{{/ifHasAttribute}}
 {{#if parent visibility.isOpen logic="or"}}
 final _{{resolveName "Ffi"}}_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
@@ -115,8 +115,8 @@ class {{resolveName}}$Impl{{!!
 {{#inheritedProperties}}
 {{prefixPartial "dart/DartProperty" "  "}}
 {{/inheritedProperties}}{{/set}}
-{{#ifHasAttribute "Equatable"}}{{>dartFfiEqualityOperator}}{{/ifHasAttribute}}{{!!
-}}{{#ifHasAttribute "PointerEquatable"}}{{>dartFfiEqualityOperator}}{{/ifHasAttribute}}
+{{#ifHasAttribute "Equatable"}}{{prefixPartial "dart/DartEqualityOperator" "  "}}{{/ifHasAttribute}}{{!!
+}}{{#ifHasAttribute "PointerEquatable"}}{{prefixPartial "dart/DartEqualityOperator" "  "}}{{/ifHasAttribute}}
 }
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) =>
@@ -156,22 +156,6 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) : {{!!
 }}this(_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}));
 {{/dartConstructor}}{{!!
-
-}}{{+dartFfiEqualityFunction}}
-final __are_equal = __lib.nativeLibrary.lookupFunction<
-    Uint8 Function(Pointer<Void>, Pointer<Void>),
-    int Function(Pointer<Void>, Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_are_equal');
-{{/dartFfiEqualityFunction}}{{!!
-
-}}{{+dartFfiEqualityOperator}}
-  @override
-  bool operator ==(dynamic other) {
-    if (identical(this, other)) return true;
-    if (other is! {{resolveName}}$Impl) return false;
-    return __are_equal((this as {{resolveName}}$Impl).handle, other.handle) != 0;
-  }
-{{/dartFfiEqualityOperator}}{{!!
 
 }}{{+dartImplRedirect}} => {{resolveName parent}}$Impl.{{resolveName visibility}}{{resolveName}}({{!!
     }}{{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!

--- a/gluecodium/src/main/resources/templates/dart/DartEqualityOperator.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEqualityOperator.mustache
@@ -1,0 +1,26 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+@override
+bool operator ==(dynamic other) {
+  if (identical(this, other)) return true;
+  if (other is! {{resolveName}}$Impl) return false;
+  return __are_equal((this as {{resolveName}}$Impl).handle, other.handle) != 0;
+}

--- a/gluecodium/src/main/resources/templates/dart/DartFfiEqualityFunction.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFfiEqualityFunction.mustache
@@ -1,0 +1,24 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+final __are_equal = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+  >('{{libraryName}}_{{resolveName "Ffi"}}_are_equal');

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -97,6 +97,7 @@ final _{{resolveName "Ffi"}}_get_raw_pointer = __lib.nativeLibrary.lookupFunctio
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
     >('{{libraryName}}_{{resolveName "Ffi"}}_get_raw_pointer');
+{{#ifHasAttribute "Equatable"}}{{>dart/DartFfiEqualityFunction}}{{/ifHasAttribute}}
 final _{{resolveName "Ffi"}}_get_type_id = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -184,6 +185,9 @@ class {{resolveName}}$Impl {{#if parent}}extends {{resolveName parent}}$Impl {{/
 {{#properties}}
 {{prefixPartial "dart/DartProperty" "  "}}
 {{/properties}}
+{{#ifHasAttribute "Equatable"}}{{#set self=this nameSuffix="$Impl"}}{{#self}}{{!!
+}}{{prefixPartial "dart/DartEqualityOperator" "  "}}{{!!
+}}{{/self}}{{/set}}{{/ifHasAttribute}}
 }
 
 {{#set parent=this}}{{#each inheritedFunctions functions}}

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/ffi/ffi_smoke_EquatableInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/ffi/ffi_smoke_EquatableInterface.cpp
@@ -1,0 +1,81 @@
+#include "ffi_smoke_EquatableInterface.h"
+#include "ConversionBase.h"
+#include "CallbacksQueue.h"
+#include "ProxyCache.h"
+#include "smoke/EquatableInterface.h"
+#include <memory>
+#include <memory>
+#include <new>
+class smoke_EquatableInterface_Proxy : public ::smoke::EquatableInterface {
+public:
+    smoke_EquatableInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter)
+        : token(token), isolate_id(isolate_id), deleter(deleter) { }
+    ~smoke_EquatableInterface_Proxy() {
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
+            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        });
+    }
+private:
+    uint64_t token;
+    int32_t isolate_id;
+    FfiOpaqueHandle deleter;
+    inline void dispatch(std::function<void()>&& callback) const
+    {
+        gluecodium::ffi::IsolateContext::is_current(isolate_id)
+            ? callback()
+            : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
+    }
+};
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+library_smoke_EquatableInterface_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::EquatableInterface>(
+            *reinterpret_cast<std::shared_ptr<::smoke::EquatableInterface>*>(handle)
+        )
+    );
+}
+void
+library_smoke_EquatableInterface_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::EquatableInterface>*>(handle);
+}
+bool
+library_smoke_EquatableInterface_are_equal(FfiOpaqueHandle handle1, FfiOpaqueHandle handle2) {
+    bool isNull1 = handle1 == 0;
+    bool isNull2 = handle2 == 0;
+    if (isNull1 && isNull2) return true;
+    if (isNull1 || isNull2) return false;
+    return **reinterpret_cast<std::shared_ptr<::smoke::EquatableInterface>*>(handle1) ==
+        **reinterpret_cast<std::shared_ptr<::smoke::EquatableInterface>*>(handle2);
+}
+FfiOpaqueHandle
+library_smoke_EquatableInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter) {
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_EquatableInterface_Proxy>(token);
+    std::shared_ptr<smoke_EquatableInterface_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_EquatableInterface_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_EquatableInterface_Proxy>(
+            new (std::nothrow) smoke_EquatableInterface_Proxy(token, isolate_id, deleter)
+        );
+        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
+}
+FfiOpaqueHandle
+library_smoke_EquatableInterface_get_raw_pointer(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        reinterpret_cast<std::shared_ptr<::smoke::EquatableInterface>*>(handle)->get()
+    );
+}
+FfiOpaqueHandle
+library_smoke_EquatableInterface_get_type_id(FfiOpaqueHandle handle) {
+    const auto& type_repository = ::gluecodium::get_type_repository(static_cast<::smoke::EquatableInterface*>(nullptr));
+    const auto& type_id = type_repository.get_id(reinterpret_cast<std::shared_ptr<::smoke::EquatableInterface>*>(handle)->get());
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::string(type_id));
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/EquatableInterface.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/EquatableInterface.dart
@@ -1,0 +1,77 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+abstract class EquatableInterface {
+  void release() {}
+}
+// EquatableInterface "private" section, not exported.
+final _smoke_EquatableInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_EquatableInterface_copy_handle');
+final _smoke_EquatableInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_EquatableInterface_release_handle');
+final _smoke_EquatableInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Pointer),
+    Pointer<Void> Function(int, int, Pointer)
+  >('library_smoke_EquatableInterface_create_proxy');
+final _smoke_EquatableInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_EquatableInterface_get_raw_pointer');
+final __are_equal = __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+  >('library_smoke_EquatableInterface_are_equal');final _smoke_EquatableInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_EquatableInterface_get_type_id');
+class EquatableInterface$Impl implements EquatableInterface {
+  final Pointer<Void> handle;
+  EquatableInterface$Impl(this.handle);
+  @override
+  void release() => _smoke_EquatableInterface_release_handle(handle);
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other)) return true;
+    if (other is! EquatableInterface$Impl) return false;
+    return __are_equal((this as EquatableInterface$Impl).handle, other.handle) != 0;
+  }
+}
+Pointer<Void> smoke_EquatableInterface_toFfi(EquatableInterface value) {
+  if (value is EquatableInterface$Impl) return _smoke_EquatableInterface_copy_handle(value.handle);
+  final result = _smoke_EquatableInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.LibraryContext.isolateId,
+    __lib.uncacheObjectFfi
+  );
+  __lib.reverseCache[_smoke_EquatableInterface_get_raw_pointer(result)] = value;
+  return result;
+}
+EquatableInterface smoke_EquatableInterface_fromFfi(Pointer<Void> handle) {
+  final instance = __lib.reverseCache[_smoke_EquatableInterface_get_raw_pointer(handle)] as EquatableInterface;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_EquatableInterface_copy_handle(handle);
+  final _type_id_handle = _smoke_EquatableInterface_get_type_id(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
+  final result = factoryConstructor == null
+    ? EquatableInterface$Impl(_copied_handle)
+    : factoryConstructor(_copied_handle);
+  String_releaseFfiHandle(_type_id_handle);
+  return result;
+}
+void smoke_EquatableInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_EquatableInterface_release_handle(handle);
+Pointer<Void> smoke_EquatableInterface_toFfi_nullable(EquatableInterface value) =>
+  value != null ? smoke_EquatableInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+EquatableInterface smoke_EquatableInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_EquatableInterface_fromFfi(handle) : null;
+void smoke_EquatableInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_EquatableInterface_release_handle(handle);
+// End of EquatableInterface "private" section.


### PR DESCRIPTION
Updated Dart templates to support @Equatable interfaces. Added smoke and
functional tests.

Resolves: #108
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>