### PR TITLE
Preserve referential equality in Java code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added referential integrity in generated Java code. Meaning, when the same C++ object is passed
+    twice to Java side, it is not guaranteed to be the same object on Java side as well.
+
 ## 6.6.0
 Release date: 2020-04-22
 ### Features:

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -317,9 +317,11 @@ feature(Constants cpp android swift dart SOURCES
 
 feature(Equatable cpp android swift dart SOURCES
     src/test/EquatableImpl.cpp
+    src/test/RefEquality.cpp
 
     lime/hello/HelloWorldEquatable.lime
     lime/test/Equatable.lime
+    lime/test/RefEquality.lime
 )
 
 feature(Nullable cpp android swift dart SOURCES

--- a/examples/libhello/lime/test/RefEquality.lime
+++ b/examples/libhello/lime/test/RefEquality.lime
@@ -1,0 +1,31 @@
+# Copyright (C) 2016-2019 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+class DummyClass {
+}
+
+interface DummyInterface {
+}
+
+class DummyFactory {
+    static fun getDummyClassSingleton(): DummyClass
+    static fun createDummyClass(): DummyClass
+    static fun getDummyInterfaceSingleton(): DummyInterface
+    static fun createDummyInterface(): DummyInterface
+}

--- a/examples/libhello/src/test/RefEquality.cpp
+++ b/examples/libhello/src/test/RefEquality.cpp
@@ -1,0 +1,62 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2019 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/DummyClass.h"
+#include "test/DummyFactory.h"
+#include "test/DummyInterface.h"
+
+namespace test
+{
+namespace {
+class DummyClassImpl : public DummyClass {
+public:
+    ~DummyClassImpl() = default;
+};
+
+class DummyInterfaceImpl : public DummyInterface {
+public:
+    ~DummyInterfaceImpl() = default;
+};
+
+std::shared_ptr<DummyClass> s_dummy_class = std::make_shared<DummyClassImpl>();
+std::shared_ptr<DummyInterface> s_dummy_interface = std::make_shared<DummyInterfaceImpl>();
+}
+
+std::shared_ptr<DummyClass>
+DummyFactory::get_dummy_class_singleton() {
+    return s_dummy_class;
+}
+
+std::shared_ptr<DummyClass>
+DummyFactory::create_dummy_class() {
+    return std::make_shared<DummyClassImpl>();
+}
+
+std::shared_ptr<DummyInterface>
+DummyFactory::get_dummy_interface_singleton() {
+    return s_dummy_interface;
+}
+
+std::shared_ptr<DummyInterface>
+DummyFactory::create_dummy_interface() {
+    return std::make_shared<DummyInterfaceImpl>();
+}
+
+}

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/RefEqualityTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/RefEqualityTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.os.Build;
+import com.example.here.hello.BuildConfig;
+import com.here.android.RobolectricApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(
+    sdk = Build.VERSION_CODES.M,
+    application = RobolectricApplication.class,
+    constants = BuildConfig.class)
+public final class RefEqualityTest {
+
+  @Test
+  public void refEqualityPreservedForClass() {
+    DummyClass instance1 = DummyFactory.getDummyClassSingleton();
+    DummyClass instance2 = DummyFactory.getDummyClassSingleton();
+
+    assertTrue(instance1 == instance2);
+  }
+
+  @Test
+  public void refInequalityPreservedForClass() {
+    DummyClass instance1 = DummyFactory.getDummyClassSingleton();
+    DummyClass instance2 = DummyFactory.createDummyClass();
+
+    assertFalse(instance1 == instance2);
+  }
+
+  @Test
+  public void refEqualityPreservedForInterface() {
+    DummyInterface instance1 = DummyFactory.getDummyInterfaceSingleton();
+    DummyInterface instance2 = DummyFactory.getDummyInterfaceSingleton();
+
+    assertTrue(instance1 == instance2);
+  }
+
+  @Test
+  public void refInequalityPreservedForInterface() {
+    DummyInterface instance1 = DummyFactory.getDummyInterfaceSingleton();
+    DummyInterface instance2 = DummyFactory.createDummyInterface();
+
+    assertFalse(instance1 == instance2);
+  }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
@@ -245,6 +245,7 @@ open class JavaGeneratorSuite protected constructor(
         private const val JNI_REFERENCE = "JniReference"
         private const val JNI_CALL_JAVA_METHOD = "JniCallJavaMethod"
         private const val JNI_CLASS_CACHE = "JniClassCache"
+        private const val JNI_WRAPPER_CACHE = "JniWrapperCache"
 
         private val UTILS_FILES = listOf(
             CPP_PROXY_BASE,
@@ -252,10 +253,14 @@ open class JavaGeneratorSuite protected constructor(
             JNI_BASE,
             JNI_CPP_CONVERSION_UTILS,
             BOXING_CONVERSION_UTILS,
-            JNI_CLASS_CACHE
+            JNI_CLASS_CACHE,
+            JNI_WRAPPER_CACHE
         )
         private val UTILS_FILES_HEADER_ONLY = listOf(
-            JNI_TEMPLATE_METAINFO, JNI_REFERENCE, JNI_CALL_JAVA_METHOD, ARRAY_CONVERSION_UTILS
+            JNI_TEMPLATE_METAINFO,
+            JNI_REFERENCE,
+            JNI_CALL_JAVA_METHOD,
+            ARRAY_CONVERSION_UTILS
         )
 
         private const val NATIVE_BASE_JAVA = "NativeBase.java"

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -26,6 +26,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 
 extern "C" {
 
@@ -63,8 +64,13 @@ extern "C" {
 JNIEXPORT void JNICALL
 Java_{{mangledName}}_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-{{#unless isFunctionalInterface}}    delete reinterpret_cast<std::shared_ptr<{{cppFullyQualifiedName}}>*> (_jpointerRef);{{/unless}}
-{{#if isFunctionalInterface}}    delete reinterpret_cast<{{cppFullyQualifiedName}}*>(_jpointerRef);{{/if}}
+{{#unless isFunctionalInterface}}
+    auto p_nobj = reinterpret_cast<std::shared_ptr<{{cppFullyQualifiedName}}>*>(_jpointerRef);
+    {{>common/InternalNamespace}}jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+{{/unless}}{{#if isFunctionalInterface}}
+    delete reinterpret_cast<{{cppFullyQualifiedName}}*>(_jpointerRef);
+{{/if}}
 }
 {{/instanceOf}}
 {{#hasNativeEquatable}}

--- a/gluecodium/src/main/resources/templates/jni/InstanceConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/InstanceConversionImplementation.mustache
@@ -26,6 +26,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 
 {{#internalNamespace}}
@@ -93,10 +94,10 @@ convert_to_jni(JNIEnv* _jenv, const {{>cppTypeName}}& _ninput)
     JniReference<jobject> jResult;
 {{/if}}{{#unless isFunctionalInterface}}
     auto jResult = {{>common/InternalNamespace}}jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+
+    jResult = {{>common/InternalNamespace}}jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
 {{/unless}}
 
 {{#if hasTypeRepository}}
@@ -113,6 +114,9 @@ convert_to_jni(JNIEnv* _jenv, const {{>cppTypeName}}& _ninput)
     }
     jResult = {{>common/InternalNamespace}}jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+{{#unless isFunctionalInterface}}
+    {{>common/InternalNamespace}}jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+{{/unless}}
 
     return jResult;
 }

--- a/gluecodium/src/main/resources/templates/jni/utils/JniWrapperCacheHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniWrapperCacheHeader.mustache
@@ -1,0 +1,82 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{>java/CopyrightHeader}}
+
+#pragma once
+
+#include "JniReference.h"
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+{{#internalNamespace}}
+namespace {{.}}
+{
+{{/internalNamespace}}
+namespace jni
+{
+
+class JniWrapperCache
+{
+public:
+    template<class T>
+    static void cache_wrapper(JNIEnv* jenv, std::shared_ptr<T> nobj, const JniReference<jobject>& jobj) {
+        std::lock_guard<std::mutex> lock(s_mutex);
+        s_wrapper_cache[nobj.get()] = jenv->NewWeakGlobalRef(jobj.get());
+    }
+
+    template<class T>
+    static JniReference<jobject> get_cached_wrapper(JNIEnv* jenv, std::shared_ptr<T> nobj) {
+        std::lock_guard<std::mutex> lock(s_mutex);
+
+        auto iter = s_wrapper_cache.find(nobj.get());
+        if (iter == s_wrapper_cache.end()) return {};
+
+        auto jobj = jenv->NewLocalRef(iter->second);
+        if (jenv->IsSameObject(jobj, NULL)) {
+            jenv->DeleteLocalRef(jobj);
+            return {};
+        } else {
+            return make_local_ref(jenv, jobj);
+        }
+    }
+
+    template<class T>
+    static void remove_cached_wrapper(JNIEnv* jenv, std::shared_ptr<T> nobj) {
+        std::lock_guard<std::mutex> lock(s_mutex);
+
+        auto iter = s_wrapper_cache.find(nobj.get());
+        if (iter == s_wrapper_cache.end()) return;
+
+        jenv->DeleteWeakGlobalRef(iter->second);
+        s_wrapper_cache.erase(iter);
+    }
+
+private:
+    static std::mutex s_mutex;
+    static std::unordered_map<const void*, jobject> s_wrapper_cache;
+};
+
+}
+{{#internalNamespace}}
+}
+{{/internalNamespace}}

--- a/gluecodium/src/main/resources/templates/jni/utils/JniWrapperCacheImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniWrapperCacheImplementation.mustache
@@ -1,0 +1,36 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{>java/CopyrightHeader}}
+
+#include "JniWrapperCache.h"
+
+{{#internalNamespace}}
+namespace {{.}}
+{
+{{/internalNamespace}}
+namespace jni
+{
+std::mutex JniWrapperCache::s_mutex{};
+std::unordered_map<const void*, jobject> JniWrapperCache::s_wrapper_cache{};
+}
+{{#internalNamespace}}
+}
+{{/internalNamespace}}

--- a/gluecodium/src/test/resources/namespace_smoke/basic/output/android/jni/com_example_smoke_Basic.cpp
+++ b/gluecodium/src/test/resources/namespace_smoke/basic/output/android/jni/com_example_smoke_Basic.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jstring
 Java_com_example_smoke_Basic_basicMethod(JNIEnv* _jenv, jobject _jinstance, jstring jinputString)
@@ -19,6 +20,8 @@ Java_com_example_smoke_Basic_basicMethod(JNIEnv* _jenv, jobject _jinstance, jstr
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Basic_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::root::space::smoke::Basic>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::root::space::smoke::Basic>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/com_example_smoke_BasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/com_example_smoke_BasicTypes.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jstring
 Java_com_example_smoke_BasicTypes_stringFunction(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
@@ -96,6 +97,8 @@ Java_com_example_smoke_BasicTypes_ulongFunction(JNIEnv* _jenv, jobject _jinstanc
 JNIEXPORT void JNICALL
 Java_com_example_smoke_BasicTypes_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::BasicTypes>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::BasicTypes>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/constructors/output/android/jni/com_example_smoke_Constructors.cpp
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android/jni/com_example_smoke_Constructors.cpp
@@ -7,6 +7,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jlong
 Java_com_example_smoke_Constructors_create__(JNIEnv* _jenv, jobject _jinstance)
@@ -101,6 +102,8 @@ Java_com_example_smoke_Constructors_create__Ljava_util_List_2(JNIEnv* _jenv, job
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Constructors_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::Constructors>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::Constructors>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_Dates.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_Dates.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jobject
 Java_com_example_smoke_Dates_dateMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -51,6 +52,8 @@ Java_com_example_smoke_Dates_setDateProperty(JNIEnv* _jenv, jobject _jinstance, 
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Dates_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::Dates>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::Dates>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/android/jni/com_example_smoke_EquatableClass.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android/jni/com_example_smoke_EquatableClass.cpp
@@ -7,11 +7,14 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 JNIEXPORT void JNICALL
 Java_com_example_smoke_EquatableClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::EquatableClass>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::EquatableClass>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 jboolean
 Java_com_example_smoke_EquatableClass_equals(JNIEnv* _jenv, jobject _jinstance, jobject jrhs)

--- a/gluecodium/src/test/resources/smoke/equatable/output/android/jni/com_example_smoke_EquatableInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android/jni/com_example_smoke_EquatableInterfaceImpl.cpp
@@ -6,11 +6,14 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 JNIEXPORT void JNICALL
 Java_com_example_smoke_EquatableInterfaceImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::EquatableInterface>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::EquatableInterface>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 jboolean
 Java_com_example_smoke_EquatableInterfaceImpl_equals(JNIEnv* _jenv, jobject _jinstance, jobject jrhs)

--- a/gluecodium/src/test/resources/smoke/equatable/output/android/jni/com_example_smoke_PointerEquatableClass.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android/jni/com_example_smoke_PointerEquatableClass.cpp
@@ -6,11 +6,14 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 JNIEXPORT void JNICALL
 Java_com_example_smoke_PointerEquatableClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::PointerEquatableClass>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::PointerEquatableClass>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 jboolean
 Java_com_example_smoke_PointerEquatableClass_equals(JNIEnv* _jenv, jobject _jinstance, jobject jrhs)

--- a/gluecodium/src/test/resources/smoke/errors/output/android/jni/com_example_smoke_Errors.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/android/jni/com_example_smoke_Errors.cpp
@@ -9,6 +9,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 void
 Java_com_example_smoke_Errors_methodWithErrors(JNIEnv* _jenv, jobject _jinstance)
@@ -90,6 +91,8 @@ Java_com_example_smoke_Errors_methodWithPayloadErrorAndReturnValue(JNIEnv* _jenv
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Errors_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::Errors>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::Errors>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithBasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithBasicTypes.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jobject
 Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithList(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -178,6 +179,8 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_setSetProperty(JNIEnv* _jenv, 
 JNIEXPORT void JNICALL
 Java_com_example_smoke_GenericTypesWithBasicTypes_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithCompoundTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithCompoundTypes.cpp
@@ -12,6 +12,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jobject
 Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithStructList(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -136,6 +137,8 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap(JNIE
 JNIEXPORT void JNICALL
 Java_com_example_smoke_GenericTypesWithCompoundTypes_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithGenericTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithGenericTypes.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jobject
 Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithListOfLists(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -115,6 +116,8 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys(JNI
 JNIEXPORT void JNICALL
 Java_com_example_smoke_GenericTypesWithGenericTypes_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromClass.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromClass.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 void
 Java_com_example_smoke_ChildClassFromClass_childClassMethod(JNIEnv* _jenv, jobject _jinstance)
@@ -21,6 +22,8 @@ Java_com_example_smoke_ChildClassFromClass_childClassMethod(JNIEnv* _jenv, jobje
 JNIEXPORT void JNICALL
 Java_com_example_smoke_ChildClassFromClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::ChildClassFromClass>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::ChildClassFromClass>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromClass__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromClass__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {
@@ -41,10 +42,9 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ChildClassFromClass
         return {};
     }
     auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
     const auto& id = ::gluecodium::get_type_repository(static_cast< ::smoke::ChildClassFromClass* >(nullptr)).get_id(_ninput.get());
     const auto& javaClass = CachedJavaClass<::smoke::ChildClassFromClass>::get_java_class(id);
     auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::ChildClassFromClass>(_ninput);
@@ -55,6 +55,7 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ChildClassFromClass
     }
     jResult = ::gluecodium::jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
     return jResult;
 }
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromInterface.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 void
 Java_com_example_smoke_ChildClassFromInterface_childClassMethod(JNIEnv* _jenv, jobject _jinstance)
@@ -21,6 +22,8 @@ Java_com_example_smoke_ChildClassFromInterface_childClassMethod(JNIEnv* _jenv, j
 JNIEXPORT void JNICALL
 Java_com_example_smoke_ChildClassFromInterface_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::ChildClassFromInterface>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::ChildClassFromInterface>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromInterface__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {
@@ -41,10 +42,9 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ChildClassFromInter
         return {};
     }
     auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
     const auto& id = ::gluecodium::get_type_repository(static_cast< ::smoke::ChildClassFromInterface* >(nullptr)).get_id(_ninput.get());
     const auto& javaClass = CachedJavaClass<::smoke::ChildClassFromInterface>::get_java_class(id);
     auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::ChildClassFromInterface>(_ninput);
@@ -55,6 +55,7 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ChildClassFromInter
     }
     jResult = ::gluecodium::jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
     return jResult;
 }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_ExternalClass.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_ExternalClass.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 void
 Java_com_example_smoke_ExternalClass_someMethod(JNIEnv* _jenv, jobject _jinstance, jbyte jsomeParameter)
@@ -34,6 +35,8 @@ Java_com_example_smoke_ExternalClass_getSomeProperty(JNIEnv* _jenv, jobject _jin
 JNIEXPORT void JNICALL
 Java_com_example_smoke_ExternalClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::fire::Baz>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::fire::Baz>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_ExternalClass__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_ExternalClass__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {
@@ -41,10 +42,9 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::fire::Baz>& _ninput)
         return {};
     }
     auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
     auto &javaClass = CachedJavaClass<::fire::Baz>::java_class;
     auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::fire::Baz>(_ninput);
     if ( pInstanceSharedPointer == nullptr )
@@ -54,6 +54,7 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::fire::Baz>& _ninput)
     }
     jResult = ::gluecodium::jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
     return jResult;
 }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_ExternalInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_ExternalInterfaceImpl.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 void
 Java_com_example_smoke_ExternalInterfaceImpl_someMethod(JNIEnv* _jenv, jobject _jinstance, jbyte jsomeParameter)
@@ -34,6 +35,8 @@ Java_com_example_smoke_ExternalInterfaceImpl_getSomeProperty(JNIEnv* _jenv, jobj
 JNIEXPORT void JNICALL
 Java_com_example_smoke_ExternalInterfaceImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::ExternalInterface>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::ExternalInterface>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_ExternalInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_ExternalInterface__Conversion.cpp
@@ -6,6 +6,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {
@@ -47,10 +48,9 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ExternalInterface>&
         return {};
     }
     auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
     const auto& id = ::gluecodium::get_type_repository(static_cast< ::smoke::ExternalInterface* >(nullptr)).get_id(_ninput.get());
     const auto& javaClass = CachedJavaClass<::smoke::ExternalInterface>::get_java_class(id);
     auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::ExternalInterface>(_ninput);
@@ -61,6 +61,7 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ExternalInterface>&
     }
     jResult = ::gluecodium::jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
     return jResult;
 }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleClass.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleClass.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jstring
 Java_com_example_smoke_SimpleClass_getStringValue(JNIEnv* _jenv, jobject _jinstance)
@@ -37,6 +38,8 @@ Java_com_example_smoke_SimpleClass_useSimpleClass(JNIEnv* _jenv, jobject _jinsta
 JNIEXPORT void JNICALL
 Java_com_example_smoke_SimpleClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::SimpleClass>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::SimpleClass>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleClass__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleClass__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {
@@ -41,10 +42,9 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::SimpleClass>& _ninp
         return {};
     }
     auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
     auto &javaClass = CachedJavaClass<::smoke::SimpleClass>::java_class;
     auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::SimpleClass>(_ninput);
     if ( pInstanceSharedPointer == nullptr )
@@ -54,6 +54,7 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::SimpleClass>& _ninp
     }
     jResult = ::gluecodium::jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
     return jResult;
 }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterfaceImpl.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jstring
 Java_com_example_smoke_SimpleInterfaceImpl_getStringValue(JNIEnv* _jenv, jobject _jinstance)
@@ -37,6 +38,8 @@ Java_com_example_smoke_SimpleInterfaceImpl_useSimpleInterface(JNIEnv* _jenv, job
 JNIEXPORT void JNICALL
 Java_com_example_smoke_SimpleInterfaceImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::SimpleInterface>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::SimpleInterface>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterface__Conversion.cpp
@@ -6,6 +6,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {
@@ -47,10 +48,9 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::SimpleInterface>& _
         return {};
     }
     auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
     const auto& id = ::gluecodium::get_type_repository(static_cast< ::smoke::SimpleInterface* >(nullptr)).get_id(_ninput.get());
     const auto& javaClass = CachedJavaClass<::smoke::SimpleInterface>::get_java_class(id);
     auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::SimpleInterface>(_ninput);
@@ -61,6 +61,7 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::SimpleInterface>& _
     }
     jResult = ::gluecodium::jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
     return jResult;
 }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas.cpp
@@ -9,6 +9,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jobject
 Java_com_example_smoke_Lambdas_deconfuse(JNIEnv* _jenv, jobject _jinstance, jstring jvalue, jobject jconfuser)
@@ -43,6 +44,8 @@ Java_com_example_smoke_Lambdas_fuse(JNIEnv* _jenv, jobject _jinstance, jobject j
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Lambdas_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::Lambdas>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::Lambdas>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ConfounderImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ConfounderImpl.cpp
@@ -7,6 +7,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jobject
 Java_com_example_smoke_Lambdas_00024ConfounderImpl_confuse(JNIEnv* _jenv, jobject _jinstance, jstring jp0)

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Confounder__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Confounder__Conversion.cpp
@@ -6,6 +6,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Indexer__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Indexer__Conversion.cpp
@@ -6,6 +6,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListener__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListener__Conversion.cpp
@@ -6,6 +6,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {
@@ -47,10 +48,9 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::CalculatorListener>
         return {};
     }
     auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
     const auto& id = ::gluecodium::get_type_repository(static_cast< ::smoke::CalculatorListener* >(nullptr)).get_id(_ninput.get());
     const auto& javaClass = CachedJavaClass<::smoke::CalculatorListener>::get_java_class(id);
     auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::CalculatorListener>(_ninput);
@@ -61,6 +61,7 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::CalculatorListener>
     }
     jResult = ::gluecodium::jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
     return jResult;
 }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithProperties__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithProperties__Conversion.cpp
@@ -6,6 +6,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {
@@ -47,10 +48,9 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ListenerWithPropert
         return {};
     }
     auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
     const auto& id = ::gluecodium::get_type_repository(static_cast< ::smoke::ListenerWithProperties* >(nullptr)).get_id(_ninput.get());
     const auto& javaClass = CachedJavaClass<::smoke::ListenerWithProperties>::get_java_class(id);
     auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::ListenerWithProperties>(_ninput);
@@ -61,6 +61,7 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ListenerWithPropert
     }
     jResult = ::gluecodium::jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
     return jResult;
 }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenersWithReturnValues__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenersWithReturnValues__Conversion.cpp
@@ -6,6 +6,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {
@@ -47,10 +48,9 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ListenersWithReturn
         return {};
     }
     auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
     const auto& id = ::gluecodium::get_type_repository(static_cast< ::smoke::ListenersWithReturnValues* >(nullptr)).get_id(_ninput.get());
     const auto& javaClass = CachedJavaClass<::smoke::ListenersWithReturnValues>::get_java_class(id);
     auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::ListenersWithReturnValues>(_ninput);
@@ -61,6 +61,7 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ListenersWithReturn
     }
     jResult = ::gluecodium::jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
     return jResult;
 }
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_MethodOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_MethodOverloads.cpp
@@ -7,6 +7,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jboolean
 Java_com_example_smoke_MethodOverloads_isBoolean__Z(JNIEnv* _jenv, jobject _jinstance, jboolean jinput)
@@ -159,6 +160,8 @@ Java_com_example_smoke_MethodOverloads_isFloat__Ljava_util_List_2(JNIEnv* _jenv,
 JNIEXPORT void JNICALL
 Java_com_example_smoke_MethodOverloads_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID.cpp
@@ -8,6 +8,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jlong
 Java_com_example_namerules_NAME_1RULES_1DROID_create(JNIEnv* _jenv, jobject _jinstance)
@@ -126,6 +127,8 @@ Java_com_example_namerules_NAME_1RULES_1DROID_STORE_1STRUCT_1PROPERTY(JNIEnv* _j
 JNIEXPORT void JNICALL
 Java_com_example_namerules_NAME_1RULES_1DROID_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::namerules::NameRules>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::namerules::NameRules>*>(_jpointerRef);
+    ::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree.cpp
@@ -9,6 +9,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jobject
 Java_com_example_smoke_LevelOne_00024LevelTwo_00024LevelThree_foo(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -28,6 +29,8 @@ Java_com_example_smoke_LevelOne_00024LevelTwo_00024LevelThree_foo(JNIEnv* _jenv,
 JNIEXPORT void JNICALL
 Java_com_example_smoke_LevelOne_00024LevelTwo_00024LevelThree_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {
@@ -41,10 +42,9 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::LevelOne::LevelTwo:
         return {};
     }
     auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
     auto &javaClass = CachedJavaClass<::smoke::LevelOne::LevelTwo::LevelThree>::java_class;
     auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>(_ninput);
     if ( pInstanceSharedPointer == nullptr )
@@ -54,6 +54,7 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::LevelOne::LevelTwo:
     }
     jResult = ::gluecodium::jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
     return jResult;
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_NestedReferences.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_NestedReferences.cpp
@@ -7,6 +7,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jobject
 Java_com_example_smoke_NestedReferences_insideOut(JNIEnv* _jenv, jobject _jinstance, jobject jstruct1, jobject jstruct2)
@@ -29,6 +30,8 @@ Java_com_example_smoke_NestedReferences_insideOut(JNIEnv* _jenv, jobject _jinsta
 JNIEXPORT void JNICALL
 Java_com_example_smoke_NestedReferences_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::NestedReferences>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::NestedReferences>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_NestedReferences__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_NestedReferences__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {
@@ -41,10 +42,9 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::NestedReferences>& 
         return {};
     }
     auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
     auto &javaClass = CachedJavaClass<::smoke::NestedReferences>::java_class;
     auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::NestedReferences>(_ninput);
     if ( pInstanceSharedPointer == nullptr )
@@ -54,6 +54,7 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::NestedReferences>& 
     }
     jResult = ::gluecodium::jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
     return jResult;
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerClass.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jstring
 Java_com_example_smoke_OuterClass_00024InnerClass_foo(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
@@ -25,6 +26,8 @@ Java_com_example_smoke_OuterClass_00024InnerClass_foo(JNIEnv* _jenv, jobject _ji
 JNIEXPORT void JNICALL
 Java_com_example_smoke_OuterClass_00024InnerClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::OuterClass::InnerClass>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::OuterClass::InnerClass>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerInterfaceImpl.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jstring
 Java_com_example_smoke_OuterClass_00024InnerInterfaceImpl_foo(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
@@ -25,6 +26,8 @@ Java_com_example_smoke_OuterClass_00024InnerInterfaceImpl_foo(JNIEnv* _jenv, job
 JNIEXPORT void JNICALL
 Java_com_example_smoke_OuterClass_00024InnerInterfaceImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::OuterClass::InnerInterface>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::OuterClass::InnerInterface>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterInterface_InnerClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterInterface_InnerClass.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jstring
 Java_com_example_smoke_OuterInterface_00024InnerClass_foo(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
@@ -25,6 +26,8 @@ Java_com_example_smoke_OuterInterface_00024InnerClass_foo(JNIEnv* _jenv, jobject
 JNIEXPORT void JNICALL
 Java_com_example_smoke_OuterInterface_00024InnerClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::OuterInterface::InnerClass>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::OuterInterface::InnerClass>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterInterface_InnerInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterInterface_InnerInterfaceImpl.cpp
@@ -6,6 +6,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jstring
 Java_com_example_smoke_OuterInterface_00024InnerInterfaceImpl_foo(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
@@ -25,6 +26,8 @@ Java_com_example_smoke_OuterInterface_00024InnerInterfaceImpl_foo(JNIEnv* _jenv,
 JNIEXPORT void JNICALL
 Java_com_example_smoke_OuterInterface_00024InnerInterfaceImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::OuterInterface::InnerInterface>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::OuterInterface::InnerInterface>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable.cpp
@@ -9,6 +9,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jstring
 Java_com_example_smoke_Nullable_methodWithString(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
@@ -423,6 +424,8 @@ Java_com_example_smoke_Nullable_setInstanceProperty(JNIEnv* _jenv, jobject _jins
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Nullable_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::Nullable>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::Nullable>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android/jni/com_example_smoke_barInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android/jni/com_example_smoke_barInterface__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"
+#include "JniWrapperCache.h"
 #include <new>
 namespace gluecodium
 {
@@ -41,10 +42,9 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::fooInterface>& _nin
         return {};
     }
     auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject( _ninput.get( ) );
-    if ( jResult )
-    {
-        return jResult;
-    }
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
     auto &javaClass = CachedJavaClass<::smoke::fooInterface>::java_class;
     auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::fooInterface>(_ninput);
     if ( pInstanceSharedPointer == nullptr )
@@ -54,6 +54,7 @@ convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::fooInterface>& _nin
     }
     jResult = ::gluecodium::jni::create_instance_object(
         _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
     return jResult;
 }
 }

--- a/gluecodium/src/test/resources/smoke/properties/output/android/jni/com_example_smoke_Properties.cpp
+++ b/gluecodium/src/test/resources/smoke/properties/output/android/jni/com_example_smoke_Properties.cpp
@@ -9,6 +9,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jlong
 Java_com_example_smoke_Properties_getBuiltInTypeProperty(JNIEnv* _jenv, jobject _jinstance)
@@ -223,6 +224,8 @@ Java_com_example_smoke_Properties_getStaticReadonlyProperty(JNIEnv* _jenv, jobje
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Properties_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {
-    delete reinterpret_cast<std::shared_ptr<::smoke::Properties>*> (_jpointerRef);
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::Properties>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
 }
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_StructsWithMethodsInterface_Vector3.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_StructsWithMethodsInterface_Vector3.cpp
@@ -7,6 +7,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jdouble
 Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_distanceTo(JNIEnv* _jenv, jobject _jinstance, jobject jother)

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Vector.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Vector.cpp
@@ -7,6 +7,7 @@
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
+#include "JniWrapperCache.h"
 extern "C" {
 jdouble
 Java_com_example_smoke_Vector_distanceTo(JNIEnv* _jenv, jobject _jinstance, jobject jother)


### PR DESCRIPTION
Added JavaWrapperCache template to cache Java objects created to wrap
instances passed from C++ to Java. Updated other Java templates to use
this cache to preserve referential equality (i.e. the same C++ instance
passed to Java twice will be represented by the same Java object, see #46).

Added functional tests. Updated smoke tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>