### PR TITLE
Preserve referential equality in Swift code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 ### Features:
-  * Added referential integrity in generated Java code. Meaning, when the same C++ object is passed
-    twice to Java side, it is not guaranteed to be the same object on Java side as well.
+  * Added referential integrity in generated Java/Swift code. Meaning, when the same C++ object is
+    passed twice to Java/Swift side, it is now guaranteed to be the same object on Java/Swift side
+    as well.
 
 ## 6.6.0
 Release date: 2020-04-22

--- a/cmake/modules/gluecodium/gluecodium/runGenerate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/runGenerate.cmake
@@ -78,7 +78,7 @@ function(_collect_all_files_in_single_compilation_units)
         # Include all conversion headers first, so all later generic conversions relying on specialization have all these defined
         _include_all(jni "android/jni/*_Conversion.h" "android/jni/*.cpp")
     elseif(APIGEN_GENERATOR MATCHES swift)
-        _include_all(cbridge "cbridge/*.cpp")
+        _include_all(cbridge "cbridge/*.cpp" "cbridge_internal/*.cpp")
         # Collect all includes to be used in the modulemap
         _include_all(cbridge_header "cbridge/*.h")
         _concatenate_swift_files()

--- a/examples/platforms/ios/Tests/main.swift
+++ b/examples/platforms/ios/Tests/main.swift
@@ -55,6 +55,7 @@ let allTests = [
     testCase(NullableStructsTests.allTests),
     testCase(PlainDataStructuresFromTypeCollectionTests.allTests),
     testCase(PlainDataStructuresTests.allTests),
+    testCase(RefEqualityTests.allTests),
     testCase(SerializationTests.allTests),
     testCase(SetTypeTests.allTests),
     testCase(StaticBooleanMethodsTests.allTests),

--- a/examples/platforms/ios/Tests/testTests/AttributesTests.swift
+++ b/examples/platforms/ios/Tests/testTests/AttributesTests.swift
@@ -61,7 +61,7 @@ class AttributesTests: XCTestCase {
       XCTAssertEqual(0, instance.callCount)
 
       let result1 = instance.cachedProperty
-      let result2 = instance.cachedProperty
+      let _ = instance.cachedProperty
 
       XCTAssertEqual(1, instance.callCount)
       XCTAssertEqual(["foo", "bar"], result1)
@@ -71,7 +71,7 @@ class AttributesTests: XCTestCase {
       XCTAssertEqual(0, CachedProperties.staticCallCount)
 
       let result1 = CachedProperties.staticCachedProperty
-      let result2 = CachedProperties.staticCachedProperty
+      let _ = CachedProperties.staticCachedProperty
 
       XCTAssertEqual(1, CachedProperties.staticCallCount)
       XCTAssertEqual(Data([0, 1, 2]), result1)

--- a/examples/platforms/ios/Tests/testTests/RefEqualityTests.swift
+++ b/examples/platforms/ios/Tests/testTests/RefEqualityTests.swift
@@ -1,0 +1,60 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import hello
+
+class RefEqualityTests: XCTestCase {
+
+    func testRefEqualityPreservedForClass() {
+        let instance1 = DummyFactory.getDummyClassSingleton()
+        let instance2 = DummyFactory.getDummyClassSingleton()
+
+        XCTAssertTrue(instance1 === instance2)
+    }
+
+    func testRefInequalityPreservedForClass() {
+        let instance1 = DummyFactory.getDummyClassSingleton()
+        let instance2 = DummyFactory.createDummyClass()
+
+        XCTAssertFalse(instance1 === instance2)
+    }
+
+    func testRefEqualityPreservedForInterface() {
+        let instance1 = DummyFactory.getDummyInterfaceSingleton()
+        let instance2 = DummyFactory.getDummyInterfaceSingleton()
+
+        XCTAssertTrue(instance1 === instance2)
+    }
+
+    func testRefInequalityPreservedForInterface() {
+        let instance1 = DummyFactory.getDummyInterfaceSingleton()
+        let instance2 = DummyFactory.createDummyInterface()
+
+        XCTAssertFalse(instance1 === instance2)
+    }
+
+    static var allTests = [
+        ("testRefEqualityPreservedForClass", testRefEqualityPreservedForClass),
+        ("testRefInequalityPreservedForClass", testRefInequalityPreservedForClass),
+        ("testRefEqualityPreservedForInterface", testRefEqualityPreservedForInterface),
+        ("testRefInequalityPreservedForInterface", testRefInequalityPreservedForInterface)
+    ]
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeComponents.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeComponents.kt
@@ -29,6 +29,12 @@ object CBridgeComponents {
     val PROXY_CACHE_FILENAME = Paths.get(
         CBridgeNameRules.CBRIDGE_INTERNAL, CBridgeNameRules.INCLUDE_DIR, "CachedProxyBase.h"
     ).toString()
+    val WRAPPER_CACHE_HEADER = Paths.get(
+        CBridgeNameRules.CBRIDGE_INTERNAL, CBridgeNameRules.INCLUDE_DIR, "WrapperCache.h"
+    ).toString()
+    val WRAPPER_CACHE_IMPL = Paths.get(
+        CBridgeNameRules.CBRIDGE_INTERNAL, CBridgeNameRules.SRC_DIR, "WrapperCache.cpp"
+    ).toString()
 
     fun collectImplementationIncludes(cInterface: CInterface): List<Include> {
         val includes = mutableListOf<Include>()

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
@@ -225,7 +225,9 @@ class CBridgeGenerator(
             GeneratorSuite.copyCommonFile(
                 Paths.get(CBRIDGE_PUBLIC, INCLUDE_DIR, "ByteArrayHandle.h").toString(), ""
             ),
-            GeneratorSuite.copyCommonFile(CBridgeComponents.PROXY_CACHE_FILENAME, "")
+            GeneratorSuite.copyCommonFile(CBridgeComponents.PROXY_CACHE_FILENAME, ""),
+            GeneratorSuite.copyCommonFile(CBridgeComponents.WRAPPER_CACHE_HEADER, ""),
+            GeneratorSuite.copyCommonFile(CBridgeComponents.WRAPPER_CACHE_IMPL, "")
         )
 
         private fun generateHeaderContent(model: CInterface) =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeModelBuilder.kt
@@ -117,6 +117,7 @@ class CBridgeModelBuilder(
         }
         cInterface.implementationIncludes.add(cppIncludeResolver.typeRepositoryInclude)
         cInterface.implementationIncludes.add(Include.createInternalInclude(CBridgeNameRules.TYPE_INIT_REPOSITORY))
+        cInterface.implementationIncludes.add(Include.createInternalInclude(CBridgeComponents.WRAPPER_CACHE_HEADER))
 
         storeResult(cInterface)
         closeContext()

--- a/gluecodium/src/main/resources/cbridge_internal/include/WrapperCache.h
+++ b/gluecodium/src/main/resources/cbridge_internal/include/WrapperCache.h
@@ -1,0 +1,64 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include <unordered_map>
+
+static std::atomic<bool> wrapper_cache_is_alive;
+
+namespace
+{
+class WrapperCache {
+public:
+    using CppPtr = const void*;
+    using SwiftPtr = const void*;
+
+    explicit WrapperCache() noexcept { wrapper_cache_is_alive = true; }
+    ~WrapperCache() { wrapper_cache_is_alive = false; }
+
+    void
+    cache_wrapper(CppPtr cpp_ptr, SwiftPtr swift_ptr) {
+        std::lock_guard<std::mutex> lock(mutex);
+        cache[cpp_ptr] = swift_ptr;
+    }
+
+    SwiftPtr
+    get_cached_wrapper(CppPtr cpp_ptr) {
+        std::lock_guard<std::mutex> lock(mutex);
+        auto iter = cache.find(cpp_ptr);
+        return (iter != cache.end()) ? iter->second : nullptr;
+    }
+
+    void
+    remove_cached_wrapper(CppPtr cpp_ptr) {
+        std::lock_guard<std::mutex> lock(mutex);
+        cache.erase(cpp_ptr);
+    }
+
+private:
+    std::mutex mutex;
+    std::unordered_map<CppPtr, SwiftPtr> cache;
+};
+}
+
+static WrapperCache& get_wrapper_cache();

--- a/gluecodium/src/main/resources/cbridge_internal/src/WrapperCache.cpp
+++ b/gluecodium/src/main/resources/cbridge_internal/src/WrapperCache.cpp
@@ -1,0 +1,34 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "cbridge_internal/include/WrapperCache.h"
+
+// Handle cases of non-deterministic ordering of construction and destruction of global
+// variables. This is on two ends:
+// 1. Use function static variable to ensure it's constructed on first use.
+// 2. Use an "alive" flag to ensure it won't crash if destructed early. (e.g. storing a
+//    shared_ptr to a proxy object as a static variable)
+static WrapperCache& get_wrapper_cache()
+{
+    static WrapperCache cache;
+    return cache;
+}

--- a/gluecodium/src/main/resources/templates/cbridge/InterfaceHeader.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/InterfaceHeader.mustache
@@ -37,7 +37,9 @@ _GLUECODIUM_C_EXPORT {{>cbridge/FunctionSignature}};
 
 {{#if selfType}}
 _GLUECODIUM_C_EXPORT void {{name}}_release_handle(_baseRef handle);
-_GLUECODIUM_C_EXPORT _baseRef {{name}}_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef {{name}}_copy_handle(_baseRef handle);{{#unless isFunctionalInterface}}
+_GLUECODIUM_C_EXPORT const void* {{name}}_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void {{name}}_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);{{/unless}}
 {{#if hasTypeRepository}}_GLUECODIUM_C_EXPORT void* {{name}}_get_typed(_baseRef handle);{{/if}}
 
 {{/if}}

--- a/gluecodium/src/main/resources/templates/cbridge/InterfaceImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/InterfaceImpl.mustache
@@ -20,7 +20,12 @@
   !}}
 {{#if selfType}}
 void {{name}}_release_handle(_baseRef handle) {
-    delete get_pointer<{{selfType.name}}>(handle);
+    auto ptr_ptr = get_pointer<{{selfType.name}}>(handle);{{#unless isFunctionalInterface}}
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }{{/unless}}
+    delete ptr_ptr;
 }
 
 _baseRef {{name}}_copy_handle(_baseRef handle) {
@@ -28,6 +33,19 @@ _baseRef {{name}}_copy_handle(_baseRef handle) {
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<{{selfType.name}}>(handle)))
         : 0;
 }
+
+{{#unless isFunctionalInterface}}
+const void* {{name}}_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<{{selfType.name}}>(handle)->get())
+        : nullptr;
+}
+
+void {{name}}_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<{{selfType.name}}>(handle)->get(), swift_pointer);
+}
+{{/unless}}
 
 {{#if hasTypeRepository}}
 extern "C" {

--- a/gluecodium/src/main/resources/templates/swift/ClassConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ClassConversion.mustache
@@ -71,16 +71,24 @@ internal func {{mangledName}}copyFromCType(_ handle: _baseRef) -> {{name}} {
         return re_constructed
     }
 {{/if}}
+    if let swift_pointer = {{cInstance}}_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? {{name}} {
+        return re_constructed
+    }
 {{#if hasTypeRepository}}
     if let swift_pointer = {{cInstance}}_get_typed({{cInstance}}_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? {{name}} {
+        {{cInstance}}_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 {{/if}}{{#unless hasTypeRepository}}
-    return {{implName}}(c{{simpleName}}: {{cInstance}}_copy_handle(handle))
+    let result = {{implName}}(c{{simpleName}}: {{cInstance}}_copy_handle(handle))
+    {{cInstance}}_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 {{/unless}}
 }
+
 internal func {{mangledName}}moveFromCType(_ handle: _baseRef) -> {{name}} {
 {{#if isInterface}}
     if let swift_pointer = {{cInstance}}_get_swift_object_from_cache(handle),
@@ -89,14 +97,21 @@ internal func {{mangledName}}moveFromCType(_ handle: _baseRef) -> {{name}} {
         return re_constructed
     }
 {{/if}}
+    if let swift_pointer = {{cInstance}}_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? {{name}} {
+        return re_constructed
+    }
 {{#if hasTypeRepository}}
     if let swift_pointer = {{cInstance}}_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? {{name}} {
+        {{cInstance}}_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 {{/if}}{{#unless hasTypeRepository}}
-    return {{implName}}(c{{simpleName}}: handle)
+    let result = {{implName}}(c{{simpleName}}: handle)
+    {{cInstance}}_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 {{/unless}}
 }
 

--- a/gluecodium/src/test/resources/namespace_smoke/basic/output/cbridge/src/root/space/smoke/cbridge_Basic.cpp
+++ b/gluecodium/src/test/resources/namespace_smoke/basic/output/cbridge/src/root/space/smoke/cbridge_Basic.cpp
@@ -3,6 +3,7 @@
 #include "cbridge/include/root/space/smoke/cbridge_Basic.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "root/space/smoke/Basic.h"
@@ -10,12 +11,26 @@
 #include <new>
 #include <string>
 void smoke_Basic_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_Basic_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)))
         : 0;
+}
+const void* smoke_Basic_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)->get())
+        : nullptr;
+}
+void smoke_Basic_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)->get(), swift_pointer);
 }
 _baseRef smoke_Basic_basicMethod(_baseRef inputString) {
     return Conversion<std::string>::toBaseRef(::root::space::smoke::Basic::basic_method(Conversion<std::string>::toCpp(inputString)));

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cbridge/include/smoke/cbridge_BasicTypes.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cbridge/include/smoke/cbridge_BasicTypes.h
@@ -11,6 +11,8 @@ extern "C" {
 #include <stdint.h>
 _GLUECODIUM_C_EXPORT void smoke_BasicTypes_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_BasicTypes_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_BasicTypes_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_BasicTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT _baseRef smoke_BasicTypes_stringFunction(_baseRef input);
 _GLUECODIUM_C_EXPORT bool smoke_BasicTypes_boolFunction(bool input);
 _GLUECODIUM_C_EXPORT float smoke_BasicTypes_floatFunction(float input);

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cbridge/src/smoke/cbridge_BasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cbridge/src/smoke/cbridge_BasicTypes.cpp
@@ -3,6 +3,7 @@
 #include "cbridge/include/smoke/cbridge_BasicTypes.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/BasicTypes.h"
@@ -10,12 +11,26 @@
 #include <new>
 #include <string>
 void smoke_BasicTypes_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_BasicTypes_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)))
         : 0;
+}
+const void* smoke_BasicTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)->get())
+        : nullptr;
+}
+void smoke_BasicTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)->get(), swift_pointer);
 }
 _baseRef smoke_BasicTypes_stringFunction(_baseRef input) {
     return Conversion<std::string>::toBaseRef(::smoke::BasicTypes::string_function(Conversion<std::string>::toCpp(input)));

--- a/gluecodium/src/test/resources/smoke/basic_types/output/swift/smoke/BasicTypes.swift
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/swift/smoke/BasicTypes.swift
@@ -74,10 +74,22 @@ extension BasicTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func BasicTypes_copyFromCType(_ handle: _baseRef) -> BasicTypes {
-    return BasicTypes(cBasicTypes: smoke_BasicTypes_copy_handle(handle))
+    if let swift_pointer = smoke_BasicTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? BasicTypes {
+        return re_constructed
+    }
+    let result = BasicTypes(cBasicTypes: smoke_BasicTypes_copy_handle(handle))
+    smoke_BasicTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func BasicTypes_moveFromCType(_ handle: _baseRef) -> BasicTypes {
-    return BasicTypes(cBasicTypes: handle)
+    if let swift_pointer = smoke_BasicTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? BasicTypes {
+        return re_constructed
+    }
+    let result = BasicTypes(cBasicTypes: handle)
+    smoke_BasicTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func BasicTypes_copyFromCType(_ handle: _baseRef) -> BasicTypes? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -153,10 +153,22 @@ extension Comments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func Comments_copyFromCType(_ handle: _baseRef) -> Comments {
-    return Comments(cComments: smoke_Comments_copy_handle(handle))
+    if let swift_pointer = smoke_Comments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Comments {
+        return re_constructed
+    }
+    let result = Comments(cComments: smoke_Comments_copy_handle(handle))
+    smoke_Comments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Comments_moveFromCType(_ handle: _baseRef) -> Comments {
-    return Comments(cComments: handle)
+    if let swift_pointer = smoke_Comments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Comments {
+        return re_constructed
+    }
+    let result = Comments(cComments: handle)
+    smoke_Comments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Comments_copyFromCType(_ handle: _baseRef) -> Comments? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsInterface.swift
@@ -201,8 +201,13 @@ internal func CommentsInterface_copyFromCType(_ handle: _baseRef) -> CommentsInt
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CommentsInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_CommentsInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CommentsInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_CommentsInterface_get_typed(smoke_CommentsInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? CommentsInterface {
+        smoke_CommentsInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -213,8 +218,13 @@ internal func CommentsInterface_moveFromCType(_ handle: _baseRef) -> CommentsInt
         smoke_CommentsInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_CommentsInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CommentsInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_CommentsInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? CommentsInterface {
+        smoke_CommentsInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
@@ -99,10 +99,22 @@ extension CommentsLinks: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func CommentsLinks_copyFromCType(_ handle: _baseRef) -> CommentsLinks {
-    return CommentsLinks(cCommentsLinks: smoke_CommentsLinks_copy_handle(handle))
+    if let swift_pointer = smoke_CommentsLinks_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CommentsLinks {
+        return re_constructed
+    }
+    let result = CommentsLinks(cCommentsLinks: smoke_CommentsLinks_copy_handle(handle))
+    smoke_CommentsLinks_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func CommentsLinks_moveFromCType(_ handle: _baseRef) -> CommentsLinks {
-    return CommentsLinks(cCommentsLinks: handle)
+    if let swift_pointer = smoke_CommentsLinks_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CommentsLinks {
+        return re_constructed
+    }
+    let result = CommentsLinks(cCommentsLinks: handle)
+    smoke_CommentsLinks_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func CommentsLinks_copyFromCType(_ handle: _baseRef) -> CommentsLinks? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationComments.swift
@@ -101,8 +101,13 @@ internal func DeprecationComments_copyFromCType(_ handle: _baseRef) -> Deprecati
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DeprecationComments {
         return re_constructed
     }
+    if let swift_pointer = smoke_DeprecationComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DeprecationComments {
+        return re_constructed
+    }
     if let swift_pointer = smoke_DeprecationComments_get_typed(smoke_DeprecationComments_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? DeprecationComments {
+        smoke_DeprecationComments_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -113,8 +118,13 @@ internal func DeprecationComments_moveFromCType(_ handle: _baseRef) -> Deprecati
         smoke_DeprecationComments_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_DeprecationComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DeprecationComments {
+        return re_constructed
+    }
     if let swift_pointer = smoke_DeprecationComments_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? DeprecationComments {
+        smoke_DeprecationComments_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationCommentsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationCommentsOnly.swift
@@ -90,8 +90,13 @@ internal func DeprecationCommentsOnly_copyFromCType(_ handle: _baseRef) -> Depre
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DeprecationCommentsOnly {
         return re_constructed
     }
+    if let swift_pointer = smoke_DeprecationCommentsOnly_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DeprecationCommentsOnly {
+        return re_constructed
+    }
     if let swift_pointer = smoke_DeprecationCommentsOnly_get_typed(smoke_DeprecationCommentsOnly_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? DeprecationCommentsOnly {
+        smoke_DeprecationCommentsOnly_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -102,8 +107,13 @@ internal func DeprecationCommentsOnly_moveFromCType(_ handle: _baseRef) -> Depre
         smoke_DeprecationCommentsOnly_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_DeprecationCommentsOnly_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DeprecationCommentsOnly {
+        return re_constructed
+    }
     if let swift_pointer = smoke_DeprecationCommentsOnly_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? DeprecationCommentsOnly {
+        smoke_DeprecationCommentsOnly_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/LongComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/LongComments.swift
@@ -37,10 +37,22 @@ extension LongComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func LongComments_copyFromCType(_ handle: _baseRef) -> LongComments {
-    return LongComments(cLongComments: smoke_LongComments_copy_handle(handle))
+    if let swift_pointer = smoke_LongComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LongComments {
+        return re_constructed
+    }
+    let result = LongComments(cLongComments: smoke_LongComments_copy_handle(handle))
+    smoke_LongComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func LongComments_moveFromCType(_ handle: _baseRef) -> LongComments {
-    return LongComments(cLongComments: handle)
+    if let swift_pointer = smoke_LongComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LongComments {
+        return re_constructed
+    }
+    let result = LongComments(cLongComments: handle)
+    smoke_LongComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func LongComments_copyFromCType(_ handle: _baseRef) -> LongComments? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MultiLineComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MultiLineComments.swift
@@ -58,10 +58,22 @@ extension MultiLineComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func MultiLineComments_copyFromCType(_ handle: _baseRef) -> MultiLineComments {
-    return MultiLineComments(cMultiLineComments: smoke_MultiLineComments_copy_handle(handle))
+    if let swift_pointer = smoke_MultiLineComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MultiLineComments {
+        return re_constructed
+    }
+    let result = MultiLineComments(cMultiLineComments: smoke_MultiLineComments_copy_handle(handle))
+    smoke_MultiLineComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func MultiLineComments_moveFromCType(_ handle: _baseRef) -> MultiLineComments {
-    return MultiLineComments(cMultiLineComments: handle)
+    if let swift_pointer = smoke_MultiLineComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MultiLineComments {
+        return re_constructed
+    }
+    let result = MultiLineComments(cMultiLineComments: handle)
+    smoke_MultiLineComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func MultiLineComments_copyFromCType(_ handle: _baseRef) -> MultiLineComments? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
@@ -63,10 +63,22 @@ extension PlatformComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func PlatformComments_copyFromCType(_ handle: _baseRef) -> PlatformComments {
-    return PlatformComments(cPlatformComments: smoke_PlatformComments_copy_handle(handle))
+    if let swift_pointer = smoke_PlatformComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PlatformComments {
+        return re_constructed
+    }
+    let result = PlatformComments(cPlatformComments: smoke_PlatformComments_copy_handle(handle))
+    smoke_PlatformComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func PlatformComments_moveFromCType(_ handle: _baseRef) -> PlatformComments {
-    return PlatformComments(cPlatformComments: handle)
+    if let swift_pointer = smoke_PlatformComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PlatformComments {
+        return re_constructed
+    }
+    let result = PlatformComments(cPlatformComments: handle)
+    smoke_PlatformComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func PlatformComments_copyFromCType(_ handle: _baseRef) -> PlatformComments? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/UnicodeComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/UnicodeComments.swift
@@ -39,10 +39,22 @@ extension UnicodeComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func UnicodeComments_copyFromCType(_ handle: _baseRef) -> UnicodeComments {
-    return UnicodeComments(cUnicodeComments: smoke_UnicodeComments_copy_handle(handle))
+    if let swift_pointer = smoke_UnicodeComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UnicodeComments {
+        return re_constructed
+    }
+    let result = UnicodeComments(cUnicodeComments: smoke_UnicodeComments_copy_handle(handle))
+    smoke_UnicodeComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func UnicodeComments_moveFromCType(_ handle: _baseRef) -> UnicodeComments {
-    return UnicodeComments(cUnicodeComments: handle)
+    if let swift_pointer = smoke_UnicodeComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UnicodeComments {
+        return re_constructed
+    }
+    let result = UnicodeComments(cUnicodeComments: handle)
+    smoke_UnicodeComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func UnicodeComments_copyFromCType(_ handle: _baseRef) -> UnicodeComments? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/ConstantsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/ConstantsInterface.swift
@@ -37,10 +37,22 @@ extension ConstantsInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func ConstantsInterface_copyFromCType(_ handle: _baseRef) -> ConstantsInterface {
-    return ConstantsInterface(cConstantsInterface: smoke_ConstantsInterface_copy_handle(handle))
+    if let swift_pointer = smoke_ConstantsInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ConstantsInterface {
+        return re_constructed
+    }
+    let result = ConstantsInterface(cConstantsInterface: smoke_ConstantsInterface_copy_handle(handle))
+    smoke_ConstantsInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func ConstantsInterface_moveFromCType(_ handle: _baseRef) -> ConstantsInterface {
-    return ConstantsInterface(cConstantsInterface: handle)
+    if let swift_pointer = smoke_ConstantsInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ConstantsInterface {
+        return re_constructed
+    }
+    let result = ConstantsInterface(cConstantsInterface: handle)
+    smoke_ConstantsInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func ConstantsInterface_copyFromCType(_ handle: _baseRef) -> ConstantsInterface? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/StructConstants.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/StructConstants.swift
@@ -49,10 +49,22 @@ extension StructConstants: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func StructConstants_copyFromCType(_ handle: _baseRef) -> StructConstants {
-    return StructConstants(cStructConstants: smoke_StructConstants_copy_handle(handle))
+    if let swift_pointer = smoke_StructConstants_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructConstants {
+        return re_constructed
+    }
+    let result = StructConstants(cStructConstants: smoke_StructConstants_copy_handle(handle))
+    smoke_StructConstants_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func StructConstants_moveFromCType(_ handle: _baseRef) -> StructConstants {
-    return StructConstants(cStructConstants: handle)
+    if let swift_pointer = smoke_StructConstants_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructConstants {
+        return re_constructed
+    }
+    let result = StructConstants(cStructConstants: handle)
+    smoke_StructConstants_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func StructConstants_copyFromCType(_ handle: _baseRef) -> StructConstants? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/constructors/output/cbridge/src/smoke/cbridge_Constructors.cpp
+++ b/gluecodium/src/test/resources/smoke/constructors/output/cbridge/src/smoke/cbridge_Constructors.cpp
@@ -3,6 +3,7 @@
 #include "cbridge/include/smoke/cbridge_Constructors.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/Constructors.h"
@@ -11,12 +12,26 @@
 #include <string>
 #include <vector>
 void smoke_Constructors_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Constructors>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::Constructors>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_Constructors_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)))
         : 0;
+}
+const void* smoke_Constructors_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)->get())
+        : nullptr;
+}
+void smoke_Constructors_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_Constructors(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/ChildConstructors.swift
+++ b/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/ChildConstructors.swift
@@ -36,15 +36,25 @@ internal func getRef(_ ref: ChildConstructors?, owning: Bool = true) -> RefHolde
         : RefHolder(handle_copy)
 }
 internal func ChildConstructors_copyFromCType(_ handle: _baseRef) -> ChildConstructors {
+    if let swift_pointer = smoke_ChildConstructors_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildConstructors {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ChildConstructors_get_typed(smoke_ChildConstructors_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ChildConstructors {
+        smoke_ChildConstructors_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 }
 internal func ChildConstructors_moveFromCType(_ handle: _baseRef) -> ChildConstructors {
+    if let swift_pointer = smoke_ChildConstructors_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildConstructors {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ChildConstructors_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ChildConstructors {
+        smoke_ChildConstructors_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/Constructors.swift
+++ b/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/Constructors.swift
@@ -96,15 +96,25 @@ extension Constructors: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func Constructors_copyFromCType(_ handle: _baseRef) -> Constructors {
+    if let swift_pointer = smoke_Constructors_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Constructors {
+        return re_constructed
+    }
     if let swift_pointer = smoke_Constructors_get_typed(smoke_Constructors_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? Constructors {
+        smoke_Constructors_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 }
 internal func Constructors_moveFromCType(_ handle: _baseRef) -> Constructors {
+    if let swift_pointer = smoke_Constructors_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Constructors {
+        return re_constructed
+    }
     if let swift_pointer = smoke_Constructors_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? Constructors {
+        smoke_Constructors_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/dates/output/cbridge/include/smoke/cbridge_Dates.h
+++ b/gluecodium/src/test/resources/smoke/dates/output/cbridge/include/smoke/cbridge_Dates.h
@@ -1,6 +1,5 @@
 //
 //
-
 #pragma once
 #ifdef __cplusplus
 extern "C" {
@@ -15,6 +14,8 @@ _GLUECODIUM_C_EXPORT void smoke_Dates_DateStruct_release_optional_handle(_baseRe
 _GLUECODIUM_C_EXPORT double smoke_Dates_DateStruct_dateField_get(_baseRef handle);
 _GLUECODIUM_C_EXPORT void smoke_Dates_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_Dates_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_Dates_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_Dates_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT double smoke_Dates_dateMethod(_baseRef _instance, double input);
 _GLUECODIUM_C_EXPORT double smoke_Dates_dateProperty_get(_baseRef _instance);
 _GLUECODIUM_C_EXPORT void smoke_Dates_dateProperty_set(_baseRef _instance, double newValue);

--- a/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_Dates.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_Dates.cpp
@@ -4,6 +4,7 @@
 #include "cbridge/include/smoke/cbridge_Dates.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/Dates.h"
@@ -11,12 +12,26 @@
 #include <memory>
 #include <new>
 void smoke_Dates_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Dates>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::Dates>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_Dates_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Dates>>(handle)))
         : 0;
+}
+const void* smoke_Dates_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Dates>>(handle)->get())
+        : nullptr;
+}
+void smoke_Dates_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Dates>>(handle)->get(), swift_pointer);
 }
 _baseRef
 smoke_Dates_DateStruct_create_handle( double dateField )

--- a/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/Dates.swift
+++ b/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/Dates.swift
@@ -51,10 +51,22 @@ extension Dates: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func Dates_copyFromCType(_ handle: _baseRef) -> Dates {
-    return Dates(cDates: smoke_Dates_copy_handle(handle))
+    if let swift_pointer = smoke_Dates_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Dates {
+        return re_constructed
+    }
+    let result = Dates(cDates: smoke_Dates_copy_handle(handle))
+    smoke_Dates_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Dates_moveFromCType(_ handle: _baseRef) -> Dates {
-    return Dates(cDates: handle)
+    if let swift_pointer = smoke_Dates_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Dates {
+        return re_constructed
+    }
+    let result = Dates(cDates: handle)
+    smoke_Dates_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Dates_copyFromCType(_ handle: _baseRef) -> Dates? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/DefaultValues.swift
+++ b/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/DefaultValues.swift
@@ -162,10 +162,22 @@ extension DefaultValues: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func DefaultValues_copyFromCType(_ handle: _baseRef) -> DefaultValues {
-    return DefaultValues(cDefaultValues: smoke_DefaultValues_copy_handle(handle))
+    if let swift_pointer = smoke_DefaultValues_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DefaultValues {
+        return re_constructed
+    }
+    let result = DefaultValues(cDefaultValues: smoke_DefaultValues_copy_handle(handle))
+    smoke_DefaultValues_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func DefaultValues_moveFromCType(_ handle: _baseRef) -> DefaultValues {
-    return DefaultValues(cDefaultValues: handle)
+    if let swift_pointer = smoke_DefaultValues_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DefaultValues {
+        return re_constructed
+    }
+    let result = DefaultValues(cDefaultValues: handle)
+    smoke_DefaultValues_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func DefaultValues_copyFromCType(_ handle: _baseRef) -> DefaultValues? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/Enums.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/Enums.swift
@@ -76,10 +76,22 @@ extension Enums: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func Enums_copyFromCType(_ handle: _baseRef) -> Enums {
-    return Enums(cEnums: smoke_Enums_copy_handle(handle))
+    if let swift_pointer = smoke_Enums_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Enums {
+        return re_constructed
+    }
+    let result = Enums(cEnums: smoke_Enums_copy_handle(handle))
+    smoke_Enums_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Enums_moveFromCType(_ handle: _baseRef) -> Enums {
-    return Enums(cEnums: handle)
+    if let swift_pointer = smoke_Enums_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Enums {
+        return re_constructed
+    }
+    let result = Enums(cEnums: handle)
+    smoke_Enums_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Enums_copyFromCType(_ handle: _baseRef) -> Enums? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumsInTypeCollectionInterface.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumsInTypeCollectionInterface.swift
@@ -30,10 +30,22 @@ extension EnumsInTypeCollectionInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func EnumsInTypeCollectionInterface_copyFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface {
-    return EnumsInTypeCollectionInterface(cEnumsInTypeCollectionInterface: smoke_EnumsInTypeCollectionInterface_copy_handle(handle))
+    if let swift_pointer = smoke_EnumsInTypeCollectionInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EnumsInTypeCollectionInterface {
+        return re_constructed
+    }
+    let result = EnumsInTypeCollectionInterface(cEnumsInTypeCollectionInterface: smoke_EnumsInTypeCollectionInterface_copy_handle(handle))
+    smoke_EnumsInTypeCollectionInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func EnumsInTypeCollectionInterface_moveFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface {
-    return EnumsInTypeCollectionInterface(cEnumsInTypeCollectionInterface: handle)
+    if let swift_pointer = smoke_EnumsInTypeCollectionInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EnumsInTypeCollectionInterface {
+        return re_constructed
+    }
+    let result = EnumsInTypeCollectionInterface(cEnumsInTypeCollectionInterface: handle)
+    smoke_EnumsInTypeCollectionInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func EnumsInTypeCollectionInterface_copyFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableClass.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableClass.cpp
@@ -3,6 +3,7 @@
 #include "cbridge/include/smoke/cbridge_EquatableClass.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/EquatableClass.h"
@@ -11,12 +12,26 @@
 #include <new>
 #include <string>
 void smoke_EquatableClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_EquatableClass_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)))
         : 0;
+}
+const void* smoke_EquatableClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)->get())
+        : nullptr;
+}
+void smoke_EquatableClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)->get(), swift_pointer);
 }
 bool smoke_EquatableClass_equal(_baseRef lhs, _baseRef rhs) {
     return **get_pointer<std::shared_ptr<::smoke::EquatableClass>>(lhs) == **get_pointer<std::shared_ptr<::smoke::EquatableClass>>(rhs);

--- a/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableInterface.cpp
@@ -4,18 +4,33 @@
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/CachedProxyBase.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/EquatableInterface.h"
 #include <memory>
 #include <new>
 void smoke_EquatableInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_EquatableInterface_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)))
         : 0;
+}
+const void* smoke_EquatableInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get())
+        : nullptr;
+}
+void smoke_EquatableInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_EquatableInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_PointerEquatableClass.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_PointerEquatableClass.cpp
@@ -1,21 +1,35 @@
 //
 //
-
 #include "cbridge/include/smoke/cbridge_PointerEquatableClass.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/PointerEquatableClass.h"
 #include <memory>
 #include <new>
 void smoke_PointerEquatableClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_PointerEquatableClass_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)))
         : 0;
+}
+const void* smoke_PointerEquatableClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get())
+        : nullptr;
+}
+void smoke_PointerEquatableClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get(), swift_pointer);
 }
 bool smoke_PointerEquatableClass_equal(_baseRef lhs, _baseRef rhs) {
     return *get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(lhs) == *get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(rhs);

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableClass.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableClass.swift
@@ -52,10 +52,22 @@ extension EquatableClass: Hashable {
     }
 }
 internal func EquatableClass_copyFromCType(_ handle: _baseRef) -> EquatableClass {
-    return EquatableClass(cEquatableClass: smoke_EquatableClass_copy_handle(handle))
+    if let swift_pointer = smoke_EquatableClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableClass {
+        return re_constructed
+    }
+    let result = EquatableClass(cEquatableClass: smoke_EquatableClass_copy_handle(handle))
+    smoke_EquatableClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func EquatableClass_moveFromCType(_ handle: _baseRef) -> EquatableClass {
-    return EquatableClass(cEquatableClass: handle)
+    if let swift_pointer = smoke_EquatableClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableClass {
+        return re_constructed
+    }
+    let result = EquatableClass(cEquatableClass: handle)
+    smoke_EquatableClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func EquatableClass_copyFromCType(_ handle: _baseRef) -> EquatableClass? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableInterface.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableInterface.swift
@@ -61,8 +61,13 @@ internal func EquatableInterface_copyFromCType(_ handle: _baseRef) -> EquatableI
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_EquatableInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_EquatableInterface_get_typed(smoke_EquatableInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? EquatableInterface {
+        smoke_EquatableInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -73,8 +78,13 @@ internal func EquatableInterface_moveFromCType(_ handle: _baseRef) -> EquatableI
         smoke_EquatableInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_EquatableInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_EquatableInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? EquatableInterface {
+        smoke_EquatableInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/PointerEquatableClass.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/PointerEquatableClass.swift
@@ -34,10 +34,22 @@ extension PointerEquatableClass: Hashable {
     }
 }
 internal func PointerEquatableClass_copyFromCType(_ handle: _baseRef) -> PointerEquatableClass {
-    return PointerEquatableClass(cPointerEquatableClass: smoke_PointerEquatableClass_copy_handle(handle))
+    if let swift_pointer = smoke_PointerEquatableClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PointerEquatableClass {
+        return re_constructed
+    }
+    let result = PointerEquatableClass(cPointerEquatableClass: smoke_PointerEquatableClass_copy_handle(handle))
+    smoke_PointerEquatableClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func PointerEquatableClass_moveFromCType(_ handle: _baseRef) -> PointerEquatableClass {
-    return PointerEquatableClass(cPointerEquatableClass: handle)
+    if let swift_pointer = smoke_PointerEquatableClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PointerEquatableClass {
+        return re_constructed
+    }
+    let result = PointerEquatableClass(cPointerEquatableClass: handle)
+    smoke_PointerEquatableClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func PointerEquatableClass_copyFromCType(_ handle: _baseRef) -> PointerEquatableClass? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/errors/output/cbridge/include/smoke/cbridge_Errors.h
+++ b/gluecodium/src/test/resources/smoke/errors/output/cbridge/include/smoke/cbridge_Errors.h
@@ -40,6 +40,8 @@ typedef struct {
 } smoke_Errors_methodWithPayloadErrorAndReturnValue_result;
 _GLUECODIUM_C_EXPORT void smoke_Errors_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_Errors_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_Errors_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_Errors_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT smoke_Errors_methodWithErrors_result smoke_Errors_methodWithErrors();
 _GLUECODIUM_C_EXPORT smoke_Errors_methodWithExternalErrors_result smoke_Errors_methodWithExternalErrors();
 _GLUECODIUM_C_EXPORT smoke_Errors_methodWithErrorsAndReturnValue_result smoke_Errors_methodWithErrorsAndReturnValue();

--- a/gluecodium/src/test/resources/smoke/errors/output/cbridge/include/smoke/cbridge_ErrorsInterface.h
+++ b/gluecodium/src/test/resources/smoke/errors/output/cbridge/include/smoke/cbridge_ErrorsInterface.h
@@ -40,6 +40,8 @@ typedef struct {
 } smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_result;
 _GLUECODIUM_C_EXPORT void smoke_ErrorsInterface_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_ErrorsInterface_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_ErrorsInterface_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_ErrorsInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT void* smoke_ErrorsInterface_get_typed(_baseRef handle);
 typedef struct {
     void* swift_pointer;

--- a/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_Errors.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_Errors.cpp
@@ -3,6 +3,7 @@
 #include "cbridge/include/smoke/cbridge_Errors.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "foo/Bar.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
@@ -12,12 +13,26 @@
 #include <new>
 #include <string>
 void smoke_Errors_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Errors>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::Errors>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_Errors_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Errors>>(handle)))
         : 0;
+}
+const void* smoke_Errors_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Errors>>(handle)->get())
+        : nullptr;
+}
+void smoke_Errors_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Errors>>(handle)->get(), swift_pointer);
 }
 smoke_Errors_methodWithErrors_result smoke_Errors_methodWithErrors() {
     auto&& ERROR_VALUE = ::smoke::Errors::method_with_errors().value();

--- a/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_ErrorsInterface.cpp
@@ -4,6 +4,7 @@
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/CachedProxyBase.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/ErrorsInterface.h"
@@ -12,12 +13,26 @@
 #include <new>
 #include <string>
 void smoke_ErrorsInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_ErrorsInterface_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)))
         : 0;
+}
+const void* smoke_ErrorsInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get())
+        : nullptr;
+}
+void smoke_ErrorsInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ErrorsInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/Errors.swift
+++ b/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/Errors.swift
@@ -71,10 +71,22 @@ extension Errors: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func Errors_copyFromCType(_ handle: _baseRef) -> Errors {
-    return Errors(cErrors: smoke_Errors_copy_handle(handle))
+    if let swift_pointer = smoke_Errors_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Errors {
+        return re_constructed
+    }
+    let result = Errors(cErrors: smoke_Errors_copy_handle(handle))
+    smoke_Errors_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Errors_moveFromCType(_ handle: _baseRef) -> Errors {
-    return Errors(cErrors: handle)
+    if let swift_pointer = smoke_Errors_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Errors {
+        return re_constructed
+    }
+    let result = Errors(cErrors: handle)
+    smoke_Errors_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Errors_copyFromCType(_ handle: _baseRef) -> Errors? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/ErrorsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/ErrorsInterface.swift
@@ -145,8 +145,13 @@ internal func ErrorsInterface_copyFromCType(_ handle: _baseRef) -> ErrorsInterfa
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ErrorsInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_ErrorsInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ErrorsInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ErrorsInterface_get_typed(smoke_ErrorsInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ErrorsInterface {
+        smoke_ErrorsInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -157,8 +162,13 @@ internal func ErrorsInterface_moveFromCType(_ handle: _baseRef) -> ErrorsInterfa
         smoke_ErrorsInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_ErrorsInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ErrorsInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ErrorsInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ErrorsInterface {
+        smoke_ErrorsInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/cbridge/include/package/cbridge_Class.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/cbridge/include/package/cbridge_Class.h
@@ -17,6 +17,8 @@ typedef struct {
 } package_Class_fun_result;
 _GLUECODIUM_C_EXPORT void package_Class_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef package_Class_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* package_Class_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void package_Class_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT void* package_Class_get_typed(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef package_Class_constructor();
 _GLUECODIUM_C_EXPORT package_Class_fun_result package_Class_fun(_baseRef _instance, _baseRef double);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/cbridge/include/package/cbridge_Interface.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/cbridge/include/package/cbridge_Interface.h
@@ -1,6 +1,5 @@
 //
 //
-
 #pragma once
 #ifdef __cplusplus
 extern "C" {
@@ -9,6 +8,8 @@ extern "C" {
 #include "cbridge/include/Export.h"
 _GLUECODIUM_C_EXPORT void package_Interface_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef package_Interface_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* package_Interface_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void package_Interface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT void* package_Interface_get_typed(_baseRef handle);
 typedef struct {
     void* swift_pointer;

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Class.swift
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Class.swift
@@ -59,15 +59,25 @@ extension Class: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func Class_copyFromCType(_ handle: _baseRef) -> Class {
+    if let swift_pointer = package_Class_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Class {
+        return re_constructed
+    }
     if let swift_pointer = package_Class_get_typed(package_Class_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? Class {
+        package_Class_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 }
 internal func Class_moveFromCType(_ handle: _baseRef) -> Class {
+    if let swift_pointer = package_Class_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Class {
+        return re_constructed
+    }
     if let swift_pointer = package_Class_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? Class {
+        package_Class_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Interface.swift
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Interface.swift
@@ -48,8 +48,13 @@ internal func Interface_copyFromCType(_ handle: _baseRef) -> Interface {
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Interface {
         return re_constructed
     }
+    if let swift_pointer = package_Interface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Interface {
+        return re_constructed
+    }
     if let swift_pointer = package_Interface_get_typed(package_Interface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? Interface {
+        package_Interface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -60,8 +65,13 @@ internal func Interface_moveFromCType(_ handle: _baseRef) -> Interface {
         package_Interface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = package_Interface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Interface {
+        return re_constructed
+    }
     if let swift_pointer = package_Interface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? Interface {
+        package_Interface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithBasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithBasicTypes.cpp
@@ -3,6 +3,7 @@
 #include "cbridge/include/smoke/cbridge_GenericTypesWithBasicTypes.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/GenericTypesWithBasicTypes.h"
@@ -12,12 +13,26 @@
 #include <unordered_set>
 #include <vector>
 void smoke_GenericTypesWithBasicTypes_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_GenericTypesWithBasicTypes_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)))
         : 0;
+}
+const void* smoke_GenericTypesWithBasicTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get())
+        : nullptr;
+}
+void smoke_GenericTypesWithBasicTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get(), swift_pointer);
 }
 _baseRef
 smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle( _baseRef numbersList, _baseRef numbersMap, _baseRef numbersSet )

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithCompoundTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithCompoundTypes.cpp
@@ -5,6 +5,7 @@
 #include "cbridge/include/smoke/cbridge_GenericTypesWithCompoundTypes.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/GenericTypesWithCompoundTypes.h"
@@ -15,12 +16,26 @@
 #include <unordered_set>
 #include <vector>
 void smoke_GenericTypesWithCompoundTypes_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)))
         : 0;
+}
+const void* smoke_GenericTypesWithCompoundTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get())
+        : nullptr;
+}
+void smoke_GenericTypesWithCompoundTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get(), swift_pointer);
 }
 _baseRef
 smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle( double value )

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithGenericTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithGenericTypes.cpp
@@ -3,6 +3,7 @@
 #include "cbridge/include/smoke/cbridge_GenericTypesWithGenericTypes.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/GenericTypesWithGenericTypes.h"
@@ -12,12 +13,26 @@
 #include <unordered_set>
 #include <vector>
 void smoke_GenericTypesWithGenericTypes_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_GenericTypesWithGenericTypes_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)))
         : 0;
+}
+const void* smoke_GenericTypesWithGenericTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get())
+        : nullptr;
+}
+void smoke_GenericTypesWithGenericTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get(), swift_pointer);
 }
 _baseRef smoke_GenericTypesWithGenericTypes_methodWithListOfLists(_baseRef _instance, _baseRef input) {
     return Conversion<std::vector<std::vector<int32_t>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_list_of_lists(Conversion<std::vector<std::vector<int32_t>>>::toCpp(input)));

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithBasicTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithBasicTypes.swift
@@ -95,10 +95,22 @@ extension GenericTypesWithBasicTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func GenericTypesWithBasicTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes {
-    return GenericTypesWithBasicTypes(cGenericTypesWithBasicTypes: smoke_GenericTypesWithBasicTypes_copy_handle(handle))
+    if let swift_pointer = smoke_GenericTypesWithBasicTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithBasicTypes {
+        return re_constructed
+    }
+    let result = GenericTypesWithBasicTypes(cGenericTypesWithBasicTypes: smoke_GenericTypesWithBasicTypes_copy_handle(handle))
+    smoke_GenericTypesWithBasicTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func GenericTypesWithBasicTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes {
-    return GenericTypesWithBasicTypes(cGenericTypesWithBasicTypes: handle)
+    if let swift_pointer = smoke_GenericTypesWithBasicTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithBasicTypes {
+        return re_constructed
+    }
+    let result = GenericTypesWithBasicTypes(cGenericTypesWithBasicTypes: handle)
+    smoke_GenericTypesWithBasicTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func GenericTypesWithBasicTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithCompoundTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithCompoundTypes.swift
@@ -84,10 +84,22 @@ extension GenericTypesWithCompoundTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func GenericTypesWithCompoundTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes {
-    return GenericTypesWithCompoundTypes(cGenericTypesWithCompoundTypes: smoke_GenericTypesWithCompoundTypes_copy_handle(handle))
+    if let swift_pointer = smoke_GenericTypesWithCompoundTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithCompoundTypes {
+        return re_constructed
+    }
+    let result = GenericTypesWithCompoundTypes(cGenericTypesWithCompoundTypes: smoke_GenericTypesWithCompoundTypes_copy_handle(handle))
+    smoke_GenericTypesWithCompoundTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func GenericTypesWithCompoundTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes {
-    return GenericTypesWithCompoundTypes(cGenericTypesWithCompoundTypes: handle)
+    if let swift_pointer = smoke_GenericTypesWithCompoundTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithCompoundTypes {
+        return re_constructed
+    }
+    let result = GenericTypesWithCompoundTypes(cGenericTypesWithCompoundTypes: handle)
+    smoke_GenericTypesWithCompoundTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func GenericTypesWithCompoundTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithGenericTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithGenericTypes.swift
@@ -54,10 +54,22 @@ extension GenericTypesWithGenericTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func GenericTypesWithGenericTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes {
-    return GenericTypesWithGenericTypes(cGenericTypesWithGenericTypes: smoke_GenericTypesWithGenericTypes_copy_handle(handle))
+    if let swift_pointer = smoke_GenericTypesWithGenericTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithGenericTypes {
+        return re_constructed
+    }
+    let result = GenericTypesWithGenericTypes(cGenericTypesWithGenericTypes: smoke_GenericTypesWithGenericTypes_copy_handle(handle))
+    smoke_GenericTypesWithGenericTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func GenericTypesWithGenericTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes {
-    return GenericTypesWithGenericTypes(cGenericTypesWithGenericTypes: handle)
+    if let swift_pointer = smoke_GenericTypesWithGenericTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithGenericTypes {
+        return re_constructed
+    }
+    let result = GenericTypesWithGenericTypes(cGenericTypesWithGenericTypes: handle)
+    smoke_GenericTypesWithGenericTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func GenericTypesWithGenericTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromClass.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromClass.cpp
@@ -4,6 +4,7 @@
 #include "cbridge/include/smoke/cbridge_ParentClass.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/ChildClassFromClass.h"
@@ -11,12 +12,26 @@
 #include <memory>
 #include <new>
 void smoke_ChildClassFromClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_ChildClassFromClass_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)))
         : 0;
+}
+const void* smoke_ChildClassFromClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get())
+        : nullptr;
+}
+void smoke_ChildClassFromClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ChildClassFromClass(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromInterface.cpp
@@ -5,6 +5,7 @@
 #include "cbridge/include/smoke/cbridge_ParentInterface.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/ChildClassFromInterface.h"
@@ -13,12 +14,26 @@
 #include <new>
 #include <string>
 void smoke_ChildClassFromInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_ChildClassFromInterface_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)))
         : 0;
+}
+const void* smoke_ChildClassFromInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get())
+        : nullptr;
+}
+void smoke_ChildClassFromInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ChildClassFromInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildInterface.cpp
@@ -6,6 +6,7 @@
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/CachedProxyBase.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/ChildInterface.h"
@@ -14,12 +15,26 @@
 #include <new>
 #include <string>
 void smoke_ChildInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_ChildInterface_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)))
         : 0;
+}
+const void* smoke_ChildInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get())
+        : nullptr;
+}
+void smoke_ChildInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ChildInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromClass.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromClass.swift
@@ -24,15 +24,25 @@ internal func getRef(_ ref: ChildClassFromClass?, owning: Bool = true) -> RefHol
         : RefHolder(handle_copy)
 }
 internal func ChildClassFromClass_copyFromCType(_ handle: _baseRef) -> ChildClassFromClass {
+    if let swift_pointer = smoke_ChildClassFromClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromClass {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ChildClassFromClass_get_typed(smoke_ChildClassFromClass_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ChildClassFromClass {
+        smoke_ChildClassFromClass_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 }
 internal func ChildClassFromClass_moveFromCType(_ handle: _baseRef) -> ChildClassFromClass {
+    if let swift_pointer = smoke_ChildClassFromClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromClass {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ChildClassFromClass_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ChildClassFromClass {
+        smoke_ChildClassFromClass_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromInterface.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromInterface.swift
@@ -46,15 +46,25 @@ extension ChildClassFromInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func ChildClassFromInterface_copyFromCType(_ handle: _baseRef) -> ChildClassFromInterface {
+    if let swift_pointer = smoke_ChildClassFromInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ChildClassFromInterface_get_typed(smoke_ChildClassFromInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ChildClassFromInterface {
+        smoke_ChildClassFromInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 }
 internal func ChildClassFromInterface_moveFromCType(_ handle: _baseRef) -> ChildClassFromInterface {
+    if let swift_pointer = smoke_ChildClassFromInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ChildClassFromInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ChildClassFromInterface {
+        smoke_ChildClassFromInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildInterface.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildInterface.swift
@@ -82,8 +82,13 @@ internal func ChildInterface_copyFromCType(_ handle: _baseRef) -> ChildInterface
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_ChildInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ChildInterface_get_typed(smoke_ChildInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ChildInterface {
+        smoke_ChildInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -94,8 +99,13 @@ internal func ChildInterface_moveFromCType(_ handle: _baseRef) -> ChildInterface
         smoke_ChildInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_ChildInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ChildInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ChildInterface {
+        smoke_ChildInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalChild.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalChild.swift
@@ -21,15 +21,25 @@ internal func getRef(_ ref: InternalChild?, owning: Bool = true) -> RefHolder {
         : RefHolder(handle_copy)
 }
 internal func InternalChild_copyFromCType(_ handle: _baseRef) -> InternalChild {
+    if let swift_pointer = smoke_InternalChild_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalChild {
+        return re_constructed
+    }
     if let swift_pointer = smoke_InternalChild_get_typed(smoke_InternalChild_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InternalChild {
+        smoke_InternalChild_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 }
 internal func InternalChild_moveFromCType(_ handle: _baseRef) -> InternalChild {
+    if let swift_pointer = smoke_InternalChild_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalChild {
+        return re_constructed
+    }
     if let swift_pointer = smoke_InternalChild_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InternalChild {
+        smoke_InternalChild_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalParent.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalParent.swift
@@ -31,15 +31,25 @@ extension InternalParent: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func InternalParent_copyFromCType(_ handle: _baseRef) -> InternalParent {
+    if let swift_pointer = smoke_InternalParent_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalParent {
+        return re_constructed
+    }
     if let swift_pointer = smoke_InternalParent_get_typed(smoke_InternalParent_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InternalParent {
+        smoke_InternalParent_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 }
 internal func InternalParent_moveFromCType(_ handle: _baseRef) -> InternalParent {
+    if let swift_pointer = smoke_InternalParent_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalParent {
+        return re_constructed
+    }
     if let swift_pointer = smoke_InternalParent_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InternalParent {
+        smoke_InternalParent_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_ExternalClass.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_ExternalClass.cpp
@@ -3,6 +3,7 @@
 #include "cbridge/include/smoke/cbridge_ExternalClass.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "foo/Bar.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
@@ -10,12 +11,26 @@
 #include <new>
 #include <string>
 void smoke_ExternalClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::fire::Baz>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::fire::Baz>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_ExternalClass_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::fire::Baz>>(handle)))
         : 0;
+}
+const void* smoke_ExternalClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::fire::Baz>>(handle)->get())
+        : nullptr;
+}
+void smoke_ExternalClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::fire::Baz>>(handle)->get(), swift_pointer);
 }
 _baseRef
 smoke_ExternalClass_SomeStruct_create_handle( _baseRef someField )

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_ExternalInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_ExternalInterface.cpp
@@ -4,6 +4,7 @@
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/CachedProxyBase.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "foo/Bar.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
@@ -11,12 +12,26 @@
 #include <new>
 #include <string>
 void smoke_ExternalInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_ExternalInterface_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)))
         : 0;
+}
+const void* smoke_ExternalInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get())
+        : nullptr;
+}
+void smoke_ExternalInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ExternalInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleClass.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleClass.cpp
@@ -3,6 +3,7 @@
 #include "cbridge/include/smoke/cbridge_SimpleClass.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/SimpleClass.h"
@@ -10,12 +11,26 @@
 #include <new>
 #include <string>
 void smoke_SimpleClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_SimpleClass_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)))
         : 0;
+}
+const void* smoke_SimpleClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)->get())
+        : nullptr;
+}
+void smoke_SimpleClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)->get(), swift_pointer);
 }
 _baseRef smoke_SimpleClass_getStringValue(_baseRef _instance) {
     return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(_instance)->get()->get_string_value());

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleInterface.cpp
@@ -4,6 +4,7 @@
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/CachedProxyBase.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/SimpleInterface.h"
@@ -11,12 +12,26 @@
 #include <new>
 #include <string>
 void smoke_SimpleInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_SimpleInterface_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)))
         : 0;
+}
+const void* smoke_SimpleInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get())
+        : nullptr;
+}
+void smoke_SimpleInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_SimpleInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/ExternalClass.swift
+++ b/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/ExternalClass.swift
@@ -47,10 +47,22 @@ extension ExternalClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func ExternalClass_copyFromCType(_ handle: _baseRef) -> ExternalClass {
-    return ExternalClass(cExternalClass: smoke_ExternalClass_copy_handle(handle))
+    if let swift_pointer = smoke_ExternalClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExternalClass {
+        return re_constructed
+    }
+    let result = ExternalClass(cExternalClass: smoke_ExternalClass_copy_handle(handle))
+    smoke_ExternalClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func ExternalClass_moveFromCType(_ handle: _baseRef) -> ExternalClass {
-    return ExternalClass(cExternalClass: handle)
+    if let swift_pointer = smoke_ExternalClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExternalClass {
+        return re_constructed
+    }
+    let result = ExternalClass(cExternalClass: handle)
+    smoke_ExternalClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func ExternalClass_copyFromCType(_ handle: _baseRef) -> ExternalClass? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/ExternalInterface.swift
+++ b/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/ExternalInterface.swift
@@ -67,8 +67,13 @@ internal func ExternalInterface_copyFromCType(_ handle: _baseRef) -> ExternalInt
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExternalInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_ExternalInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExternalInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ExternalInterface_get_typed(smoke_ExternalInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ExternalInterface {
+        smoke_ExternalInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -79,8 +84,13 @@ internal func ExternalInterface_moveFromCType(_ handle: _baseRef) -> ExternalInt
         smoke_ExternalInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_ExternalInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExternalInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ExternalInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ExternalInterface {
+        smoke_ExternalInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleClass.swift
+++ b/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleClass.swift
@@ -33,10 +33,22 @@ extension SimpleClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func SimpleClass_copyFromCType(_ handle: _baseRef) -> SimpleClass {
-    return SimpleClass(cSimpleClass: smoke_SimpleClass_copy_handle(handle))
+    if let swift_pointer = smoke_SimpleClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SimpleClass {
+        return re_constructed
+    }
+    let result = SimpleClass(cSimpleClass: smoke_SimpleClass_copy_handle(handle))
+    smoke_SimpleClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func SimpleClass_moveFromCType(_ handle: _baseRef) -> SimpleClass {
-    return SimpleClass(cSimpleClass: handle)
+    if let swift_pointer = smoke_SimpleClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SimpleClass {
+        return re_constructed
+    }
+    let result = SimpleClass(cSimpleClass: handle)
+    smoke_SimpleClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func SimpleClass_copyFromCType(_ handle: _baseRef) -> SimpleClass? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleInterface.swift
+++ b/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleInterface.swift
@@ -65,8 +65,13 @@ internal func SimpleInterface_copyFromCType(_ handle: _baseRef) -> SimpleInterfa
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SimpleInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_SimpleInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SimpleInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_SimpleInterface_get_typed(smoke_SimpleInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? SimpleInterface {
+        smoke_SimpleInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -77,8 +82,13 @@ internal func SimpleInterface_moveFromCType(_ handle: _baseRef) -> SimpleInterfa
         smoke_SimpleInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_SimpleInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SimpleInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_SimpleInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? SimpleInterface {
+        smoke_SimpleInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/lambdas/output/cbridge/include/smoke/cbridge_Lambdas.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/cbridge/include/smoke/cbridge_Lambdas.h
@@ -10,6 +10,8 @@ extern "C" {
 #include <stdint.h>
 _GLUECODIUM_C_EXPORT void smoke_Lambdas_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_Lambdas_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_Lambdas_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_Lambdas_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT _baseRef smoke_Lambdas_deconfuse(_baseRef _instance, _baseRef value, _baseRef confuser);
 _GLUECODIUM_C_EXPORT _baseRef smoke_Lambdas_fuse(_baseRef items, _baseRef callback);
 _GLUECODIUM_C_EXPORT void smoke_Lambdas_Producer_release_handle(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/cbridge/src/smoke/cbridge_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/cbridge/src/smoke/cbridge_Lambdas.cpp
@@ -4,6 +4,7 @@
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/CachedProxyBase.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/Lambdas.h"
@@ -13,12 +14,26 @@
 #include <unordered_map>
 #include <vector>
 void smoke_Lambdas_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_Lambdas_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)))
         : 0;
+}
+const void* smoke_Lambdas_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)->get())
+        : nullptr;
+}
+void smoke_Lambdas_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)->get(), swift_pointer);
 }
 _baseRef smoke_Lambdas_deconfuse(_baseRef _instance, _baseRef value, _baseRef confuser) {
     return Conversion<::smoke::Lambdas::Producer>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Lambdas>>(_instance)->get()->deconfuse(Conversion<std::string>::toCpp(value), Conversion<::smoke::Lambdas::Confuser>::toCpp(confuser)));
@@ -27,7 +42,8 @@ _baseRef smoke_Lambdas_fuse(_baseRef items, _baseRef callback) {
     return Conversion<std::unordered_map<int32_t, std::string>>::toBaseRef(::smoke::Lambdas::fuse(Conversion<std::vector<std::string>>::toCpp(items), Conversion<::smoke::Lambdas::Indexer>::toCpp(callback)));
 }
 void smoke_Lambdas_Producer_release_handle(_baseRef handle) {
-    delete get_pointer<::smoke::Lambdas::Producer>(handle);
+    auto ptr_ptr = get_pointer<::smoke::Lambdas::Producer>(handle);
+    delete ptr_ptr;
 }
 _baseRef smoke_Lambdas_Producer_copy_handle(_baseRef handle) {
     return handle
@@ -65,7 +81,8 @@ const void* smoke_Lambdas_Producer_get_swift_object_from_cache(_baseRef handle) 
     return handle ? smoke_Lambdas_ProducerProxy::get_swift_object(get_pointer<::smoke::Lambdas::Producer>(handle)) : nullptr;
 }
 void smoke_Lambdas_Confuser_release_handle(_baseRef handle) {
-    delete get_pointer<::smoke::Lambdas::Confuser>(handle);
+    auto ptr_ptr = get_pointer<::smoke::Lambdas::Confuser>(handle);
+    delete ptr_ptr;
 }
 _baseRef smoke_Lambdas_Confuser_copy_handle(_baseRef handle) {
     return handle
@@ -103,7 +120,8 @@ const void* smoke_Lambdas_Confuser_get_swift_object_from_cache(_baseRef handle) 
     return handle ? smoke_Lambdas_ConfuserProxy::get_swift_object(get_pointer<::smoke::Lambdas::Confuser>(handle)) : nullptr;
 }
 void smoke_Lambdas_Consumer_release_handle(_baseRef handle) {
-    delete get_pointer<::smoke::Lambdas::Consumer>(handle);
+    auto ptr_ptr = get_pointer<::smoke::Lambdas::Consumer>(handle);
+    delete ptr_ptr;
 }
 _baseRef smoke_Lambdas_Consumer_copy_handle(_baseRef handle) {
     return handle
@@ -140,7 +158,8 @@ const void* smoke_Lambdas_Consumer_get_swift_object_from_cache(_baseRef handle) 
     return handle ? smoke_Lambdas_ConsumerProxy::get_swift_object(get_pointer<::smoke::Lambdas::Consumer>(handle)) : nullptr;
 }
 void smoke_Lambdas_Indexer_release_handle(_baseRef handle) {
-    delete get_pointer<::smoke::Lambdas::Indexer>(handle);
+    auto ptr_ptr = get_pointer<::smoke::Lambdas::Indexer>(handle);
+    delete ptr_ptr;
 }
 _baseRef smoke_Lambdas_Indexer_copy_handle(_baseRef handle) {
     return handle
@@ -178,7 +197,8 @@ const void* smoke_Lambdas_Indexer_get_swift_object_from_cache(_baseRef handle) {
     return handle ? smoke_Lambdas_IndexerProxy::get_swift_object(get_pointer<::smoke::Lambdas::Indexer>(handle)) : nullptr;
 }
 void smoke_Lambdas_NullableConfuser_release_handle(_baseRef handle) {
-    delete get_pointer<::smoke::Lambdas::NullableConfuser>(handle);
+    auto ptr_ptr = get_pointer<::smoke::Lambdas::NullableConfuser>(handle);
+    delete ptr_ptr;
 }
 _baseRef smoke_Lambdas_NullableConfuser_copy_handle(_baseRef handle) {
     return handle

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
@@ -42,10 +42,22 @@ extension Lambdas: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func Lambdas_copyFromCType(_ handle: _baseRef) -> Lambdas {
-    return Lambdas(cLambdas: smoke_Lambdas_copy_handle(handle))
+    if let swift_pointer = smoke_Lambdas_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Lambdas {
+        return re_constructed
+    }
+    let result = Lambdas(cLambdas: smoke_Lambdas_copy_handle(handle))
+    smoke_Lambdas_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Lambdas_moveFromCType(_ handle: _baseRef) -> Lambdas {
-    return Lambdas(cLambdas: handle)
+    if let swift_pointer = smoke_Lambdas_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Lambdas {
+        return re_constructed
+    }
+    let result = Lambdas(cLambdas: handle)
+    smoke_Lambdas_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Lambdas_copyFromCType(_ handle: _baseRef) -> Lambdas? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasInterface.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasInterface.swift
@@ -58,8 +58,13 @@ internal func LambdasInterface_copyFromCType(_ handle: _baseRef) -> LambdasInter
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LambdasInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_LambdasInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LambdasInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_LambdasInterface_get_typed(smoke_LambdasInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? LambdasInterface {
+        smoke_LambdasInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -70,8 +75,13 @@ internal func LambdasInterface_moveFromCType(_ handle: _baseRef) -> LambdasInter
         smoke_LambdasInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_LambdasInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LambdasInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_LambdasInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? LambdasInterface {
+        smoke_LambdasInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
@@ -36,10 +36,22 @@ extension LambdasWithStructuredTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func LambdasWithStructuredTypes_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes {
-    return LambdasWithStructuredTypes(cLambdasWithStructuredTypes: smoke_LambdasWithStructuredTypes_copy_handle(handle))
+    if let swift_pointer = smoke_LambdasWithStructuredTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LambdasWithStructuredTypes {
+        return re_constructed
+    }
+    let result = LambdasWithStructuredTypes(cLambdasWithStructuredTypes: smoke_LambdasWithStructuredTypes_copy_handle(handle))
+    smoke_LambdasWithStructuredTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func LambdasWithStructuredTypes_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes {
-    return LambdasWithStructuredTypes(cLambdasWithStructuredTypes: handle)
+    if let swift_pointer = smoke_LambdasWithStructuredTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LambdasWithStructuredTypes {
+        return re_constructed
+    }
+    let result = LambdasWithStructuredTypes(cLambdasWithStructuredTypes: handle)
+    smoke_LambdasWithStructuredTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func LambdasWithStructuredTypes_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/include/smoke/cbridge_CalculatorListener.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/include/smoke/cbridge_CalculatorListener.h
@@ -1,6 +1,5 @@
 //
 //
-
 #pragma once
 #ifdef __cplusplus
 extern "C" {
@@ -16,6 +15,8 @@ _GLUECODIUM_C_EXPORT void smoke_CalculatorListener_ResultStruct_release_optional
 _GLUECODIUM_C_EXPORT double smoke_CalculatorListener_ResultStruct_result_get(_baseRef handle);
 _GLUECODIUM_C_EXPORT void smoke_CalculatorListener_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_CalculatorListener_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_CalculatorListener_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_CalculatorListener_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT void* smoke_CalculatorListener_get_typed(_baseRef handle);
 typedef struct {
     void* swift_pointer;

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_CalculatorListener.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_CalculatorListener.cpp
@@ -4,6 +4,7 @@
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/CachedProxyBase.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/CalculationResult.h"
@@ -13,12 +14,26 @@
 #include <unordered_map>
 #include <vector>
 void smoke_CalculatorListener_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_CalculatorListener_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)))
         : 0;
+}
+const void* smoke_CalculatorListener_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get())
+        : nullptr;
+}
+void smoke_CalculatorListener_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_CalculatorListener(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenerWithProperties.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenerWithProperties.cpp
@@ -4,6 +4,7 @@
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/CachedProxyBase.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/CalculationResult.h"
@@ -14,12 +15,26 @@
 #include <unordered_map>
 #include <vector>
 void smoke_ListenerWithProperties_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_ListenerWithProperties_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)))
         : 0;
+}
+const void* smoke_ListenerWithProperties_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get())
+        : nullptr;
+}
+void smoke_ListenerWithProperties_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ListenerWithProperties(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenersWithReturnValues.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenersWithReturnValues.cpp
@@ -4,6 +4,7 @@
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/CachedProxyBase.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/CalculationResult.h"
@@ -14,12 +15,26 @@
 #include <unordered_map>
 #include <vector>
 void smoke_ListenersWithReturnValues_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_ListenersWithReturnValues_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)))
         : 0;
+}
+const void* smoke_ListenersWithReturnValues_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get())
+        : nullptr;
+}
+void smoke_ListenersWithReturnValues_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ListenersWithReturnValues(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Calculator.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Calculator.swift
@@ -34,10 +34,22 @@ extension Calculator: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func Calculator_copyFromCType(_ handle: _baseRef) -> Calculator {
-    return Calculator(cCalculator: smoke_Calculator_copy_handle(handle))
+    if let swift_pointer = smoke_Calculator_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Calculator {
+        return re_constructed
+    }
+    let result = Calculator(cCalculator: smoke_Calculator_copy_handle(handle))
+    smoke_Calculator_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Calculator_moveFromCType(_ handle: _baseRef) -> Calculator {
-    return Calculator(cCalculator: handle)
+    if let swift_pointer = smoke_Calculator_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Calculator {
+        return re_constructed
+    }
+    let result = Calculator(cCalculator: handle)
+    smoke_Calculator_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Calculator_copyFromCType(_ handle: _baseRef) -> Calculator? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/CalculatorListener.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/CalculatorListener.swift
@@ -103,8 +103,13 @@ internal func CalculatorListener_copyFromCType(_ handle: _baseRef) -> Calculator
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CalculatorListener {
         return re_constructed
     }
+    if let swift_pointer = smoke_CalculatorListener_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CalculatorListener {
+        return re_constructed
+    }
     if let swift_pointer = smoke_CalculatorListener_get_typed(smoke_CalculatorListener_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? CalculatorListener {
+        smoke_CalculatorListener_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -115,8 +120,13 @@ internal func CalculatorListener_moveFromCType(_ handle: _baseRef) -> Calculator
         smoke_CalculatorListener_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_CalculatorListener_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CalculatorListener {
+        return re_constructed
+    }
     if let swift_pointer = smoke_CalculatorListener_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? CalculatorListener {
+        smoke_CalculatorListener_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenerWithProperties.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenerWithProperties.swift
@@ -175,8 +175,13 @@ internal func ListenerWithProperties_copyFromCType(_ handle: _baseRef) -> Listen
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerWithProperties {
         return re_constructed
     }
+    if let swift_pointer = smoke_ListenerWithProperties_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerWithProperties {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ListenerWithProperties_get_typed(smoke_ListenerWithProperties_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ListenerWithProperties {
+        smoke_ListenerWithProperties_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -187,8 +192,13 @@ internal func ListenerWithProperties_moveFromCType(_ handle: _baseRef) -> Listen
         smoke_ListenerWithProperties_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_ListenerWithProperties_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerWithProperties {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ListenerWithProperties_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ListenerWithProperties {
+        smoke_ListenerWithProperties_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenersWithReturnValues.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenersWithReturnValues.swift
@@ -105,8 +105,13 @@ internal func ListenersWithReturnValues_copyFromCType(_ handle: _baseRef) -> Lis
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenersWithReturnValues {
         return re_constructed
     }
+    if let swift_pointer = smoke_ListenersWithReturnValues_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenersWithReturnValues {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ListenersWithReturnValues_get_typed(smoke_ListenersWithReturnValues_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ListenersWithReturnValues {
+        smoke_ListenersWithReturnValues_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -117,8 +122,13 @@ internal func ListenersWithReturnValues_moveFromCType(_ handle: _baseRef) -> Lis
         smoke_ListenersWithReturnValues_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_ListenersWithReturnValues_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenersWithReturnValues {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ListenersWithReturnValues_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ListenersWithReturnValues {
+        smoke_ListenersWithReturnValues_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/include/smoke/cbridge_MethodOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/include/smoke/cbridge_MethodOverloads.h
@@ -1,6 +1,5 @@
 //
 //
-
 #pragma once
 #ifdef __cplusplus
 extern "C" {
@@ -19,6 +18,8 @@ _GLUECODIUM_C_EXPORT double smoke_MethodOverloads_Point_x_get(_baseRef handle);
 _GLUECODIUM_C_EXPORT double smoke_MethodOverloads_Point_y_get(_baseRef handle);
 _GLUECODIUM_C_EXPORT void smoke_MethodOverloads_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_MethodOverloads_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_MethodOverloads_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_MethodOverloads_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT bool smoke_MethodOverloads_isBoolean_Boolean(_baseRef _instance, bool input);
 _GLUECODIUM_C_EXPORT bool smoke_MethodOverloads_isBoolean_Byte(_baseRef _instance, int8_t input);
 _GLUECODIUM_C_EXPORT bool smoke_MethodOverloads_isBoolean_String(_baseRef _instance, _baseRef input);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/include/smoke/cbridge_SpecialNames.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/include/smoke/cbridge_SpecialNames.h
@@ -1,6 +1,5 @@
 //
 //
-
 #pragma once
 #ifdef __cplusplus
 extern "C" {
@@ -9,6 +8,8 @@ extern "C" {
 #include "cbridge/include/Export.h"
 _GLUECODIUM_C_EXPORT void smoke_SpecialNames_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_SpecialNames_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_SpecialNames_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_SpecialNames_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT void smoke_SpecialNames_create(_baseRef _instance);
 _GLUECODIUM_C_EXPORT void smoke_SpecialNames_release(_baseRef _instance);
 _GLUECODIUM_C_EXPORT void smoke_SpecialNames_createProxy(_baseRef _instance);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/MethodOverloads.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/MethodOverloads.swift
@@ -82,10 +82,22 @@ extension MethodOverloads: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func MethodOverloads_copyFromCType(_ handle: _baseRef) -> MethodOverloads {
-    return MethodOverloads(cMethodOverloads: smoke_MethodOverloads_copy_handle(handle))
+    if let swift_pointer = smoke_MethodOverloads_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MethodOverloads {
+        return re_constructed
+    }
+    let result = MethodOverloads(cMethodOverloads: smoke_MethodOverloads_copy_handle(handle))
+    smoke_MethodOverloads_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func MethodOverloads_moveFromCType(_ handle: _baseRef) -> MethodOverloads {
-    return MethodOverloads(cMethodOverloads: handle)
+    if let swift_pointer = smoke_MethodOverloads_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MethodOverloads {
+        return re_constructed
+    }
+    let result = MethodOverloads(cMethodOverloads: handle)
+    smoke_MethodOverloads_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func MethodOverloads_copyFromCType(_ handle: _baseRef) -> MethodOverloads? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SpecialNames.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SpecialNames.swift
@@ -38,10 +38,22 @@ extension SpecialNames: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func SpecialNames_copyFromCType(_ handle: _baseRef) -> SpecialNames {
-    return SpecialNames(cSpecialNames: smoke_SpecialNames_copy_handle(handle))
+    if let swift_pointer = smoke_SpecialNames_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SpecialNames {
+        return re_constructed
+    }
+    let result = SpecialNames(cSpecialNames: smoke_SpecialNames_copy_handle(handle))
+    smoke_SpecialNames_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func SpecialNames_moveFromCType(_ handle: _baseRef) -> SpecialNames {
-    return SpecialNames(cSpecialNames: handle)
+    if let swift_pointer = smoke_SpecialNames_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SpecialNames {
+        return re_constructed
+    }
+    let result = SpecialNames(cSpecialNames: handle)
+    smoke_SpecialNames_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func SpecialNames_copyFromCType(_ handle: _baseRef) -> SpecialNames? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/name_rules/output/cbridge/include/namerules/cbridge_NameRules.h
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/cbridge/include/namerules/cbridge_NameRules.h
@@ -25,6 +25,8 @@ _GLUECODIUM_C_EXPORT double namerules_NameRules_ExampleStruct_iValue_get(_baseRe
 _GLUECODIUM_C_EXPORT _baseRef namerules_NameRules_ExampleStruct_iIntValue_get(_baseRef handle);
 _GLUECODIUM_C_EXPORT void namerules_NameRules_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef namerules_NameRules_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* namerules_NameRules_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void namerules_NameRules_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT _baseRef namerules_NameRules_create();
 _GLUECODIUM_C_EXPORT namerules_NameRules_someMethod_result namerules_NameRules_someMethod(_baseRef _instance, _baseRef someArgument);
 _GLUECODIUM_C_EXPORT uint32_t namerules_NameRules_intProperty_get(_baseRef _instance);

--- a/gluecodium/src/test/resources/smoke/name_rules/output/cbridge/src/namerules/cbridge_NameRules.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/cbridge/src/namerules/cbridge_NameRules.cpp
@@ -5,17 +5,32 @@
 #include "cbridge/include/namerules/cbridge_NameRules.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "namerules/NameRules.h"
 #include <memory>
 #include <new>
 #include <vector>
 void namerules_NameRules_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::namerules::NameRules>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::namerules::NameRules>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef namerules_NameRules_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)))
         : 0;
+}
+const void* namerules_NameRules_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)->get())
+        : nullptr;
+}
+void namerules_NameRules_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)->get(), swift_pointer);
 }
 _baseRef
 namerules_NameRules_ExampleStruct_create_handle( double iValue, _baseRef iIntValue )

--- a/gluecodium/src/test/resources/smoke/name_rules/output/swift/namerules/INameRules.swift
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/swift/namerules/INameRules.swift
@@ -90,10 +90,22 @@ extension INameRules: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func INameRules_copyFromCType(_ handle: _baseRef) -> INameRules {
-    return INameRules(cINameRules: namerules_NameRules_copy_handle(handle))
+    if let swift_pointer = namerules_NameRules_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? INameRules {
+        return re_constructed
+    }
+    let result = INameRules(cINameRules: namerules_NameRules_copy_handle(handle))
+    namerules_NameRules_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func INameRules_moveFromCType(_ handle: _baseRef) -> INameRules {
-    return INameRules(cINameRules: handle)
+    if let swift_pointer = namerules_NameRules_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? INameRules {
+        return re_constructed
+    }
+    let result = INameRules(cINameRules: handle)
+    namerules_NameRules_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func INameRules_copyFromCType(_ handle: _baseRef) -> INameRules? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/include/smoke/cbridge_LevelOne.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/include/smoke/cbridge_LevelOne.h
@@ -12,8 +12,12 @@ extern "C" {
 #include <stdint.h>
 _GLUECODIUM_C_EXPORT void smoke_LevelOne_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_LevelOne_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_LevelOne_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_LevelOne_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT void smoke_LevelOne_LevelTwo_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_LevelOne_LevelTwo_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_LevelOne_LevelTwo_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_LevelOne_LevelTwo_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 typedef uint32_t smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum;
 _GLUECODIUM_C_EXPORT _baseRef smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle(_baseRef stringField);
 _GLUECODIUM_C_EXPORT void smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle(_baseRef handle);
@@ -24,6 +28,8 @@ _GLUECODIUM_C_EXPORT _baseRef smoke_LevelOne_LevelTwo_LevelThree_LevelFour_strin
 _GLUECODIUM_C_EXPORT _baseRef smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fooFactory();
 _GLUECODIUM_C_EXPORT void smoke_LevelOne_LevelTwo_LevelThree_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_LevelOne_LevelTwo_LevelThree_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_LevelOne_LevelTwo_LevelThree_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_LevelOne_LevelTwo_LevelThree_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT _baseRef smoke_LevelOne_LevelTwo_LevelThree_foo(_baseRef _instance, _baseRef input);
 #ifdef __cplusplus
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/include/smoke/cbridge_UseFreeTypes.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/include/smoke/cbridge_UseFreeTypes.h
@@ -18,6 +18,8 @@ typedef struct {
 } smoke_UseFreeTypes_doStuff_result;
 _GLUECODIUM_C_EXPORT void smoke_UseFreeTypes_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_UseFreeTypes_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_UseFreeTypes_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_UseFreeTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT smoke_UseFreeTypes_doStuff_result smoke_UseFreeTypes_doStuff(_baseRef _instance, _baseRef point, smoke_FreeEnum mode);
 #ifdef __cplusplus
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_LevelOne.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_LevelOne.cpp
@@ -3,6 +3,7 @@
 #include "cbridge/include/smoke/cbridge_LevelOne.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/LevelOne.h"
@@ -12,28 +13,70 @@
 #include <new>
 #include <string>
 void smoke_LevelOne_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_LevelOne_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)))
         : 0;
 }
+const void* smoke_LevelOne_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)->get())
+        : nullptr;
+}
+void smoke_LevelOne_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)->get(), swift_pointer);
+}
 void smoke_LevelOne_LevelTwo_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_LevelOne_LevelTwo_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)))
         : 0;
 }
+const void* smoke_LevelOne_LevelTwo_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get())
+        : nullptr;
+}
+void smoke_LevelOne_LevelTwo_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get(), swift_pointer);
+}
 void smoke_LevelOne_LevelTwo_LevelThree_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_LevelOne_LevelTwo_LevelThree_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)))
         : 0;
+}
+const void* smoke_LevelOne_LevelTwo_LevelThree_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get())
+        : nullptr;
+}
+void smoke_LevelOne_LevelTwo_LevelThree_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get(), swift_pointer);
 }
 _baseRef
 smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle( _baseRef stringField )

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterClass.cpp
@@ -4,6 +4,7 @@
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/CachedProxyBase.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/OuterClass.h"
@@ -11,34 +12,76 @@
 #include <new>
 #include <string>
 void smoke_OuterClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_OuterClass_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)))
         : 0;
 }
+const void* smoke_OuterClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)->get())
+        : nullptr;
+}
+void smoke_OuterClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)->get(), swift_pointer);
+}
 _baseRef smoke_OuterClass_foo(_baseRef _instance, _baseRef input) {
     return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterClass>>(_instance)->get()->foo(Conversion<std::string>::toCpp(input)));
 }
 void smoke_OuterClass_InnerClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_OuterClass_InnerClass_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)))
         : 0;
 }
+const void* smoke_OuterClass_InnerClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get())
+        : nullptr;
+}
+void smoke_OuterClass_InnerClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get(), swift_pointer);
+}
 _baseRef smoke_OuterClass_InnerClass_foo(_baseRef _instance, _baseRef input) {
     return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(_instance)->get()->foo(Conversion<std::string>::toCpp(input)));
 }
 void smoke_OuterClass_InnerInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_OuterClass_InnerInterface_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)))
         : 0;
+}
+const void* smoke_OuterClass_InnerInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get())
+        : nullptr;
+}
+void smoke_OuterClass_InnerInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_OuterClass_InnerInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterInterface.cpp
@@ -4,6 +4,7 @@
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/CachedProxyBase.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/OuterInterface.h"
@@ -11,12 +12,26 @@
 #include <new>
 #include <string>
 void smoke_OuterInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_OuterInterface_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)))
         : 0;
+}
+const void* smoke_OuterInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get())
+        : nullptr;
+}
+void smoke_OuterInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_OuterInterface(_baseRef handle);
@@ -60,23 +75,51 @@ const void* smoke_OuterInterface_get_swift_object_from_cache(_baseRef handle) {
     return handle ? smoke_OuterInterfaceProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get()) : nullptr;
 }
 void smoke_OuterInterface_InnerClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_OuterInterface_InnerClass_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)))
         : 0;
 }
+const void* smoke_OuterInterface_InnerClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get())
+        : nullptr;
+}
+void smoke_OuterInterface_InnerClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get(), swift_pointer);
+}
 _baseRef smoke_OuterInterface_InnerClass_foo(_baseRef _instance, _baseRef input) {
     return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(_instance)->get()->foo(Conversion<std::string>::toCpp(input)));
 }
 void smoke_OuterInterface_InnerInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_OuterInterface_InnerInterface_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)))
         : 0;
+}
+const void* smoke_OuterInterface_InnerInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get())
+        : nullptr;
+}
+void smoke_OuterInterface_InnerInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get(), swift_pointer);
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_OuterInterface_InnerInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/LevelOne.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/LevelOne.swift
@@ -70,10 +70,22 @@ extension LevelOne: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func LevelOne_copyFromCType(_ handle: _baseRef) -> LevelOne {
-    return LevelOne(cLevelOne: smoke_LevelOne_copy_handle(handle))
+    if let swift_pointer = smoke_LevelOne_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne {
+        return re_constructed
+    }
+    let result = LevelOne(cLevelOne: smoke_LevelOne_copy_handle(handle))
+    smoke_LevelOne_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func LevelOne_moveFromCType(_ handle: _baseRef) -> LevelOne {
-    return LevelOne(cLevelOne: handle)
+    if let swift_pointer = smoke_LevelOne_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne {
+        return re_constructed
+    }
+    let result = LevelOne(cLevelOne: handle)
+    smoke_LevelOne_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func LevelOne_copyFromCType(_ handle: _baseRef) -> LevelOne? {
     guard handle != 0 else {
@@ -112,10 +124,22 @@ extension LevelOne.LevelTwo: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func LevelOne_LevelTwo_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo {
-    return LevelOne.LevelTwo(cLevelTwo: smoke_LevelOne_LevelTwo_copy_handle(handle))
+    if let swift_pointer = smoke_LevelOne_LevelTwo_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne.LevelTwo {
+        return re_constructed
+    }
+    let result = LevelOne.LevelTwo(cLevelTwo: smoke_LevelOne_LevelTwo_copy_handle(handle))
+    smoke_LevelOne_LevelTwo_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func LevelOne_LevelTwo_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo {
-    return LevelOne.LevelTwo(cLevelTwo: handle)
+    if let swift_pointer = smoke_LevelOne_LevelTwo_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne.LevelTwo {
+        return re_constructed
+    }
+    let result = LevelOne.LevelTwo(cLevelTwo: handle)
+    smoke_LevelOne_LevelTwo_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func LevelOne_LevelTwo_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo? {
     guard handle != 0 else {
@@ -154,10 +178,22 @@ extension LevelOne.LevelTwo.LevelThree: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func LevelOne_LevelTwo_LevelThree_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree {
-    return LevelOne.LevelTwo.LevelThree(cLevelThree: smoke_LevelOne_LevelTwo_LevelThree_copy_handle(handle))
+    if let swift_pointer = smoke_LevelOne_LevelTwo_LevelThree_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne.LevelTwo.LevelThree {
+        return re_constructed
+    }
+    let result = LevelOne.LevelTwo.LevelThree(cLevelThree: smoke_LevelOne_LevelTwo_LevelThree_copy_handle(handle))
+    smoke_LevelOne_LevelTwo_LevelThree_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func LevelOne_LevelTwo_LevelThree_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree {
-    return LevelOne.LevelTwo.LevelThree(cLevelThree: handle)
+    if let swift_pointer = smoke_LevelOne_LevelTwo_LevelThree_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne.LevelTwo.LevelThree {
+        return re_constructed
+    }
+    let result = LevelOne.LevelTwo.LevelThree(cLevelThree: handle)
+    smoke_LevelOne_LevelTwo_LevelThree_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func LevelOne_LevelTwo_LevelThree_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/NestedReferences.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/NestedReferences.swift
@@ -40,10 +40,22 @@ extension NestedReferences: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func NestedReferences_copyFromCType(_ handle: _baseRef) -> NestedReferences {
-    return NestedReferences(cNestedReferences: smoke_NestedReferences_copy_handle(handle))
+    if let swift_pointer = smoke_NestedReferences_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? NestedReferences {
+        return re_constructed
+    }
+    let result = NestedReferences(cNestedReferences: smoke_NestedReferences_copy_handle(handle))
+    smoke_NestedReferences_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func NestedReferences_moveFromCType(_ handle: _baseRef) -> NestedReferences {
-    return NestedReferences(cNestedReferences: handle)
+    if let swift_pointer = smoke_NestedReferences_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? NestedReferences {
+        return re_constructed
+    }
+    let result = NestedReferences(cNestedReferences: handle)
+    smoke_NestedReferences_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func NestedReferences_copyFromCType(_ handle: _baseRef) -> NestedReferences? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClass.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClass.swift
@@ -65,10 +65,22 @@ extension OuterClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func OuterClass_copyFromCType(_ handle: _baseRef) -> OuterClass {
-    return OuterClass(cOuterClass: smoke_OuterClass_copy_handle(handle))
+    if let swift_pointer = smoke_OuterClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass {
+        return re_constructed
+    }
+    let result = OuterClass(cOuterClass: smoke_OuterClass_copy_handle(handle))
+    smoke_OuterClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func OuterClass_moveFromCType(_ handle: _baseRef) -> OuterClass {
-    return OuterClass(cOuterClass: handle)
+    if let swift_pointer = smoke_OuterClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass {
+        return re_constructed
+    }
+    let result = OuterClass(cOuterClass: handle)
+    smoke_OuterClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func OuterClass_copyFromCType(_ handle: _baseRef) -> OuterClass? {
     guard handle != 0 else {
@@ -107,10 +119,22 @@ extension OuterClass.InnerClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func OuterClass_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterClass.InnerClass {
-    return OuterClass.InnerClass(cInnerClass: smoke_OuterClass_InnerClass_copy_handle(handle))
+    if let swift_pointer = smoke_OuterClass_InnerClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerClass {
+        return re_constructed
+    }
+    let result = OuterClass.InnerClass(cInnerClass: smoke_OuterClass_InnerClass_copy_handle(handle))
+    smoke_OuterClass_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func OuterClass_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterClass.InnerClass {
-    return OuterClass.InnerClass(cInnerClass: handle)
+    if let swift_pointer = smoke_OuterClass_InnerClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerClass {
+        return re_constructed
+    }
+    let result = OuterClass.InnerClass(cInnerClass: handle)
+    smoke_OuterClass_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func OuterClass_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterClass.InnerClass? {
     guard handle != 0 else {
@@ -173,8 +197,13 @@ internal func OuterClass_InnerInterface_copyFromCType(_ handle: _baseRef) -> Out
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_OuterClass_InnerInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_OuterClass_InnerInterface_get_typed(smoke_OuterClass_InnerInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? OuterClass.InnerInterface {
+        smoke_OuterClass_InnerInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -185,8 +214,13 @@ internal func OuterClass_InnerInterface_moveFromCType(_ handle: _baseRef) -> Out
         smoke_OuterClass_InnerInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_OuterClass_InnerInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_OuterClass_InnerInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? OuterClass.InnerInterface {
+        smoke_OuterClass_InnerInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterInterface.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterInterface.swift
@@ -57,8 +57,13 @@ internal func OuterInterface_copyFromCType(_ handle: _baseRef) -> OuterInterface
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_OuterInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_OuterInterface_get_typed(smoke_OuterInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? OuterInterface {
+        smoke_OuterInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -69,8 +74,13 @@ internal func OuterInterface_moveFromCType(_ handle: _baseRef) -> OuterInterface
         smoke_OuterInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_OuterInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_OuterInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? OuterInterface {
+        smoke_OuterInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -128,10 +138,22 @@ extension InnerClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func InnerClass_copyFromCType(_ handle: _baseRef) -> InnerClass {
-    return InnerClass(cInnerClass: smoke_OuterInterface_InnerClass_copy_handle(handle))
+    if let swift_pointer = smoke_OuterInterface_InnerClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerClass {
+        return re_constructed
+    }
+    let result = InnerClass(cInnerClass: smoke_OuterInterface_InnerClass_copy_handle(handle))
+    smoke_OuterInterface_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func InnerClass_moveFromCType(_ handle: _baseRef) -> InnerClass {
-    return InnerClass(cInnerClass: handle)
+    if let swift_pointer = smoke_OuterInterface_InnerClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerClass {
+        return re_constructed
+    }
+    let result = InnerClass(cInnerClass: handle)
+    smoke_OuterInterface_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func InnerClass_copyFromCType(_ handle: _baseRef) -> InnerClass? {
     guard handle != 0 else {
@@ -213,8 +235,13 @@ internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_OuterInterface_InnerInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_OuterInterface_InnerInterface_get_typed(smoke_OuterInterface_InnerInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InnerInterface {
+        smoke_OuterInterface_InnerInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -225,8 +252,13 @@ internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface
         smoke_OuterInterface_InnerInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_OuterInterface_InnerInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_OuterInterface_InnerInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InnerInterface {
+        smoke_OuterInterface_InnerInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/UseFreeTypes.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/UseFreeTypes.swift
@@ -36,10 +36,22 @@ extension UseFreeTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func UseFreeTypes_copyFromCType(_ handle: _baseRef) -> UseFreeTypes {
-    return UseFreeTypes(cUseFreeTypes: smoke_UseFreeTypes_copy_handle(handle))
+    if let swift_pointer = smoke_UseFreeTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UseFreeTypes {
+        return re_constructed
+    }
+    let result = UseFreeTypes(cUseFreeTypes: smoke_UseFreeTypes_copy_handle(handle))
+    smoke_UseFreeTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func UseFreeTypes_moveFromCType(_ handle: _baseRef) -> UseFreeTypes {
-    return UseFreeTypes(cUseFreeTypes: handle)
+    if let swift_pointer = smoke_UseFreeTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UseFreeTypes {
+        return re_constructed
+    }
+    let result = UseFreeTypes(cUseFreeTypes: handle)
+    smoke_UseFreeTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func UseFreeTypes_copyFromCType(_ handle: _baseRef) -> UseFreeTypes? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/nullable/output/swift/smoke/Nullable.swift
+++ b/gluecodium/src/test/resources/smoke/nullable/output/swift/smoke/Nullable.swift
@@ -234,10 +234,22 @@ extension Nullable: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func Nullable_copyFromCType(_ handle: _baseRef) -> Nullable {
-    return Nullable(cNullable: smoke_Nullable_copy_handle(handle))
+    if let swift_pointer = smoke_Nullable_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Nullable {
+        return re_constructed
+    }
+    let result = Nullable(cNullable: smoke_Nullable_copy_handle(handle))
+    smoke_Nullable_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Nullable_moveFromCType(_ handle: _baseRef) -> Nullable {
-    return Nullable(cNullable: handle)
+    if let swift_pointer = smoke_Nullable_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Nullable {
+        return re_constructed
+    }
+    let result = Nullable(cNullable: handle)
+    smoke_Nullable_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Nullable_copyFromCType(_ handle: _baseRef) -> Nullable? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcChildClass.swift
+++ b/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcChildClass.swift
@@ -22,15 +22,25 @@ internal func getRef(_ ref: ObjcChildClass?, owning: Bool = true) -> RefHolder {
         : RefHolder(handle_copy)
 }
 internal func ObjcChildClass_copyFromCType(_ handle: _baseRef) -> ObjcChildClass {
+    if let swift_pointer = smoke_ObjcChildClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcChildClass {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ObjcChildClass_get_typed(smoke_ObjcChildClass_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ObjcChildClass {
+        smoke_ObjcChildClass_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 }
 internal func ObjcChildClass_moveFromCType(_ handle: _baseRef) -> ObjcChildClass {
+    if let swift_pointer = smoke_ObjcChildClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcChildClass {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ObjcChildClass_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ObjcChildClass {
+        smoke_ObjcChildClass_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcChildInterface.swift
+++ b/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcChildInterface.swift
@@ -49,8 +49,13 @@ internal func ObjcChildInterface_copyFromCType(_ handle: _baseRef) -> ObjcChildI
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcChildInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_ObjcChildInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcChildInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ObjcChildInterface_get_typed(smoke_ObjcChildInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ObjcChildInterface {
+        smoke_ObjcChildInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -61,8 +66,13 @@ internal func ObjcChildInterface_moveFromCType(_ handle: _baseRef) -> ObjcChildI
         smoke_ObjcChildInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_ObjcChildInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcChildInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ObjcChildInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ObjcChildInterface {
+        smoke_ObjcChildInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcClass.swift
+++ b/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcClass.swift
@@ -32,15 +32,25 @@ extension ObjcClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func ObjcClass_copyFromCType(_ handle: _baseRef) -> ObjcClass {
+    if let swift_pointer = smoke_ObjcClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcClass {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ObjcClass_get_typed(smoke_ObjcClass_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ObjcClass {
+        smoke_ObjcClass_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 }
 internal func ObjcClass_moveFromCType(_ handle: _baseRef) -> ObjcClass {
+    if let swift_pointer = smoke_ObjcClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcClass {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ObjcClass_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ObjcClass {
+        smoke_ObjcClass_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcImplementerClass.swift
+++ b/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcImplementerClass.swift
@@ -32,15 +32,25 @@ extension ObjcImplementerClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func ObjcImplementerClass_copyFromCType(_ handle: _baseRef) -> ObjcImplementerClass {
+    if let swift_pointer = smoke_ObjcImplementerClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcImplementerClass {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ObjcImplementerClass_get_typed(smoke_ObjcImplementerClass_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ObjcImplementerClass {
+        smoke_ObjcImplementerClass_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 }
 internal func ObjcImplementerClass_moveFromCType(_ handle: _baseRef) -> ObjcImplementerClass {
+    if let swift_pointer = smoke_ObjcImplementerClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcImplementerClass {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ObjcImplementerClass_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ObjcImplementerClass {
+        smoke_ObjcImplementerClass_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcInterface.swift
+++ b/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcInterface.swift
@@ -49,8 +49,13 @@ internal func ObjcInterface_copyFromCType(_ handle: _baseRef) -> ObjcInterface {
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_ObjcInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ObjcInterface_get_typed(smoke_ObjcInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ObjcInterface {
+        smoke_ObjcInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -61,8 +66,13 @@ internal func ObjcInterface_moveFromCType(_ handle: _baseRef) -> ObjcInterface {
         smoke_ObjcInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_ObjcInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_ObjcInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ObjcInterface {
+        smoke_ObjcInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/platform_names/output/cbridge/include/smoke/cbridge_bazInterface.h
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/cbridge/include/smoke/cbridge_bazInterface.h
@@ -11,6 +11,8 @@ extern "C" {
 #include <stdint.h>
 _GLUECODIUM_C_EXPORT void smoke_PlatformNamesInterface_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_PlatformNamesInterface_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_PlatformNamesInterface_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_PlatformNamesInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT _baseRef smoke_bazInterface_BazMethod(_baseRef _instance, _baseRef BazParameter);
 _GLUECODIUM_C_EXPORT _baseRef smoke_bazInterface_make(_baseRef makeParameter);
 _GLUECODIUM_C_EXPORT uint32_t smoke_PlatformNamesInterface_basicProperty_get(_baseRef _instance);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazInterface.swift
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazInterface.swift
@@ -50,10 +50,22 @@ extension bazInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func bazInterface_copyFromCType(_ handle: _baseRef) -> bazInterface {
-    return bazInterface(cbazInterface: smoke_PlatformNamesInterface_copy_handle(handle))
+    if let swift_pointer = smoke_PlatformNamesInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? bazInterface {
+        return re_constructed
+    }
+    let result = bazInterface(cbazInterface: smoke_PlatformNamesInterface_copy_handle(handle))
+    smoke_PlatformNamesInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func bazInterface_moveFromCType(_ handle: _baseRef) -> bazInterface {
-    return bazInterface(cbazInterface: handle)
+    if let swift_pointer = smoke_PlatformNamesInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? bazInterface {
+        return re_constructed
+    }
+    let result = bazInterface(cbazInterface: handle)
+    smoke_PlatformNamesInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func bazInterface_copyFromCType(_ handle: _baseRef) -> bazInterface? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazListener.swift
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazListener.swift
@@ -57,8 +57,13 @@ internal func bazListener_copyFromCType(_ handle: _baseRef) -> bazListener {
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? bazListener {
         return re_constructed
     }
+    if let swift_pointer = smoke_PlatformNamesListener_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? bazListener {
+        return re_constructed
+    }
     if let swift_pointer = smoke_PlatformNamesListener_get_typed(smoke_PlatformNamesListener_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? bazListener {
+        smoke_PlatformNamesListener_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -69,8 +74,13 @@ internal func bazListener_moveFromCType(_ handle: _baseRef) -> bazListener {
         smoke_PlatformNamesListener_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_PlatformNamesListener_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? bazListener {
+        return re_constructed
+    }
     if let swift_pointer = smoke_PlatformNamesListener_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? bazListener {
+        smoke_PlatformNamesListener_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/CachedProperties.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/CachedProperties.swift
@@ -32,10 +32,22 @@ extension CachedProperties: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func CachedProperties_copyFromCType(_ handle: _baseRef) -> CachedProperties {
-    return CachedProperties(cCachedProperties: smoke_CachedProperties_copy_handle(handle))
+    if let swift_pointer = smoke_CachedProperties_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CachedProperties {
+        return re_constructed
+    }
+    let result = CachedProperties(cCachedProperties: smoke_CachedProperties_copy_handle(handle))
+    smoke_CachedProperties_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func CachedProperties_moveFromCType(_ handle: _baseRef) -> CachedProperties {
-    return CachedProperties(cCachedProperties: handle)
+    if let swift_pointer = smoke_CachedProperties_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CachedProperties {
+        return re_constructed
+    }
+    let result = CachedProperties(cCachedProperties: handle)
+    smoke_CachedProperties_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func CachedProperties_copyFromCType(_ handle: _baseRef) -> CachedProperties? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/Properties.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/Properties.swift
@@ -121,10 +121,22 @@ extension Properties: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func Properties_copyFromCType(_ handle: _baseRef) -> Properties {
-    return Properties(cProperties: smoke_Properties_copy_handle(handle))
+    if let swift_pointer = smoke_Properties_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Properties {
+        return re_constructed
+    }
+    let result = Properties(cProperties: smoke_Properties_copy_handle(handle))
+    smoke_Properties_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Properties_moveFromCType(_ handle: _baseRef) -> Properties {
-    return Properties(cProperties: handle)
+    if let swift_pointer = smoke_Properties_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Properties {
+        return re_constructed
+    }
+    let result = Properties(cProperties: handle)
+    smoke_Properties_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Properties_copyFromCType(_ handle: _baseRef) -> Properties? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/PropertiesInterface.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/PropertiesInterface.swift
@@ -66,8 +66,13 @@ internal func PropertiesInterface_copyFromCType(_ handle: _baseRef) -> Propertie
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PropertiesInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_PropertiesInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PropertiesInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_PropertiesInterface_get_typed(smoke_PropertiesInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? PropertiesInterface {
+        smoke_PropertiesInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -78,8 +83,13 @@ internal func PropertiesInterface_moveFromCType(_ handle: _baseRef) -> Propertie
         smoke_PropertiesInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_PropertiesInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PropertiesInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_PropertiesInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? PropertiesInterface {
+        smoke_PropertiesInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipFunctions.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipFunctions.h
@@ -9,6 +9,8 @@ extern "C" {
 #include "cbridge/include/StringHandle.h"
 _GLUECODIUM_C_EXPORT void smoke_SkipFunctions_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_SkipFunctions_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_SkipFunctions_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_SkipFunctions_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT _baseRef smoke_SkipFunctions_notInJava(_baseRef input);
 _GLUECODIUM_C_EXPORT float smoke_SkipFunctions_notInDart(float input);
 #ifdef __cplusplus

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipFunctions.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipFunctions.swift
@@ -34,10 +34,22 @@ extension SkipFunctions: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func SkipFunctions_copyFromCType(_ handle: _baseRef) -> SkipFunctions {
-    return SkipFunctions(cSkipFunctions: smoke_SkipFunctions_copy_handle(handle))
+    if let swift_pointer = smoke_SkipFunctions_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipFunctions {
+        return re_constructed
+    }
+    let result = SkipFunctions(cSkipFunctions: smoke_SkipFunctions_copy_handle(handle))
+    smoke_SkipFunctions_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func SkipFunctions_moveFromCType(_ handle: _baseRef) -> SkipFunctions {
-    return SkipFunctions(cSkipFunctions: handle)
+    if let swift_pointer = smoke_SkipFunctions_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipFunctions {
+        return re_constructed
+    }
+    let result = SkipFunctions(cSkipFunctions: handle)
+    smoke_SkipFunctions_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func SkipFunctions_copyFromCType(_ handle: _baseRef) -> SkipFunctions? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTypes.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTypes.swift
@@ -44,10 +44,22 @@ extension SkipTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func SkipTypes_copyFromCType(_ handle: _baseRef) -> SkipTypes {
-    return SkipTypes(cSkipTypes: smoke_SkipTypes_copy_handle(handle))
+    if let swift_pointer = smoke_SkipTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipTypes {
+        return re_constructed
+    }
+    let result = SkipTypes(cSkipTypes: smoke_SkipTypes_copy_handle(handle))
+    smoke_SkipTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func SkipTypes_moveFromCType(_ handle: _baseRef) -> SkipTypes {
-    return SkipTypes(cSkipTypes: handle)
+    if let swift_pointer = smoke_SkipTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipTypes {
+        return re_constructed
+    }
+    let result = SkipTypes(cSkipTypes: handle)
+    smoke_SkipTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func SkipTypes_copyFromCType(_ handle: _baseRef) -> SkipTypes? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_Structs.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_Structs.cpp
@@ -3,6 +3,7 @@
 #include "cbridge/include/smoke/cbridge_Structs.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "foo/Bar.h"
 #include "foo/Bazz.h"
 #include "gluecodium/Optional.h"
@@ -15,12 +16,26 @@
 #include <string>
 #include <vector>
 void smoke_Structs_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Structs>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::Structs>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_Structs_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Structs>>(handle)))
         : 0;
+}
+const void* smoke_Structs_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get())
+        : nullptr;
+}
+void smoke_Structs_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get(), swift_pointer);
 }
 _baseRef
 smoke_Structs_Point_create_handle( double x, double y )

--- a/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethodsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethodsInterface.cpp
@@ -3,6 +3,7 @@
 #include "cbridge/include/smoke/cbridge_StructsWithMethodsInterface.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/StructsWithMethodsInterface.h"
@@ -11,12 +12,26 @@
 #include <new>
 #include <string>
 void smoke_StructsWithMethodsInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle);
+    auto ptr_ptr = get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle);
+    auto& wrapper_cache = get_wrapper_cache();
+    if (wrapper_cache_is_alive) {
+        wrapper_cache.remove_cached_wrapper(ptr_ptr->get());
+    }
+    delete ptr_ptr;
 }
 _baseRef smoke_StructsWithMethodsInterface_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)))
         : 0;
+}
+const void* smoke_StructsWithMethodsInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get())
+        : nullptr;
+}
+void smoke_StructsWithMethodsInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get(), swift_pointer);
 }
 _baseRef
 smoke_StructsWithMethodsInterface_Vector3_create_handle( double x, double y, double z )

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/Structs.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/Structs.swift
@@ -210,10 +210,22 @@ extension Structs: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func Structs_copyFromCType(_ handle: _baseRef) -> Structs {
-    return Structs(cStructs: smoke_Structs_copy_handle(handle))
+    if let swift_pointer = smoke_Structs_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Structs {
+        return re_constructed
+    }
+    let result = Structs(cStructs: smoke_Structs_copy_handle(handle))
+    smoke_Structs_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Structs_moveFromCType(_ handle: _baseRef) -> Structs {
-    return Structs(cStructs: handle)
+    if let swift_pointer = smoke_Structs_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Structs {
+        return re_constructed
+    }
+    let result = Structs(cStructs: handle)
+    smoke_Structs_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func Structs_copyFromCType(_ handle: _baseRef) -> Structs? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithConstantsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithConstantsInterface.swift
@@ -43,10 +43,22 @@ extension StructsWithConstantsInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func StructsWithConstantsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface {
-    return StructsWithConstantsInterface(cStructsWithConstantsInterface: smoke_StructsWithConstantsInterface_copy_handle(handle))
+    if let swift_pointer = smoke_StructsWithConstantsInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructsWithConstantsInterface {
+        return re_constructed
+    }
+    let result = StructsWithConstantsInterface(cStructsWithConstantsInterface: smoke_StructsWithConstantsInterface_copy_handle(handle))
+    smoke_StructsWithConstantsInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func StructsWithConstantsInterface_moveFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface {
-    return StructsWithConstantsInterface(cStructsWithConstantsInterface: handle)
+    if let swift_pointer = smoke_StructsWithConstantsInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructsWithConstantsInterface {
+        return re_constructed
+    }
+    let result = StructsWithConstantsInterface(cStructsWithConstantsInterface: handle)
+    smoke_StructsWithConstantsInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func StructsWithConstantsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithMethodsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithMethodsInterface.swift
@@ -90,10 +90,22 @@ extension StructsWithMethodsInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func StructsWithMethodsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface {
-    return StructsWithMethodsInterface(cStructsWithMethodsInterface: smoke_StructsWithMethodsInterface_copy_handle(handle))
+    if let swift_pointer = smoke_StructsWithMethodsInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructsWithMethodsInterface {
+        return re_constructed
+    }
+    let result = StructsWithMethodsInterface(cStructsWithMethodsInterface: smoke_StructsWithMethodsInterface_copy_handle(handle))
+    smoke_StructsWithMethodsInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func StructsWithMethodsInterface_moveFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface {
-    return StructsWithMethodsInterface(cStructsWithMethodsInterface: handle)
+    if let swift_pointer = smoke_StructsWithMethodsInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructsWithMethodsInterface {
+        return re_constructed
+    }
+    let result = StructsWithMethodsInterface(cStructsWithMethodsInterface: handle)
+    smoke_StructsWithMethodsInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func StructsWithMethodsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/TypeDefs.swift
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/TypeDefs.swift
@@ -83,10 +83,22 @@ extension TypeDefs: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func TypeDefs_copyFromCType(_ handle: _baseRef) -> TypeDefs {
-    return TypeDefs(cTypeDefs: smoke_TypeDefs_copy_handle(handle))
+    if let swift_pointer = smoke_TypeDefs_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? TypeDefs {
+        return re_constructed
+    }
+    let result = TypeDefs(cTypeDefs: smoke_TypeDefs_copy_handle(handle))
+    smoke_TypeDefs_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func TypeDefs_moveFromCType(_ handle: _baseRef) -> TypeDefs {
-    return TypeDefs(cTypeDefs: handle)
+    if let swift_pointer = smoke_TypeDefs_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? TypeDefs {
+        return re_constructed
+    }
+    let result = TypeDefs(cTypeDefs: handle)
+    smoke_TypeDefs_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func TypeDefs_copyFromCType(_ handle: _baseRef) -> TypeDefs? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalClass.swift
@@ -26,10 +26,22 @@ extension InternalClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func InternalClass_copyFromCType(_ handle: _baseRef) -> InternalClass {
-    return InternalClass(cInternalClass: smoke_InternalClass_copy_handle(handle))
+    if let swift_pointer = smoke_InternalClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalClass {
+        return re_constructed
+    }
+    let result = InternalClass(cInternalClass: smoke_InternalClass_copy_handle(handle))
+    smoke_InternalClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func InternalClass_moveFromCType(_ handle: _baseRef) -> InternalClass {
-    return InternalClass(cInternalClass: handle)
+    if let swift_pointer = smoke_InternalClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalClass {
+        return re_constructed
+    }
+    let result = InternalClass(cInternalClass: handle)
+    smoke_InternalClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func InternalClass_copyFromCType(_ handle: _baseRef) -> InternalClass? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalInterface.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalInterface.swift
@@ -48,8 +48,13 @@ internal func InternalInterface_copyFromCType(_ handle: _baseRef) -> InternalInt
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_InternalInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_InternalInterface_get_typed(smoke_InternalInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InternalInterface {
+        smoke_InternalInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -60,8 +65,13 @@ internal func InternalInterface_moveFromCType(_ handle: _baseRef) -> InternalInt
         smoke_InternalInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_InternalInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_InternalInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InternalInterface {
+        smoke_InternalInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicClass.swift
@@ -89,10 +89,22 @@ extension PublicClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 internal func PublicClass_copyFromCType(_ handle: _baseRef) -> PublicClass {
-    return PublicClass(cPublicClass: smoke_PublicClass_copy_handle(handle))
+    if let swift_pointer = smoke_PublicClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PublicClass {
+        return re_constructed
+    }
+    let result = PublicClass(cPublicClass: smoke_PublicClass_copy_handle(handle))
+    smoke_PublicClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func PublicClass_moveFromCType(_ handle: _baseRef) -> PublicClass {
-    return PublicClass(cPublicClass: handle)
+    if let swift_pointer = smoke_PublicClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PublicClass {
+        return re_constructed
+    }
+    let result = PublicClass(cPublicClass: handle)
+    smoke_PublicClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
 }
 internal func PublicClass_copyFromCType(_ handle: _baseRef) -> PublicClass? {
     guard handle != 0 else {

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicInterface.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicInterface.swift
@@ -48,8 +48,13 @@ internal func PublicInterface_copyFromCType(_ handle: _baseRef) -> PublicInterfa
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PublicInterface {
         return re_constructed
     }
+    if let swift_pointer = smoke_PublicInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PublicInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_PublicInterface_get_typed(smoke_PublicInterface_copy_handle(handle)),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? PublicInterface {
+        smoke_PublicInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
@@ -60,8 +65,13 @@ internal func PublicInterface_moveFromCType(_ handle: _baseRef) -> PublicInterfa
         smoke_PublicInterface_release_handle(handle)
         return re_constructed
     }
+    if let swift_pointer = smoke_PublicInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PublicInterface {
+        return re_constructed
+    }
     if let swift_pointer = smoke_PublicInterface_get_typed(handle),
         let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? PublicInterface {
+        smoke_PublicInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")


### PR DESCRIPTION
Added WrapperCache.h static (non-template) implementation to cache Swift
objects created to wrap instances passed from C++ to Swift. Updated
other Swift templates to use this cache to preserve referential equality
(i.e. the same C++ instance passed to Swift twice will be represented by
the same Swift object, see #46).

Added functional tests. Updated smoke tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>