### PR TITLE
Fix missing doc comments for `@Cpp(CString)` parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Added referential integrity for classes and interfaces in generated platform code. Meaning, when
     the same C++ object is passed twice to platform (Java/Swift/Dart) side, it is now guaranteed to
     be the same object on platform side as well.
+### Bug fixes:
+  * Fixed missing documentation comments on parameters marked with `@Cpp(CString)`.
 
 ## 6.6.1
 Release date: 2020-04-27

--- a/gluecodium/src/main/java/com/here/gluecodium/model/cpp/CppParameter.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/cpp/CppParameter.kt
@@ -30,5 +30,9 @@ class CppParameter(
 
     fun hasComment() = isNotNull || !comment.isEmpty
 
-    fun copy(type: CppTypeRef? = null) = CppParameter(name, type ?: this.type, isNotNull)
+    fun copy(type: CppTypeRef? = null): CppParameter {
+        val cppParameter = CppParameter(name, type ?: this.type, isNotNull)
+        cppParameter.comment = comment
+        return cppParameter
+    }
 }

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -200,3 +200,9 @@ class CommentsLinks {
         random_field: comments.SomeStruct
     }
 }
+
+class CommentsOnCstring {
+    // Method that takes a C string as input and returns an std::string it as output.
+    // @param[inputString] May or may not be a C string.
+    static fun returnInputString(@Cpp(CString) inputString: String): String
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsOnCstring.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsOnCstring.h
@@ -1,0 +1,27 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT CommentsOnCstring {
+public:
+    CommentsOnCstring();
+    virtual ~CommentsOnCstring() = 0;
+public:
+    /**
+     * Method that takes a C string as input and returns an std::string it as output.
+     * \param[in] input_string May or may not be a C string.
+     * \return
+     */
+    static ::std::string return_input_string( const char* input_string );
+    /**
+     * Method that takes a C string as input and returns an std::string it as output.
+     * \param[in] input_string May or may not be a C string.
+     * \return
+     */
+    static ::std::string return_input_string( const ::std::string& input_string );
+};
+}


### PR DESCRIPTION
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>