### PR TITLE
Add support for nested lists in doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Added referential integrity for classes and interfaces in generated platform code. Meaning, when
     the same C++ object is passed twice to platform (Java/Swift/Dart) side, it is now guaranteed to
     be the same object on platform side as well.
+### Bug fixes:
+  * Fixed handling of nested lists in IDL doc comments.
 
 ## 6.6.1
 Release date: 2020-04-27

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftCommentsProcessor.kt
@@ -22,13 +22,15 @@ package com.here.gluecodium.platform.swift
 import com.here.gluecodium.platform.common.CommentsProcessor
 import com.vladsch.flexmark.ast.LinkRef
 import com.vladsch.flexmark.formatter.Formatter
+import com.vladsch.flexmark.parser.ParserEmulationProfile
+import com.vladsch.flexmark.util.options.MutableDataSet
 import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
 
 /**
  * Parse markdown comments and process links
  */
 class SwiftCommentsProcessor(werror: Boolean) :
-    CommentsProcessor(Formatter.builder().build(), werror) {
+    CommentsProcessor(Formatter.builder(FORMATTER_OPTIONS).build(), werror) {
 
     override fun processLink(linkNode: LinkRef, linkReference: String) {
         linkNode.reference = BasedSequenceImpl.of(linkReference)
@@ -38,4 +40,9 @@ class SwiftCommentsProcessor(werror: Boolean) :
     }
 
     override val nullReference = "nil"
+
+    companion object {
+        private val FORMATTER_OPTIONS = MutableDataSet()
+            .set(Formatter.FORMATTER_EMULATION_PROFILE, ParserEmulationProfile.PEGDOWN)
+    }
 }

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -173,6 +173,8 @@ class CommentsLinks {
     // * error: [comments.SomethingWrong]
     // * type from aux sources, same package: [AuxClass]
     // * type from aux sources, different package: [fire.AuxStruct]
+    //   * we can also have
+    //   * nested lists
     //
     // Not working for Java:
     // * typedef: [comments.Usefulness]

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
@@ -63,7 +63,12 @@ public final class CommentsLinks extends NativeBase {
      * <li>top level enum item: {@link com.example.smoke.TypeCollectionEnum#ITEM}</li>
      * <li>error: {@link com.example.smoke.Comments.SomethingWrongException}</li>
      * <li>type from aux sources, same package: {@link com.example.smoke.AuxClass}</li>
-     * <li>type from aux sources, different package: {@link com.example.fire.AuxStruct}</li>
+     * <li>type from aux sources, different package: {@link com.example.fire.AuxStruct}
+     * <ul>
+     * <li>we can also have</li>
+     * <li>nested lists</li>
+     * </ul>
+     * </li>
      * </ul>
      * <p>Not working for Java:</p>
      * <ul>

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
@@ -64,6 +64,8 @@ public:
      * * error: ::smoke::Comments::SomeEnum
      * * type from aux sources, same package: ::smoke::AuxClass
      * * type from aux sources, different package: ::fire::AuxStruct
+     *   * we can also have
+     *   * nested lists
      *
      * Not working for Java:
      * * typedef: ::smoke::Comments::Usefulness

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
@@ -35,6 +35,8 @@ abstract class CommentsLinks {
   /// * error: [Comments_SomethingWrongException]
   /// * type from aux sources, same package: [AuxClass]
   /// * type from aux sources, different package: [AuxStruct]
+  ///   * we can also have
+  ///   * nested lists
   ///
   /// Not working for Java:
   /// * typedef: [bool]

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
@@ -37,6 +37,8 @@ class CommentsLinks {
     // * error: [comments.SomethingWrong]
     // * type from aux sources, same package: [AuxClass]
     // * type from aux sources, different package: [fire.AuxStruct]
+    //   * we can also have
+    //   * nested lists
     //
     // Not working for Java:
     // * typedef: [comments.Usefulness]

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
@@ -54,6 +54,8 @@ public class CommentsLinks {
     /// * error: `Comments.SomethingWrongError`
     /// * type from aux sources, same package: `AuxClass`
     /// * type from aux sources, different package: `AuxStruct`
+    ///     * we can also have
+    ///     * nested lists
     ///
     /// Not working for Java:
     /// * typedef: `Comments.Usefulness`

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -644,14 +644,16 @@ internal class AntlrLimeModelBuilder(
         commentContexts: List<LimeParser.DocCommentContext>,
         ctx: ParserRuleContext
     ): LimeStructuredComment {
-        val commentString = commentContexts.joinToString(separator = "\n") {
+        val commentString = commentContexts.joinToString(separator = "\n") { it ->
             when {
-                it.DelimitedCommentOpen() != null -> it.DelimitedCommentText()?.text?.dropLast(2)
-                    ?.split('\n')?.joinToString("\n") { line -> line.trim() } ?: ""
-                it.LineCommentOpen() != null -> it.LineCommentText()?.text?.trim() ?: ""
+                it.DelimitedCommentOpen() != null ->
+                    it.DelimitedCommentText()?.text?.dropLast(2) ?: ""
+                it.LineCommentOpen() != null ->
+                    it.LineCommentText()?.text?.trimEnd { ch -> ch == '\n' } ?: ""
                 else -> ""
             }
-        }
+        }.trimIndent().split('\n').joinToString("\n") { line -> line.trimEnd() }
+
         val lexer = LimedocLexer(CharStreams.fromString(commentString))
         val parser = LimedocParser(CommonTokenStream(lexer))
         parser.removeErrorListeners()

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimedocBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimedocBuilder.kt
@@ -46,6 +46,10 @@ internal class AntlrLimedocBuilder(private val currentPath: LimePath) : LimedocP
         contentCollector += "" to "\n".repeat(ctx.NewLine().size)
     }
 
+    override fun enterDescriptionLine(ctx: LimedocParser.DescriptionLineContext) {
+        contentCollector += "" to ctx.WhiteSpace().joinToString("") { it.text }
+    }
+
     override fun exitDecriptionFirstWord(ctx: LimedocParser.DecriptionFirstWordContext) {
         contentCollector += when {
             ctx.inlineTag() != null -> convertInlineTag(ctx.inlineTag())


### PR DESCRIPTION
Updated model builders for LIME model and LimeDoc comments to preserve
most of leading whitespace, only trimming "common" whitespace of a block
of text (see documentation or trimIndent() Kotlin function). This
enabled support for Markdown nested lists as their syntax requires
leading whitespace being preserved.

Updated SwiftCommentsProcessor to output nested lists with indentation
of 4 spaces instead of default 2. General Markdown syntax allows
arbitrary indentation for nested lists, as long as it's uniform. Apple's
Markup flavor mandates 4 spaces instead.

Added an appropriate use case for smoke tests.

Resolves: #304
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>