### PR TITLE
Synchronises invocations of Gradle

### DIFF
--- a/cmake/modules/gluecodium/gluecodium/Generate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/Generate.cmake
@@ -66,11 +66,6 @@ else()
 endif()
 
 set(APIGEN_GLUECODIUM_DIR ${CMAKE_CURRENT_LIST_DIR})
-if(WIN32)
-  set(APIGEN_GLUECODIUM_GRADLE_WRAPPER ${APIGEN_GLUECODIUM_DIR}/gradlew.bat)
-else()
-  set(APIGEN_GLUECODIUM_GRADLE_WRAPPER ${APIGEN_GLUECODIUM_DIR}/gradlew)
-endif()
 
 include(${APIGEN_GLUECODIUM_DIR}/GeneratedSources.cmake)
 
@@ -193,7 +188,6 @@ function(apigen_generate)
   add_custom_command(OUTPUT ${_generated_files}
     COMMAND ${CMAKE_COMMAND}
         -DAPIGEN_TARGET=${APIGEN_TARGET}
-        -DAPIGEN_GLUECODIUM_GRADLE_WRAPPER=${APIGEN_GLUECODIUM_GRADLE_WRAPPER}
         -DBUILD_LOCAL_GLUECODIUM=${BUILD_LOCAL_GLUECODIUM}
         -DAPIGEN_GLUECODIUM_ARGS=${APIGEN_GLUECODIUM_ARGS}
         -DAPIGEN_GLUECODIUM_VERSION=${apigen_generate_VERSION}
@@ -202,7 +196,6 @@ function(apigen_generate)
         -DAPIGEN_OUTPUT_DIR=${APIGEN_OUTPUT_DIR}
         -DAPIGEN_COMMON_OUTPUT_DIR=${APIGEN_COMMON_OUTPUT_DIR}
         -DAPIGEN_BUILD_OUTPUT_DIR=${APIGEN_BUILD_OUTPUT_DIR}
-        -DAPIGEN_VERBOSE=${APIGEN_VERBOSE}
         # Pass on the interface lime files from dependencies, only INTERFACE_SOURCES is propagated transitively as of CMake 3.16
         -DAPIGEN_AUX_FILES=${_lime_interface_sources};${_lime_sources}
         -P ${APIGEN_GLUECODIUM_DIR}/runGenerate.cmake

--- a/cmake/modules/gluecodium/gluecodium/Gradle.cmake
+++ b/cmake/modules/gluecodium/gluecodium/Gradle.cmake
@@ -1,0 +1,39 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+if (NOT APIGEN_GLUECODIUM_DIR)
+    message(FATAL_ERROR "APIGEN_GLUECODIUM_DIR must be specified")
+endif ()
+
+if (NOT APIGEN_OUTPUT_DIR)
+    message(FATAL_ERROR "APIGEN_OUTPUT_DIR must be specified")
+endif ()
+
+if(APIGEN_COMMON_OUTPUT_DIR)
+    set(_lock_directory ${APIGEN_COMMON_OUTPUT_DIR})
+else()
+    set(_lock_directory ${APIGEN_OUTPUT_DIR})
+endif()
+
+message ("Using locking file to invocate gradle: ${_lock_directory}-lock.cmake")
+file (LOCK ${_lock_directory}-lock.cmake TIMEOUT 600)
+
+if(WIN32)
+  set(APIGEN_GLUECODIUM_GRADLE_WRAPPER ${APIGEN_GLUECODIUM_DIR}/gradlew.bat)
+else()
+  set(APIGEN_GLUECODIUM_GRADLE_WRAPPER ${APIGEN_GLUECODIUM_DIR}/gradlew)
+endif()

--- a/cmake/modules/gluecodium/java/runCompile.cmake
+++ b/cmake/modules/gluecodium/java/runCompile.cmake
@@ -1,0 +1,56 @@
+#!/usr/bin/env cmake -P
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+set (_required_vars APIGEN_GLUECODIUM_DIR APIGEN_OUTPUT_DIR APIGEN_JAVA_COMPILE_OUTPUT_DIR)
+foreach(_var ${_required_vars})
+    if (NOT ${_var})
+        message(FATAL_ERROR "${_var} must be specified")
+    endif ()
+endforeach()
+
+include(${APIGEN_GLUECODIUM_DIR}/Gradle.cmake)
+
+list(APPEND _java_source_dirs "${APIGEN_OUTPUT_DIR}/android")
+
+if (APIGEN_COMMON_OUTPUT_DIR)
+  list(APPEND _java_source_dirs "${APIGEN_COMMON_OUTPUT_DIR}/android")
+endif ()
+
+string(REPLACE ";" "\;" _java_source_dirs "${_java_source_dirs}")
+string(REPLACE ";" "\;" APIGEN_JAVA_LOCAL_DEPENDENCIES "${APIGEN_JAVA_LOCAL_DEPENDENCIES}")
+string(REPLACE ";" "\;" APIGEN_JAVA_LOCAL_DEPENDENCIES_DIRS "${APIGEN_JAVA_LOCAL_DEPENDENCIES_DIRS}")
+string(REPLACE ";" "\;" APIGEN_JAVA_REMOTE_DEPENDENCIES "${APIGEN_JAVA_REMOTE_DEPENDENCIES}")
+string(REPLACE ";" "\;" APIGEN_JAVA_LOCAL_JARS "${APIGEN_JAVA_LOCAL_JARS}")
+
+execute_process(
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${APIGEN_JAVA_COMPILE_OUTPUT_DIR}
+  COMMAND ${APIGEN_GLUECODIUM_GRADLE_WRAPPER}
+    -b=compileJava.gradle
+    -PsrcDirs=${_java_source_dirs}
+    -PoutputDir=${APIGEN_JAVA_COMPILE_OUTPUT_DIR}
+    -PlocalDependencies=${APIGEN_JAVA_LOCAL_DEPENDENCIES}
+    -PlocalDependenciesDirs=${APIGEN_JAVA_LOCAL_DEPENDENCIES_DIRS}
+    -PlocalJars=${APIGEN_JAVA_LOCAL_JARS}
+    -PremoteDependencies=${APIGEN_JAVA_REMOTE_DEPENDENCIES}
+    compileJava
+  WORKING_DIRECTORY ${APIGEN_GLUECODIUM_DIR}
+  RESULT_VARIABLE COMPILE_RESULT)
+
+if(COMPILE_RESULT)
+    message(FATAL_ERROR "Failed to compile Java")
+endif()


### PR DESCRIPTION
Parallel invocations lead to unexpected behaviour
There was locking file which is already used to
synchronise generation of code. The same locking
file is now used to synchronise compilation of Java code

Signed-off-by: Yauheni Khnykin <yauheni.khnykin@here.com>