### PR TITLE
Fix ref equality for Java constructors

### DIFF
--- a/examples/libhello/lime/test/RefEquality.lime
+++ b/examples/libhello/lime/test/RefEquality.lime
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 HERE Europe B.V.
+# Copyright (C) 2016-2020 HERE Europe B.V.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 package test
 
 class DummyClass {
+    constructor create()
+    static fun dummyClassRoundTrip(input: DummyClass): DummyClass
 }
 
 interface DummyInterface {

--- a/examples/libhello/src/test/RefEquality.cpp
+++ b/examples/libhello/src/test/RefEquality.cpp
@@ -40,6 +40,16 @@ std::shared_ptr<DummyInterface> s_dummy_interface = std::make_shared<DummyInterf
 }
 
 std::shared_ptr<DummyClass>
+DummyClass::create() {
+    return std::make_shared<DummyClassImpl>();
+}
+
+std::shared_ptr<DummyClass>
+DummyClass::dummy_class_round_trip(const std::shared_ptr<DummyClass>& input) {
+    return input;
+}
+
+std::shared_ptr<DummyClass>
 DummyFactory::get_dummy_class_singleton() {
     return s_dummy_class;
 }

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/RefEqualityTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/RefEqualityTest.java
@@ -67,4 +67,20 @@ public final class RefEqualityTest {
 
     assertFalse(instance1 == instance2);
   }
+
+  @Test
+  public void refEqualityPreservedForClassConstructor() {
+    DummyClass instance1 = new DummyClass();
+    DummyClass instance2 = DummyClass.dummyClassRoundTrip(instance1);
+
+    assertTrue(instance1 == instance2);
+  }
+
+  @Test
+  public void refInequalityPreservedForClassConstructor() {
+    DummyClass instance1 = new DummyClass();
+    DummyClass instance2 = new DummyClass();
+
+    assertFalse(instance1 == instance2);
+  }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniModelBuilder.kt
@@ -116,7 +116,8 @@ class JniModelBuilder(
             internalNamespace = internalNamespace,
             isEquatable = limeContainer.attributes.have(LimeAttributeType.EQUATABLE),
             isPointerEquatable = limeContainer.attributes.have(LimeAttributeType.POINTER_EQUATABLE),
-            hasTypeRepository = cppClass.isInheritable || cppClass.inheritances.isNotEmpty()
+            hasTypeRepository = cppClass.isInheritable || cppClass.inheritances.isNotEmpty(),
+            hasConstructors = limeContainer.constructors.isNotEmpty()
         )
 
         limeContainer.parent?.type?.let {

--- a/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniContainer.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniContainer.kt
@@ -42,7 +42,8 @@ class JniContainer(
     val isEquatable: Boolean = false,
     val isPointerEquatable: Boolean = false,
     @Suppress("unused") val hasTypeRepository: Boolean = false,
-    @Suppress("unused") val isFunctionalInterface: Boolean = false
+    @Suppress("unused") val isFunctionalInterface: Boolean = false,
+    @Suppress("unused") val hasConstructors: Boolean = false
 ) : JniElement {
     val methods: MutableList<JniMethod> = mutableListOf()
     val parentMethods: MutableList<JniMethod> = mutableListOf()

--- a/gluecodium/src/main/resources/templates/java/Class.mustache
+++ b/gluecodium/src/main/resources/templates/java/Class.mustache
@@ -43,6 +43,7 @@
     {{visibility}} {{className}}({{joinPartial parameters "java/Parameter" ", "}}){{#exception}} throws {{name}}{{/exception}} {
 {{#if isImplClass}}
         this({{name}}({{join parameters delimiter=", " }}));
+        cacheThisInstance();
 {{/if}}{{#unless isImplClass}}
         {{className}} _other = {{name}}({{join parameters delimiter=", " }});
 {{#fields}}        this.{{name}} = _other.{{name}};
@@ -52,6 +53,9 @@
 {{/constructors}}{{/set}}
 {{#if isImplClass}}
 {{prefixPartial "java/NativeConstructor" "    "}}
+{{#if constructors}}
+    private native void cacheThisInstance();
+{{/if}}
 {{/if}}
 {{#if fields}}{{#unless constructors}}
 

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -72,6 +72,17 @@ Java_{{mangledName}}_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlon
     delete reinterpret_cast<{{cppFullyQualifiedName}}*>(_jpointerRef);
 {{/if}}
 }
+
+{{#if hasConstructors}}
+JNIEXPORT void JNICALL
+Java_{{mangledName}}_cacheThisInstance(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto jobj = {{>common/InternalNamespace}}jni::make_non_releasing_ref(_jinstance);
+    auto long_ptr = {{>common/InternalNamespace}}jni::get_field_value(_jenv, jobj, "nativeHandle", (int64_t*)nullptr);
+    auto nobj = *reinterpret_cast<std::shared_ptr<{{cppFullyQualifiedName}}>*>(long_ptr);
+    {{>common/InternalNamespace}}jni::JniWrapperCache::cache_wrapper(_jenv, nobj, jobj);
+}
+{{/if}}
 {{/instanceOf}}
 {{#hasNativeEquatable}}
 jboolean

--- a/gluecodium/src/test/resources/smoke/constructors/output/android/com/example/smoke/ChildConstructors.java
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android/com/example/smoke/ChildConstructors.java
@@ -1,15 +1,16 @@
 /*
  *
-
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
 public final class ChildConstructors extends Constructors {
     public ChildConstructors() {
         this(createNoArgsChild());
+        cacheThisInstance();
     }
     public ChildConstructors(@NonNull final Constructors other) {
         this(createCopyFromParent(other));
+        cacheThisInstance();
     }
     /**
      * For internal use only.
@@ -18,6 +19,7 @@ public final class ChildConstructors extends Constructors {
     protected ChildConstructors(final long nativeHandle) {
         super(nativeHandle);
     }
+    private native void cacheThisInstance();
     private static native long createNoArgsChild();
     private static native long createCopyFromParent(@NonNull final Constructors other);
 }

--- a/gluecodium/src/test/resources/smoke/constructors/output/android/com/example/smoke/Constructors.java
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android/com/example/smoke/Constructors.java
@@ -23,18 +23,23 @@ public class Constructors extends NativeBase {
     }
     public Constructors() {
         this(create());
+        cacheThisInstance();
     }
     public Constructors(@NonNull final Constructors other) {
         this(create(other));
+        cacheThisInstance();
     }
     public Constructors(@NonNull final String foo, final long bar) {
         this(create(foo, bar));
+        cacheThisInstance();
     }
     public Constructors(@NonNull final String input) throws Constructors.ConstructorExplodedException {
         this(create(input));
+        cacheThisInstance();
     }
     public Constructors(@NonNull final List<Double> input) {
         this(create(input));
+        cacheThisInstance();
     }
     /**
      * For internal use only.
@@ -49,6 +54,7 @@ public class Constructors extends NativeBase {
         });
     }
     private static native void disposeNativeHandle(long nativeHandle);
+    private native void cacheThisInstance();
     private static native long create();
     private static native long create(@NonNull final Constructors other);
     private static native long create(@NonNull final String foo, final long bar);

--- a/gluecodium/src/test/resources/smoke/constructors/output/android/jni/com_example_smoke_Constructors.cpp
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android/jni/com_example_smoke_Constructors.cpp
@@ -106,4 +106,12 @@ Java_com_example_smoke_Constructors_disposeNativeHandle(JNIEnv* _jenv, jobject _
     ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
     delete p_nobj;
 }
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Constructors_cacheThisInstance(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto jobj = ::gluecodium::jni::make_non_releasing_ref(_jinstance);
+    auto long_ptr = ::gluecodium::jni::get_field_value(_jenv, jobj, "nativeHandle", (int64_t*)nullptr);
+    auto nobj = *reinterpret_cast<std::shared_ptr<::smoke::Constructors>*>(long_ptr);
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, nobj, jobj);
+}
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android/com/example/package/Class.java
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android/com/example/package/Class.java
@@ -7,6 +7,7 @@ import java.util.List;
 public final class Class extends InterfaceImpl {
     public Class() {
         this(constructor());
+        cacheThisInstance();
     }
     /**
      * For internal use only.
@@ -15,6 +16,7 @@ public final class Class extends InterfaceImpl {
     protected Class(final long nativeHandle) {
         super(nativeHandle);
     }
+    private native void cacheThisInstance();
     private static native long constructor();
     @NonNull
     public native Struct fun(@NonNull final List<Struct> double) throws ExceptionException;

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android/com/example/namerules/NAME_RULES_DROID.java
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android/com/example/namerules/NAME_RULES_DROID.java
@@ -30,6 +30,7 @@ public final class NAME_RULES_DROID extends NativeBase {
     }
     public NAME_RULES_DROID() {
         this(create());
+        cacheThisInstance();
     }
     /**
      * For internal use only.
@@ -44,6 +45,7 @@ public final class NAME_RULES_DROID extends NativeBase {
         });
     }
     private static native void disposeNativeHandle(long nativeHandle);
+    private native void cacheThisInstance();
     private static native long create();
     public native double some_method(final NAME_RULES_DROID.EXAMPLE_STRUCT_DROID some_argument) throws NAME_RULES_DROID.example_x;
     public native long loadIntProperty();

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID.cpp
@@ -131,4 +131,12 @@ Java_com_example_namerules_NAME_1RULES_1DROID_disposeNativeHandle(JNIEnv* _jenv,
     ::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
     delete p_nobj;
 }
+JNIEXPORT void JNICALL
+Java_com_example_namerules_NAME_1RULES_1DROID_cacheThisInstance(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto jobj = ::jni::make_non_releasing_ref(_jinstance);
+    auto long_ptr = ::jni::get_field_value(_jenv, jobj, "nativeHandle", (int64_t*)nullptr);
+    auto nobj = *reinterpret_cast<std::shared_ptr<::namerules::NameRules>*>(long_ptr);
+    ::jni::JniWrapperCache::cache_wrapper(_jenv, nobj, jobj);
+}
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android/com/example/smoke/barInterface.java
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android/com/example/smoke/barInterface.java
@@ -1,6 +1,5 @@
 /*
  *
-
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
@@ -8,6 +7,7 @@ import com.example.NativeBase;
 public final class barInterface extends NativeBase {
     public barInterface(@NonNull final String makeParameter) {
         this(make(makeParameter));
+        cacheThisInstance();
     }
     /**
      * For internal use only.
@@ -22,6 +22,7 @@ public final class barInterface extends NativeBase {
         });
     }
     private static native void disposeNativeHandle(long nativeHandle);
+    private native void cacheThisInstance();
     @NonNull
     public native barStruct BarMethod(@NonNull final String BarParameter);
     private static native long make(@NonNull final String makeParameter);


### PR DESCRIPTION
JNI implementation for Java constructor is not able to use "wrapper
cache" to cache the object being create (because the object does not
exist yet). This leads to corner-case bugs where a constructor-created
object is breaking referential equality on Java side.

Updated Java and JNI templates to circumvent this. Added functional and
smoke tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>