### PR TITLE
Fix ref equality for Swift constructors

### DIFF
--- a/examples/platforms/ios/Tests/testTests/RefEqualityTests.swift
+++ b/examples/platforms/ios/Tests/testTests/RefEqualityTests.swift
@@ -51,10 +51,26 @@ class RefEqualityTests: XCTestCase {
         XCTAssertFalse(instance1 === instance2)
     }
 
+    func testRefEqualityPreservedForClassConstructor() {
+        let instance1 = DummyClass()
+        let instance2 = DummyClass.dummyClassRoundTrip(input: instance1)
+
+        XCTAssertTrue(instance1 === instance2)
+    }
+
+    func testRefInequalityPreservedForClassConstructor() {
+        let instance1 = DummyClass()
+        let instance2 = DummyClass()
+
+        XCTAssertFalse(instance1 === instance2)
+    }
+
     static var allTests = [
         ("testRefEqualityPreservedForClass", testRefEqualityPreservedForClass),
         ("testRefInequalityPreservedForClass", testRefInequalityPreservedForClass),
         ("testRefEqualityPreservedForInterface", testRefEqualityPreservedForInterface),
-        ("testRefInequalityPreservedForInterface", testRefInequalityPreservedForInterface)
+        ("testRefInequalityPreservedForInterface", testRefInequalityPreservedForInterface),
+        ("testRefEqualityPreservedForClassConstructor", testRefEqualityPreservedForClassConstructor),
+        ("testRefInequalityPreservedForClassConstructor", testRefInequalityPreservedForClassConstructor)
     ]
 }

--- a/gluecodium/src/main/resources/templates/swift/ClassDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ClassDefinition.mustache
@@ -43,6 +43,7 @@
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = _result{{/unless}}
+        {{cInstance}}_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
 
 {{/constructors}}{{/set}}{{!!

--- a/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/ChildConstructors.swift
+++ b/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/ChildConstructors.swift
@@ -5,10 +5,12 @@ public class ChildConstructors: Constructors {
     public override init() {
         let _result = ChildConstructors.create()
         super.init(cConstructors: _result)
+        smoke_ChildConstructors_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
     public override init(other: Constructors) {
         let _result = ChildConstructors.create(other: other)
         super.init(cConstructors: _result)
+        smoke_ChildConstructors_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
     init(cChildConstructors: _baseRef) {
         super.init(cConstructors: cChildConstructors)

--- a/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/Constructors.swift
+++ b/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/Constructors.swift
@@ -9,6 +9,7 @@ public class Constructors {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = _result
+        smoke_Constructors_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
     public init(other: Constructors) {
         let _result = Constructors.create(other: other)
@@ -16,6 +17,7 @@ public class Constructors {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = _result
+        smoke_Constructors_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
     public init(foo: String, bar: UInt64) {
         let _result = Constructors.create(foo: foo, bar: bar)
@@ -23,6 +25,7 @@ public class Constructors {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = _result
+        smoke_Constructors_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
     public init(input: String) throws {
         let _result = try Constructors.create(input: input)
@@ -30,6 +33,7 @@ public class Constructors {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = _result
+        smoke_Constructors_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
     public init(input: [Double]) {
         let _result = Constructors.create(input: input)
@@ -37,6 +41,7 @@ public class Constructors {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = _result
+        smoke_Constructors_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
     let c_instance : _baseRef
     init(cConstructors: _baseRef) {

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Class.swift
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Class.swift
@@ -8,6 +8,7 @@ public class Class: Interface {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = _result
+        package_Class_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
     public var property: Enum {
         get {

--- a/gluecodium/src/test/resources/smoke/name_rules/output/swift/namerules/INameRules.swift
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/swift/namerules/INameRules.swift
@@ -10,6 +10,7 @@ public class INameRules {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = _result
+        namerules_NameRules_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
     public var intPropertyPod: UInt32 {
         get {

--- a/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazInterface.swift
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazInterface.swift
@@ -8,6 +8,7 @@ public class bazInterface {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = _result
+        smoke_PlatformNamesInterface_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
     public var BAZ_PROPERTY: UInt32 {
         get {


### PR DESCRIPTION
Updated Swift templates to cache "wrapper" objects created with custom
constructors. Added functional and smoke tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>