### PR TITLE
Fix ref equality for Dart constructors

### DIFF
--- a/examples/platforms/dart/test/RefEquality_test.dart
+++ b/examples/platforms/dart/test/RefEquality_test.dart
@@ -69,4 +69,26 @@ void main() {
     instance1.release();
     instance2.release();
   });
+  _testSuite.test("Ref equality preserved for a class constructor", () {
+    final instance1 = DummyClass();
+    final instance2 = DummyClass.dummyClassRoundTrip(instance1);
+
+    final result = instance1 == instance2;
+
+    expect(result, isTrue);
+
+    instance1.release();
+    instance2.release();
+  });
+  _testSuite.test("Ref inequality preserved for a class constructor", () {
+    final instance1 = DummyClass();
+    final instance2 = DummyClass();
+
+    final result = instance1 == instance2;
+
+    expect(result, isFalse);
+
+    instance1.release();
+    instance2.release();
+  });
 }

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -173,7 +173,11 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 
 }}{{+dartConstructor}}{{resolveName parent}}$Impl.{{resolveName visibility}}{{resolveName}}({{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) : {{!!
-}}this(_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}));
+}}{{#unless hasClassParent}}handle = {{/unless}}{{#if hasClassParent}}super({{/if}}{{!!
+}}_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
+}}{{#if hasClassParent}}){{/if}} {
+  __lib.reverseCache[_{{resolveName parent "Ffi"}}_get_raw_pointer(handle)] = this;
+}
 {{/dartConstructor}}{{!!
 
 }}{{+dartImplRedirect}} => {{resolveName parent}}$Impl.{{resolveName visibility}}{{resolveName}}({{!!

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/Constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/Constructors.dart
@@ -121,11 +121,21 @@ class Constructors$Impl implements Constructors {
     _smoke_Constructors_release_handle(handle);
     handle = null;
   }
-  Constructors$Impl.create() : this(_create());
-  Constructors$Impl.fromOther(Constructors other) : this(_fromOther(other));
-  Constructors$Impl.fromMulti(String foo, int bar) : this(_fromMulti(foo, bar));
-  Constructors$Impl.fromString(String input) : this(_fromString(input));
-  Constructors$Impl.fromList(List<double> input) : this(_fromList(input));
+  Constructors$Impl.create() : handle = _create() {
+    __lib.reverseCache[_smoke_Constructors_get_raw_pointer(handle)] = this;
+  }
+  Constructors$Impl.fromOther(Constructors other) : handle = _fromOther(other) {
+    __lib.reverseCache[_smoke_Constructors_get_raw_pointer(handle)] = this;
+  }
+  Constructors$Impl.fromMulti(String foo, int bar) : handle = _fromMulti(foo, bar) {
+    __lib.reverseCache[_smoke_Constructors_get_raw_pointer(handle)] = this;
+  }
+  Constructors$Impl.fromString(String input) : handle = _fromString(input) {
+    __lib.reverseCache[_smoke_Constructors_get_raw_pointer(handle)] = this;
+  }
+  Constructors$Impl.fromList(List<double> input) : handle = _fromList(input) {
+    __lib.reverseCache[_smoke_Constructors_get_raw_pointer(handle)] = this;
+  }
   static Pointer<Void> _create() {
     final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Constructors_create');
     final __result_handle = _create_ffi(__lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/Class.dart
@@ -59,7 +59,9 @@ class Class$Impl implements Class {
     _package_Class_release_handle(handle);
     handle = null;
   }
-  Class$Impl.constructor() : this(_constructor());
+  Class$Impl.constructor() : handle = _constructor() {
+    __lib.reverseCache[_package_Class_get_raw_pointer(handle)] = this;
+  }
   static Pointer<Void> _constructor() {
     final _constructor_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_package_Class_constructor');
     final __result_handle = _constructor_ffi(__lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeInterface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/weeInterface.dart
@@ -36,7 +36,9 @@ class weeInterface$Impl implements weeInterface {
     _smoke_PlatformNamesInterface_release_handle(handle);
     handle = null;
   }
-  weeInterface$Impl.make(String makeParameter) : this(_make(makeParameter));
+  weeInterface$Impl.make(String makeParameter) : handle = _make(makeParameter) {
+    __lib.reverseCache[_smoke_PlatformNamesInterface_get_raw_pointer(handle)] = this;
+  }
   @override
   weeStruct WeeMethod(String WeeParameter) {
     final _WeeMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesInterface_basicMethod__String');

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalClassWithFunctions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalClassWithFunctions.dart
@@ -34,8 +34,12 @@ class InternalClassWithFunctions$Impl implements InternalClassWithFunctions {
     _smoke_InternalClassWithFunctions_release_handle(handle);
     handle = null;
   }
-  InternalClassWithFunctions$Impl.internal_make() : this(_make());
-  InternalClassWithFunctions$Impl.internal_remake(String foo) : this(_remake(foo));
+  InternalClassWithFunctions$Impl.internal_make() : handle = _make() {
+    __lib.reverseCache[_smoke_InternalClassWithFunctions_get_raw_pointer(handle)] = this;
+  }
+  InternalClassWithFunctions$Impl.internal_remake(String foo) : handle = _remake(foo) {
+    __lib.reverseCache[_smoke_InternalClassWithFunctions_get_raw_pointer(handle)] = this;
+  }
   @override
   internal_fooBar() {
     final _fooBar_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithFunctions_fooBar');


### PR DESCRIPTION
Updated Dart templates to cache "wrapper" objects created with custom
constructors. Added functional and smoke tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>