### PR TITLE
Relax restrictions for @Equatable structs in LimeIDL and C++

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -324,6 +324,13 @@ feature(Equatable cpp android swift dart SOURCES
     lime/test/RefEquality.lime
 )
 
+# TODO: #202 enable for android, swift, and dart; and merge into Equatable
+feature(SimpleEquatable cpp SOURCES
+    src/test/SimpleEquality.cpp
+
+    lime/test/SimpleEquality.lime
+)
+
 feature(Nullable cpp android swift dart SOURCES
     src/test/NullableInstances.cpp
     src/test/NullableInterfaceImpl.cpp

--- a/examples/libhello/lime/test/SimpleEquality.lime
+++ b/examples/libhello/lime/test/SimpleEquality.lime
@@ -1,0 +1,37 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+class NonEquatableClass {
+}
+
+interface NonEquatableInterface {
+}
+
+class NonEquatableFactory {
+    static fun createNonEquatableClass(): NonEquatableClass
+    static fun createNonEquatableInterface(): NonEquatableInterface
+}
+
+@Equatable
+struct SimpleEquatableStruct {
+    classField: NonEquatableClass
+    interfaceField: NonEquatableInterface
+    nullableClassField: NonEquatableClass?
+    nullableInterfaceField: NonEquatableInterface?
+}

--- a/examples/libhello/src/test/RefEquality.cpp
+++ b/examples/libhello/src/test/RefEquality.cpp
@@ -1,5 +1,5 @@
 // -------------------------------------------------------------------------------------------------
-// Copyright (C) 2016-2019 HERE Europe B.V.
+// Copyright (C) 2016-2020 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/libhello/src/test/SimpleEquality.cpp
+++ b/examples/libhello/src/test/SimpleEquality.cpp
@@ -1,0 +1,48 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/NonEquatableClass.h"
+#include "test/NonEquatableFactory.h"
+#include "test/NonEquatableInterface.h"
+
+namespace test
+{
+namespace {
+class NonEquatableClassImpl : public NonEquatableClass {
+public:
+    ~NonEquatableClassImpl() = default;
+};
+
+class NonEquatableInterfaceImpl : public NonEquatableInterface {
+public:
+    ~NonEquatableInterfaceImpl() = default;
+};
+}
+
+std::shared_ptr<NonEquatableClass>
+NonEquatableFactory::create_non_equatable_class() {
+    return std::make_shared<NonEquatableClassImpl>();
+}
+
+std::shared_ptr<NonEquatableInterface>
+NonEquatableFactory::create_non_equatable_interface() {
+    return std::make_shared<NonEquatableInterfaceImpl>();
+}
+}

--- a/examples/platforms/cpp/tests/EquatableTest.cpp
+++ b/examples/platforms/cpp/tests/EquatableTest.cpp
@@ -21,6 +21,8 @@
 #include "test/Equatable.h"
 #include "test/EquatableInterface.h"
 #include "test/EquatableInterfaceFactory.h"
+#include "test/NonEquatableFactory.h"
+#include "test/SimpleEquatableStruct.h"
 #include "test/SomeEquatableClass.h"
 #include "test/SomePointerEquatableClass.h"
 #include <gmock/gmock.h>
@@ -125,6 +127,64 @@ TEST( EquatableTest, unequal_interfaces )
 
     EXPECT_FALSE(equalizer(one_class, other_class));
     EXPECT_NE(hasher(one_class), hasher(other_class));
+}
+
+TEST( EquatableTest, equal_structs_simple_equality )
+{
+    auto class1 = NonEquatableFactory::create_non_equatable_class();
+    auto class2 = NonEquatableFactory::create_non_equatable_class();
+    auto interface1 = NonEquatableFactory::create_non_equatable_interface();
+    auto interface2 = NonEquatableFactory::create_non_equatable_interface();
+    test::SimpleEquatableStruct some_struct{class1, interface1, class2, interface2};
+    test::SimpleEquatableStruct another_struct{class1, interface1, class2, interface2};
+
+    lorem_ipsum::test::hash<test::SimpleEquatableStruct> hasher;
+
+    EXPECT_EQ(some_struct, another_struct);
+    EXPECT_EQ(hasher(some_struct), hasher(another_struct));
+}
+
+TEST( EquatableTest, equal_structs_simple_equality_with_nulls )
+{
+    auto class1 = NonEquatableFactory::create_non_equatable_class();
+    auto interface1 = NonEquatableFactory::create_non_equatable_interface();
+    test::SimpleEquatableStruct some_struct{class1, interface1, nullptr, nullptr};
+    test::SimpleEquatableStruct another_struct{class1, interface1, nullptr, nullptr};
+
+    lorem_ipsum::test::hash<test::SimpleEquatableStruct> hasher;
+
+    EXPECT_EQ(some_struct, another_struct);
+    EXPECT_EQ(hasher(some_struct), hasher(another_struct));
+}
+
+TEST( EquatableTest, unequal_structs_simple_equality )
+{
+    auto class1 = NonEquatableFactory::create_non_equatable_class();
+    auto class2 = NonEquatableFactory::create_non_equatable_class();
+    auto interface1 = NonEquatableFactory::create_non_equatable_interface();
+    auto interface2 = NonEquatableFactory::create_non_equatable_interface();
+    test::SimpleEquatableStruct some_struct{class1, interface1, class2, interface2};
+    test::SimpleEquatableStruct another_struct{class2, interface2, class1, interface1};
+
+    lorem_ipsum::test::hash<test::SimpleEquatableStruct> hasher;
+
+    EXPECT_NE(some_struct, another_struct);
+    EXPECT_NE(hasher(some_struct), hasher(another_struct));
+}
+
+TEST( EquatableTest, unequal_structs_simple_equality_with_nulls )
+{
+    auto class1 = NonEquatableFactory::create_non_equatable_class();
+    auto class2 = NonEquatableFactory::create_non_equatable_class();
+    auto interface1 = NonEquatableFactory::create_non_equatable_interface();
+    auto interface2 = NonEquatableFactory::create_non_equatable_interface();
+    test::SimpleEquatableStruct some_struct{class1, interface1, class2, nullptr};
+    test::SimpleEquatableStruct another_struct{class1, interface1, nullptr, interface2};
+
+    lorem_ipsum::test::hash<test::SimpleEquatableStruct> hasher;
+
+    EXPECT_NE(some_struct, another_struct);
+    EXPECT_NE(hasher(some_struct), hasher(another_struct));
 }
 
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppModelBuilder.kt
@@ -267,6 +267,7 @@ class CppModelBuilder(
             isNotNull = isInstance && !isNullable,
             isNullable = isNullable,
             hasImmutableType = hasImmutableType,
+            isInstance = isInstance,
             isClassEquatable = isInstance && limeField.typeRef.type.attributes.have(LimeAttributeType.EQUATABLE),
             isClassPointerEquatable = isInstance && limeField.typeRef.type.attributes.have(LimeAttributeType.POINTER_EQUATABLE),
             getterName = getterName,

--- a/gluecodium/src/main/java/com/here/gluecodium/model/cpp/CppField.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/cpp/CppField.kt
@@ -27,6 +27,7 @@ class CppField(
     val isNotNull: Boolean = false,
     val isNullable: Boolean = false,
     val hasImmutableType: Boolean = false,
+    isInstance: Boolean = false,
     val isClassEquatable: Boolean = false,
     val isClassPointerEquatable: Boolean = false,
     val getterName: String? = null,
@@ -41,4 +42,8 @@ class CppField(
 
     @Suppress("unused")
     val needsPointerValueEqual = isNullable && !isClassPointerEquatable || isClassEquatable
+
+    @Suppress("unused")
+    val needsRawPointerEqual =
+        isNullable && isInstance && !isClassEquatable && !isClassPointerEquatable
 }

--- a/gluecodium/src/main/resources/templates/cpp/CppStructImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppStructImpl.mustache
@@ -87,10 +87,11 @@ static_assert(
 {{/methods}}{{/set}}
 {{/if}}{{!!
 
-}}{{+fieldEq}}{{#needsPointerValueEqual}}( ( {{name}} && rhs.{{name}} )
-            ? ( *{{name}} == *rhs.{{name}} )
+}}{{+fieldEq}}{{#if needsPointerValueEqual}}( ( {{name}} && rhs.{{name}} )
+            ? {{#if needsRawPointerEqual}}( &*{{name}} == &*rhs.{{name}} ){{/if}}{{!!
+            }}{{#unless needsRawPointerEqual}}( *{{name}} == *rhs.{{name}} ){{/unless}}
             : ( static_cast< bool >( {{name}} ) == static_cast< bool >( rhs.{{name}} ) ) ){{!!
-}}{{/needsPointerValueEqual}}{{^needsPointerValueEqual}}{{!!
-}}{{name}} == rhs.{{name}}{{/needsPointerValueEqual}}{{/fieldEq}}{{!!
+}}{{/if}}{{#unless needsPointerValueEqual}}{{!!
+}}{{name}} == rhs.{{name}}{{/unless}}{{/fieldEq}}{{!!
 
 }}{{+structConstructorParameter}}{{type.name}} {{name}}{{/structConstructorParameter}}

--- a/gluecodium/src/test/resources/smoke/equatable/input/SimpleEquality.lime
+++ b/gluecodium/src/test/resources/smoke/equatable/input/SimpleEquality.lime
@@ -1,0 +1,32 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+class NonEquatableClass {
+}
+
+interface NonEquatableInterface {
+}
+
+@Equatable
+struct SimpleEquatableStruct {
+    classField: NonEquatableClass
+    interfaceField: NonEquatableInterface
+    nullableClassField: NonEquatableClass?
+    nullableInterfaceField: NonEquatableInterface?
+}

--- a/gluecodium/src/test/resources/smoke/equatable/output/cpp/src/smoke/SimpleEquatableStruct.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cpp/src/smoke/SimpleEquatableStruct.cpp
@@ -1,0 +1,45 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#include "smoke/NonEquatableClass.h"
+#include "smoke/NonEquatableInterface.h"
+#include "smoke/SimpleEquatableStruct.h"
+#include <utility>
+namespace smoke {
+SimpleEquatableStruct::SimpleEquatableStruct( )
+    : class_field{ }, interface_field{ }, nullable_class_field{ }, nullable_interface_field{ }
+{
+}
+SimpleEquatableStruct::SimpleEquatableStruct( ::std::shared_ptr< ::smoke::NonEquatableClass > class_field, ::std::shared_ptr< ::smoke::NonEquatableInterface > interface_field, ::std::shared_ptr< ::smoke::NonEquatableClass > nullable_class_field, ::std::shared_ptr< ::smoke::NonEquatableInterface > nullable_interface_field )
+    : class_field( std::move( class_field ) ), interface_field( std::move( interface_field ) ), nullable_class_field( std::move( nullable_class_field ) ), nullable_interface_field( std::move( nullable_interface_field ) )
+{
+}
+bool SimpleEquatableStruct::operator==( const SimpleEquatableStruct& rhs ) const
+{
+    return class_field == rhs.class_field &&
+        interface_field == rhs.interface_field &&
+        ( ( nullable_class_field && rhs.nullable_class_field )
+            ? ( &*nullable_class_field == &*rhs.nullable_class_field )
+            : ( static_cast< bool >( nullable_class_field ) == static_cast< bool >( rhs.nullable_class_field ) ) ) &&
+        ( ( nullable_interface_field && rhs.nullable_interface_field )
+            ? ( &*nullable_interface_field == &*rhs.nullable_interface_field )
+            : ( static_cast< bool >( nullable_interface_field ) == static_cast< bool >( rhs.nullable_interface_field ) ) );
+}
+bool SimpleEquatableStruct::operator!=( const SimpleEquatableStruct& rhs ) const
+{
+    return !( *this == rhs );
+}
+}
+namespace gluecodium {
+std::size_t
+hash< ::smoke::SimpleEquatableStruct >::operator( )( const ::smoke::SimpleEquatableStruct& t ) const
+{
+    size_t hash_value = 43;
+    hash_value = ( hash_value ^ ::gluecodium::hash< decltype( ::smoke::SimpleEquatableStruct::class_field ) >( )( t.class_field ) ) << 1;
+hash_value = ( hash_value ^ ::gluecodium::hash< decltype( ::smoke::SimpleEquatableStruct::interface_field ) >( )( t.interface_field ) ) << 1;
+hash_value = ( hash_value ^ ::gluecodium::hash< decltype( ::smoke::SimpleEquatableStruct::nullable_class_field ) >( )( t.nullable_class_field ) ) << 1;
+hash_value = ( hash_value ^ ::gluecodium::hash< decltype( ::smoke::SimpleEquatableStruct::nullable_interface_field ) >( )( t.nullable_interface_field ) ) << 1;
+    return hash_value;
+}
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/validator/LimeGenericTypesValidator.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/validator/LimeGenericTypesValidator.kt
@@ -23,6 +23,7 @@ import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.common.LimeTypeRefsVisitor
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeBasicType
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
@@ -69,7 +70,7 @@ internal class LimeGenericTypesValidator(private val logger: LimeLogger) :
             limeTypeRef.isNullable -> false
             actualType is LimeEnumeration -> true
             actualType.attributes.have(LimeAttributeType.EQUATABLE) -> true
-            actualType.attributes.have(LimeAttributeType.POINTER_EQUATABLE) -> true
+            actualType is LimeContainerWithInheritance -> true
             actualType is LimeBasicType -> actualType.typeId != LimeBasicType.TypeId.BLOB &&
                     actualType.typeId != LimeBasicType.TypeId.DATE
             actualType is LimeTypeAlias -> isHashable(actualType.typeRef)

--- a/lime-loader/src/main/java/com/here/gluecodium/validator/LimeStructsValidator.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/validator/LimeStructsValidator.kt
@@ -22,6 +22,7 @@ package com.here.gluecodium.validator
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeStruct
 
@@ -44,8 +45,8 @@ internal class LimeStructsValidator(private val logger: LimeLogger) {
     private fun validateEquatable(limeStruct: LimeStruct): Boolean {
         val nonEquatableFieldTypes = limeStruct.childTypes.asSequence()
             .map { it.type }
+            .filterNot { it is LimeContainerWithInheritance }
             .filterNot { it.attributes.have(LimeAttributeType.EQUATABLE) }
-            .filterNot { it.attributes.have(LimeAttributeType.POINTER_EQUATABLE) }
 
         return when {
             limeStruct.fields.isEmpty() -> {

--- a/lime-loader/src/test/java/com/here/gluecodium/validator/LimeGenericTypesValidatorTest.kt
+++ b/lime-loader/src/test/java/com/here/gluecodium/validator/LimeGenericTypesValidatorTest.kt
@@ -28,6 +28,7 @@ import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeField
+import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeModel
@@ -86,11 +87,8 @@ class LimeGenericTypesValidatorTest(
                 attributes =
                     LimeAttributes.Builder().addAttribute(LimeAttributeType.EQUATABLE).build()
             ), true),
-            arrayOf(LimeClass(
-                EMPTY_PATH,
-                attributes = LimeAttributes.Builder()
-                    .addAttribute(LimeAttributeType.POINTER_EQUATABLE).build()
-            ), true),
+            arrayOf(LimeClass(EMPTY_PATH), true),
+            arrayOf(LimeInterface(EMPTY_PATH), true),
             arrayOf(LimeTypeAlias(EMPTY_PATH, typeRef = LimeBasicTypeRef.INT), true),
             arrayOf(LimeTypeAlias(
                 EMPTY_PATH,

--- a/lime-loader/src/test/java/com/here/gluecodium/validator/LimeStructsValidatorTest.kt
+++ b/lime-loader/src/test/java/com/here/gluecodium/validator/LimeStructsValidatorTest.kt
@@ -22,7 +22,7 @@ package com.here.gluecodium.validator
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributes
 import com.here.gluecodium.model.lime.LimeBasicTypeRef
-import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
@@ -100,32 +100,8 @@ class LimeStructsValidatorTest {
     }
 
     @Test
-    fun validateEquatableWithNonEquatableContainerType() {
-        val limeContainer = LimeClass(EMPTY_PATH)
-        val limeField = LimeField(EMPTY_PATH, typeRef = LimeDirectTypeRef(limeContainer))
-        allElements[""] =
-            LimeStruct(EMPTY_PATH, attributes = equatableAttributes, fields = listOf(limeField))
-
-        assertFalse(validator.validate(limeModel))
-    }
-
-    @Test
-    fun validateEquatableWithEquatableContainerType() {
-        val limeContainer = LimeClass(EMPTY_PATH, attributes = equatableAttributes)
-        val limeField = LimeField(EMPTY_PATH, typeRef = LimeDirectTypeRef(limeContainer))
-        allElements[""] =
-            LimeStruct(EMPTY_PATH, attributes = equatableAttributes, fields = listOf(limeField))
-
-        assertTrue(validator.validate(limeModel))
-    }
-
-    @Test
-    fun validateEquatableWithPointerEquatableContainerType() {
-        val limeContainer = LimeClass(
-            EMPTY_PATH,
-            attributes =
-                LimeAttributes.Builder().addAttribute(LimeAttributeType.POINTER_EQUATABLE).build()
-        )
+    fun validateEquatableWithContainerType() {
+        val limeContainer = object : LimeContainerWithInheritance(EMPTY_PATH) {}
         val limeField = LimeField(EMPTY_PATH, typeRef = LimeDirectTypeRef(limeContainer))
         allElements[""] =
             LimeStruct(EMPTY_PATH, attributes = equatableAttributes, fields = listOf(limeField))


### PR DESCRIPTION
Updated LIME validators to relax restrictions on @Equatable structs by
allowing fields of any class or interface type, instead of only
@Equatable and @PointerEquatable class/interface types as before (see #202).

Updated C++ model and templates to perform equality comparison for such
fields based on raw pointers.

Added functional and smoke tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>