### PR TITLE
Fix linking issues for CBridge WrapperCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Added referential integrity for classes and interfaces in generated platform code. Meaning, when
     the same C++ object is passed twice to platform (Java/Swift/Dart) side, it is now guaranteed to
     be the same object on platform side as well.
+### Bug fixes:
+  * Fixed linking issue for Swift modularized builds.
 
 ## 6.6.2
 Release date: 2020-05-04

--- a/cmake/modules/gluecodium/gluecodium/runGenerate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/runGenerate.cmake
@@ -80,7 +80,7 @@ function(_collect_all_files_in_single_compilation_units)
         # Include all conversion headers first, so all later generic conversions relying on specialization have all these defined
         _include_all(jni "android/jni/*_Conversion.h" "android/jni/*.cpp")
     elseif(APIGEN_GENERATOR MATCHES swift)
-        _include_all(cbridge "cbridge/*.cpp" "cbridge_internal/*.cpp")
+        _include_all(cbridge "cbridge/*.cpp")
         # Collect all includes to be used in the modulemap
         _include_all(cbridge_header "cbridge/*.h")
         _concatenate_swift_files()

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
@@ -93,13 +93,15 @@ class CBridgeGenerator(
                 "BuiltinHandle",
                 Paths.get(CBRIDGE_PUBLIC, SRC_DIR, "BuiltinHandle.cpp").toString()
             ),
-            generateHelperContent(
-                "TypeInitRepository",
-                CBridgeNameRules.TYPE_INIT_REPOSITORY
-            ),
+            generateHelperContent("TypeInitRepository", CBridgeNameRules.TYPE_INIT_REPOSITORY),
             generateHelperContent(
                 "TypeInitRepositoryImpl",
                 Paths.get(CBRIDGE_PUBLIC, SRC_DIR, "TypeInitRepository.cpp").toString()
+            ),
+            generateHelperContent("WrapperCacheHeader", CBridgeComponents.WRAPPER_CACHE_HEADER),
+            generateHelperContent(
+                "WrapperCacheImpl",
+                Paths.get(CBRIDGE_PUBLIC, SRC_DIR, "WrapperCache.cpp").toString()
             )
         )
 
@@ -225,9 +227,7 @@ class CBridgeGenerator(
             GeneratorSuite.copyCommonFile(
                 Paths.get(CBRIDGE_PUBLIC, INCLUDE_DIR, "ByteArrayHandle.h").toString(), ""
             ),
-            GeneratorSuite.copyCommonFile(CBridgeComponents.PROXY_CACHE_FILENAME, ""),
-            GeneratorSuite.copyCommonFile(CBridgeComponents.WRAPPER_CACHE_HEADER, ""),
-            GeneratorSuite.copyCommonFile(CBridgeComponents.WRAPPER_CACHE_IMPL, "")
+            GeneratorSuite.copyCommonFile(CBridgeComponents.PROXY_CACHE_FILENAME, "")
         )
 
         private fun generateHeaderContent(model: CInterface) =

--- a/gluecodium/src/main/resources/templates/cbridge/InterfaceImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/InterfaceImpl.mustache
@@ -32,18 +32,18 @@ _baseRef {{name}}_copy_handle(_baseRef handle) {
 {{#unless isFunctionalInterface}}
 const void* {{name}}_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<{{selfType.name}}>(handle)->get())
+        ? {{>common/InternalNamespace}}get_wrapper_cache().get_cached_wrapper(get_pointer<{{selfType.name}}>(handle)->get())
         : nullptr;
 }
 
 void {{name}}_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<{{selfType.name}}>(handle)->get(), swift_pointer);
+    {{>common/InternalNamespace}}get_wrapper_cache().cache_wrapper(get_pointer<{{selfType.name}}>(handle)->get(), swift_pointer);
 }
 
 void {{name}}_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<{{selfType.name}}>(handle)->get());
+    {{>common/InternalNamespace}}get_wrapper_cache().remove_cached_wrapper(get_pointer<{{selfType.name}}>(handle)->get());
 }
 {{/unless}}
 

--- a/gluecodium/src/main/resources/templates/cbridge/WrapperCacheHeader.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/WrapperCacheHeader.mustache
@@ -1,3 +1,23 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
 // -------------------------------------------------------------------------------------------------
 // Copyright (C) 2016-2020 HERE Europe B.V.
 //
@@ -26,8 +46,9 @@
 
 static std::atomic<bool> wrapper_cache_is_alive;
 
-namespace
-{
+{{#internalNamespace}}
+namespace {{.}} {
+{{/internalNamespace}}
 class WrapperCache {
 public:
     using CppPtr = const void*;
@@ -44,6 +65,8 @@ private:
     std::mutex mutex;
     std::unordered_map<CppPtr, SwiftPtr> cache;
 };
-}
 
-static WrapperCache& get_wrapper_cache();
+WrapperCache& get_wrapper_cache();
+{{#internalNamespace}}
+}
+{{/internalNamespace}}

--- a/gluecodium/src/main/resources/templates/cbridge/WrapperCacheImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/WrapperCacheImpl.mustache
@@ -1,3 +1,23 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
 // -------------------------------------------------------------------------------------------------
 // Copyright (C) 2016-2020 HERE Europe B.V.
 //
@@ -21,6 +41,10 @@
 #pragma once
 
 #include "cbridge_internal/include/WrapperCache.h"
+
+{{#internalNamespace}}
+namespace {{.}} {
+{{/internalNamespace}}
 
 WrapperCache::WrapperCache() noexcept { wrapper_cache_is_alive = true; }
 WrapperCache::~WrapperCache() { wrapper_cache_is_alive = false; }
@@ -49,8 +73,12 @@ WrapperCache::remove_cached_wrapper(WrapperCache::CppPtr cpp_ptr) {
 // 1. Use function static variable to ensure it's constructed on first use.
 // 2. Use an "alive" flag to ensure it won't crash if destructed early. (e.g. storing a
 //    shared_ptr to a proxy object as a static variable)
-static WrapperCache& get_wrapper_cache()
+WrapperCache& get_wrapper_cache()
 {
     static WrapperCache cache;
     return cache;
 }
+
+{{#internalNamespace}}
+}
+{{/internalNamespace}}

--- a/gluecodium/src/test/resources/namespace_smoke/basic/output/cbridge/src/root/space/smoke/cbridge_Basic.cpp
+++ b/gluecodium/src/test/resources/namespace_smoke/basic/output/cbridge/src/root/space/smoke/cbridge_Basic.cpp
@@ -20,16 +20,16 @@ _baseRef smoke_Basic_copy_handle(_baseRef handle) {
 }
 const void* smoke_Basic_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)->get())
         : nullptr;
 }
 void smoke_Basic_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)->get(), swift_pointer);
 }
 void smoke_Basic_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)->get());
 }
 _baseRef smoke_Basic_basicMethod(_baseRef inputString) {
     return Conversion<std::string>::toBaseRef(::root::space::smoke::Basic::basic_method(Conversion<std::string>::toCpp(inputString)));

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cbridge/src/smoke/cbridge_BasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cbridge/src/smoke/cbridge_BasicTypes.cpp
@@ -20,16 +20,16 @@ _baseRef smoke_BasicTypes_copy_handle(_baseRef handle) {
 }
 const void* smoke_BasicTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)->get())
         : nullptr;
 }
 void smoke_BasicTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)->get(), swift_pointer);
 }
 void smoke_BasicTypes_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)->get());
 }
 _baseRef smoke_BasicTypes_stringFunction(_baseRef input) {
     return Conversion<std::string>::toBaseRef(::smoke::BasicTypes::string_function(Conversion<std::string>::toCpp(input)));

--- a/gluecodium/src/test/resources/smoke/constructors/output/cbridge/src/smoke/cbridge_Constructors.cpp
+++ b/gluecodium/src/test/resources/smoke/constructors/output/cbridge/src/smoke/cbridge_Constructors.cpp
@@ -21,16 +21,16 @@ _baseRef smoke_Constructors_copy_handle(_baseRef handle) {
 }
 const void* smoke_Constructors_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)->get())
         : nullptr;
 }
 void smoke_Constructors_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)->get(), swift_pointer);
 }
 void smoke_Constructors_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_Constructors(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_Dates.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_Dates.cpp
@@ -21,16 +21,16 @@ _baseRef smoke_Dates_copy_handle(_baseRef handle) {
 }
 const void* smoke_Dates_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Dates>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Dates>>(handle)->get())
         : nullptr;
 }
 void smoke_Dates_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Dates>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Dates>>(handle)->get(), swift_pointer);
 }
 void smoke_Dates_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Dates>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Dates>>(handle)->get());
 }
 _baseRef
 smoke_Dates_DateStruct_create_handle( double dateField )

--- a/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableClass.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableClass.cpp
@@ -21,16 +21,16 @@ _baseRef smoke_EquatableClass_copy_handle(_baseRef handle) {
 }
 const void* smoke_EquatableClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)->get())
         : nullptr;
 }
 void smoke_EquatableClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)->get(), swift_pointer);
 }
 void smoke_EquatableClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)->get());
 }
 bool smoke_EquatableClass_equal(_baseRef lhs, _baseRef rhs) {
     return **get_pointer<std::shared_ptr<::smoke::EquatableClass>>(lhs) == **get_pointer<std::shared_ptr<::smoke::EquatableClass>>(rhs);

--- a/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableInterface.cpp
@@ -20,16 +20,16 @@ _baseRef smoke_EquatableInterface_copy_handle(_baseRef handle) {
 }
 const void* smoke_EquatableInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_EquatableInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_EquatableInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_EquatableInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_PointerEquatableClass.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_PointerEquatableClass.cpp
@@ -19,16 +19,16 @@ _baseRef smoke_PointerEquatableClass_copy_handle(_baseRef handle) {
 }
 const void* smoke_PointerEquatableClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get())
         : nullptr;
 }
 void smoke_PointerEquatableClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get(), swift_pointer);
 }
 void smoke_PointerEquatableClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get());
 }
 bool smoke_PointerEquatableClass_equal(_baseRef lhs, _baseRef rhs) {
     return *get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(lhs) == *get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(rhs);

--- a/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_Errors.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_Errors.cpp
@@ -22,16 +22,16 @@ _baseRef smoke_Errors_copy_handle(_baseRef handle) {
 }
 const void* smoke_Errors_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Errors>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Errors>>(handle)->get())
         : nullptr;
 }
 void smoke_Errors_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Errors>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Errors>>(handle)->get(), swift_pointer);
 }
 void smoke_Errors_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Errors>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Errors>>(handle)->get());
 }
 smoke_Errors_methodWithErrors_result smoke_Errors_methodWithErrors() {
     auto&& ERROR_VALUE = ::smoke::Errors::method_with_errors().value();

--- a/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_ErrorsInterface.cpp
@@ -22,16 +22,16 @@ _baseRef smoke_ErrorsInterface_copy_handle(_baseRef handle) {
 }
 const void* smoke_ErrorsInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_ErrorsInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_ErrorsInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ErrorsInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithBasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithBasicTypes.cpp
@@ -22,16 +22,16 @@ _baseRef smoke_GenericTypesWithBasicTypes_copy_handle(_baseRef handle) {
 }
 const void* smoke_GenericTypesWithBasicTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get())
         : nullptr;
 }
 void smoke_GenericTypesWithBasicTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get(), swift_pointer);
 }
 void smoke_GenericTypesWithBasicTypes_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get());
 }
 _baseRef
 smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle( _baseRef numbersList, _baseRef numbersMap, _baseRef numbersSet )

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithCompoundTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithCompoundTypes.cpp
@@ -25,16 +25,16 @@ _baseRef smoke_GenericTypesWithCompoundTypes_copy_handle(_baseRef handle) {
 }
 const void* smoke_GenericTypesWithCompoundTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get())
         : nullptr;
 }
 void smoke_GenericTypesWithCompoundTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get(), swift_pointer);
 }
 void smoke_GenericTypesWithCompoundTypes_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get());
 }
 _baseRef
 smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle( double value )

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithGenericTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithGenericTypes.cpp
@@ -22,16 +22,16 @@ _baseRef smoke_GenericTypesWithGenericTypes_copy_handle(_baseRef handle) {
 }
 const void* smoke_GenericTypesWithGenericTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get())
         : nullptr;
 }
 void smoke_GenericTypesWithGenericTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get(), swift_pointer);
 }
 void smoke_GenericTypesWithGenericTypes_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get());
 }
 _baseRef smoke_GenericTypesWithGenericTypes_methodWithListOfLists(_baseRef _instance, _baseRef input) {
     return Conversion<std::vector<std::vector<int32_t>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_list_of_lists(Conversion<std::vector<std::vector<int32_t>>>::toCpp(input)));

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromClass.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromClass.cpp
@@ -21,16 +21,16 @@ _baseRef smoke_ChildClassFromClass_copy_handle(_baseRef handle) {
 }
 const void* smoke_ChildClassFromClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get())
         : nullptr;
 }
 void smoke_ChildClassFromClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get(), swift_pointer);
 }
 void smoke_ChildClassFromClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ChildClassFromClass(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromInterface.cpp
@@ -23,16 +23,16 @@ _baseRef smoke_ChildClassFromInterface_copy_handle(_baseRef handle) {
 }
 const void* smoke_ChildClassFromInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_ChildClassFromInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_ChildClassFromInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ChildClassFromInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildInterface.cpp
@@ -24,16 +24,16 @@ _baseRef smoke_ChildInterface_copy_handle(_baseRef handle) {
 }
 const void* smoke_ChildInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_ChildInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_ChildInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ChildInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_ExternalClass.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_ExternalClass.cpp
@@ -20,16 +20,16 @@ _baseRef smoke_ExternalClass_copy_handle(_baseRef handle) {
 }
 const void* smoke_ExternalClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::fire::Baz>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::fire::Baz>>(handle)->get())
         : nullptr;
 }
 void smoke_ExternalClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::fire::Baz>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::fire::Baz>>(handle)->get(), swift_pointer);
 }
 void smoke_ExternalClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::fire::Baz>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::fire::Baz>>(handle)->get());
 }
 _baseRef
 smoke_ExternalClass_SomeStruct_create_handle( _baseRef someField )

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_ExternalInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_ExternalInterface.cpp
@@ -21,16 +21,16 @@ _baseRef smoke_ExternalInterface_copy_handle(_baseRef handle) {
 }
 const void* smoke_ExternalInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_ExternalInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_ExternalInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ExternalInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleClass.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleClass.cpp
@@ -20,16 +20,16 @@ _baseRef smoke_SimpleClass_copy_handle(_baseRef handle) {
 }
 const void* smoke_SimpleClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)->get())
         : nullptr;
 }
 void smoke_SimpleClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)->get(), swift_pointer);
 }
 void smoke_SimpleClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)->get());
 }
 _baseRef smoke_SimpleClass_getStringValue(_baseRef _instance) {
     return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(_instance)->get()->get_string_value());

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleInterface.cpp
@@ -21,16 +21,16 @@ _baseRef smoke_SimpleInterface_copy_handle(_baseRef handle) {
 }
 const void* smoke_SimpleInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_SimpleInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_SimpleInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_SimpleInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/cbridge/src/smoke/cbridge_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/cbridge/src/smoke/cbridge_Lambdas.cpp
@@ -23,16 +23,16 @@ _baseRef smoke_Lambdas_copy_handle(_baseRef handle) {
 }
 const void* smoke_Lambdas_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)->get())
         : nullptr;
 }
 void smoke_Lambdas_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)->get(), swift_pointer);
 }
 void smoke_Lambdas_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)->get());
 }
 _baseRef smoke_Lambdas_deconfuse(_baseRef _instance, _baseRef value, _baseRef confuser) {
     return Conversion<::smoke::Lambdas::Producer>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Lambdas>>(_instance)->get()->deconfuse(Conversion<std::string>::toCpp(value), Conversion<::smoke::Lambdas::Confuser>::toCpp(confuser)));

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_CalculatorListener.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_CalculatorListener.cpp
@@ -23,16 +23,16 @@ _baseRef smoke_CalculatorListener_copy_handle(_baseRef handle) {
 }
 const void* smoke_CalculatorListener_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get())
         : nullptr;
 }
 void smoke_CalculatorListener_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get(), swift_pointer);
 }
 void smoke_CalculatorListener_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_CalculatorListener(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenerWithProperties.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenerWithProperties.cpp
@@ -24,16 +24,16 @@ _baseRef smoke_ListenerWithProperties_copy_handle(_baseRef handle) {
 }
 const void* smoke_ListenerWithProperties_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get())
         : nullptr;
 }
 void smoke_ListenerWithProperties_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get(), swift_pointer);
 }
 void smoke_ListenerWithProperties_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ListenerWithProperties(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenersWithReturnValues.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenersWithReturnValues.cpp
@@ -24,16 +24,16 @@ _baseRef smoke_ListenersWithReturnValues_copy_handle(_baseRef handle) {
 }
 const void* smoke_ListenersWithReturnValues_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get())
         : nullptr;
 }
 void smoke_ListenersWithReturnValues_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get(), swift_pointer);
 }
 void smoke_ListenersWithReturnValues_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ListenersWithReturnValues(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/name_rules/output/cbridge/src/namerules/cbridge_NameRules.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/cbridge/src/namerules/cbridge_NameRules.cpp
@@ -20,16 +20,16 @@ _baseRef namerules_NameRules_copy_handle(_baseRef handle) {
 }
 const void* namerules_NameRules_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)->get())
+        ? ::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)->get())
         : nullptr;
 }
 void namerules_NameRules_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)->get(), swift_pointer);
+    ::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)->get(), swift_pointer);
 }
 void namerules_NameRules_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)->get());
+    ::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)->get());
 }
 _baseRef
 namerules_NameRules_ExampleStruct_create_handle( double iValue, _baseRef iIntValue )

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_LevelOne.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_LevelOne.cpp
@@ -22,16 +22,16 @@ _baseRef smoke_LevelOne_copy_handle(_baseRef handle) {
 }
 const void* smoke_LevelOne_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)->get())
         : nullptr;
 }
 void smoke_LevelOne_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)->get(), swift_pointer);
 }
 void smoke_LevelOne_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)->get());
 }
 void smoke_LevelOne_LevelTwo_release_handle(_baseRef handle) {
     delete get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle);
@@ -43,16 +43,16 @@ _baseRef smoke_LevelOne_LevelTwo_copy_handle(_baseRef handle) {
 }
 const void* smoke_LevelOne_LevelTwo_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get())
         : nullptr;
 }
 void smoke_LevelOne_LevelTwo_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get(), swift_pointer);
 }
 void smoke_LevelOne_LevelTwo_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get());
 }
 void smoke_LevelOne_LevelTwo_LevelThree_release_handle(_baseRef handle) {
     delete get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle);
@@ -64,16 +64,16 @@ _baseRef smoke_LevelOne_LevelTwo_LevelThree_copy_handle(_baseRef handle) {
 }
 const void* smoke_LevelOne_LevelTwo_LevelThree_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get())
         : nullptr;
 }
 void smoke_LevelOne_LevelTwo_LevelThree_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get(), swift_pointer);
 }
 void smoke_LevelOne_LevelTwo_LevelThree_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get());
 }
 _baseRef
 smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle( _baseRef stringField )

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterClass.cpp
@@ -21,16 +21,16 @@ _baseRef smoke_OuterClass_copy_handle(_baseRef handle) {
 }
 const void* smoke_OuterClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)->get());
 }
 _baseRef smoke_OuterClass_foo(_baseRef _instance, _baseRef input) {
     return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterClass>>(_instance)->get()->foo(Conversion<std::string>::toCpp(input)));
@@ -45,16 +45,16 @@ _baseRef smoke_OuterClass_InnerClass_copy_handle(_baseRef handle) {
 }
 const void* smoke_OuterClass_InnerClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterClass_InnerClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterClass_InnerClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get());
 }
 _baseRef smoke_OuterClass_InnerClass_foo(_baseRef _instance, _baseRef input) {
     return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(_instance)->get()->foo(Conversion<std::string>::toCpp(input)));
@@ -69,16 +69,16 @@ _baseRef smoke_OuterClass_InnerInterface_copy_handle(_baseRef handle) {
 }
 const void* smoke_OuterClass_InnerInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterClass_InnerInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterClass_InnerInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_OuterClass_InnerInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterInterface.cpp
@@ -21,16 +21,16 @@ _baseRef smoke_OuterInterface_copy_handle(_baseRef handle) {
 }
 const void* smoke_OuterInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_OuterInterface(_baseRef handle);
@@ -83,16 +83,16 @@ _baseRef smoke_OuterInterface_InnerClass_copy_handle(_baseRef handle) {
 }
 const void* smoke_OuterInterface_InnerClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterInterface_InnerClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterInterface_InnerClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get());
 }
 _baseRef smoke_OuterInterface_InnerClass_foo(_baseRef _instance, _baseRef input) {
     return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(_instance)->get()->foo(Conversion<std::string>::toCpp(input)));
@@ -107,16 +107,16 @@ _baseRef smoke_OuterInterface_InnerInterface_copy_handle(_baseRef handle) {
 }
 const void* smoke_OuterInterface_InnerInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterInterface_InnerInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterInterface_InnerInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_OuterInterface_InnerInterface(_baseRef handle);

--- a/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_Structs.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_Structs.cpp
@@ -25,16 +25,16 @@ _baseRef smoke_Structs_copy_handle(_baseRef handle) {
 }
 const void* smoke_Structs_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get())
         : nullptr;
 }
 void smoke_Structs_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get(), swift_pointer);
 }
 void smoke_Structs_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get());
 }
 _baseRef
 smoke_Structs_Point_create_handle( double x, double y )

--- a/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethodsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethodsInterface.cpp
@@ -21,16 +21,16 @@ _baseRef smoke_StructsWithMethodsInterface_copy_handle(_baseRef handle) {
 }
 const void* smoke_StructsWithMethodsInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_StructsWithMethodsInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_StructsWithMethodsInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!wrapper_cache_is_alive) return;
-    get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get());
 }
 _baseRef
 smoke_StructsWithMethodsInterface_Vector3_create_handle( double x, double y, double z )


### PR DESCRIPTION
Updated WrapperCache implementation in CBridge to be a Mustache template
instead of a static file. Moved WrapperCache class itself from an
anonymous namespace into "internal namespace" to resolve linking issues
for modularized builds.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>