### PR TITLE
Relax restrictions for @Equatable structs in Java

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -324,8 +324,8 @@ feature(Equatable cpp android swift dart SOURCES
     lime/test/RefEquality.lime
 )
 
-# TODO: #202 enable for android, swift, and dart; and merge into Equatable
-feature(SimpleEquatable cpp SOURCES
+# TODO: #202 enable for swift and dart; and merge into Equatable
+feature(SimpleEquatable cpp android SOURCES
     src/test/SimpleEquality.cpp
 
     lime/test/SimpleEquality.lime

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/RefEqualityTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/RefEqualityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 HERE Europe B.V.
+ * Copyright (C) 2016-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/SimpleEqualityTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/SimpleEqualityTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import android.os.Build;
+import com.example.here.hello.BuildConfig;
+import com.here.android.RobolectricApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(
+    sdk = Build.VERSION_CODES.M,
+    application = RobolectricApplication.class,
+    constants = BuildConfig.class)
+public final class SimpleEqualityTest {
+
+  final NonEquatableClass class1 = NonEquatableFactory.createNonEquatableClass();
+  final NonEquatableClass class2 = NonEquatableFactory.createNonEquatableClass();
+  final NonEquatableInterface interface1 = NonEquatableFactory.createNonEquatableInterface();
+  final NonEquatableInterface interface2 = NonEquatableFactory.createNonEquatableInterface();
+
+  @Test
+  public void simpleEqualityForStructs() {
+    SimpleEquatableStruct struct1 =
+        new SimpleEquatableStruct(class1, interface1, class2, interface2);
+    SimpleEquatableStruct struct2 =
+        new SimpleEquatableStruct(class1, interface1, class2, interface2);
+
+    assertEquals(struct1, struct2);
+    assertEquals(struct1.hashCode(), struct2.hashCode());
+  }
+
+  @Test
+  public void simpleEqualityForStructsWithNulls() {
+    SimpleEquatableStruct struct1 = new SimpleEquatableStruct(class1, interface1, null, null);
+    SimpleEquatableStruct struct2 = new SimpleEquatableStruct(class1, interface1, null, null);
+
+    assertEquals(struct1, struct2);
+    assertEquals(struct1.hashCode(), struct2.hashCode());
+  }
+
+  @Test
+  public void simpleInequalityForStructs() {
+    SimpleEquatableStruct struct1 =
+        new SimpleEquatableStruct(class1, interface1, class2, interface2);
+    SimpleEquatableStruct struct2 =
+        new SimpleEquatableStruct(class2, interface2, class1, interface1);
+
+    assertNotEquals(struct1, struct2);
+    assertNotEquals(struct1.hashCode(), struct2.hashCode());
+  }
+
+  @Test
+  public void simpleInequalityForStructsWithNulls() {
+    SimpleEquatableStruct struct1 = new SimpleEquatableStruct(class1, interface1, class2, null);
+    SimpleEquatableStruct struct2 = new SimpleEquatableStruct(class1, interface1, null, interface2);
+
+    assertNotEquals(struct1, struct2);
+    assertNotEquals(struct1.hashCode(), struct2.hashCode());
+  }
+}

--- a/gluecodium/src/test/resources/smoke/equatable/output/android/com/example/smoke/SimpleEquatableStruct.java
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android/com/example/smoke/SimpleEquatableStruct.java
@@ -1,0 +1,41 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+public final class SimpleEquatableStruct {
+    @NonNull
+    public NonEquatableClass classField;
+    @NonNull
+    public NonEquatableInterface interfaceField;
+    @Nullable
+    public NonEquatableClass nullableClassField;
+    @Nullable
+    public NonEquatableInterface nullableInterfaceField;
+    public SimpleEquatableStruct(@NonNull final NonEquatableClass classField, @NonNull final NonEquatableInterface interfaceField, @Nullable final NonEquatableClass nullableClassField, @Nullable final NonEquatableInterface nullableInterfaceField) {
+        this.classField = classField;
+        this.interfaceField = interfaceField;
+        this.nullableClassField = nullableClassField;
+        this.nullableInterfaceField = nullableInterfaceField;
+    }
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (!(obj instanceof SimpleEquatableStruct)) return false;
+        final SimpleEquatableStruct other = (SimpleEquatableStruct) obj;
+        return java.util.Objects.equals(this.classField, other.classField) &&
+                java.util.Objects.equals(this.interfaceField, other.interfaceField) &&
+                java.util.Objects.equals(this.nullableClassField, other.nullableClassField) &&
+                java.util.Objects.equals(this.nullableInterfaceField, other.nullableInterfaceField);
+    }
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 31 * hash + (this.classField != null ? this.classField.hashCode() : 0);
+        hash = 31 * hash + (this.interfaceField != null ? this.interfaceField.hashCode() : 0);
+        hash = 31 * hash + (this.nullableClassField != null ? this.nullableClassField.hashCode() : 0);
+        hash = 31 * hash + (this.nullableInterfaceField != null ? this.nullableInterfaceField.hashCode() : 0);
+        return hash;
+    }
+}


### PR DESCRIPTION
Default language-provided implementations for equality and hash code in
Java already work exactly as needed: equality is referential equality
and hash code is based on object reference as well (see #202). So no
additional implementation is needed in Gluecodium.

Added smoke and functional tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>