### PR TITLE
Relax restrictions for @Equatable structs in Swift

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -324,8 +324,8 @@ feature(Equatable cpp android swift dart SOURCES
     lime/test/RefEquality.lime
 )
 
-# TODO: #202 enable for swift and dart; and merge into Equatable
-feature(SimpleEquatable cpp android SOURCES
+# TODO: #202 enable for dart; and merge into Equatable
+feature(SimpleEquatable cpp android swift SOURCES
     src/test/SimpleEquality.cpp
 
     lime/test/SimpleEquality.lime

--- a/examples/platforms/ios/Tests/main.swift
+++ b/examples/platforms/ios/Tests/main.swift
@@ -58,6 +58,7 @@ let allTests = [
     testCase(RefEqualityTests.allTests),
     testCase(SerializationTests.allTests),
     testCase(SetTypeTests.allTests),
+    testCase(SimpleEqualityTests.allTests),
     testCase(StaticBooleanMethodsTests.allTests),
     testCase(StaticByteArrayMethodsTests.allTests),
     testCase(StaticFloatDoubleMethodsTests.allTests),

--- a/examples/platforms/ios/Tests/testTests/SimpleEqualityTests.swift
+++ b/examples/platforms/ios/Tests/testTests/SimpleEqualityTests.swift
@@ -1,0 +1,83 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import hello
+
+class SimpleEqualityTests: XCTestCase {
+
+    let class1 = NonEquatableFactory.createNonEquatableClass()
+    let class2 = NonEquatableFactory.createNonEquatableClass()
+    let interface1 = NonEquatableFactory.createNonEquatableInterface()
+    let interface2 = NonEquatableFactory.createNonEquatableInterface()
+
+    func testSimpleEquality() {
+        let struct1 = SimpleEquatableStruct(classField: class1, interfaceField: interface1,
+                                            nullableClassField: class2, nullableInterfaceField: interface2)
+        let struct2 = SimpleEquatableStruct(classField: class1, interfaceField: interface1,
+                                            nullableClassField: class2, nullableInterfaceField: interface2)
+
+        XCTAssertEqual(struct1, struct2)
+        XCTAssertEqual(hash(struct1), hash(struct2))
+    }
+
+    func testSimpleEqualityWithNils() {
+        let struct1 = SimpleEquatableStruct(classField: class1, interfaceField: interface1,
+                                            nullableClassField: nil, nullableInterfaceField: nil)
+        let struct2 = SimpleEquatableStruct(classField: class1, interfaceField: interface1,
+                                            nullableClassField: nil, nullableInterfaceField: nil)
+
+        XCTAssertEqual(struct1, struct2)
+        XCTAssertEqual(hash(struct1), hash(struct2))
+    }
+
+    func testSimpleInequality() {
+        let struct1 = SimpleEquatableStruct(classField: class1, interfaceField: interface1,
+                                            nullableClassField: class2, nullableInterfaceField: interface2)
+        let struct2 = SimpleEquatableStruct(classField: class2, interfaceField: interface2,
+                                            nullableClassField: class1, nullableInterfaceField: interface1)
+
+        XCTAssertNotEqual(struct1, struct2)
+        XCTAssertNotEqual(hash(struct1), hash(struct2))
+    }
+
+    func testSimpleInequalityWithNils() {
+        let struct1 = SimpleEquatableStruct(classField: class1, interfaceField: interface1,
+                                            nullableClassField: class2, nullableInterfaceField: nil)
+        let struct2 = SimpleEquatableStruct(classField: class1, interfaceField: interface1,
+                                            nullableClassField: nil, nullableInterfaceField: interface2)
+
+        XCTAssertNotEqual(struct1, struct2)
+        XCTAssertNotEqual(hash(struct1), hash(struct2))
+    }
+
+    func hash<H>(_ value: H) -> Int where H: Hashable {
+        var hasher = Hasher()
+        value.hash(into: &hasher)
+        return hasher.finalize()
+    }
+
+    static var allTests = [
+        ("testSimpleEquality", testSimpleEquality),
+        ("testSimpleEqualityWithNils", testSimpleEqualityWithNils),
+        ("testSimpleInequality", testSimpleInequality),
+        ("testSimpleInequalityWithNils", testSimpleInequalityWithNils)
+    ]
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftField.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftField.kt
@@ -23,7 +23,8 @@ class SwiftField(
     name: String,
     visibility: SwiftVisibility?,
     type: SwiftType,
-    val defaultValue: SwiftValue?
+    val defaultValue: SwiftValue?,
+    val isRefEquatable: Boolean = false
 ) : SwiftTypedModelElement(name, visibility, type) {
 
     override val childElements

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftStruct.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftStruct.kt
@@ -56,6 +56,9 @@ class SwiftStruct(
     val needsReducedConstructor =
         internalFields.isNotEmpty() && internalFields.all { it.defaultValue != null }
 
+    @Suppress("unused")
+    val needsExplicitHashable = isEquatable && fields.any { it.isRefEquatable }
+
     override fun withAlias(aliasName: String): SwiftType {
         val swiftStruct = SwiftStruct(
             name,

--- a/gluecodium/src/main/resources/templates/swift/Struct.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Struct.mustache
@@ -89,6 +89,24 @@
     }
 
 {{/constructors}}{{/set}}{{!!
+}}{{#if needsExplicitHashable}}
+    public static func == (lhs: {{simpleName}}, rhs: {{simpleName}}) -> Bool {
+        return
+{{#fields}}
+            lhs.{{name}} =={{#if isRefEquatable}}={{/if}} rhs.{{name}}{{#if iter.hasNext}} &&{{/if}}
+{{/fields}}
+    }
+
+    public func hash(into hasher: inout Hasher) {
+{{#fields}}{{#if isRefEquatable}}{{#if type.optional}}
+        hasher.combine({{name}} != nil ? Unmanaged<AnyObject>.passUnretained({{name}}!).toOpaque().hashValue : 0)
+{{/if}}{{#unless type.optional}}
+        hasher.combine(Unmanaged<AnyObject>.passUnretained({{name}}).toOpaque().hashValue)
+{{/unless}}{{/if}}{{#unless isRefEquatable}}
+        hasher.combine({{name}})
+{{/unless}}{{/fields}}
+    }
+{{/if}}{{!!
 }}{{#if methods}}
 
 {{#set selfIsStruct=true}}{{#methods}}

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/SimpleEquatableStruct.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/SimpleEquatableStruct.swift
@@ -1,0 +1,79 @@
+//
+//
+import Foundation
+public struct SimpleEquatableStruct: Hashable {
+    public var classField: NonEquatableClass
+    public var interfaceField: NonEquatableInterface
+    public var nullableClassField: NonEquatableClass?
+    public var nullableInterfaceField: NonEquatableInterface?
+    public init(classField: NonEquatableClass, interfaceField: NonEquatableInterface, nullableClassField: NonEquatableClass? = nil, nullableInterfaceField: NonEquatableInterface? = nil) {
+        self.classField = classField
+        self.interfaceField = interfaceField
+        self.nullableClassField = nullableClassField
+        self.nullableInterfaceField = nullableInterfaceField
+    }
+    internal init(cHandle: _baseRef) {
+        classField = NonEquatableClass_moveFromCType(smoke_SimpleEquatableStruct_classField_get(cHandle))
+        interfaceField = NonEquatableInterface_moveFromCType(smoke_SimpleEquatableStruct_interfaceField_get(cHandle))
+        nullableClassField = NonEquatableClass_moveFromCType(smoke_SimpleEquatableStruct_nullableClassField_get(cHandle))
+        nullableInterfaceField = NonEquatableInterface_moveFromCType(smoke_SimpleEquatableStruct_nullableInterfaceField_get(cHandle))
+    }
+    public static func == (lhs: SimpleEquatableStruct, rhs: SimpleEquatableStruct) -> Bool {
+        return
+            lhs.classField === rhs.classField &&
+            lhs.interfaceField === rhs.interfaceField &&
+            lhs.nullableClassField === rhs.nullableClassField &&
+            lhs.nullableInterfaceField === rhs.nullableInterfaceField
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(Unmanaged<AnyObject>.passUnretained(classField).toOpaque().hashValue)
+        hasher.combine(Unmanaged<AnyObject>.passUnretained(interfaceField).toOpaque().hashValue)
+        hasher.combine(nullableClassField != nil ? Unmanaged<AnyObject>.passUnretained(nullableClassField!).toOpaque().hashValue : 0)
+        hasher.combine(nullableInterfaceField != nil ? Unmanaged<AnyObject>.passUnretained(nullableInterfaceField!).toOpaque().hashValue : 0)
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> SimpleEquatableStruct {
+    return SimpleEquatableStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> SimpleEquatableStruct {
+    defer {
+        smoke_SimpleEquatableStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: SimpleEquatableStruct) -> RefHolder {
+    let c_classField = moveToCType(swiftType.classField)
+    let c_interfaceField = moveToCType(swiftType.interfaceField)
+    let c_nullableClassField = moveToCType(swiftType.nullableClassField)
+    let c_nullableInterfaceField = moveToCType(swiftType.nullableInterfaceField)
+    return RefHolder(smoke_SimpleEquatableStruct_create_handle(c_classField.ref, c_interfaceField.ref, c_nullableClassField.ref, c_nullableInterfaceField.ref))
+}
+internal func moveToCType(_ swiftType: SimpleEquatableStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_SimpleEquatableStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> SimpleEquatableStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_SimpleEquatableStruct_unwrap_optional_handle(handle)
+    return SimpleEquatableStruct(cHandle: unwrappedHandle) as SimpleEquatableStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> SimpleEquatableStruct? {
+    defer {
+        smoke_SimpleEquatableStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: SimpleEquatableStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_classField = moveToCType(swiftType.classField)
+    let c_interfaceField = moveToCType(swiftType.interfaceField)
+    let c_nullableClassField = moveToCType(swiftType.nullableClassField)
+    let c_nullableInterfaceField = moveToCType(swiftType.nullableInterfaceField)
+    return RefHolder(smoke_SimpleEquatableStruct_create_optional_handle(c_classField.ref, c_interfaceField.ref, c_nullableClassField.ref, c_nullableInterfaceField.ref))
+}
+internal func moveToCType(_ swiftType: SimpleEquatableStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_SimpleEquatableStruct_release_optional_handle)
+}


### PR DESCRIPTION
Updated Swift model and templates to relax restrictions on @Equatable
structs by allowing fields of any class or interface type, instead of
only @Equatable and @PointerEquatable class/interface types as before
(see #202).

Added functional and smoke tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>