### PR TITLE
Relax restrictions for @Equatable structs in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   * Added referential integrity for classes and interfaces in generated platform code. Meaning, when
     the same C++ object is passed twice to platform (Java/Swift/Dart) side, it is now guaranteed to
     be the same object on platform side as well.
+  * Relaxed restrictions on `@Equatable` structs in IDL. Such structs now can contains fields of
+    any class or interface types (not just those that are `@Equatable` themselves).
+### Bug fixes:
+  * Fixed `hashCode` implementation for `@Equatable` structs with collection type fields in Dart.
 
 ## 6.6.5
 Release date: 2020-05-11

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -318,16 +318,11 @@ feature(Constants cpp android swift dart SOURCES
 feature(Equatable cpp android swift dart SOURCES
     src/test/EquatableImpl.cpp
     src/test/RefEquality.cpp
+    src/test/SimpleEquality.cpp
 
     lime/hello/HelloWorldEquatable.lime
     lime/test/Equatable.lime
     lime/test/RefEquality.lime
-)
-
-# TODO: #202 enable for dart; and merge into Equatable
-feature(SimpleEquatable cpp android swift SOURCES
-    src/test/SimpleEquality.cpp
-
     lime/test/SimpleEquality.lime
 )
 

--- a/examples/platforms/dart/main.dart
+++ b/examples/platforms/dart/main.dart
@@ -46,6 +46,7 @@ import "test/PlainDataStructuresTypeCollection_test.dart" as PlainDataStructures
 import "test/Properties_test.dart" as PropertiesTests;
 import "test/RefEquality_test.dart" as RefEqualityTests;
 import "test/Sets_test.dart" as SetsTests;
+import "test/SimpleEquality_test.dart" as SimpleEqualityTests;
 import "test/StaticBooleanMethods_test.dart" as StaticBooleanMethodsTests;
 import "test/StaticFloatDoubleMethods_test.dart" as StaticFloatDoubleMethodsTests;
 import "test/StaticIntMethods_test.dart" as StaticIntMethodsTests;
@@ -82,6 +83,7 @@ final _allTests = [
   PropertiesTests.main,
   RefEqualityTests.main,
   SetsTests.main,
+  SimpleEqualityTests.main,
   StaticBooleanMethodsTests.main,
   StaticFloatDoubleMethodsTests.main,
   StaticIntMethodsTests.main,

--- a/examples/platforms/dart/test/EquatableStructs_test.dart
+++ b/examples/platforms/dart/test/EquatableStructs_test.dart
@@ -40,79 +40,71 @@ void main() {
   });
 
   _testSuite.test("Equatable struct equals to self", () {
-    final result = struct == struct;
-
-    expect(result, isTrue);
+    expect(struct == struct, isTrue);
+    expect(struct.hashCode == struct.hashCode, isTrue);
   });
   _testSuite.test("Equatable struct equals", () {
     final otherStruct = createEquatableStruct();
 
-    final result = struct == otherStruct;
-
-    expect(result, isTrue);
+    expect(struct == otherStruct, isTrue);
+    print(struct.hashCode);
+    print(otherStruct.hashCode);
+    expect(struct.hashCode == otherStruct.hashCode, isTrue);
   });
   _testSuite.test("Equatable struct not equals Boolean field", () {
     final otherStruct = createEquatableStruct();
     otherStruct.boolField = false;
 
-    final result = struct == otherStruct;
-
-    expect(result, isFalse);
+    expect(struct == otherStruct, isFalse);
+    expect(struct.hashCode == otherStruct.hashCode, isFalse);
   });
   _testSuite.test("Equatable struct not equals Int field", () {
     final otherStruct = createEquatableStruct();
     otherStruct.intField += 1;
 
-    final result = struct == otherStruct;
-
-    expect(result, isFalse);
+    expect(struct == otherStruct, isFalse);
+    expect(struct.hashCode == otherStruct.hashCode, isFalse);
   });
   _testSuite.test("Equatable struct not equals Double field", () {
     final otherStruct = createEquatableStruct();
     otherStruct.doubleField += 1.0;
 
-    final result = struct == otherStruct;
-
-    expect(result, isFalse);
+    expect(struct == otherStruct, isFalse);
+    expect(struct.hashCode == otherStruct.hashCode, isFalse);
   });
   _testSuite.test("Equatable struct not equals String field", () {
     final otherStruct = createEquatableStruct();
     otherStruct.stringField += "foo";
 
-    final result = struct == otherStruct;
-
-    expect(result, isFalse);
+    expect(struct == otherStruct, isFalse);
+    expect(struct.hashCode == otherStruct.hashCode, isFalse);
   });
   _testSuite.test("Equatable struct not equals Struct field", () {
     final otherStruct = createEquatableStruct();
     otherStruct.structField.fooField += "bar";
 
-    final result = struct == otherStruct;
-
-    expect(result, isFalse);
+    expect(struct == otherStruct, isFalse);
+    expect(struct.hashCode == otherStruct.hashCode, isFalse);
   });
   _testSuite.test("Equatable struct not equals Enum field", () {
     final otherStruct = createEquatableStruct();
     otherStruct.enumField = SomeSomeEnum.foo;
 
-    final result = struct == otherStruct;
-
-    expect(result, isFalse);
+    expect(struct == otherStruct, isFalse);
+    expect(struct.hashCode == otherStruct.hashCode, isFalse);
   });
   _testSuite.test("Equatable struct not equals List field", () {
     final otherStruct = createEquatableStruct();
     otherStruct.arrayField.add("three");
 
-    final result = struct == otherStruct;
-
-    expect(result, isFalse);
+    expect(struct == otherStruct, isFalse);
+    expect(struct.hashCode == otherStruct.hashCode, isFalse);
   });
   _testSuite.test("Equatable struct not equals Map field", () {
     final otherStruct = createEquatableStruct();
     otherStruct.mapField.addAll({42: "four"});
 
-    final result = struct == otherStruct;
-
-    expect(result, isFalse);
+    expect(struct == otherStruct, isFalse);
+    expect(struct.hashCode == otherStruct.hashCode, isFalse);
   });
 }

--- a/examples/platforms/dart/test/SimpleEquality_test.dart
+++ b/examples/platforms/dart/test/SimpleEquality_test.dart
@@ -1,0 +1,74 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:hello/test.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("SimpleEquality");
+
+void main() {
+  NonEquatableClass class1;
+  NonEquatableClass class2;
+  NonEquatableInterface interface1;
+  NonEquatableInterface interface2;
+
+  setUp(() {
+    class1 = NonEquatableFactory.createNonEquatableClass();
+    class2 = NonEquatableFactory.createNonEquatableClass();
+    interface1 = NonEquatableFactory.createNonEquatableInterface();
+    interface2 = NonEquatableFactory.createNonEquatableInterface();
+  });
+  tearDown(() {
+    class1.release();
+    class2.release();
+    interface1.release();
+    interface2.release();
+  });
+
+  _testSuite.test("Simple equality for structs", () {
+    final struct1 = SimpleEquatableStruct(class1, interface1, class2, interface2);
+    final struct2 = SimpleEquatableStruct(class1, interface1, class2, interface2);
+
+    expect(struct1 == struct2, isTrue);
+    expect(struct1.hashCode == struct2.hashCode, isTrue);
+  });
+  _testSuite.test("Simple equality for structs with nulls", () {
+    final struct1 = SimpleEquatableStruct(class1, interface1, null, null);
+    final struct2 = SimpleEquatableStruct(class1, interface1, null, null);
+
+    expect(struct1 == struct2, isTrue);
+    expect(struct1.hashCode == struct2.hashCode, isTrue);
+  });
+  _testSuite.test("Simple inequality for structs", () {
+    final struct1 = SimpleEquatableStruct(class1, interface1, class2, interface2);
+    final struct2 = SimpleEquatableStruct(class2, interface2, class1, interface1);
+
+    expect(struct1 == struct2, isFalse);
+    expect(struct1.hashCode == struct2.hashCode, isFalse);
+  });
+  _testSuite.test("Simple inequality for structs with nulls", () {
+    final struct1 = SimpleEquatableStruct(class1, interface1, class2, null);
+    final struct2 = SimpleEquatableStruct(class1, interface1, null, interface2);
+
+    expect(struct1 == struct2, isFalse);
+    expect(struct1.hashCode == struct2.hashCode, isFalse);
+  });
+}

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -58,7 +58,7 @@ class {{resolveName}} {
   int get hashCode {
     int result = 7;
 {{#fields}}
-    result = 31 * result + {{resolveName visibility}}{{resolveName}}.hashCode;
+    result = 31 * result + {{>dartFieldHash}};
 {{/fields}}
     return result;
   }
@@ -127,4 +127,12 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveN
 }}{{#instanceOf typeRef.type.actualType "LimeMap"}}DeepCollectionEquality().equals({{resolveName visibility}}{{resolveName}}, _other.{{resolveName visibility}}{{resolveName}}){{/instanceOf}}{{!!
 }}{{#notInstanceOf typeRef.type.actualType "LimeList"}}{{#notInstanceOf typeRef.type.actualType "LimeSet"}}{{#notInstanceOf typeRef.type.actualType "LimeMap"}}{{!!
 }}{{resolveName visibility}}{{resolveName}} == _other.{{resolveName visibility}}{{resolveName}}{{/notInstanceOf}}{{/notInstanceOf}}{{/notInstanceOf}}{{!!
-}}{{/dartFieldEq}}
+}}{{/dartFieldEq}}{{!!
+
+}}{{+dartFieldHash}}{{!!
+}}{{#instanceOf typeRef.type.actualType "LimeList"}}DeepCollectionEquality().hash({{resolveName visibility}}{{resolveName}}){{/instanceOf}}{{!!
+}}{{#instanceOf typeRef.type.actualType "LimeSet"}}DeepCollectionEquality().hash({{resolveName visibility}}{{resolveName}}){{/instanceOf}}{{!!
+}}{{#instanceOf typeRef.type.actualType "LimeMap"}}DeepCollectionEquality().hash({{resolveName visibility}}{{resolveName}}){{/instanceOf}}{{!!
+}}{{#notInstanceOf typeRef.type.actualType "LimeList"}}{{#notInstanceOf typeRef.type.actualType "LimeSet"}}{{#notInstanceOf typeRef.type.actualType "LimeMap"}}{{!!
+}}{{resolveName visibility}}{{resolveName}}.hashCode{{/notInstanceOf}}{{/notInstanceOf}}{{/notInstanceOf}}{{!!
+}}{{/dartFieldHash}}

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/Equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/Equatable.dart
@@ -6,7 +6,6 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 enum SomeEnum {
     foo,
     bar
@@ -105,8 +104,8 @@ class EquatableStruct {
     result = 31 * result + stringField.hashCode;
     result = 31 * result + structField.hashCode;
     result = 31 * result + enumField.hashCode;
-    result = 31 * result + arrayField.hashCode;
-    result = 31 * result + mapField.hashCode;
+    result = 31 * result + DeepCollectionEquality().hash(arrayField);
+    result = 31 * result + DeepCollectionEquality().hash(mapField);
     return result;
   }
 }
@@ -285,8 +284,8 @@ class EquatableNullableStruct {
     result = 31 * result + stringField.hashCode;
     result = 31 * result + structField.hashCode;
     result = 31 * result + enumField.hashCode;
-    result = 31 * result + arrayField.hashCode;
-    result = 31 * result + mapField.hashCode;
+    result = 31 * result + DeepCollectionEquality().hash(arrayField);
+    result = 31 * result + DeepCollectionEquality().hash(mapField);
     return result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/EquatableStructWithInternalFields.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/EquatableStructWithInternalFields.dart
@@ -6,7 +6,6 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 class EquatableStructWithInternalFields {
   String publicField;
   String internal_internalField;
@@ -30,9 +29,9 @@ class EquatableStructWithInternalFields {
     int result = 7;
     result = 31 * result + publicField.hashCode;
     result = 31 * result + internal_internalField.hashCode;
-    result = 31 * result + internal_internalListField.hashCode;
-    result = 31 * result + internal_internalMapField.hashCode;
-    result = 31 * result + internal_internalSetField.hashCode;
+    result = 31 * result + DeepCollectionEquality().hash(internal_internalListField);
+    result = 31 * result + DeepCollectionEquality().hash(internal_internalMapField);
+    result = 31 * result + DeepCollectionEquality().hash(internal_internalSetField);
     return result;
   }
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/SimpleEquatableStruct.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/SimpleEquatableStruct.dart
@@ -1,0 +1,119 @@
+import 'dart:collection';
+import 'package:collection/collection.dart';
+import 'package:library/src/smoke/NonEquatableClass.dart';
+import 'package:library/src/smoke/NonEquatableInterface.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+class SimpleEquatableStruct {
+  NonEquatableClass classField;
+  NonEquatableInterface interfaceField;
+  NonEquatableClass nullableClassField;
+  NonEquatableInterface nullableInterfaceField;
+  SimpleEquatableStruct(this.classField, this.interfaceField, this.nullableClassField, this.nullableInterfaceField);
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other)) return true;
+    if (other is! SimpleEquatableStruct) return false;
+    SimpleEquatableStruct _other = other;
+    return classField == _other.classField &&
+        interfaceField == _other.interfaceField &&
+        nullableClassField == _other.nullableClassField &&
+        nullableInterfaceField == _other.nullableInterfaceField;
+  }
+  @override
+  int get hashCode {
+    int result = 7;
+    result = 31 * result + classField.hashCode;
+    result = 31 * result + interfaceField.hashCode;
+    result = 31 * result + nullableClassField.hashCode;
+    result = 31 * result + nullableInterfaceField.hashCode;
+    return result;
+  }
+}
+// SimpleEquatableStruct "private" section, not exported.
+final _smoke_SimpleEquatableStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
+  >('library_smoke_SimpleEquatableStruct_create_handle');
+final _smoke_SimpleEquatableStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SimpleEquatableStruct_release_handle');
+final _smoke_SimpleEquatableStruct_get_field_classField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SimpleEquatableStruct_get_field_classField');
+final _smoke_SimpleEquatableStruct_get_field_interfaceField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SimpleEquatableStruct_get_field_interfaceField');
+final _smoke_SimpleEquatableStruct_get_field_nullableClassField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SimpleEquatableStruct_get_field_nullableClassField');
+final _smoke_SimpleEquatableStruct_get_field_nullableInterfaceField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SimpleEquatableStruct_get_field_nullableInterfaceField');
+Pointer<Void> smoke_SimpleEquatableStruct_toFfi(SimpleEquatableStruct value) {
+  final _classField_handle = smoke_NonEquatableClass_toFfi(value.classField);
+  final _interfaceField_handle = smoke_NonEquatableInterface_toFfi(value.interfaceField);
+  final _nullableClassField_handle = smoke_NonEquatableClass_toFfi_nullable(value.nullableClassField);
+  final _nullableInterfaceField_handle = smoke_NonEquatableInterface_toFfi_nullable(value.nullableInterfaceField);
+  final _result = _smoke_SimpleEquatableStruct_create_handle(_classField_handle, _interfaceField_handle, _nullableClassField_handle, _nullableInterfaceField_handle);
+  smoke_NonEquatableClass_releaseFfiHandle(_classField_handle);
+  smoke_NonEquatableInterface_releaseFfiHandle(_interfaceField_handle);
+  smoke_NonEquatableClass_releaseFfiHandle_nullable(_nullableClassField_handle);
+  smoke_NonEquatableInterface_releaseFfiHandle_nullable(_nullableInterfaceField_handle);
+  return _result;
+}
+SimpleEquatableStruct smoke_SimpleEquatableStruct_fromFfi(Pointer<Void> handle) {
+  final _classField_handle = _smoke_SimpleEquatableStruct_get_field_classField(handle);
+  final _interfaceField_handle = _smoke_SimpleEquatableStruct_get_field_interfaceField(handle);
+  final _nullableClassField_handle = _smoke_SimpleEquatableStruct_get_field_nullableClassField(handle);
+  final _nullableInterfaceField_handle = _smoke_SimpleEquatableStruct_get_field_nullableInterfaceField(handle);
+  final _result = SimpleEquatableStruct(
+    smoke_NonEquatableClass_fromFfi(_classField_handle),
+    smoke_NonEquatableInterface_fromFfi(_interfaceField_handle),
+    smoke_NonEquatableClass_fromFfi_nullable(_nullableClassField_handle),
+    smoke_NonEquatableInterface_fromFfi_nullable(_nullableInterfaceField_handle)
+  );
+  smoke_NonEquatableClass_releaseFfiHandle(_classField_handle);
+  smoke_NonEquatableInterface_releaseFfiHandle(_interfaceField_handle);
+  smoke_NonEquatableClass_releaseFfiHandle_nullable(_nullableClassField_handle);
+  smoke_NonEquatableInterface_releaseFfiHandle_nullable(_nullableInterfaceField_handle);
+  return _result;
+}
+void smoke_SimpleEquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_SimpleEquatableStruct_release_handle(handle);
+// Nullable SimpleEquatableStruct
+final _smoke_SimpleEquatableStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SimpleEquatableStruct_create_handle_nullable');
+final _smoke_SimpleEquatableStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SimpleEquatableStruct_release_handle_nullable');
+final _smoke_SimpleEquatableStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SimpleEquatableStruct_get_value_nullable');
+Pointer<Void> smoke_SimpleEquatableStruct_toFfi_nullable(SimpleEquatableStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_SimpleEquatableStruct_toFfi(value);
+  final result = _smoke_SimpleEquatableStruct_create_handle_nullable(_handle);
+  smoke_SimpleEquatableStruct_releaseFfiHandle(_handle);
+  return result;
+}
+SimpleEquatableStruct smoke_SimpleEquatableStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_SimpleEquatableStruct_get_value_nullable(handle);
+  final result = smoke_SimpleEquatableStruct_fromFfi(_handle);
+  smoke_SimpleEquatableStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_SimpleEquatableStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_SimpleEquatableStruct_release_handle_nullable(handle);
+// End of SimpleEquatableStruct "private" section.


### PR DESCRIPTION
Default language-provided implementations for equality and hash code in
Dart already work exactly as needed: equality is referential equality
and hash code is based on object reference as well. So no
additional implementation is needed in Gluecodium.

Added smoke and functional tests.

Also fixed hashCode implementation for struct fields of collection types
in Dart. Updated related "equality" functional tests to also test
hashCode.

Resolves: #202
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>