### PR TITLE
Add support for Markdown escaped characters in IDL doc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Added referential integrity for classes and interfaces in generated platform code. Meaning, when
     the same C++ object is passed twice to platform (Java/Swift/Dart) side, it is now guaranteed to
     be the same object on platform side as well.
+### Bug fixes:
+  * Fixed handling of `\` backslash in IDL doc comments to support Markdown escaped characters.
 
 ## 6.6.4
 Release date: 2020-05-06

--- a/gluecodium/src/test/resources/smoke/comments/input/PlatformComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/PlatformComments.lime
@@ -34,7 +34,7 @@ class PlatformComments {
     fun doMagic()
 
     // This is some very useful method that measures the usefulness of its input or \\esc\@pe\{s\}.
-    // @param[input] Very useful {@Cpp input [PlatformComments] }parameter that \\esc\@pe\{s\}
+    // @param[input] Very useful {@Cpp input [PlatformComments] }parameter that \[\\esc\@pe\{s\}\]
     // @return {@Cpp Usefulness}{@Java Uselessness [SomeEnum]}{@Swift Usefulness}{@Dart Uselessness [SomeEnum]} of the input
     // @throws Sometimes it happens{@Swift  but not on iOS [SomethingWrong] \\esc\@pe\{s\} }.
     fun someMethodWithAllComments(input: String): Boolean throws SomethingWrong

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/PlatformComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/PlatformComments.java
@@ -56,7 +56,7 @@ public final class PlatformComments extends NativeBase {
     public native void doMagic();
     /**
      * <p>This is some very useful method that measures the usefulness of its input or \esc@pe{s}.</p>
-     * @param input <p>Very useful parameter that \esc@pe{s}</p>
+     * @param input <p>Very useful parameter that [\esc@pe{s}]</p>
      * @return <p>Uselessness {@link com.example.smoke.PlatformComments.SomeEnum} of the input</p>
      * @throws PlatformComments.SomethingWrongException <p>Sometimes it happens.</p>
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/PlatformComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/PlatformComments.h
@@ -40,7 +40,7 @@ public:
     virtual void do_magic(  ) = 0;
     /**
      * This is some very useful method that measures the usefulness of its input or \esc@pe{s}.
-     * \param[in] input Very useful input ::smoke::PlatformComments parameter that \esc@pe{s}
+     * \param[in] input Very useful input ::smoke::PlatformComments parameter that \[\esc@pe{s}\]
      * \return Usefulness of the input
      * \retval ::smoke::PlatformComments::SomeEnum Sometimes it happens.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/PlatformComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/PlatformComments.dart
@@ -11,7 +11,7 @@ abstract class PlatformComments {
   /// Colors everything in fuchsia.
   doMagic();
   /// This is some very useful method that measures the usefulness of its input or \esc@pe{s}.
-  /// @param[input] Very useful parameter that \esc@pe{s}
+  /// @param[input] Very useful parameter that \[\esc@pe{s}\]
   /// @return Uselessness [PlatformComments_SomeEnum] of the input
   /// @throws Sometimes it happens.
   bool someMethodWithAllComments(String input);

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/PlatformComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/PlatformComments.lime
@@ -16,7 +16,7 @@ class PlatformComments {
     // {@Cpp Cooks very special C++ sauce.}{@Java Makes some coffee.}{@Swift Eats a hip bruschetta.}{@Dart Colors everything in fuchsia.}
     fun doMagic()
     // This is some very useful method that measures the usefulness of its input or \\esc\@pe\{s\}.
-    // @param[input] Very useful {@Cpp input [PlatformComments] }parameter that \\esc\@pe\{s\}
+    // @param[input] Very useful {@Cpp input [PlatformComments] }parameter that \\[\\esc\@pe\{s\}\\]
     // @return {@Cpp Usefulness}{@Java Uselessness [SomeEnum]}{@Swift Usefulness}{@Dart Uselessness [SomeEnum]} of the input
     // @throws Sometimes it happens{@Swift  but not on iOS [SomethingWrong] \\esc\@pe\{s\} }.
     fun someMethodWithAllComments(

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
@@ -38,7 +38,7 @@ public class PlatformComments {
         return moveFromCType(smoke_PlatformComments_doMagic(self.c_instance))
     }
     /// This is some very useful method that measures the usefulness of its input or \esc@pe{s}.
-    /// - Parameter input: Very useful parameter that \esc@pe{s}
+    /// - Parameter input: Very useful parameter that \[\esc@pe{s}\]
     /// - Returns: Usefulness of the input
     /// - Throws: `PlatformComments.SomethingWrongError` Sometimes it happens but not on iOS `PlatformComments.SomethingWrongError` \esc@pe{s} .
     public func someMethodWithAllComments(input: String) throws -> Bool {

--- a/lime-loader/src/main/antlr/LimedocLexer.g4
+++ b/lime-loader/src/main/antlr/LimedocLexer.g4
@@ -50,6 +50,7 @@ LCurl : '{' ;
 RCurl : '}' ;
 
 EscapedChar: '\\' ('@' | '{' | '}' | '\\') ;
+MarkdownEscapedChar: '\\' ('`' | '*' | '_' | '[' | ']' | '(' | ')' | '#' | '+' | '-' | '.' | '!') ;
 
 fragment Letter
     : [a-zA-Z]

--- a/lime-loader/src/main/antlr/LimedocParser.g4
+++ b/lime-loader/src/main/antlr/LimedocParser.g4
@@ -84,5 +84,5 @@ inlineTagContent
     ;
 
 textContent
-    : TextContent | Name | Identifier | EscapedChar | '[' | ']'
+    : TextContent | Name | Identifier | EscapedChar | MarkdownEscapedChar | '[' | ']'
     ;


### PR DESCRIPTION
Resolves: #327
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>