### PR TITLE
Fix Dart crash on isolate shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug fixes:
   * Fixed static initialization issue for Swift modularized builds.
   * Fixed handling of `\` backslash in IDL doc comments to support Markdown escaped characters.
+  * Fixed Dart crash on isolate shutdown.
 
 ## 6.6.4
 Release date: 2020-05-06

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
@@ -33,8 +33,10 @@ public:
         }}{{#if setter}}, p{{iter.position}}s(p{{iter.position}}s){{/if}}{{#if iter.hasNext}}, {{/if}}{{/each}}{{/if}} { }
 
     ~{{resolveName}}_Proxy() {
-        {{>ffi/FfiInternal}}::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        {{>ffi/FfiInternal}}::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
 

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/ffi/ffi_smoke_EquatableInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/ffi/ffi_smoke_EquatableInterface.cpp
@@ -11,8 +11,10 @@ public:
     smoke_EquatableInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter)
         : token(token), isolate_id(isolate_id), deleter(deleter) { }
     ~smoke_EquatableInterface_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
 private:

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
@@ -15,8 +15,10 @@ public:
     smoke_ErrorsInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0), f1(f1), f2(f2), f3(f3), f4(f4) { }
     ~smoke_ErrorsInterface_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     std::error_code

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
@@ -13,8 +13,10 @@ public:
     smoke_SimpleInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0), f1(f1) { }
     ~smoke_SimpleInterface_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     std::string

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
@@ -20,8 +20,10 @@ public:
     smoke_Lambdas_Producer_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_Producer_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     std::string
@@ -51,8 +53,10 @@ public:
     smoke_Lambdas_Confuser_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_Confuser_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     ::smoke::Lambdas::Producer
@@ -83,8 +87,10 @@ public:
     smoke_Lambdas_Consumer_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_Consumer_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     void
@@ -110,8 +116,10 @@ public:
     smoke_Lambdas_Indexer_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_Indexer_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     int32_t
@@ -143,8 +151,10 @@ public:
     smoke_Lambdas_NullableConfuser_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_NullableConfuser_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     gluecodium::optional<::smoke::Lambdas::Producer>

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
@@ -13,8 +13,10 @@ public:
     smoke_StandaloneProducer_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_StandaloneProducer_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     std::string

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
@@ -15,8 +15,10 @@ public:
     smoke_CalculatorListener_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4, FfiOpaqueHandle f5)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0), f1(f1), f2(f2), f3(f3), f4(f4), f5(f5) { }
     ~smoke_CalculatorListener_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     void

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
@@ -17,8 +17,10 @@ public:
     smoke_ListenerWithProperties_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s, FfiOpaqueHandle p1g, FfiOpaqueHandle p1s, FfiOpaqueHandle p2g, FfiOpaqueHandle p2s, FfiOpaqueHandle p3g, FfiOpaqueHandle p3s, FfiOpaqueHandle p4g, FfiOpaqueHandle p4s, FfiOpaqueHandle p5g, FfiOpaqueHandle p5s, FfiOpaqueHandle p6g, FfiOpaqueHandle p6s)
         : token(token), isolate_id(isolate_id), deleter(deleter), p0g(p0g), p0s(p0s), p1g(p1g), p1s(p1s), p2g(p2g), p2s(p2s), p3g(p3g), p3s(p3s), p4g(p4g), p4s(p4s), p5g(p5g), p5s(p5s), p6g(p6g), p6s(p6s) { }
     ~smoke_ListenerWithProperties_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     std::string

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
@@ -16,8 +16,10 @@ public:
     smoke_ListenersWithReturnValues_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4, FfiOpaqueHandle f5, FfiOpaqueHandle f6)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0), f1(f1), f2(f2), f3(f3), f4(f4), f5(f5), f6(f6) { }
     ~smoke_ListenersWithReturnValues_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     double

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
@@ -13,8 +13,10 @@ public:
     smoke_OuterClass_InnerInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_OuterClass_InnerInterface_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     std::string

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
@@ -13,8 +13,10 @@ public:
     smoke_OuterInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_OuterInterface_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     std::string
@@ -45,8 +47,10 @@ public:
     smoke_OuterInterface_InnerInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_OuterInterface_InnerInterface_Proxy() {
-        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this]() {
-            (*reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter))(token, this);
+        auto token_local = token;
+        auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
+        gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
+            (*deleter_local)(token_local, this);
         });
     }
     std::string


### PR DESCRIPTION
Updated Dart templates to capture proxy object fields when scheduling a
deletion callback in the callback queue. This avoids the crash when the
deletion callback being executed during isolate shutdown accesses fields
of an already-deleted proxy object.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>