### PR TITLE
Add functional tests for @Cpp(Const) methods

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -403,6 +403,12 @@ feature(Extensions swift SOURCES
     lime/test/Extensions.lime
 )
 
+feature(CppConst cpp android swift dart SOURCES
+    lime/test/CppConstMethods.lime
+
+    src/test/CppConstMethods.cpp
+)
+
 if(APPLE)
     # This feature is intended for Swift only. It also does not compile outside of Apple platforms.
     feature(ObjcInterface swift SOURCES

--- a/examples/libhello/lime/test/CppConstMethods.lime
+++ b/examples/libhello/lime/test/CppConstMethods.lime
@@ -1,0 +1,34 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+class CppConstClass {
+    constructor create()
+    @Cpp(Const)
+    fun getFoo(): String
+}
+
+interface CppConstInterface {
+    @Cpp(Const)
+    fun getFoo(): String
+}
+
+class CppConstInterfaceFactory {
+    static fun createCppConstInterface(): CppConstInterface
+    static fun callGetFoo(callback: CppConstInterface): String
+}

--- a/examples/libhello/src/test/CppConstMethods.cpp
+++ b/examples/libhello/src/test/CppConstMethods.cpp
@@ -1,0 +1,55 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/CppConstClass.h"
+#include "test/CppConstInterface.h"
+#include "test/CppConstInterfaceFactory.h"
+
+namespace test
+{
+namespace
+{
+class CppConstClassImpl : public CppConstClass {
+public:
+    std::string get_foo() const { return "foo"; }
+};
+
+class CppConstInterfaceImpl : public CppConstInterface {
+public:
+    std::string get_foo() const { return "foo"; }
+};
+}
+
+std::shared_ptr<CppConstClass>
+CppConstClass::create() {
+    return std::make_shared<CppConstClassImpl>();
+}
+
+std::shared_ptr<CppConstInterface>
+CppConstInterfaceFactory::create_cpp_const_interface() {
+    return std::make_shared<CppConstInterfaceImpl>();
+}
+
+std::string
+CppConstInterfaceFactory::call_get_foo(const std::shared_ptr<CppConstInterface>& callback) {
+    return callback->get_foo();
+}
+
+}

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/CppConstMethodsTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/CppConstMethodsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2016-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+import static junit.framework.Assert.assertEquals;
+
+import android.os.Build;
+import com.example.here.hello.BuildConfig;
+import com.here.android.RobolectricApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(
+    sdk = Build.VERSION_CODES.M,
+    application = RobolectricApplication.class,
+    constants = BuildConfig.class)
+public final class CppConstMethodsTest {
+
+  static class CppConstCallback implements CppConstInterface {
+    @Override
+    public String getFoo() {
+      return "FOO";
+    }
+  }
+
+  @Test
+  public void callCppConstMethodOnClass() {
+    String result = new CppConstClass().getFoo();
+
+    assertEquals("foo", result);
+  }
+
+  @Test
+  public void callCppConstMethodOnInterface() {
+    String result = CppConstInterfaceFactory.createCppConstInterface().getFoo();
+
+    assertEquals("foo", result);
+  }
+
+  @Test
+  public void callCppConstMethodOnInterfaceInCpp() {
+    String result = CppConstInterfaceFactory.callGetFoo(new CppConstCallback());
+
+    assertEquals("FOO", result);
+  }
+}

--- a/examples/platforms/dart/main.dart
+++ b/examples/platforms/dart/main.dart
@@ -22,6 +22,7 @@ import "test/Blobs_test.dart" as BlobsTests;
 import "test/CallbacksMultithreaded_test.dart" as CallbacksMultithreadedTests;
 import "test/Classes_test.dart" as ClassesTests;
 import "test/Constants_test.dart" as ConstantsTests;
+import "test/CppConstMethods_test.dart" as CppConstMethodsTests;
 import "test/Dates_test.dart" as DatesTests;
 import "test/Defaults_test.dart" as DefaultsTests;
 import "test/EquatableClasses_test.dart" as EquatableClassesTests;
@@ -59,6 +60,7 @@ final _allTests = [
   CallbacksMultithreadedTests.main,
   ClassesTests.main,
   ConstantsTests.main,
+  CppConstMethodsTests.main,
   DatesTests.main,
   DefaultsTests.main,
   EquatableClassesTests.main,

--- a/examples/platforms/dart/test/CppConstMethods_test.dart
+++ b/examples/platforms/dart/test/CppConstMethods_test.dart
@@ -1,0 +1,54 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:hello/test.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("CppConstMethods");
+
+class CppConstCallback extends CppConstInterface {
+  @override
+  String getFoo() => "FOO";
+}
+
+void main() {
+  _testSuite.test("Cpp const method on class", () {
+    final instance = CppConstClass();
+    final result = instance.getFoo();
+
+    expect(result, "foo");
+
+    instance.release();
+  });
+  _testSuite.test("Cpp const method on interface", () {
+    final instance = CppConstInterfaceFactory.createCppConstInterface();
+    final result = instance.getFoo();
+
+    expect(result, "foo");
+
+    instance.release();
+  });
+  _testSuite.test("Cpp const method on interface in Cpp", () {
+    final result = CppConstInterfaceFactory.callGetFoo(CppConstCallback());
+
+    expect(result, "FOO");
+  });
+}

--- a/examples/platforms/ios/Tests/main.swift
+++ b/examples/platforms/ios/Tests/main.swift
@@ -26,6 +26,7 @@ let allTests = [
     testCase(AttributesInterfaceTests.allTests),
     testCase(AttributesTests.allTests),
     testCase(ConstantsTests.allTests),
+    testCase(CppConstMethodsTests.allTests),
     testCase(DatesTests.allTests),
     testCase(DefaultsTests.allTests),
     testCase(EnumsTests.allTests),

--- a/examples/platforms/ios/Tests/testTests/CppConstMethodsTests.swift
+++ b/examples/platforms/ios/Tests/testTests/CppConstMethodsTests.swift
@@ -1,0 +1,53 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import hello
+
+class CppConstMethodsTests: XCTestCase {
+
+    class CppConstCallback: CppConstInterface {
+        public func getFoo() -> String { return "FOO" }
+    }
+
+    func testCppConstMethodOnClass() {
+        let result = CppConstClass().getFoo()
+
+        XCTAssertEqual("foo", result)
+    }
+
+    func testCppConstMethodOnInterface() {
+        let result = CppConstInterfaceFactory.createCppConstInterface().getFoo()
+
+        XCTAssertEqual("foo", result)
+    }
+
+    func testCppConstMethodOnInterfaceInCpp() {
+        let result = CppConstInterfaceFactory.callGetFoo(callback: CppConstCallback())
+
+        XCTAssertEqual("FOO", result)
+    }
+
+    static var allTests = [
+        ("testCppConstMethodOnClass", testCppConstMethodOnClass),
+        ("testCppConstMethodOnInterface", testCppConstMethodOnInterface),
+        ("testCppConstMethodOnInterfaceInCpp", testCppConstMethodOnInterfaceInCpp)
+    ]
+}


### PR DESCRIPTION
Added functional tests for the following use cases:
* Calling `@Cpp(Const)` method on a class
* Calling `@Cpp(Const)` method on an interface
* Calling `@Cpp(Const)` method on a platform-created interface in C++

Resolves: #134
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>