### PR TITLE
Improve documentation comments in generated Dart code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     be the same object on platform side as well.
   * Relaxed restrictions on `@Equatable` structs in IDL. Such structs now can contains fields of
     any class or interface types (not just those that are `@Equatable` themselves).
+  * Improved doc comments in generated Dart code to be more compliant with Dart documentation
+    guidelines.
 ### Bug fixes:
   * Fixed `hashCode` implementation for `@Equatable` structs with collection type fields in Dart.
 ### Deprecated:

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
@@ -20,11 +20,14 @@
   !}}
 {{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "/// "}}
 {{/unless}}{{/resolveName}}{{!!
-}}{{#parameters}}{{#set self=this}}{{#resolveName comment}}{{#unless this.isEmpty}}/// @param[{{resolveName self}}] {{prefix this "/// " skipFirstLine=true}}
+}}{{#parameters}}{{#set self=this}}{{#resolveName comment}}{{#unless this.isEmpty}}{{!!
+}}/// [{{resolveName self}}] {{prefix this "/// " skipFirstLine=true}}
 {{/unless}}{{/resolveName}}{{/set}}{{/parameters}}{{!!
-}}{{#resolveName returnType.comment}}{{#unless this.isEmpty}}/// @return {{prefix this "/// " skipFirstLine=true}}
+}}{{#resolveName returnType.comment}}{{#unless this.isEmpty}}{{!!
+}}/// Returns [{{resolveName returnType.typeRef}}]. {{prefix this "/// " skipFirstLine=true}}
 {{/unless}}{{/resolveName}}{{!!
-}}{{#if thrownType}}{{#resolveName thrownType.comment}}{{#unless this.isEmpty}}/// @throws {{prefix this "/// " skipFirstLine=true}}
+}}{{#if thrownType}}{{#resolveName thrownType.comment}}{{#unless this.isEmpty}}{{!!
+}}/// Throws [{{resolveName exception}}]. {{prefix this "/// " skipFirstLine=true}}
 {{/unless}}{{/resolveName}}{{/if}}{{!!
 }}{{#ifHasAttribute "Deprecated"}}
 @Deprecated("{{getAttribute "Deprecated"}}")

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/Comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/Comments.dart
@@ -10,34 +10,34 @@ abstract class Comments {
   /// This is some very useful constant.
   static final bool veryUseful = true;
   /// This is some very useful method that measures the usefulness of its input.
-  /// @param[inputParameter] Very useful input parameter
-  /// @return Usefulness of the input
-  /// @throws Sometimes it happens.
+  /// [inputParameter] Very useful input parameter
+  /// Returns [bool]. Usefulness of the input
+  /// Throws [Comments_SomethingWrongException]. Sometimes it happens.
   bool someMethodWithAllComments(String inputParameter);
   /// This is some very useful method that measures the usefulness of its input.
-  /// @param[input] Very useful input parameter
+  /// [input] Very useful input parameter
   bool someMethodWithInputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
-  /// @return Usefulness of the input
+  /// Returns [bool]. Usefulness of the input
   bool someMethodWithOutputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   bool someMethodWithNoComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
-  /// @param[input] Very useful input parameter
+  /// [input] Very useful input parameter
   someMethodWithoutReturnTypeWithAllComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
   someMethodWithoutReturnTypeWithNoComments(String input);
   /// This is some very useful method that measures the usefulness of something.
-  /// @return Usefulness of the input
+  /// Returns [bool]. Usefulness of the input
   bool someMethodWithoutInputParametersWithAllComments();
   /// This is some very useful method that measures the usefulness of something.
   bool someMethodWithoutInputParametersWithNoComments();
   someMethodWithNothing();
   /// This is some very useful method that does nothing.
   someMethodWithoutReturnTypeOrInputParameters();
-  /// @param[documented] nicely documented
+  /// [documented] nicely documented
   String oneParameterCommentOnly(String undocumented, String documented);
-  /// @return nicely documented
+  /// Returns [String]. nicely documented
   String returnCommentOnly(String undocumented);
   /// Gets some very useful property.
   bool get isSomeProperty;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsInterface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsInterface.dart
@@ -39,24 +39,24 @@ abstract class CommentsInterface {
   /// This is some very useful constant.
   static final bool veryUseful = true;
   /// This is some very useful method that measures the usefulness of its input.
-  /// @param[input] Very useful input parameter
-  /// @return Usefulness of the input
+  /// [input] Very useful input parameter
+  /// Returns [bool]. Usefulness of the input
   bool someMethodWithAllComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
-  /// @param[input] Very useful input parameter
+  /// [input] Very useful input parameter
   bool someMethodWithInputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
-  /// @return Usefulness of the input
+  /// Returns [bool]. Usefulness of the input
   bool someMethodWithOutputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   bool someMethodWithNoComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
-  /// @param[input] Very useful input parameter
+  /// [input] Very useful input parameter
   someMethodWithoutReturnTypeWithAllComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
   someMethodWithoutReturnTypeWithNoComments(String input);
   /// This is some very useful method that measures the usefulness of something.
-  /// @return Usefulness of the input
+  /// Returns [bool]. Usefulness of the input
   bool someMethodWithoutInputParametersWithAllComments();
   /// This is some very useful method that measures the usefulness of something.
   bool someMethodWithoutInputParametersWithNoComments();

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/CommentsLinks.dart
@@ -44,9 +44,9 @@ abstract class CommentsLinks {
   ///
   /// Not working for Swift:
   /// * named comment: [][Comments.veryUseful]
-  /// @param[inputParameter] Sometimes takes [Comments_SomeEnum.useful]
-  /// @return Sometimes returns [Comments_SomeEnum.useful]
-  /// @throws May or may not throw [Comments_SomethingWrongException]
+  /// [inputParameter] Sometimes takes [Comments_SomeEnum.useful]
+  /// Returns [Comments_SomeEnum]. Sometimes returns [Comments_SomeEnum.useful]
+  /// Throws [Comments_SomethingWrongException]. May or may not throw [Comments_SomethingWrongException]
   Comments_SomeEnum randomMethod(Comments_SomeEnum inputParameter);
   /// Links to method overloads:
   /// * other one: [randomMethod]

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationComments.dart
@@ -23,8 +23,8 @@ abstract class DeprecationComments {
   @Deprecated("Unfortunately, this constant is deprecated. Use [comments.VeryUseful] instead.")
   static final bool veryUseful = true;
   /// This is some very useful method that measures the usefulness of its input.
-  /// @param[input] Very useful input parameter
-  /// @return Usefulness of the input
+  /// [input] Very useful input parameter
+  /// Returns [bool]. Usefulness of the input
   @Deprecated("Unfortunately, this method is deprecated.
   Use [comments.someMethodWithAllComments] instead.")
   bool someMethodWithAllComments(String input);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationCommentsOnly.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/DeprecationCommentsOnly.dart
@@ -20,8 +20,8 @@ abstract class DeprecationCommentsOnly {
   void release() {}
   @Deprecated("Unfortunately, this constant is deprecated.")
   static final bool veryUseful = true;
-  /// @param[input] Very useful input parameter
-  /// @return Usefulness of the input
+  /// [input] Very useful input parameter
+  /// Returns [bool]. Usefulness of the input
   @Deprecated("Unfortunately, this method is deprecated.")
   bool someMethodWithAllComments(String input);
   @Deprecated("Unfortunately, this property's getter is deprecated.")

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/MultiLineComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/MultiLineComments.dart
@@ -5,6 +5,7 @@ import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
+///
 /// There is a lot to say about this interface.
 /// at least it has multiline comments.
 ///
@@ -20,15 +21,16 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class MultiLineComments {
   void release();
   /// This is very important method.
+  ///
   /// It has very important parameters.
   /// It has side effects.
-  /// @param[input] Very useful input parameter.
+  /// [input] Very useful input parameter.
   /// You must not confuse it with the second parameter.
   /// But they are similar.
-  /// @param[ratio] Not as useful as the first parameter.
+  /// [ratio] Not as useful as the first parameter.
   /// But still useful.
   /// use a positive value for more happiness.
-  /// @return If you provide a useful input,
+  /// Returns [double]. If you provide a useful input,
   /// and a useful ratio you can expect a useful output.
   /// Just kidding do not expect anything from a method until
   /// you see its body.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/PlatformComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/PlatformComments.dart
@@ -11,9 +11,9 @@ abstract class PlatformComments {
   /// Colors everything in fuchsia.
   doMagic();
   /// This is some very useful method that measures the usefulness of its input or \esc@pe{s}.
-  /// @param[input] Very useful parameter that \[\esc@pe{s}\]
-  /// @return Uselessness [PlatformComments_SomeEnum] of the input
-  /// @throws Sometimes it happens.
+  /// [input] Very useful parameter that \[\esc@pe{s}\]
+  /// Returns [bool]. Uselessness [PlatformComments_SomeEnum] of the input
+  /// Throws [PlatformComments_SomethingWrongException]. Sometimes it happens.
   bool someMethodWithAllComments(String input);
 }
 enum PlatformComments_SomeEnum {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/UnicodeComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/UnicodeComments.dart
@@ -8,9 +8,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class UnicodeComments {
   void release();
   /// Süßölgefäß
-  /// @param[input] שלום
-  /// @return товарищ
-  /// @throws ネコ
+  /// [input] שלום
+  /// Returns [bool]. товарищ
+  /// Throws [Comments_SomethingWrongException]. ネコ
   bool someMethodWithAllComments(String input);
 }
 // UnicodeComments "private" section, not exported.

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -626,10 +626,14 @@ internal class AntlrLimeModelBuilder(
         val commentFromParent = structuredCommentsStack.peek().getTagBlock(commentTag, elementName)
         val ownComment =
             commentContexts?.let { parseStructuredComment(it, currentContext).description }
-                ?: LimeComment()
+                ?: LimeComment(currentPath)
         return when {
             commentFromParent.isEmpty() -> ownComment
-            ownComment.isEmpty() -> commentFromParent
+            ownComment.isEmpty() -> {
+                val elementPath =
+                    if (elementName.isNotEmpty()) currentPath else currentPath.child(commentTag)
+                commentFromParent.withPath(elementPath)
+            }
             else -> {
                 val position = currentContext.getStart()
                 throw ParseCancellationException(

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimedocBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimedocBuilder.kt
@@ -31,7 +31,7 @@ internal class AntlrLimedocBuilder(private val currentPath: LimePath) : LimedocP
 
     val result
         get() = LimeStructuredComment(
-            commentsCollector[Pair("", "")] ?: LimeComment(),
+            commentsCollector[Pair("", "")] ?: LimeComment(currentPath),
             commentsCollector
         )
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeComment.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeComment.kt
@@ -41,6 +41,8 @@ class LimeComment(
             .joinToString("") { it.second }
             .trim()
 
+    fun withPath(newPath: LimePath) = LimeComment(newPath, taggedSections)
+
     override fun toString() = taggedSections.joinToString("") {
         when (it.first) {
             "" -> escapeText(it.second)


### PR DESCRIPTION
Updated LIME loader to correctly fill in path information for all
LimeComment comments.

Updated DartNameResolver to put the first sentence of a doc comment into
a separate paragraph, but only if it's a comment to a type or to a
function. This makes it more compliant with Dart documentation
guidelines.

Updated Dart template for function doc comment to look less like JavaDoc
and more like plain text. This makes it more compliant with Dart
documentation guidelines.

Resolves: #339
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>