### PR TITLE
Remove extra blank line after Dart doc comments

### DIFF
--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -182,13 +182,13 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 
 }}{{+dartPropertyRedirect}}
 {{#getter}}
-{{>dart/DartDocumentation}}
-{{#if isStatic}}static {{/if}}{{resolveName property.typeRef}} get {{resolveName visibility}}{{resolveName property}}{{!!
+{{>dart/DartDocumentation}}{{!!
+}}{{#if isStatic}}static {{/if}}{{resolveName property.typeRef}} get {{resolveName visibility}}{{resolveName property}}{{!!
 }}{{#if isStatic}} => {{resolveName parent}}$Impl.{{resolveName property}}{{/if}};
 {{/getter}}
 {{#setter}}
-{{>dart/DartDocumentation}}
-{{#if isStatic}}static {{/if}}set {{resolveName visibility}}{{resolveName property}}({{resolveName property.typeRef}} value){{!!
+{{>dart/DartDocumentation}}{{!!
+}}{{#if isStatic}}static {{/if}}set {{resolveName visibility}}{{resolveName property}}({{resolveName property.typeRef}} value){{!!
 }}{{#if isStatic}} { {{resolveName parent}}$Impl.{{resolveName property}} = value; }{{/if}}{{#unless isStatic}};{{/unless}}
 {{/setter}}
 {{/dartPropertyRedirect}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
@@ -18,17 +18,13 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "/// "}}
-{{/unless}}{{/resolveName}}{{!!
-}}{{#parameters}}{{#set self=this}}{{#resolveName comment}}{{#unless this.isEmpty}}{{!!
-}}/// [{{resolveName self}}] {{prefix this "/// " skipFirstLine=true}}
-{{/unless}}{{/resolveName}}{{/set}}{{/parameters}}{{!!
-}}{{#resolveName returnType.comment}}{{#unless this.isEmpty}}{{!!
-}}/// Returns [{{resolveName returnType.typeRef}}]. {{prefix this "/// " skipFirstLine=true}}
-{{/unless}}{{/resolveName}}{{!!
-}}{{#if thrownType}}{{#resolveName thrownType.comment}}{{#unless this.isEmpty}}{{!!
-}}/// Throws [{{resolveName exception}}]. {{prefix this "/// " skipFirstLine=true}}
-{{/unless}}{{/resolveName}}{{/if}}{{!!
+{{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "/// "}}{{/unless}}{{/resolveName}}{{!!
+}}{{#parameters}}{{#set self=this}}{{#resolveName comment}}{{#unless this.isEmpty}}
+/// [{{resolveName self}}] {{prefix this "/// " skipFirstLine=true}}{{/unless}}{{/resolveName}}{{/set}}{{/parameters}}{{!!
+}}{{#resolveName returnType.comment}}{{#unless this.isEmpty}}
+/// Returns [{{resolveName returnType.typeRef}}]. {{prefix this "/// " skipFirstLine=true}}{{/unless}}{{/resolveName}}{{!!
+}}{{#if thrownType}}{{#resolveName thrownType.comment}}{{#unless this.isEmpty}}
+/// Throws [{{resolveName exception}}]. {{prefix this "/// " skipFirstLine=true}}{{/unless}}{{/resolveName}}{{/if}}{{!!
 }}{{#ifHasAttribute "Deprecated"}}
 @Deprecated("{{getAttribute "Deprecated"}}")
 {{/ifHasAttribute}}


### PR DESCRIPTION
Updated Dart templates to remove an extraneous blank line after doc
comments for functions and properties.

Smoke test files were not updated as smoke test comparison ignores blank
lines.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>