### PR TITLE
Use const fields in Dart FFI

### DIFF
--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
@@ -43,11 +43,11 @@ class CallbackQueue
 private:
     struct Entry
     {
-        std::function<void()> func;
+        const std::function<void()> func;
         std::promise<bool> done;
     };
 
-    std::mutex m_mutex;
+    mutable std::mutex m_mutex;
     std::queue<Entry> m_queue;
 
     bool m_is_closed = false;
@@ -86,12 +86,12 @@ public:
 class CallbackQueueManager
 {
 private:
-    std::mutex m_mutex;
+    mutable std::mutex m_mutex;
     int32_t m_next_id = 0;
     std::unordered_map<int, std::shared_ptr<CallbackQueue>> m_queues;
 
 public:
-    std::shared_ptr<CallbackQueue> getQueue(int id);
+    std::shared_ptr<CallbackQueue> getQueue(int id) const;
 
     /**
      * Create CallbackQeue with given id.

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueImpl.mustache
@@ -138,7 +138,7 @@ CallbackQueueManager::closeAllQueues()
 }
 
 std::shared_ptr<CallbackQueue>
-CallbackQueueManager::getQueue(int id)
+CallbackQueueManager::getQueue(int id) const
 {
     std::unique_lock<std::mutex> lock(m_mutex);
 

--- a/gluecodium/src/main/resources/templates/ffi/FfiIsolateContextHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiIsolateContextHeader.mustache
@@ -33,7 +33,7 @@ namespace ffi
 class IsolateContext
 {
 private:
-    int32_t m_previous_id;
+    const int32_t m_previous_id;
     static thread_local int32_t m_current_id;
 
 public:

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
@@ -93,15 +93,15 @@ public:
 {{/each}}
 
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
 {{#each inheritedFunctions functions}}
-    FfiOpaqueHandle f{{iter.position}};
+    const FfiOpaqueHandle f{{iter.position}};
 {{/each}}
 {{#each inheritedProperties properties}}
-    FfiOpaqueHandle p{{iter.position}}g;{{#if setter}}
-    FfiOpaqueHandle p{{iter.position}}s;
+    const FfiOpaqueHandle p{{iter.position}}g;{{#if setter}}
+    const FfiOpaqueHandle p{{iter.position}}s;
 {{/if}}
 {{/each}}
 

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/ffi/ffi_smoke_EquatableInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/ffi/ffi_smoke_EquatableInterface.cpp
@@ -18,9 +18,9 @@ public:
         });
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
@@ -87,14 +87,14 @@ public:
         }
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
-    FfiOpaqueHandle f1;
-    FfiOpaqueHandle f2;
-    FfiOpaqueHandle f3;
-    FfiOpaqueHandle f4;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
+    const FfiOpaqueHandle f1;
+    const FfiOpaqueHandle f2;
+    const FfiOpaqueHandle f3;
+    const FfiOpaqueHandle f4;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
@@ -41,11 +41,11 @@ public:
         return _result;
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
-    FfiOpaqueHandle f1;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
+    const FfiOpaqueHandle f1;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
@@ -37,10 +37,10 @@ public:
         return _result;
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -71,10 +71,10 @@ public:
         return _result;
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -100,10 +100,10 @@ public:
         ); });
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -135,10 +135,10 @@ public:
         return _result;
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -169,10 +169,10 @@ public:
         return _result;
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
@@ -30,10 +30,10 @@ public:
         return _result;
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
@@ -58,15 +58,15 @@ public:
         ); });
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
-    FfiOpaqueHandle f1;
-    FfiOpaqueHandle f2;
-    FfiOpaqueHandle f3;
-    FfiOpaqueHandle f4;
-    FfiOpaqueHandle f5;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
+    const FfiOpaqueHandle f1;
+    const FfiOpaqueHandle f2;
+    const FfiOpaqueHandle f3;
+    const FfiOpaqueHandle f4;
+    const FfiOpaqueHandle f5;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
@@ -122,23 +122,23 @@ public:
         ); });
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle p0g;
-    FfiOpaqueHandle p0s;
-    FfiOpaqueHandle p1g;
-    FfiOpaqueHandle p1s;
-    FfiOpaqueHandle p2g;
-    FfiOpaqueHandle p2s;
-    FfiOpaqueHandle p3g;
-    FfiOpaqueHandle p3s;
-    FfiOpaqueHandle p4g;
-    FfiOpaqueHandle p4s;
-    FfiOpaqueHandle p5g;
-    FfiOpaqueHandle p5s;
-    FfiOpaqueHandle p6g;
-    FfiOpaqueHandle p6s;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle p0g;
+    const FfiOpaqueHandle p0s;
+    const FfiOpaqueHandle p1g;
+    const FfiOpaqueHandle p1s;
+    const FfiOpaqueHandle p2g;
+    const FfiOpaqueHandle p2s;
+    const FfiOpaqueHandle p3g;
+    const FfiOpaqueHandle p3s;
+    const FfiOpaqueHandle p4g;
+    const FfiOpaqueHandle p4s;
+    const FfiOpaqueHandle p5g;
+    const FfiOpaqueHandle p5s;
+    const FfiOpaqueHandle p6g;
+    const FfiOpaqueHandle p6s;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
@@ -93,16 +93,16 @@ public:
         return _result;
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
-    FfiOpaqueHandle f1;
-    FfiOpaqueHandle f2;
-    FfiOpaqueHandle f3;
-    FfiOpaqueHandle f4;
-    FfiOpaqueHandle f5;
-    FfiOpaqueHandle f6;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
+    const FfiOpaqueHandle f1;
+    const FfiOpaqueHandle f2;
+    const FfiOpaqueHandle f3;
+    const FfiOpaqueHandle f4;
+    const FfiOpaqueHandle f5;
+    const FfiOpaqueHandle f6;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
@@ -31,10 +31,10 @@ public:
         return _result;
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
@@ -31,10 +31,10 @@ public:
         return _result;
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -65,10 +65,10 @@ public:
         return _result;
     }
 private:
-    uint64_t token;
-    int32_t isolate_id;
-    FfiOpaqueHandle deleter;
-    FfiOpaqueHandle f0;
+    const uint64_t token;
+    const int32_t isolate_id;
+    const FfiOpaqueHandle deleter;
+    const FfiOpaqueHandle f0;
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)


### PR DESCRIPTION
Updated several Dart FFI templates to use "const" or "mutable" modifier
on C++ struct fields. This allows marking some methods with a "const"
modifier as well, optimizing compilation and runtime.

Resolves: #233
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>