### PR TITLE
Make proxy classes non-copyable

### DIFF
--- a/gluecodium/src/main/resources/templates/cbridge/CppProxy.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CppProxy.mustache
@@ -29,6 +29,9 @@ public:
         mFunctions.release(mFunctions.swift_pointer);
     }
 
+    {{name}}Proxy(const {{name}}Proxy&) = delete;
+    {{name}}Proxy& operator=(const {{name}}Proxy&) = delete;
+
     {{#each inheritedFunctions functions}}
     {{#if selfParameter}}
     {{cppReturnTypeName}} {{functionName}}({{joinPartial parameters "baseApiParameter" ", "}}){{!!

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
@@ -40,6 +40,9 @@ public:
         });
     }
 
+    {{resolveName}}_Proxy(const {{resolveName}}_Proxy&) = delete;
+    {{resolveName}}_Proxy& operator=(const {{resolveName}}_Proxy&) = delete;
+
 {{#each inheritedFunctions functions}}
     {{resolveName "C++ return type"}}
     {{resolveName "C++"}}({{#parameters}}const {{resolveName typeRef "C++ parameter"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!

--- a/gluecodium/src/main/resources/templates/jni/CppProxyHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/CppProxyHeader.mustache
@@ -38,6 +38,8 @@ namespace jni
 class {{mangledName}}_CppProxy : public CppProxyBase{{#unless isFunctionalInterface}}, public {{cppFullyQualifiedName}}{{/unless}} {
 public:
     {{mangledName}}_CppProxy( JNIEnv* _jenv, JniReference<jobject> globalRef, jint _jHashCode );
+    {{mangledName}}_CppProxy( const {{mangledName}}_CppProxy& ) = delete;
+    {{mangledName}}_CppProxy& operator=( const {{mangledName}}_CppProxy& ) = delete;
 
 {{#parentMethods}}
     {{returnType.cppName}} {{cppMethodName}}( {{joinPartial parameters "jni/CppProxyMethodParameter" ", "}} ){{#if isConst}} const{{/if}} override;

--- a/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableInterface.cpp
@@ -61,6 +61,8 @@ public:
     virtual ~smoke_EquatableInterfaceProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_EquatableInterfaceProxy(const smoke_EquatableInterfaceProxy&) = delete;
+    smoke_EquatableInterfaceProxy& operator=(const smoke_EquatableInterfaceProxy&) = delete;
 private:
     smoke_EquatableInterface_FunctionTable mFunctions;
 };

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/ffi/ffi_smoke_EquatableInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/ffi/ffi_smoke_EquatableInterface.cpp
@@ -17,6 +17,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_EquatableInterface_Proxy(const smoke_EquatableInterface_Proxy&) = delete;
+    smoke_EquatableInterface_Proxy& operator=(const smoke_EquatableInterface_Proxy&) = delete;
 private:
     const uint64_t token;
     const int32_t isolate_id;

--- a/gluecodium/src/test/resources/smoke/errors/output/android/jni/com_example_smoke_ErrorsInterfaceImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/errors/output/android/jni/com_example_smoke_ErrorsInterfaceImplCppProxy.h
@@ -12,6 +12,8 @@ namespace jni
 class com_example_smoke_ErrorsInterfaceImpl_CppProxy : public CppProxyBase, public ::smoke::ErrorsInterface {
 public:
     com_example_smoke_ErrorsInterfaceImpl_CppProxy( JNIEnv* _jenv, JniReference<jobject> globalRef, jint _jHashCode );
+    com_example_smoke_ErrorsInterfaceImpl_CppProxy( const com_example_smoke_ErrorsInterfaceImpl_CppProxy& ) = delete;
+    com_example_smoke_ErrorsInterfaceImpl_CppProxy& operator=( const com_example_smoke_ErrorsInterfaceImpl_CppProxy& ) = delete;
     ::std::error_code method_with_errors(  ) override;
     ::std::error_code method_with_external_errors(  ) override;
     ::gluecodium::Return< ::std::string, ::std::error_code > method_with_errors_and_return_value(  ) override;

--- a/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_ErrorsInterface.cpp
@@ -89,6 +89,8 @@ public:
     virtual ~smoke_ErrorsInterfaceProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_ErrorsInterfaceProxy(const smoke_ErrorsInterfaceProxy&) = delete;
+    smoke_ErrorsInterfaceProxy& operator=(const smoke_ErrorsInterfaceProxy&) = delete;
     ::std::error_code method_with_errors() override {
         auto _result_with_error = mFunctions.smoke_ErrorsInterface_methodWithErrors(mFunctions.swift_pointer);
         if (!_result_with_error.has_value)

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
@@ -21,6 +21,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_ErrorsInterface_Proxy(const smoke_ErrorsInterface_Proxy&) = delete;
+    smoke_ErrorsInterface_Proxy& operator=(const smoke_ErrorsInterface_Proxy&) = delete;
     std::error_code
     method_with_errors() override {
         uint32_t _error_handle;

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildInterfaceImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildInterfaceImplCppProxy.h
@@ -12,6 +12,8 @@ namespace jni
 class com_example_smoke_ChildInterfaceImpl_CppProxy : public CppProxyBase, public ::smoke::ChildInterface {
 public:
     com_example_smoke_ChildInterfaceImpl_CppProxy( JNIEnv* _jenv, JniReference<jobject> globalRef, jint _jHashCode );
+    com_example_smoke_ChildInterfaceImpl_CppProxy( const com_example_smoke_ChildInterfaceImpl_CppProxy& ) = delete;
+    com_example_smoke_ChildInterfaceImpl_CppProxy& operator=( const com_example_smoke_ChildInterfaceImpl_CppProxy& ) = delete;
     void root_method(  ) override;
     ::std::string get_root_property(  ) const override;
     void set_root_property( const ::std::string& nvalue ) override;

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildInterface.cpp
@@ -62,6 +62,8 @@ public:
     virtual ~smoke_ChildInterfaceProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_ChildInterfaceProxy(const smoke_ChildInterfaceProxy&) = delete;
+    smoke_ChildInterfaceProxy& operator=(const smoke_ChildInterfaceProxy&) = delete;
     void root_method() override {
         mFunctions.smoke_ParentInterface_rootMethod(mFunctions.swift_pointer);
     }

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_ExternalInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_ExternalInterface.cpp
@@ -93,6 +93,8 @@ public:
     virtual ~smoke_ExternalInterfaceProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_ExternalInterfaceProxy(const smoke_ExternalInterfaceProxy&) = delete;
+    smoke_ExternalInterfaceProxy& operator=(const smoke_ExternalInterfaceProxy&) = delete;
     void some_Method(int8_t someParameter) override {
         mFunctions.smoke_ExternalInterface_someMethod(mFunctions.swift_pointer, someParameter);
     }

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleInterface.cpp
@@ -62,6 +62,8 @@ public:
     virtual ~smoke_SimpleInterfaceProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_SimpleInterfaceProxy(const smoke_SimpleInterfaceProxy&) = delete;
+    smoke_SimpleInterfaceProxy& operator=(const smoke_SimpleInterfaceProxy&) = delete;
     ::std::string get_string_value() override {
         auto _call_result = mFunctions.smoke_SimpleInterface_getStringValue(mFunctions.swift_pointer);
         return Conversion<std::string>::toCppReturn(_call_result);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
@@ -19,6 +19,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_SimpleInterface_Proxy(const smoke_SimpleInterface_Proxy&) = delete;
+    smoke_SimpleInterface_Proxy& operator=(const smoke_SimpleInterface_Proxy&) = delete;
     std::string
     get_string_value() override {
         FfiOpaqueHandle _result_handle;

--- a/gluecodium/src/test/resources/smoke/lambdas/output/cbridge/src/smoke/cbridge_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/cbridge/src/smoke/cbridge_Lambdas.cpp
@@ -60,6 +60,8 @@ public:
     virtual ~smoke_Lambdas_ProducerProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_Lambdas_ProducerProxy(const smoke_Lambdas_ProducerProxy&) = delete;
+    smoke_Lambdas_ProducerProxy& operator=(const smoke_Lambdas_ProducerProxy&) = delete;
     ::std::string operator()() {
         auto _call_result = mFunctions.smoke_Lambdas_Producer_call(mFunctions.swift_pointer);
         return Conversion<std::string>::toCppReturn(_call_result);
@@ -98,6 +100,8 @@ public:
     virtual ~smoke_Lambdas_ConfuserProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_Lambdas_ConfuserProxy(const smoke_Lambdas_ConfuserProxy&) = delete;
+    smoke_Lambdas_ConfuserProxy& operator=(const smoke_Lambdas_ConfuserProxy&) = delete;
     ::smoke::Lambdas::Producer operator()(const std::string& p0) {
         auto _call_result = mFunctions.smoke_Lambdas_Confuser_call(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(p0));
         return Conversion<::smoke::Lambdas::Producer>::toCppReturn(_call_result);
@@ -136,6 +140,8 @@ public:
     virtual ~smoke_Lambdas_ConsumerProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_Lambdas_ConsumerProxy(const smoke_Lambdas_ConsumerProxy&) = delete;
+    smoke_Lambdas_ConsumerProxy& operator=(const smoke_Lambdas_ConsumerProxy&) = delete;
     void operator()(const std::string& p0) {
         mFunctions.smoke_Lambdas_Consumer_call(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(p0));
     }
@@ -173,6 +179,8 @@ public:
     virtual ~smoke_Lambdas_IndexerProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_Lambdas_IndexerProxy(const smoke_Lambdas_IndexerProxy&) = delete;
+    smoke_Lambdas_IndexerProxy& operator=(const smoke_Lambdas_IndexerProxy&) = delete;
     int32_t operator()(const std::string& p0, float p1) {
         auto _call_result = mFunctions.smoke_Lambdas_Indexer_call(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(p0), p1);
         return _call_result;
@@ -211,6 +219,8 @@ public:
     virtual ~smoke_Lambdas_NullableConfuserProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_Lambdas_NullableConfuserProxy(const smoke_Lambdas_NullableConfuserProxy&) = delete;
+    smoke_Lambdas_NullableConfuserProxy& operator=(const smoke_Lambdas_NullableConfuserProxy&) = delete;
     ::gluecodium::optional< ::smoke::Lambdas::Producer > operator()(const ::gluecodium::optional< ::std::string >& p0) {
         auto _call_result = mFunctions.smoke_Lambdas_NullableConfuser_call(mFunctions.swift_pointer, Conversion<::gluecodium::optional< ::std::string >>::toBaseRef(p0));
         return Conversion<::gluecodium::optional< ::smoke::Lambdas::Producer >>::toCppReturn(_call_result);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
@@ -26,6 +26,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_Lambdas_Producer_Proxy(const smoke_Lambdas_Producer_Proxy&) = delete;
+    smoke_Lambdas_Producer_Proxy& operator=(const smoke_Lambdas_Producer_Proxy&) = delete;
     std::string
     operator()() {
         FfiOpaqueHandle _result_handle;
@@ -59,6 +61,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_Lambdas_Confuser_Proxy(const smoke_Lambdas_Confuser_Proxy&) = delete;
+    smoke_Lambdas_Confuser_Proxy& operator=(const smoke_Lambdas_Confuser_Proxy&) = delete;
     ::smoke::Lambdas::Producer
     operator()(const std::string& p0) {
         FfiOpaqueHandle _result_handle;
@@ -93,6 +97,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_Lambdas_Consumer_Proxy(const smoke_Lambdas_Consumer_Proxy&) = delete;
+    smoke_Lambdas_Consumer_Proxy& operator=(const smoke_Lambdas_Consumer_Proxy&) = delete;
     void
     operator()(const std::string& p0) {
         dispatch([&]() { (*reinterpret_cast<bool (*)(uint64_t, FfiOpaqueHandle)>(f0))(token,
@@ -122,6 +128,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_Lambdas_Indexer_Proxy(const smoke_Lambdas_Indexer_Proxy&) = delete;
+    smoke_Lambdas_Indexer_Proxy& operator=(const smoke_Lambdas_Indexer_Proxy&) = delete;
     int32_t
     operator()(const std::string& p0, const float p1) {
         int32_t _result_handle;
@@ -157,6 +165,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_Lambdas_NullableConfuser_Proxy(const smoke_Lambdas_NullableConfuser_Proxy&) = delete;
+    smoke_Lambdas_NullableConfuser_Proxy& operator=(const smoke_Lambdas_NullableConfuser_Proxy&) = delete;
     gluecodium::optional<::smoke::Lambdas::Producer>
     operator()(const gluecodium::optional<std::string>& p0) {
         FfiOpaqueHandle _result_handle;

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
@@ -19,6 +19,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_StandaloneProducer_Proxy(const smoke_StandaloneProducer_Proxy&) = delete;
+    smoke_StandaloneProducer_Proxy& operator=(const smoke_StandaloneProducer_Proxy&) = delete;
     std::string
     operator()() {
         FfiOpaqueHandle _result_handle;

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListenerImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListenerImplCppProxy.h
@@ -12,6 +12,8 @@ namespace jni
 class com_example_smoke_CalculatorListenerImpl_CppProxy : public CppProxyBase, public ::smoke::CalculatorListener {
 public:
     com_example_smoke_CalculatorListenerImpl_CppProxy( JNIEnv* _jenv, JniReference<jobject> globalRef, jint _jHashCode );
+    com_example_smoke_CalculatorListenerImpl_CppProxy( const com_example_smoke_CalculatorListenerImpl_CppProxy& ) = delete;
+    com_example_smoke_CalculatorListenerImpl_CppProxy& operator=( const com_example_smoke_CalculatorListenerImpl_CppProxy& ) = delete;
     void on_calculation_result( const double ncalculationResult ) override;
     void on_calculation_result_const( const double ncalculationResult ) const override;
     void on_calculation_result_struct( const ::smoke::CalculatorListener::ResultStruct& ncalculationResult ) override;

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_CalculatorListener.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_CalculatorListener.cpp
@@ -107,6 +107,8 @@ public:
     virtual ~smoke_CalculatorListenerProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_CalculatorListenerProxy(const smoke_CalculatorListenerProxy&) = delete;
+    smoke_CalculatorListenerProxy& operator=(const smoke_CalculatorListenerProxy&) = delete;
     void on_calculation_result(double calculationResult) override {
         mFunctions.smoke_CalculatorListener_onCalculationResult(mFunctions.swift_pointer, calculationResult);
     }

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenerWithProperties.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenerWithProperties.cpp
@@ -132,6 +132,8 @@ public:
     virtual ~smoke_ListenerWithPropertiesProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_ListenerWithPropertiesProxy(const smoke_ListenerWithPropertiesProxy&) = delete;
+    smoke_ListenerWithPropertiesProxy& operator=(const smoke_ListenerWithPropertiesProxy&) = delete;
     ::std::string get_message() const override {
         auto _call_result = mFunctions.smoke_ListenerWithProperties_message_get(mFunctions.swift_pointer);
         return Conversion<std::string>::toCppReturn(_call_result);

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenersWithReturnValues.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenersWithReturnValues.cpp
@@ -111,6 +111,8 @@ public:
     virtual ~smoke_ListenersWithReturnValuesProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_ListenersWithReturnValuesProxy(const smoke_ListenersWithReturnValuesProxy&) = delete;
+    smoke_ListenersWithReturnValuesProxy& operator=(const smoke_ListenersWithReturnValuesProxy&) = delete;
     double fetch_data_double() override {
         auto _call_result = mFunctions.smoke_ListenersWithReturnValues_fetchDataDouble(mFunctions.swift_pointer);
         return _call_result;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
@@ -21,6 +21,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_CalculatorListener_Proxy(const smoke_CalculatorListener_Proxy&) = delete;
+    smoke_CalculatorListener_Proxy& operator=(const smoke_CalculatorListener_Proxy&) = delete;
     void
     on_calculation_result(const double calculationResult) override {
         dispatch([&]() { (*reinterpret_cast<bool (*)(uint64_t, double)>(f0))(token,

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
@@ -23,6 +23,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_ListenerWithProperties_Proxy(const smoke_ListenerWithProperties_Proxy&) = delete;
+    smoke_ListenerWithProperties_Proxy& operator=(const smoke_ListenerWithProperties_Proxy&) = delete;
     std::string
     get_message() const override {
         FfiOpaqueHandle _result_handle;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
@@ -22,6 +22,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_ListenersWithReturnValues_Proxy(const smoke_ListenersWithReturnValues_Proxy&) = delete;
+    smoke_ListenersWithReturnValues_Proxy& operator=(const smoke_ListenersWithReturnValues_Proxy&) = delete;
     double
     fetch_data_double() override {
         double _result_handle;

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerInterfaceImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerInterfaceImplCppProxy.h
@@ -12,6 +12,8 @@ namespace jni
 class com_example_smoke_OuterClass_00024InnerInterfaceImpl_CppProxy : public CppProxyBase, public ::smoke::OuterClass::InnerInterface {
 public:
     com_example_smoke_OuterClass_00024InnerInterfaceImpl_CppProxy( JNIEnv* _jenv, JniReference<jobject> globalRef, jint _jHashCode );
+    com_example_smoke_OuterClass_00024InnerInterfaceImpl_CppProxy( const com_example_smoke_OuterClass_00024InnerInterfaceImpl_CppProxy& ) = delete;
+    com_example_smoke_OuterClass_00024InnerInterfaceImpl_CppProxy& operator=( const com_example_smoke_OuterClass_00024InnerInterfaceImpl_CppProxy& ) = delete;
     ::std::string foo( const ::std::string& ninput ) override;
 };
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterClass.cpp
@@ -107,6 +107,8 @@ public:
     virtual ~smoke_OuterClass_InnerInterfaceProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_OuterClass_InnerInterfaceProxy(const smoke_OuterClass_InnerInterfaceProxy&) = delete;
+    smoke_OuterClass_InnerInterfaceProxy& operator=(const smoke_OuterClass_InnerInterfaceProxy&) = delete;
     ::std::string foo(const std::string& input) override {
         auto _call_result = mFunctions.smoke_OuterClass_InnerInterface_foo(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(input));
         return Conversion<std::string>::toCppReturn(_call_result);

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterInterface.cpp
@@ -59,6 +59,8 @@ public:
     virtual ~smoke_OuterInterfaceProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_OuterInterfaceProxy(const smoke_OuterInterfaceProxy&) = delete;
+    smoke_OuterInterfaceProxy& operator=(const smoke_OuterInterfaceProxy&) = delete;
     ::std::string foo(const std::string& input) override {
         auto _call_result = mFunctions.smoke_OuterInterface_foo(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(input));
         return Conversion<std::string>::toCppReturn(_call_result);
@@ -145,6 +147,8 @@ public:
     virtual ~smoke_OuterInterface_InnerInterfaceProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+    smoke_OuterInterface_InnerInterfaceProxy(const smoke_OuterInterface_InnerInterfaceProxy&) = delete;
+    smoke_OuterInterface_InnerInterfaceProxy& operator=(const smoke_OuterInterface_InnerInterfaceProxy&) = delete;
     ::std::string foo(const std::string& input) override {
         auto _call_result = mFunctions.smoke_OuterInterface_InnerInterface_foo(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(input));
         return Conversion<std::string>::toCppReturn(_call_result);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
@@ -19,6 +19,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_OuterClass_InnerInterface_Proxy(const smoke_OuterClass_InnerInterface_Proxy&) = delete;
+    smoke_OuterClass_InnerInterface_Proxy& operator=(const smoke_OuterClass_InnerInterface_Proxy&) = delete;
     std::string
     foo(const std::string& input) override {
         FfiOpaqueHandle _result_handle;

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
@@ -19,6 +19,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_OuterInterface_Proxy(const smoke_OuterInterface_Proxy&) = delete;
+    smoke_OuterInterface_Proxy& operator=(const smoke_OuterInterface_Proxy&) = delete;
     std::string
     foo(const std::string& input) override {
         FfiOpaqueHandle _result_handle;
@@ -53,6 +55,8 @@ public:
             (*deleter_local)(token_local, this);
         });
     }
+    smoke_OuterInterface_InnerInterface_Proxy(const smoke_OuterInterface_InnerInterface_Proxy&) = delete;
+    smoke_OuterInterface_InnerInterface_Proxy& operator=(const smoke_OuterInterface_InnerInterface_Proxy&) = delete;
     std::string
     foo(const std::string& input) override {
         FfiOpaqueHandle _result_handle;


### PR DESCRIPTION
Updated templates for Java, Swift, and Dart to make "proxy" classes in
their respective C++ bindings layer non-copyable, by explicitly deleting
copy constructor and copy assignment operator.

Updated smoke tests.

Resolves: #89
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
