### PR TITLE
Add @nodoc to internal elements in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     any class or interface types (not just those that are `@Equatable` themselves).
   * Added support for arbitrary exception payload when calling a throwing Dart method from C++.
   * Added doc comments for `release()` methods in Dart generated code.
+  * Added `@nodoc` to internal elements in Dart generated code.
 ### Deprecated:
   * `@PointerEquatable` IDL attribute is now deprecated. It still works the same way as before but
     its use is discouraged. Referential integrity on platform side makes this attribute redundant.

--- a/gluecodium/src/main/resources/templates/dart/DartDocumentation.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartDocumentation.mustache
@@ -20,6 +20,9 @@
   !}}
 {{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "/// "}}
 {{/unless}}{{/resolveName}}{{!!
+}}{{#if visibility.isInternal}}
+/// @nodoc
+{{/if}}{{!!
 }}{{#ifHasAttribute "Deprecated"}}
 @Deprecated("{{getAttribute "Deprecated"}}")
 {{/ifHasAttribute}}

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
@@ -25,6 +25,8 @@
 /// Returns [{{resolveName returnType.typeRef}}]. {{prefix this "/// " skipFirstLine=true}}{{/unless}}{{/resolveName}}{{!!
 }}{{#if thrownType}}{{#resolveName thrownType.comment}}{{#unless this.isEmpty}}
 /// Throws [{{resolveName exception}}]. {{prefix this "/// " skipFirstLine=true}}{{/unless}}{{/resolveName}}{{/if}}{{!!
+}}{{#if visibility.isInternal}}
+/// @nodoc{{/if}}{{!!
 }}{{#ifHasAttribute "Deprecated"}}
 @Deprecated("{{getAttribute "Deprecated"}}")
 {{/ifHasAttribute}}

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -208,3 +208,9 @@ class CommentsOnCstring {
     // @param[inputString] May or may not be a C string.
     static fun returnInputString(@Cpp(CString) inputString: String): String
 }
+
+// This looks internal
+internal class InternalClassWithComments {
+    // This is definitely internal
+    fun doNothing()
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/InternalClassWithComments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/InternalClassWithComments.dart
@@ -1,0 +1,72 @@
+import 'package:library/src/BuiltInTypes__conversion.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+/// This looks internal
+/// @nodoc
+abstract class InternalClassWithComments {
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+  /// This is definitely internal
+  /// @nodoc
+  internal_doNothing();
+}
+// InternalClassWithComments "private" section, not exported.
+final _smoke_InternalClassWithComments_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_InternalClassWithComments_copy_handle');
+final _smoke_InternalClassWithComments_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_InternalClassWithComments_release_handle');
+final _smoke_InternalClassWithComments_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_InternalClassWithComments_get_raw_pointer');
+class InternalClassWithComments$Impl implements InternalClassWithComments {
+  @protected
+  Pointer<Void> handle;
+  InternalClassWithComments$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.reverseCache.remove(_smoke_InternalClassWithComments_get_raw_pointer(handle));
+    _smoke_InternalClassWithComments_release_handle(handle);
+    handle = null;
+  }
+  @override
+  internal_doNothing() {
+    final _doNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithComments_doNothing');
+    final _handle = this.handle;
+    final __result_handle = _doNothing_ffi(_handle, __lib.LibraryContext.isolateId);
+    final _result = (__result_handle);
+    (__result_handle);
+    return _result;
+  }
+}
+Pointer<Void> smoke_InternalClassWithComments_toFfi(InternalClassWithComments value) =>
+  _smoke_InternalClassWithComments_copy_handle((value as InternalClassWithComments$Impl).handle);
+InternalClassWithComments smoke_InternalClassWithComments_fromFfi(Pointer<Void> handle) {
+  final raw_handle = _smoke_InternalClassWithComments_get_raw_pointer(handle);
+  final instance = __lib.reverseCache[raw_handle] as InternalClassWithComments;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_InternalClassWithComments_copy_handle(handle);
+  final result = InternalClassWithComments$Impl(_copied_handle);
+  __lib.reverseCache[raw_handle] = result;
+  return result;
+}
+void smoke_InternalClassWithComments_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_InternalClassWithComments_release_handle(handle);
+Pointer<Void> smoke_InternalClassWithComments_toFfi_nullable(InternalClassWithComments value) =>
+  value != null ? smoke_InternalClassWithComments_toFfi(value) : Pointer<Void>.fromAddress(0);
+InternalClassWithComments smoke_InternalClassWithComments_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_InternalClassWithComments_fromFfi(handle) : null;
+void smoke_InternalClassWithComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_InternalClassWithComments_release_handle(handle);
+// End of InternalClassWithComments "private" section.

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/EquatableStructWithInternalFields.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/EquatableStructWithInternalFields.dart
@@ -8,9 +8,13 @@ import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class EquatableStructWithInternalFields {
   String publicField;
+  /// @nodoc
   String internal_internalField;
+  /// @nodoc
   List<String> internal_internalListField;
+  /// @nodoc
   Map<String, String> internal_internalMapField;
+  /// @nodoc
   Set<String> internal_internalSetField;
   EquatableStructWithInternalFields(this.publicField, this.internal_internalField, this.internal_internalListField, this.internal_internalMapField, this.internal_internalSetField);
   @override

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/ClassWithInternalLambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/ClassWithInternalLambda.dart
@@ -12,6 +12,7 @@ abstract class ClassWithInternalLambda {
   void release();
   static bool invokeInternalLambda(ClassWithInternalLambda_InternalLambda lambda, String value) => ClassWithInternalLambda$Impl.invokeInternalLambda(lambda, value);
 }
+/// @nodoc
 typedef ClassWithInternalLambda_InternalLambda = bool Function(String);
 // ClassWithInternalLambda_InternalLambda "private" section, not exported.
 final _smoke_ClassWithInternalLambda_InternalLambda_copy_handle = __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalClass.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalClass.dart
@@ -3,6 +3,7 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
+/// @nodoc
 abstract class InternalClass {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalClassWithFunctions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalClassWithFunctions.dart
@@ -4,14 +4,18 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
+/// @nodoc
 abstract class InternalClassWithFunctions {
+  /// @nodoc
   factory InternalClassWithFunctions.make() => InternalClassWithFunctions$Impl.internal_make();
+  /// @nodoc
   factory InternalClassWithFunctions.remake(String foo) => InternalClassWithFunctions$Impl.internal_remake(foo);
   /// Destroys the underlying native object.
   ///
   /// Call this to free memory when you no longer need this instance.
   /// Note that setting the instance to null will not destroy the underlying native object.
   void release();
+  /// @nodoc
   internal_fooBar();
 }
 // InternalClassWithFunctions "private" section, not exported.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalInterface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/InternalInterface.dart
@@ -5,6 +5,7 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
+/// @nodoc
 abstract class InternalInterface {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicClass.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicClass.dart
@@ -10,12 +10,17 @@ abstract class PublicClass {
   /// Call this to free memory when you no longer need this instance.
   /// Note that setting the instance to null will not destroy the underlying native object.
   void release();
+  /// @nodoc
   PublicClass_InternalStruct internal_internalMethod(PublicClass_InternalStruct input);
+  /// @nodoc
   PublicClass_InternalStruct get internal_internalStructProperty;
+  /// @nodoc
   set internal_internalStructProperty(PublicClass_InternalStruct value);
   String get internalSetterProperty;
+  /// @nodoc
   set internal_internalSetterProperty(String value);
 }
+/// @nodoc
 enum PublicClass_InternalEnum {
     foo,
     bar
@@ -75,7 +80,9 @@ PublicClass_InternalEnum smoke_PublicClass_InternalEnum_fromFfi_nullable(Pointer
 void smoke_PublicClass_InternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_PublicClass_InternalEnum_release_handle_nullable(handle);
 // End of PublicClass_InternalEnum "private" section.
+/// @nodoc
 class PublicClass_InternalStruct {
+  /// @nodoc
   String internal_stringField;
   PublicClass_InternalStruct(this.internal_stringField);
 }
@@ -138,6 +145,7 @@ void smoke_PublicClass_InternalStruct_releaseFfiHandle_nullable(Pointer<Void> ha
   _smoke_PublicClass_InternalStruct_release_handle_nullable(handle);
 // End of PublicClass_InternalStruct "private" section.
 class PublicClass_PublicStruct {
+  /// @nodoc
   PublicClass_InternalStruct internal_internalField;
   PublicClass_PublicStruct(this.internal_internalField);
 }
@@ -200,6 +208,7 @@ void smoke_PublicClass_PublicStruct_releaseFfiHandle_nullable(Pointer<Void> hand
   _smoke_PublicClass_PublicStruct_release_handle_nullable(handle);
 // End of PublicClass_PublicStruct "private" section.
 class PublicClass_PublicStructWithInternalDefaults {
+  /// @nodoc
   String internal_internalField;
   double publicField;
   PublicClass_PublicStructWithInternalDefaults(this.internal_internalField, this.publicField);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicInterface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicInterface.dart
@@ -13,7 +13,9 @@ abstract class PublicInterface {
   /// Note that setting the instance to null will not destroy the underlying native object.
   void release() {}
 }
+/// @nodoc
 class PublicInterface_InternalStruct {
+  /// @nodoc
   PublicClass_InternalStruct internal_fieldOfInternalType;
   PublicInterface_InternalStruct(this.internal_fieldOfInternalType);
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicStructWithNonDefaultInternalField.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicStructWithNonDefaultInternalField.dart
@@ -3,9 +3,9 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 class PublicStructWithNonDefaultInternalField {
   int defaultedField;
+  /// @nodoc
   String internal_internalField;
   bool publicField;
   PublicStructWithNonDefaultInternalField(this.defaultedField, this.internal_internalField, this.publicField);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicTypeCollection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/PublicTypeCollection.dart
@@ -3,8 +3,9 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
+/// @nodoc
 class InternalStruct {
+  /// @nodoc
   String internal_stringField;
   InternalStruct(this.internal_stringField);
 }


### PR DESCRIPTION
Updated Dart templates to add `@nodoc` to documentation comments of
internal elements. This excludes the marked elements from documentation
generated by Dart documentation tool.

Added/updated smoke tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>