### PR TITLE
Clean up GeneratorSuite class

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -118,13 +118,13 @@ class Gluecodium(
         limeModel: LimeModel,
         fileNamesCache: MutableMap<String, String>
     ): Boolean {
-        LOGGER.fine("Using generator $generatorName")
+        LOGGER.fine("Using generator '$generatorName'")
         val generator = GeneratorSuite.instantiateByShortName(generatorName, options)
         if (generator == null) {
             LOGGER.severe("Failed instantiation of generator '$generatorName'")
             return false
         }
-        LOGGER.fine("Instantiated generator " + generator.name)
+        LOGGER.fine("Instantiated generator '$generatorName'")
 
         val outputFiles = try {
             generator.generate(limeModel)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -66,7 +66,7 @@ import com.here.gluecodium.model.lime.LimeTypesCollection
 import com.here.gluecodium.platform.common.GeneratorSuite
 import java.util.logging.Logger
 
-class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
+class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
 
     private val libraryName = options.libraryName
     private val nameRules = NameRules(nameRuleSetFromConfig(options.dartNameRules))
@@ -448,8 +448,6 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
         limeFunction.parameters.map { it.typeRef } +
             limeFunction.returnType.typeRef +
             listOfNotNull(limeFunction.exception?.errorType)
-
-    override val name = "com.here.DartGenerator"
 
     private object TypeRefsCollector : LimeTypeRefsVisitor<List<LimeTypeRef>>() {
         override fun visitTypeRef(

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameRules.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameRules.kt
@@ -44,7 +44,7 @@ class JavaNameRules(nameRuleSet: NameRuleSet) : NameRules(nameRuleSet) {
     fun getImplementationClassName(limeElement: LimeNamedElement) = getName(limeElement) + "Impl"
 
     fun getName(limeLambdaParameter: LimeLambdaParameter, index: Int) =
-        limeLambdaParameter.attributes?.get(JAVA, NAME) ?: "p$index"
+        limeLambdaParameter.attributes.get(JAVA, NAME) ?: "p$index"
 
     private fun getPlatformName(limeElement: LimeNamedElement?) =
         limeElement?.attributes?.get(JAVA, NAME)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/lime/LimeGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/lime/LimeGeneratorSuite.kt
@@ -45,7 +45,7 @@ import com.here.gluecodium.model.lime.LimeTypedElement
 import com.here.gluecodium.model.lime.LimeTypesCollection
 import com.here.gluecodium.platform.common.GeneratorSuite
 
-class LimeGeneratorSuite : GeneratorSuite() {
+class LimeGeneratorSuite : GeneratorSuite {
 
     override fun generate(limeModel: LimeModel) = limeModel.topElements.map { generate(it) }
 
@@ -124,8 +124,6 @@ class LimeGeneratorSuite : GeneratorSuite() {
 
     private fun escapeImport(import: LimePath) =
         (import.head + import.tail).joinToString(".") { LimeTypeHelper.escapeIdentifier(it) }
-
-    override val name = "com.here.LimeGenerator"
 
     companion object {
         const val GENERATOR_NAME = "lime"

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/android/AndroidGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/android/AndroidGeneratorSuite.kt
@@ -30,8 +30,6 @@ import com.here.gluecodium.generator.jni.JniGenerator
 class AndroidGeneratorSuite(options: Gluecodium.Options) : JavaGeneratorSuite(options, true) {
     override val generatorName = GENERATOR_NAME
 
-    override val name = "com.here.AndroidGeneratorSuite"
-
     companion object {
         const val GENERATOR_NAME = "android"
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
@@ -52,7 +52,7 @@ import java.util.logging.Logger
 open class JavaGeneratorSuite protected constructor(
     options: Gluecodium.Options,
     private val enableAndroidFeatures: Boolean
-) : GeneratorSuite() {
+) : GeneratorSuite {
 
     private val rootPackage = options.javaPackages
     private val internalPackage = options.javaInternalPackages
@@ -69,8 +69,6 @@ open class JavaGeneratorSuite protected constructor(
     protected open val generatorName = GENERATOR_NAME
 
     constructor(options: Gluecodium.Options) : this(options, false)
-
-    override val name = "com.here.JavaGeneratorSuite"
 
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
         val javaPackageList =

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/baseapi/BaseApiGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/baseapi/BaseApiGeneratorSuite.kt
@@ -61,7 +61,7 @@ import java.util.logging.Logger
  * It is the underlying generator, that all others depend on, as they will invoke the actual
  * implementation through the C++ interfaces.
  */
-class BaseApiGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
+class BaseApiGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
 
     private val internalNamespace = options.cppInternalNamespace
     private val rootNamespace = options.cppRootNamespace
@@ -69,8 +69,6 @@ class BaseApiGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
     private val commentsProcessor =
         DoxygenCommentsProcessor(options.werror.contains(Gluecodium.Options.WARNING_DOC_LINKS))
     private val nameRules = CppNameRules(rootNamespace, nameRuleSetFromConfig(options.cppNameRules))
-
-    override val name = "com.here.BaseApiGenerator"
 
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
         val limeReferenceMap = limeModel.referenceMap

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/common/GeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/common/GeneratorSuite.kt
@@ -35,10 +35,7 @@ import java.nio.charset.Charset
 import org.apache.commons.io.IOUtils
 
 /** The base interface for all the generators.  */
-abstract class GeneratorSuite {
-
-    /** @return the human readable name of this generator */
-    abstract val name: String
+interface GeneratorSuite {
 
     /**
      * Triggers the generation. The model is assumed to be valid.
@@ -46,23 +43,20 @@ abstract class GeneratorSuite {
      * @param limeModel LIME model
      * @return a list of generated files with their relative destination paths
      */
-    abstract fun generate(limeModel: LimeModel): List<GeneratedFile>
+    fun generate(limeModel: LimeModel): List<GeneratedFile>
 
     companion object {
         /** Creates a new instance of a generator suite by its short identifier  */
-        fun instantiateByShortName(shortName: String, options: Gluecodium.Options): GeneratorSuite? {
-
+        fun instantiateByShortName(shortName: String, options: Gluecodium.Options) =
             when (shortName) {
-                AndroidGeneratorSuite.GENERATOR_NAME -> return AndroidGeneratorSuite(options)
-                JavaGeneratorSuite.GENERATOR_NAME -> return JavaGeneratorSuite(options)
-                BaseApiGeneratorSuite.GENERATOR_NAME -> return BaseApiGeneratorSuite(options)
-                SwiftGeneratorSuite.GENERATOR_NAME -> return SwiftGeneratorSuite(options)
-                LimeGeneratorSuite.GENERATOR_NAME -> return LimeGeneratorSuite()
-                DartGeneratorSuite.GENERATOR_NAME -> return DartGeneratorSuite(options)
+                AndroidGeneratorSuite.GENERATOR_NAME -> AndroidGeneratorSuite(options)
+                JavaGeneratorSuite.GENERATOR_NAME -> JavaGeneratorSuite(options)
+                BaseApiGeneratorSuite.GENERATOR_NAME -> BaseApiGeneratorSuite(options)
+                SwiftGeneratorSuite.GENERATOR_NAME -> SwiftGeneratorSuite(options)
+                LimeGeneratorSuite.GENERATOR_NAME -> LimeGeneratorSuite()
+                DartGeneratorSuite.GENERATOR_NAME -> DartGeneratorSuite(options)
+                else -> null
             }
-
-            return null
-        }
 
         /** @return all available generators */
         fun generatorShortNames() = setOf(

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuite.kt
@@ -50,7 +50,7 @@ import java.util.logging.Logger
  *
  * The bindings are used to build a framework for iOS, Mac and a Swift module for Linux.
  */
-class SwiftGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
+class SwiftGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
     private val internalNamespace = options.cppInternalNamespace
     private val rootNamespace = options.cppRootNamespace
     private val commentsProcessor =
@@ -175,8 +175,6 @@ class SwiftGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite() {
             }
         }
     }
-
-    override val name = "com.here.SwiftGenerator"
 
     companion object {
         private val logger = Logger.getLogger(SwiftGeneratorSuite::class.java.name)

--- a/gluecodium/src/test/java/com/here/gluecodium/GluecodiumTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/GluecodiumTest.kt
@@ -77,7 +77,6 @@ class GluecodiumTest {
         every { cache.write(true) } returns true
         every { cache.write(false) } returns false
 
-        every { generator.name } returns ""
         every { GeneratorSuite.instantiateByShortName(any(), any()) } returns generator
 
         every { modelLoader.loadModel(any(), any()) } returns LimeModel(emptyMap(), emptyList())


### PR DESCRIPTION
Removed "name" property from GeneratorSuite class. It was used only for
logging in a single place, where it can be replaced with another value
without any loss of log information.

Converted GeneratorSuite from an abstract class to an interface.
Refactored instantiateByShortName() method to be more Kotlin-idiomatic.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>