### PR TITLE
Adds CMake method to retrieve list of include directories for target

### DIFF
--- a/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
+++ b/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
@@ -26,77 +26,118 @@ cmake_minimum_required(VERSION 3.5)
 # Generated target_include_directories module
 # -------------------------------------------
 #
-# This module attaches additional include directories to the provided target.
-# These might differ depending on the previously used generator (cpp, android,
-# swift, etc.). This module depends on apigen_generate() to have been run on
-# the target first.
+# .. command:: apigen_get_target_include_directories
 #
-# .. command:: apigen_target_include_directories
+#     Returns list of include directories of the provided target. Result
+#     might depend on the previously used generator (cpp, android,
+#     swift, etc.). This method depends on apigen_generate() to have been run on
+#     the target first.
 #
 # The general form of the command is::
 #
-#     apigen_target_include_directories(target [MAIN] [COMMON])
-#        <target>    Target for which source was generated via `apigen_generate`
-#        MAIN        Add the include path to the MAIN generated source set, i.e.
-#                    code generated for the input Lime IDL files.
-#        COMMON      Add the include path to the common generated source set.
-#     If neither MAIN nor COMMON are specified, both are added. Specifying a
+#     apigen_get_target_include_directories(
+#       target                                Target for which source was
+#                                             generated via `apigen_generate`.
+#       [MAIN]                                Optional flag to add the include path of
+#                                             the MAIN generated source set, i.e. code
+#                                             generated for the input Lime IDL files.
+#       [COMMON]                              Optional flag to add the include path of
+#                                             the common generated source set.
+#       PUBLIC_RESULT_VARIABLE <variable>     Variable to return result with list of
+#                                             public include directories.
+#       [PRIVATE_RESULT_VARIABLE <variable>]  Optional variable to return result with
+#                                             list of private include directories.
+#     )
+#     Note: If neither MAIN nor COMMON are specified, both are added. Specifying a
+#     source set requires a separate common output directory to be set for
+#     `apigen_generate`.
+#
+# .. command:: apigen_target_include_directories
+#
+#     Attaches additional include directories to the provided target.
+#     These might differ depending on the previously used generator (cpp, android,
+#     swift, etc.). This method depends on apigen_generate() to have been run on
+#     the target first.
+#
+# The general form of the command is::
+#
+#     apigen_target_include_directories(
+#        target     Target for which source was generated via `apigen_generate`
+#        [MAIN]     Add the include path to the MAIN generated source set, i.e.
+#                   code generated for the input Lime IDL files.
+#        [COMMON] Add the include path to the common generated source set.
+#     )
+#     Note: If neither MAIN nor COMMON are specified, both are added. Specifying a
 #     source set requires a separate common output directory to be set for
 #     `apigen_generate`.
 #
 
-function(apigen_target_include_directories target)
+function(apigen_get_target_include_directories target)
   set(options MAIN COMMON)
-  cmake_parse_arguments(APIGEN_TARGET_INCLUDE_DIRECTORIES "${options}" "" "" ${ARGN})
-  if(NOT APIGEN_TARGET_INCLUDE_DIRECTORIES_MAIN AND NOT APIGEN_TARGET_INCLUDE_DIRECTORIES_COMMON)
-    set(APIGEN_TARGET_INCLUDE_DIRECTORIES_MAIN TRUE)
-    set(APIGEN_TARGET_INCLUDE_DIRECTORIES_COMMON TRUE)
-  endif()
+  set(single_args PUBLIC_RESULT_VARIABLE PRIVATE_RESULT_VARIABLE)
+  cmake_parse_arguments(APIGEN_TARGET_INCLUDE_DIRECTORIES "${options}" "${single_args}" "" ${ARGN})
+
+  unset (_properties_out_dir)
+  if (APIGEN_TARGET_INCLUDE_DIRECTORIES_MAIN)
+    list (APPEND _properties_out_dir APIGEN_OUTPUT_DIR)
+  endif ()
+
+  if (APIGEN_TARGET_INCLUDE_DIRECTORIES_COMMON)
+    list (APPEND _properties_out_dir APIGEN_COMMON_OUTPUT_DIR)
+  endif ()
+
+  if (NOT _properties_out_dir)
+    list (APPEND _properties_out_dir APIGEN_OUTPUT_DIR APIGEN_COMMON_OUTPUT_DIR)
+  endif ()
 
   get_target_property(GENERATOR ${target} APIGEN_GENERATOR)
 
-  if(APIGEN_TARGET_INCLUDE_DIRECTORIES_MAIN)
-    get_target_property(OUTPUT_DIR ${target} APIGEN_OUTPUT_DIR)
+  unset (_result_list_public)
+  foreach (_property_out_dir ${_properties_out_dir})
+    get_target_property(OUTPUT_DIR ${target} ${_property_out_dir})
     if (OUTPUT_DIR)
-      target_include_directories(${target}
-        PUBLIC
-          $<BUILD_INTERFACE:${OUTPUT_DIR}/cpp/include>
-          $<BUILD_INTERFACE:${OUTPUT_DIR}>)
+      list(APPEND _result_list_public $<BUILD_INTERFACE:${OUTPUT_DIR}/cpp/include>)
+      if(NOT ${GENERATOR} STREQUAL cpp)
+        list(APPEND _result_list_public $<BUILD_INTERFACE:${OUTPUT_DIR}>)
+      endif()
 
       if(${GENERATOR} MATCHES android)
-        target_include_directories(${target}
-          PUBLIC $<BUILD_INTERFACE:${OUTPUT_DIR}/android/jni>)
-      elseif(GENERATOR MATCHES dart)
-        target_include_directories(${target}
-          PUBLIC $<BUILD_INTERFACE:${OUTPUT_DIR}/dart/ffi>)
+        list(APPEND _result_list_public $<BUILD_INTERFACE:${OUTPUT_DIR}/android/jni>)
       endif()
-    endif()
-  endif()
 
-  if(APIGEN_TARGET_INCLUDE_DIRECTORIES_COMMON)
-    get_target_property(COMMON_OUTPUT_DIR ${target} APIGEN_COMMON_OUTPUT_DIR)
-    if (COMMON_OUTPUT_DIR)
-      target_include_directories(${target}
-        PUBLIC
-          $<BUILD_INTERFACE:${COMMON_OUTPUT_DIR}/cpp/include>
-          $<BUILD_INTERFACE:${COMMON_OUTPUT_DIR}>)
-      if(${GENERATOR} MATCHES android)
-        target_include_directories(${target}
-          PUBLIC $<BUILD_INTERFACE:${COMMON_OUTPUT_DIR}/android/jni>)
-      endif()
-      if(${GENERATOR} MATCHES dart)
-        target_include_directories(${target}
-          PUBLIC $<BUILD_INTERFACE:${COMMON_OUTPUT_DIR}/dart/ffi>)
+      if(GENERATOR MATCHES dart)
+        list(APPEND _result_list_public $<BUILD_INTERFACE:${OUTPUT_DIR}/dart/ffi>)
       endif()
     endif()
-  endif()
+  endforeach ()
 
   if(${GENERATOR} MATCHES android)
     # If we're not crosscompiling, we need to manually add JNI includes.
     if(NOT CMAKE_CROSSCOMPILING)
       find_package(JNI REQUIRED)
-      target_include_directories(${target}
-        PRIVATE $<BUILD_INTERFACE:${JNI_INCLUDE_DIRS}>)
+      list(APPEND _result_list_private $<BUILD_INTERFACE:${JNI_INCLUDE_DIRS}>)
     endif()
   endif()
+
+  if (APIGEN_TARGET_INCLUDE_DIRECTORIES_PUBLIC_RESULT_VARIABLE)
+    set (${APIGEN_TARGET_INCLUDE_DIRECTORIES_PUBLIC_RESULT_VARIABLE} ${_result_list_public} PARENT_SCOPE)
+  endif()
+
+  if (APIGEN_TARGET_INCLUDE_DIRECTORIES_PRIVATE_RESULT_VARIABLE)
+    set (${APIGEN_TARGET_INCLUDE_DIRECTORIES_PRIVATE_RESULT_VARIABLE} ${_result_list_private} PARENT_SCOPE)
+  endif()
+endfunction()
+
+
+function(apigen_target_include_directories target)
+  apigen_get_target_include_directories(${target} ${ARGN} PUBLIC_RESULT_VARIABLE _public_include_dirs
+    PRIVATE_RESULT_VARIABLE _private_include_dirs)
+
+  if (_public_include_dirs)
+    target_include_directories(${target} PUBLIC ${_public_include_dirs})
+  endif()
+
+  if (_private_include_dirs)
+    target_include_directories(${target} PRIVATE ${_private_include_dirs})
+  endif ()
 endfunction()


### PR DESCRIPTION
Existing method apigen_target_include_directories doesn't provide
such information, but this info is required to configure
installation and packaging.

Signed-off-by: Yauheni Khnykin <yauheni.khnykin@here.com>
