### PR TITLE
Add support for @constructor doc comment in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed Dart support for `@constructor` doc comment on structs.
+
 ## 7.0.0
 Release date: 2020-05-19
 ### Features:

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -26,7 +26,14 @@
 class {{resolveName}} {
 {{#set parent=this}}{{#fields}}{{prefixPartial "dart/DartField" "  "}}
 {{/fields}}{{/set}}
-{{#if fields}}  {{resolveName}}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
+{{#if fields}}{{#unless constructors}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
+}}{{prefix this "  /// "}}
+{{#fields}}
+  /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
+  }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
+{{/fields}}
+{{/unless}}{{/resolveName}}{{/unless}}{{!!
+}}  {{resolveName}}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{#if constructors}}  {{resolveName}}{{#if constructors}}._copy{{/if}}({{resolveName}} _other) : {{!!
 }}this._({{#fields}}_other.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{/if}}{{#unless constructors}}{{#if initializedFields}}

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -122,6 +122,10 @@ class Comments_SomeStruct {
   bool someField;
   /// Can be `null`
   String nullableField;
+  /// This is how easy it is to construct.
+  /// [someField] How useful this struct is
+  /// remains to be seen
+  /// [nullableField] Can be `null`
   Comments_SomeStruct(this.someField, this.nullableField);
 }
 // Comments_SomeStruct "private" section, not exported.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -62,6 +62,8 @@ abstract class CommentsLinks {
 class CommentsLinks_RandomStruct {
   /// Some random field [Comments_SomeStruct]
   Comments_SomeStruct randomField;
+  /// constructor comments [Comments_SomeStruct]
+  /// [randomField] Some random field [Comments_SomeStruct]
   CommentsLinks_RandomStruct(this.randomField);
 }
 // CommentsLinks_RandomStruct "private" section, not exported.


### PR DESCRIPTION
Updated Dart template for structs to include @constructor doc comment.

Updated smoke tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>