### PR TITLE
Add LimeReturnType.isVoid

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppReturnTypeNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppReturnTypeNameResolver.kt
@@ -21,8 +21,6 @@ package com.here.gluecodium.generator.ffi
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.generator.common.NameResolver
-import com.here.gluecodium.model.lime.LimeBasicType
-import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeFunction
 
@@ -46,8 +44,7 @@ internal class FfiCppReturnTypeNameResolver(
             return "$returnPrefix<$returnTypeName, ${ffiCppNameResolver.resolveName(exceptionPayload)}>"
         }
 
-        val actualReturnType = limeFunction.returnType.typeRef.type.actualType
-        return if ((actualReturnType as? LimeBasicType)?.typeId == TypeId.VOID) {
+        return if (limeFunction.returnType.isVoid) {
             STD_ERROR_CODE
         } else {
             "$returnPrefix<$returnTypeName, $STD_ERROR_CODE>"

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionException.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionException.mustache
@@ -23,11 +23,11 @@ final _{{resolveName}}_return_release_handle = __lib.nativeLibrary.lookupFunctio
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_return_release_handle');
-final _{{resolveName}}_return_get_result = {{#isNotEq returnType.typeRef.type.name "Void"}}__lib.nativeLibrary.lookupFunction<
+final _{{resolveName}}_return_get_result = {{#unless returnType.isVoid}}__lib.nativeLibrary.lookupFunction<
     {{resolveName returnType.typeRef "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName returnType.typeRef "FfiDartTypes"}} Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_return_get_result');{{/isNotEq}}{{!!
-    }}{{#isEq returnType.typeRef.type.name "Void"}}(Pointer) {};{{/isEq}}
+  >('{{libraryName}}_{{resolveName "Ffi"}}_return_get_result');{{/unless}}{{!!
+    }}{{#if returnType.isVoid}}(Pointer) {};{{/if}}
 final _{{resolveName}}_return_get_error = __lib.nativeLibrary.lookupFunction<
     {{resolveName exception.errorType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName exception.errorType "FfiDartTypes"}} Function(Pointer<Void>)

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionSignature.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionSignature.mustache
@@ -25,4 +25,4 @@
 }}{{#if isConstructor}}_{{/if}}{{#unless isConstructor}}{{resolveName visibility}}{{/unless}}{{resolveName}}({{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
 
-}}{{+ffiReturnDeclaration}}{{#returnType}}{{#isNotEq typeRef.toString "Void"}}{{resolveName typeRef}} {{/isNotEq}}{{/returnType}}{{/ffiReturnDeclaration}}
+}}{{+ffiReturnDeclaration}}{{#returnType}}{{#unless isVoid}}{{resolveName typeRef}} {{/unless}}{{/returnType}}{{/ffiReturnDeclaration}}

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -201,7 +201,7 @@ class {{resolveName}}$Impl {{#if parent}}extends {{resolveName parent}}$Impl {{/
 int _{{resolveName parent}}_{{resolveName}}_static({{!!
 }}int _token{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
-}}{{#isNotEq returnType.typeRef.toString "Void"}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/isNotEq}}{{!!
+}}{{#unless returnType.isVoid}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/unless}}{{!!
 }}{{#if thrownType}}, Pointer<{{resolveName exception.errorType "FfiApiTypes"}}> _error{{/if}}) {
   {{#if thrownType}}
   bool _error_flag = false;
@@ -211,11 +211,11 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
   final __{{resolveName}} = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
   {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
 {{/parameters}}
-  {{#isNotEq returnType.typeRef.toString "Void"}}final _result_object = {{/isNotEq}}{{!!
+  {{#unless returnType.isVoid}}final _result_object = {{/unless}}{{!!
   }}(__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}}({{#parameters}}{{!!
   }}__{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{!!
-  }}{{/parameters}});{{#isNotEq returnType.typeRef.toString "Void"}}
-  _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/isNotEq}}
+  }}{{/parameters}});{{#unless returnType.isVoid}}
+  _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/unless}}
 {{#if thrownType}}
   } on {{resolveName exception}} catch(e) {
     _error_flag = true;
@@ -308,7 +308,7 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 
 }}{{+ffiApi}}Uint8 Function(Uint64{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef "FfiApiTypes"}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
-}}{{#isNotEq returnType.typeRef.toString "Void"}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}>{{/isNotEq}}{{!!
+}}{{#unless returnType.isVoid}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}>{{/unless}}{{!!
 }}{{#if thrownType}}, Pointer<{{resolveName exception.errorType "FfiApiTypes"}}>{{/if}}){{/ffiApi}}{{!!
 
 }}{{+ffiFunctionPointers}}{{#if inheritedFunctions functions logic="or"}}, {{!!

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -56,12 +56,12 @@ class {{resolveName}}$Impl {
 int _{{resolveName parent}}_{{resolveName}}_static({{!!
 }}int _token{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
-}}{{#isNotEq returnType.typeRef.toString "Void"}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/isNotEq}}) {
-  {{#isNotEq returnType.typeRef.toString "Void"}}final _result_object = {{/isNotEq}}{{!!
+}}{{#unless returnType.isVoid}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/unless}}) {
+  {{#unless returnType.isVoid}}final _result_object = {{/unless}}{{!!
   }}(__lib.instanceCache[_token] as {{resolveName parent}})({{#parameters}}{{!!
   }}{{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}}){{#if iter.hasNext}}, {{/if}}{{!!
-  }}{{/parameters}});{{#isNotEq returnType.typeRef.toString "Void"}}
-  _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/isNotEq}}
+  }}{{/parameters}});{{#unless returnType.isVoid}}
+  _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/unless}}
 {{#parameters}}
   {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
 {{/parameters}}{{#instanceOf returnType.typeRef.type.actualType "LimeClass"}}
@@ -108,4 +108,4 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) =>
 
 }}{{+ffiApi}}Int64 Function(Uint64{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef "FfiApiTypes"}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
-}}{{#isNotEq returnType.typeRef.toString "Void"}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}>{{/isNotEq}}){{/ffiApi}}
+}}{{#unless returnType.isVoid}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}>{{/unless}}){{/ffiApi}}

--- a/gluecodium/src/main/resources/templates/lime/LimeFunction.mustache
+++ b/gluecodium/src/main/resources/templates/lime/LimeFunction.mustache
@@ -32,5 +32,5 @@
 }}{{#unless isConstructor}}{{#if isStatic}}static {{/if}}fun {{escapedName}}{{/unless}}({{#parameters}}
 {{prefixPartial "lime/LimeParameter" "    "}}
 {{/parameters}}){{!!
-}}{{#unless isConstructor}}{{#returnType}}{{#isNotEq typeRef.toString "Void"}}: {{typeRef.escapedName}}{{/isNotEq}}{{/returnType}}{{/unless}}{{!!
+}}{{#unless isConstructor}}{{#returnType}}{{#unless isVoid}}: {{typeRef.escapedName}}{{/unless}}{{/returnType}}{{/unless}}{{!!
 }}{{#thrownType}} throws {{typeRef.escapedName}}{{/thrownType}}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeReturnType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeReturnType.kt
@@ -19,6 +19,8 @@
 
 package com.here.gluecodium.model.lime
 
+import com.here.gluecodium.model.lime.LimeBasicType.TypeId
+
 /**
  * Represents a return type of a [LimeFunction].
  */
@@ -27,7 +29,11 @@ class LimeReturnType(
     val comment: LimeComment = LimeComment(),
     attributes: LimeAttributes? = null
 ) : LimeElement(attributes) {
+    val isVoid
+        get() = !typeRef.isNullable &&
+                typeRef.type.actualType.let { it is LimeBasicType && it.typeId == TypeId.VOID }
+
     companion object {
-        val VOID = LimeReturnType(LimeBasicTypeRef(LimeBasicType.TypeId.VOID))
+        val VOID = LimeReturnType(LimeBasicTypeRef(TypeId.VOID))
     }
 }


### PR DESCRIPTION
Added `isVoid` computed property to `LimeReturnType` class. Checking a
function return type for being "void" is a rather common check both in
code and in templates. Having a helper computed property for this check
saves a lot of boilerplate.

Updated Dart and LIME templates to use this property.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>