### PR TITLE
Fix multi-callbacks in Java and Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed a runtime issue in Java and Dart for platform-side objects that implement multiple
+    generated interfaces at once.
+
 ## 7.0.1
 Release date: 2020-05-25
 ### Bug fixes:

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -204,6 +204,7 @@ feature(Listeners cpp android swift dart SOURCES
     src/test/StringListeners.cpp
     src/test/ListenerRoundtrip.cpp
     src/test/ListenerWithMaps.cpp
+    src/test/MultiListener.cpp
 
     lime/hello/HelloWorldCalculatorListenerFactory.lime
     lime/hello/CalculatorListener.lime
@@ -212,6 +213,7 @@ feature(Listeners cpp android swift dart SOURCES
     lime/test/ListenerRoundtrip.lime
     lime/test/ListenerWithMaps.lime
     lime/test/ListenerNameClash.lime
+    lime/test/MultiListener.lime
 )
 
 feature(ComplexListeners cpp android swift dart SOURCES

--- a/examples/libhello/lime/test/MultiListener.lime
+++ b/examples/libhello/lime/test/MultiListener.lime
@@ -1,0 +1,36 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+interface Receiver_A {
+    fun receiveA(message: String)
+}
+
+interface Receiver_B {
+    fun receiveB(message: String)
+}
+
+class MultiSender {
+    constructor create()
+
+    fun add_receiver_A(receiver: Receiver_A)
+    fun add_receiver_B(receiver: Receiver_B)
+
+    fun notify_A_Receivers()
+    fun notify_B_Receivers()
+}

--- a/examples/libhello/src/test/MultiListener.cpp
+++ b/examples/libhello/src/test/MultiListener.cpp
@@ -1,0 +1,67 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/MultiSender.h"
+#include "test/ReceiverA.h"
+#include "test/ReceiverB.h"
+#include <vector>
+
+namespace test {
+
+struct SenderImpl : public MultiSender {
+  void add_receiver_a(const std::shared_ptr<ReceiverA>& receiver) override;
+  void add_receiver_b(const std::shared_ptr<ReceiverB>& receiver) override;
+
+  void notify_a_receivers() override;
+  void notify_b_receivers() override;
+
+  std::vector<std::shared_ptr<ReceiverA>> a_receivers;
+  std::vector<std::shared_ptr<ReceiverB>> b_receivers;
+};
+
+std::shared_ptr<MultiSender>
+MultiSender::create() {
+    return std::make_shared<SenderImpl>();
+}
+
+void
+SenderImpl::add_receiver_a(const std::shared_ptr<ReceiverA>& receiver) {
+    a_receivers.push_back(receiver);
+}
+
+void
+SenderImpl::add_receiver_b(const std::shared_ptr<ReceiverB>& receiver) {
+    b_receivers.push_back(receiver);
+}
+
+void
+SenderImpl::notify_a_receivers() {
+    for (const auto& receiver: a_receivers) {
+       receiver->receive_a("Sent from A");
+    }
+}
+
+void SenderImpl::notify_b_receivers() {
+    for (const auto& receiver: b_receivers) {
+       receiver->receive_b("Sent from B");
+    }
+}
+
+}

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/MultiListenerTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/MultiListenerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+import static junit.framework.Assert.assertEquals;
+
+import android.os.Build;
+import com.example.here.hello.BuildConfig;
+import com.here.android.RobolectricApplication;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(
+    sdk = Build.VERSION_CODES.M,
+    application = RobolectricApplication.class,
+    constants = BuildConfig.class)
+public class MultiListenerTest {
+
+  static class MultiReceiver implements ReceiverA, ReceiverB {
+    public List<String> log = new ArrayList<>();
+
+    @Override
+    public void receiveA(String message) {
+      log.add("ReceiverA: received from Sender: " + message);
+    }
+
+    @Override
+    public void receiveB(String message) {
+      log.add("ReceiverB: received from Sender: " + message);
+    }
+  }
+
+  @Test
+  public void multiSender() {
+    MultiSender mySender = new MultiSender();
+    MultiReceiver myMultiReceiver = new MultiReceiver();
+
+    mySender.addReceiverA(myMultiReceiver);
+    mySender.addReceiverB(myMultiReceiver);
+
+    mySender.notifyAReceivers();
+    mySender.notifyBReceivers();
+
+    assertEquals(2, myMultiReceiver.log.size());
+    assertEquals("ReceiverA: received from Sender: Sent from A", myMultiReceiver.log.get(0));
+    assertEquals("ReceiverB: received from Sender: Sent from B", myMultiReceiver.log.get(1));
+  }
+}

--- a/examples/platforms/dart/main.dart
+++ b/examples/platforms/dart/main.dart
@@ -40,6 +40,7 @@ import "test/ListenersWithErrors_test.dart" as ListenersWithErrorsTests;
 import "test/ListenersWithReturnValues_test.dart" as ListenersWithReturnValuesTests;
 import "test/Maps_test.dart" as MapsTests;
 import "test/MethodOverloads_test.dart" as MethodOverloadsTests;
+import "test/MultiListener_test.dart" as MultiListenerTests;
 import "test/Nullable_test.dart" as NullableTests;
 import "test/PlainDataStructures_test.dart" as PlainDataStructuresTests;
 import "test/PlainDataStructuresImmutable_test.dart" as PlainDataStructuresImmutableTests;
@@ -78,6 +79,7 @@ final _allTests = [
   ListenersWithReturnValuesTests.main,
   MapsTests.main,
   MethodOverloadsTests.main,
+  MultiListenerTests.main,
   NullableTests.main,
   PlainDataStructuresTests.main,
   PlainDataStructuresImmutableTests.main,

--- a/examples/platforms/dart/test/MultiListener_test.dart
+++ b/examples/platforms/dart/test/MultiListener_test.dart
@@ -1,0 +1,61 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:hello/test.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("MultiListener");
+
+class MultiReceiver implements ReceiverA, ReceiverB {
+  final log = List<String>();
+
+  @override
+  void receiveA(String message) {
+    log.add("ReceiverA: received from Sender: " + message);
+  }
+
+  @override
+  void receiveB(String message) {
+    log.add("ReceiverB: received from Sender: " + message);
+  }
+
+  @override
+  void release() {}
+}
+
+void main() {
+  _testSuite.test("Multi-listener works", () {
+    final mySender = MultiSender();
+    final myMultiReceiver = MultiReceiver();
+
+    mySender.addReceiverA(myMultiReceiver);
+    mySender.addReceiverB(myMultiReceiver);
+
+    mySender.notifyAReceivers();
+    mySender.notifyBReceivers();
+
+    expect(myMultiReceiver.log.length, 2);
+    expect(myMultiReceiver.log[0], "ReceiverA: received from Sender: Sent from A");
+    expect(myMultiReceiver.log[1], "ReceiverB: received from Sender: Sent from B");
+
+    mySender.release();
+  });
+}

--- a/examples/platforms/ios/Tests/main.swift
+++ b/examples/platforms/ios/Tests/main.swift
@@ -49,6 +49,7 @@ let allTests = [
     testCase(ListenersWithDictionaries.allTests),
     testCase(MapsTests.allTests),
     testCase(MethodOverloadsTests.allTests),
+    testCase(MultiListenerTests.allTests),
     testCase(NullableAttributesTests.allTests),
     testCase(NullableInstancesTests.allTests),
     testCase(NullableListenersTests.allTests),

--- a/examples/platforms/ios/Tests/testTests/MultiListenerTests.swift
+++ b/examples/platforms/ios/Tests/testTests/MultiListenerTests.swift
@@ -1,0 +1,56 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import hello
+
+class MultiListenerTests: XCTestCase {
+
+    class MultiReceiver: ReceiverA, ReceiverB {
+        var log: [String] = []
+
+        public func receiveA(message: String) {
+            log.append("ReceiverA: received from Sender: " + message)
+        }
+
+        public func receiveB(message: String) {
+            log.append("ReceiverB: received from Sender: " + message)
+        }
+    }
+
+    func testMultiSender() {
+        let mySender = MultiSender()
+        let myMultiReceiver = MultiReceiver()
+
+        mySender.addReceiverA(receiver: myMultiReceiver)
+        mySender.addReceiverB(receiver: myMultiReceiver)
+
+        mySender.notifyAReceivers()
+        mySender.notifyBReceivers()
+
+        XCTAssertEqual(2, myMultiReceiver.log.count)
+        XCTAssertEqual("ReceiverA: received from Sender: Sent from A", myMultiReceiver.log[0])
+        XCTAssertEqual("ReceiverB: received from Sender: Sent from B", myMultiReceiver.log[1])
+    }
+
+    static var allTests = [
+        ("testMultiSender", testMultiSender)
+    ]
+}

--- a/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
@@ -114,7 +114,7 @@ FfiOpaqueHandle
 }}{{#if inheritedProperties properties logic="or"}}, {{!!
 }}{{#each inheritedProperties properties}}FfiOpaqueHandle p{{iter.position}}g{{!!
 }}{{#if setter}}, FfiOpaqueHandle p{{iter.position}}s{{/if}}{{#if iter.hasNext}}, {{/if}}{{/each}}{{/if}}) {
-    auto cached_proxy = {{>ffi/FfiInternal}}::get_cached_proxy<{{resolveName}}_Proxy>(token);
+    auto cached_proxy = {{>ffi/FfiInternal}}::get_cached_proxy<{{resolveName}}_Proxy>(token, "{{resolveName}}");
     std::shared_ptr<{{resolveName}}_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<{{resolveName}}_Proxy>(cached_proxy);
@@ -126,7 +126,7 @@ FfiOpaqueHandle
             }}{{#each inheritedProperties properties}}p{{iter.position}}g{{!!
             }}{{#if setter}}, p{{iter.position}}s{{/if}}{{#if iter.hasNext}}, {{/if}}{{/each}}{{/if}})
         );
-        {{>ffi/FfiInternal}}::cache_proxy(token, *proxy_ptr);
+        {{>ffi/FfiInternal}}::cache_proxy(token, "{{resolveName}}", *proxy_ptr);
     }
 
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
@@ -137,10 +137,10 @@ FfiOpaqueHandle
 FfiOpaqueHandle
 {{libraryName}}_{{resolveName}}_create_proxy({{!!
 }}uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = {{>ffi/FfiInternal}}::get_cached_proxy<{{resolveName}}_Proxy>(token);
+    auto cached_proxy = {{>ffi/FfiInternal}}::get_cached_proxy<{{resolveName}}_Proxy>(token, "{{resolveName}}");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<{{resolveName}}_Proxy>(token, isolate_id, deleter, f0);
-        {{>ffi/FfiInternal}}::cache_proxy(token, cached_proxy);
+        {{>ffi/FfiInternal}}::cache_proxy(token, "{{resolveName}}", cached_proxy);
     }
 
     return reinterpret_cast<FfiOpaqueHandle>(

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyCache.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyCache.mustache
@@ -24,6 +24,7 @@
 
 #include <memory>
 #include <mutex>
+#include <string>
 #include <unordered_map>
 
 {{#internalNamespace}}
@@ -32,14 +33,36 @@ namespace {{.}}
 {{/internalNamespace}}
 namespace ffi
 {
-static std::unordered_map<uint64_t, std::weak_ptr<void>> _proxy_cache{};
+struct ProxyCacheKey
+{
+    uint64_t token;
+    std::string type_key;
+
+    bool
+    operator==(const ProxyCacheKey& other) const {
+        return token == other.token && type_key == other.type_key;
+    }
+};
+
+struct ProxyCacheKeyHash
+{
+    inline size_t
+    operator()(const ProxyCacheKey& key) const {
+        size_t result = 7;
+        result = 31 * result + key.token;
+        result = 31 * result + std::hash<::std::string>{}(key.type_key);
+        return result;
+    }
+};
+
+static std::unordered_map<ProxyCacheKey, std::weak_ptr<void>, ProxyCacheKeyHash> _proxy_cache{};
 static std::mutex _cache_mutex;
 
 template<class T>
 std::shared_ptr<T>
-get_cached_proxy(uint64_t token) {
+get_cached_proxy(uint64_t token, const std::string& type_key) {
     const std::lock_guard<std::mutex> lock(_cache_mutex);
-    auto iter = _proxy_cache.find(token);
+    auto iter = _proxy_cache.find({token, type_key});
     return (iter != _proxy_cache.end())
         ? std::static_pointer_cast<T>(iter->second.lock())
         : std::shared_ptr<T>{};
@@ -47,9 +70,15 @@ get_cached_proxy(uint64_t token) {
 
 template<class T>
 void
-cache_proxy(uint64_t token, std::shared_ptr<T> proxy) {
+cache_proxy(uint64_t token, const std::string& type_key, std::shared_ptr<T> proxy) {
     const std::lock_guard<std::mutex> lock(_cache_mutex);
-    _proxy_cache[token] = std::weak_ptr<void>(std::static_pointer_cast<void>(proxy));
+    _proxy_cache[{token, type_key}] = std::weak_ptr<void>(std::static_pointer_cast<void>(proxy));
+}
+
+void
+remove_cached_proxy(uint64_t token, const std::string& type_key) {
+    const std::lock_guard<std::mutex> lock(_cache_mutex);
+    _proxy_cache.erase({token, type_key});
 }
 
 }

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
@@ -33,6 +33,8 @@ public:
         }}{{#if setter}}, p{{iter.position}}s(p{{iter.position}}s){{/if}}{{#if iter.hasNext}}, {{/if}}{{/each}}{{/if}} { }
 
     ~{{resolveName}}_Proxy() {
+        {{>ffi/FfiInternal}}::remove_cached_proxy(token, "{{resolveName}}");
+
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         {{>ffi/FfiInternal}}::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {

--- a/gluecodium/src/main/resources/templates/jni/InstanceConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/InstanceConversionImplementation.mustache
@@ -47,7 +47,7 @@ REGISTER_JNI_CLASS_CACHE("{{fullJavaName}}", {{mangledName}}, {{cppFullyQualifie
 void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, {{cppFullyQualifiedName}}& result)
 {
     std::shared_ptr<{{mangledName}}_CppProxy> _nproxy{};
-    CppProxyBase::createProxy<{{mangledName}}_CppProxy, {{mangledName}}_CppProxy>(env, obj, _nproxy);
+    CppProxyBase::createProxy<{{mangledName}}_CppProxy, {{mangledName}}_CppProxy>(env, obj, "{{mangledName}}", _nproxy);
     result = std::bind(&{{mangledName}}_CppProxy::operator(), _nproxy{{!!
             }}{{#methods.0.parameters}}, std::placeholders::_{{iter.index}}{{/methods.0.parameters}});
 }
@@ -55,7 +55,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, {{cppFullyQua
 template<>
 void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<{{cppFullyQualifiedName}}>& result)
 {
-    CppProxyBase::createProxy<{{cppFullyQualifiedName}}, {{mangledName}}_CppProxy>(env, obj, result);
+    CppProxyBase::createProxy<{{cppFullyQualifiedName}}, {{mangledName}}_CppProxy>(env, obj, "{{mangledName}}", result);
 }
 {{/unless}}{{/isEq}}
 

--- a/gluecodium/src/main/resources/templates/jni/utils/CppProxyBaseHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/CppProxyBaseHeader.mustache
@@ -46,11 +46,14 @@ class CppProxyBase
 public:
     template < typename ResultType, typename ImplType >
     static void
-    createProxy( JNIEnv* jenv, const JniReference<jobject>& jobj, ::std::shared_ptr< ResultType >& result )
+    createProxy( JNIEnv* jenv,
+                 const JniReference<jobject>& jobj,
+                 const ::std::string& type_key,
+                 ::std::shared_ptr< ResultType >& result )
     {
         JniReference<jobject> globalRef = new_global_ref( jenv, jobj.get() );
         jint jHashCode = getHashCode( jenv, jobj.get() );
-        ProxyCacheKey key{globalRef.get(), jHashCode};
+        ProxyCacheKey key{globalRef.get(), jHashCode, type_key};
 
         ::std::lock_guard< GlobalJniLock > lock( sGlobalJniLock );
         sGlobalJniLock.setJniEnvForCurrentThread( jenv );
@@ -107,6 +110,7 @@ private:
     {
         jobject jObject;
         jint jHashCode;
+        ::std::string type_key;
 
         bool operator==( const ProxyCacheKey& other ) const;
     };
@@ -116,7 +120,10 @@ private:
         inline size_t
         operator( )( const ProxyCacheKey& key ) const
         {
-            return key.jHashCode;
+            size_t result = 7;
+            result = 31 * result + key.jHashCode;
+            result = 31 * result + ::std::hash<::std::string>{}(key.type_key);
+            return result;
         }
     };
 

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/ffi/ffi_smoke_EquatableInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/ffi/ffi_smoke_EquatableInterface.cpp
@@ -11,6 +11,7 @@ public:
     smoke_EquatableInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter)
         : token(token), isolate_id(isolate_id), deleter(deleter) { }
     ~smoke_EquatableInterface_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_EquatableInterface");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -62,7 +63,7 @@ library_smoke_EquatableInterface_are_equal(FfiOpaqueHandle handle1, FfiOpaqueHan
 }
 FfiOpaqueHandle
 library_smoke_EquatableInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_EquatableInterface_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_EquatableInterface_Proxy>(token, "smoke_EquatableInterface");
     std::shared_ptr<smoke_EquatableInterface_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_EquatableInterface_Proxy>(cached_proxy);
@@ -70,7 +71,7 @@ library_smoke_EquatableInterface_create_proxy(uint64_t token, int32_t isolate_id
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_EquatableInterface_Proxy>(
             new (std::nothrow) smoke_EquatableInterface_Proxy(token, isolate_id, deleter)
         );
-        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, "smoke_EquatableInterface", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
@@ -15,6 +15,7 @@ public:
     smoke_ErrorsInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0), f1(f1), f2(f2), f3(f3), f4(f4) { }
     ~smoke_ErrorsInterface_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_ErrorsInterface");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -263,7 +264,7 @@ library_smoke_ErrorsInterface_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_ErrorsInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ErrorsInterface_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ErrorsInterface_Proxy>(token, "smoke_ErrorsInterface");
     std::shared_ptr<smoke_ErrorsInterface_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ErrorsInterface_Proxy>(cached_proxy);
@@ -271,7 +272,7 @@ library_smoke_ErrorsInterface_create_proxy(uint64_t token, int32_t isolate_id, F
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ErrorsInterface_Proxy>(
             new (std::nothrow) smoke_ErrorsInterface_Proxy(token, isolate_id, deleter, f0, f1, f2, f3, f4)
         );
-        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, "smoke_ErrorsInterface", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_ExternalInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_ExternalInterface__Conversion.cpp
@@ -16,7 +16,7 @@ REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/ExternalInterfaceImpl", 
 template<>
 void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::ExternalInterface>& result)
 {
-    CppProxyBase::createProxy<::smoke::ExternalInterface, com_example_smoke_ExternalInterfaceImpl_CppProxy>(env, obj, result);
+    CppProxyBase::createProxy<::smoke::ExternalInterface, com_example_smoke_ExternalInterfaceImpl_CppProxy>(env, obj, "com_example_smoke_ExternalInterfaceImpl", result);
 }
 std::shared_ptr<::smoke::ExternalInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ExternalInterface>*)
 {

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterface__Conversion.cpp
@@ -16,7 +16,7 @@ REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/SimpleInterfaceImpl", co
 template<>
 void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::SimpleInterface>& result)
 {
-    CppProxyBase::createProxy<::smoke::SimpleInterface, com_example_smoke_SimpleInterfaceImpl_CppProxy>(env, obj, result);
+    CppProxyBase::createProxy<::smoke::SimpleInterface, com_example_smoke_SimpleInterfaceImpl_CppProxy>(env, obj, "com_example_smoke_SimpleInterfaceImpl", result);
 }
 std::shared_ptr<::smoke::SimpleInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::SimpleInterface>*)
 {

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
@@ -13,6 +13,7 @@ public:
     smoke_SimpleInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0), f1(f1) { }
     ~smoke_SimpleInterface_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_SimpleInterface");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -94,7 +95,7 @@ library_smoke_SimpleInterface_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_SimpleInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_SimpleInterface_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_SimpleInterface_Proxy>(token, "smoke_SimpleInterface");
     std::shared_ptr<smoke_SimpleInterface_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_SimpleInterface_Proxy>(cached_proxy);
@@ -102,7 +103,7 @@ library_smoke_SimpleInterface_create_proxy(uint64_t token, int32_t isolate_id, F
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_SimpleInterface_Proxy>(
             new (std::nothrow) smoke_SimpleInterface_Proxy(token, isolate_id, deleter, f0, f1)
         );
-        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, "smoke_SimpleInterface", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Confounder__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Confounder__Conversion.cpp
@@ -16,7 +16,7 @@ REGISTER_JNI_CLASS_CACHE("com/example/smoke/Lambdas$ConfounderImpl", com_example
 void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::smoke::Lambdas::Confuser& result)
 {
     std::shared_ptr<com_example_smoke_Lambdas_00024ConfounderImpl_CppProxy> _nproxy{};
-    CppProxyBase::createProxy<com_example_smoke_Lambdas_00024ConfounderImpl_CppProxy, com_example_smoke_Lambdas_00024ConfounderImpl_CppProxy>(env, obj, _nproxy);
+    CppProxyBase::createProxy<com_example_smoke_Lambdas_00024ConfounderImpl_CppProxy, com_example_smoke_Lambdas_00024ConfounderImpl_CppProxy>(env, obj, "com_example_smoke_Lambdas_00024ConfounderImpl", _nproxy);
     result = std::bind(&com_example_smoke_Lambdas_00024ConfounderImpl_CppProxy::operator(), _nproxy, std::placeholders::_1);
 }
 ::smoke::Lambdas::Confuser convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, ::smoke::Lambdas::Confuser*)

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Indexer__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Indexer__Conversion.cpp
@@ -16,7 +16,7 @@ REGISTER_JNI_CLASS_CACHE("com/example/smoke/Lambdas$IndexerImpl", com_example_sm
 void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::smoke::Lambdas::Indexer& result)
 {
     std::shared_ptr<com_example_smoke_Lambdas_00024IndexerImpl_CppProxy> _nproxy{};
-    CppProxyBase::createProxy<com_example_smoke_Lambdas_00024IndexerImpl_CppProxy, com_example_smoke_Lambdas_00024IndexerImpl_CppProxy>(env, obj, _nproxy);
+    CppProxyBase::createProxy<com_example_smoke_Lambdas_00024IndexerImpl_CppProxy, com_example_smoke_Lambdas_00024IndexerImpl_CppProxy>(env, obj, "com_example_smoke_Lambdas_00024IndexerImpl", _nproxy);
     result = std::bind(&com_example_smoke_Lambdas_00024IndexerImpl_CppProxy::operator(), _nproxy, std::placeholders::_1, std::placeholders::_2);
 }
 ::smoke::Lambdas::Indexer convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, ::smoke::Lambdas::Indexer*)

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
@@ -20,6 +20,7 @@ public:
     smoke_Lambdas_Producer_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_Producer_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_Lambdas_Producer");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -55,6 +56,7 @@ public:
     smoke_Lambdas_Confuser_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_Confuser_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_Lambdas_Confuser");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -91,6 +93,7 @@ public:
     smoke_Lambdas_Consumer_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_Consumer_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_Lambdas_Consumer");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -122,6 +125,7 @@ public:
     smoke_Lambdas_Indexer_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_Indexer_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_Lambdas_Indexer");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -159,6 +163,7 @@ public:
     smoke_Lambdas_NullableConfuser_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_NullableConfuser_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_Lambdas_NullableConfuser");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -440,10 +445,10 @@ library_smoke_Lambdas_NullableConfuser_get_value_nullable(FfiOpaqueHandle handle
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_Producer_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Producer_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Producer_Proxy>(token, "smoke_Lambdas_Producer");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_Lambdas_Producer_Proxy>(token, isolate_id, deleter, f0);
-        gluecodium::ffi::cache_proxy(token, cached_proxy);
+        gluecodium::ffi::cache_proxy(token, "smoke_Lambdas_Producer", cached_proxy);
     }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::Producer(
@@ -457,10 +462,10 @@ library_smoke_Lambdas_Producer_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_Confuser_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Confuser_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Confuser_Proxy>(token, "smoke_Lambdas_Confuser");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_Lambdas_Confuser_Proxy>(token, isolate_id, deleter, f0);
-        gluecodium::ffi::cache_proxy(token, cached_proxy);
+        gluecodium::ffi::cache_proxy(token, "smoke_Lambdas_Confuser", cached_proxy);
     }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::Confuser(
@@ -474,10 +479,10 @@ library_smoke_Lambdas_Confuser_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_Consumer_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Consumer_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Consumer_Proxy>(token, "smoke_Lambdas_Consumer");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_Lambdas_Consumer_Proxy>(token, isolate_id, deleter, f0);
-        gluecodium::ffi::cache_proxy(token, cached_proxy);
+        gluecodium::ffi::cache_proxy(token, "smoke_Lambdas_Consumer", cached_proxy);
     }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::Consumer(
@@ -491,10 +496,10 @@ library_smoke_Lambdas_Consumer_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_Indexer_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Indexer_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Indexer_Proxy>(token, "smoke_Lambdas_Indexer");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_Lambdas_Indexer_Proxy>(token, isolate_id, deleter, f0);
-        gluecodium::ffi::cache_proxy(token, cached_proxy);
+        gluecodium::ffi::cache_proxy(token, "smoke_Lambdas_Indexer", cached_proxy);
     }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::Indexer(
@@ -508,10 +513,10 @@ library_smoke_Lambdas_Indexer_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_NullableConfuser_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_NullableConfuser_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_NullableConfuser_Proxy>(token, "smoke_Lambdas_NullableConfuser");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_Lambdas_NullableConfuser_Proxy>(token, isolate_id, deleter, f0);
-        gluecodium::ffi::cache_proxy(token, cached_proxy);
+        gluecodium::ffi::cache_proxy(token, "smoke_Lambdas_NullableConfuser", cached_proxy);
     }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::NullableConfuser(

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
@@ -13,6 +13,7 @@ public:
     smoke_StandaloneProducer_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_StandaloneProducer_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_StandaloneProducer");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -88,10 +89,10 @@ library_smoke_StandaloneProducer_get_value_nullable(FfiOpaqueHandle handle)
 }
 FfiOpaqueHandle
 library_smoke_StandaloneProducer_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_StandaloneProducer_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_StandaloneProducer_Proxy>(token, "smoke_StandaloneProducer");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_StandaloneProducer_Proxy>(token, isolate_id, deleter, f0);
-        gluecodium::ffi::cache_proxy(token, cached_proxy);
+        gluecodium::ffi::cache_proxy(token, "smoke_StandaloneProducer", cached_proxy);
     }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::StandaloneProducer(

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListener__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListener__Conversion.cpp
@@ -16,7 +16,7 @@ REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/CalculatorListenerImpl",
 template<>
 void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::CalculatorListener>& result)
 {
-    CppProxyBase::createProxy<::smoke::CalculatorListener, com_example_smoke_CalculatorListenerImpl_CppProxy>(env, obj, result);
+    CppProxyBase::createProxy<::smoke::CalculatorListener, com_example_smoke_CalculatorListenerImpl_CppProxy>(env, obj, "com_example_smoke_CalculatorListenerImpl", result);
 }
 std::shared_ptr<::smoke::CalculatorListener> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::CalculatorListener>*)
 {

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithProperties__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithProperties__Conversion.cpp
@@ -16,7 +16,7 @@ REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/ListenerWithPropertiesIm
 template<>
 void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::ListenerWithProperties>& result)
 {
-    CppProxyBase::createProxy<::smoke::ListenerWithProperties, com_example_smoke_ListenerWithPropertiesImpl_CppProxy>(env, obj, result);
+    CppProxyBase::createProxy<::smoke::ListenerWithProperties, com_example_smoke_ListenerWithPropertiesImpl_CppProxy>(env, obj, "com_example_smoke_ListenerWithPropertiesImpl", result);
 }
 std::shared_ptr<::smoke::ListenerWithProperties> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ListenerWithProperties>*)
 {

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenersWithReturnValues__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenersWithReturnValues__Conversion.cpp
@@ -16,7 +16,7 @@ REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/ListenersWithReturnValue
 template<>
 void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::ListenersWithReturnValues>& result)
 {
-    CppProxyBase::createProxy<::smoke::ListenersWithReturnValues, com_example_smoke_ListenersWithReturnValuesImpl_CppProxy>(env, obj, result);
+    CppProxyBase::createProxy<::smoke::ListenersWithReturnValues, com_example_smoke_ListenersWithReturnValuesImpl_CppProxy>(env, obj, "com_example_smoke_ListenersWithReturnValuesImpl", result);
 }
 std::shared_ptr<::smoke::ListenersWithReturnValues> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ListenersWithReturnValues>*)
 {

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
@@ -15,6 +15,7 @@ public:
     smoke_CalculatorListener_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4, FfiOpaqueHandle f5)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0), f1(f1), f2(f2), f3(f3), f4(f4), f5(f5) { }
     ~smoke_CalculatorListener_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_CalculatorListener");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -141,7 +142,7 @@ library_smoke_CalculatorListener_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_CalculatorListener_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4, FfiOpaqueHandle f5) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_CalculatorListener_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_CalculatorListener_Proxy>(token, "smoke_CalculatorListener");
     std::shared_ptr<smoke_CalculatorListener_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_CalculatorListener_Proxy>(cached_proxy);
@@ -149,7 +150,7 @@ library_smoke_CalculatorListener_create_proxy(uint64_t token, int32_t isolate_id
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_CalculatorListener_Proxy>(
             new (std::nothrow) smoke_CalculatorListener_Proxy(token, isolate_id, deleter, f0, f1, f2, f3, f4, f5)
         );
-        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, "smoke_CalculatorListener", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
@@ -17,6 +17,7 @@ public:
     smoke_ListenerWithProperties_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s, FfiOpaqueHandle p1g, FfiOpaqueHandle p1s, FfiOpaqueHandle p2g, FfiOpaqueHandle p2s, FfiOpaqueHandle p3g, FfiOpaqueHandle p3s, FfiOpaqueHandle p4g, FfiOpaqueHandle p4s, FfiOpaqueHandle p5g, FfiOpaqueHandle p5s, FfiOpaqueHandle p6g, FfiOpaqueHandle p6s)
         : token(token), isolate_id(isolate_id), deleter(deleter), p0g(p0g), p0s(p0s), p1g(p1g), p1s(p1s), p2g(p2g), p2s(p2s), p3g(p3g), p3s(p3s), p4g(p4g), p4s(p4s), p5g(p5g), p5s(p5s), p6g(p6g), p6s(p6s) { }
     ~smoke_ListenerWithProperties_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_ListenerWithProperties");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -269,7 +270,7 @@ library_smoke_ListenerWithProperties_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_ListenerWithProperties_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s, FfiOpaqueHandle p1g, FfiOpaqueHandle p1s, FfiOpaqueHandle p2g, FfiOpaqueHandle p2s, FfiOpaqueHandle p3g, FfiOpaqueHandle p3s, FfiOpaqueHandle p4g, FfiOpaqueHandle p4s, FfiOpaqueHandle p5g, FfiOpaqueHandle p5s, FfiOpaqueHandle p6g, FfiOpaqueHandle p6s) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ListenerWithProperties_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ListenerWithProperties_Proxy>(token, "smoke_ListenerWithProperties");
     std::shared_ptr<smoke_ListenerWithProperties_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ListenerWithProperties_Proxy>(cached_proxy);
@@ -277,7 +278,7 @@ library_smoke_ListenerWithProperties_create_proxy(uint64_t token, int32_t isolat
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ListenerWithProperties_Proxy>(
             new (std::nothrow) smoke_ListenerWithProperties_Proxy(token, isolate_id, deleter, p0g, p0s, p1g, p1s, p2g, p2s, p3g, p3s, p4g, p4s, p5g, p5s, p6g, p6s)
         );
-        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, "smoke_ListenerWithProperties", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
@@ -16,6 +16,7 @@ public:
     smoke_ListenersWithReturnValues_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4, FfiOpaqueHandle f5, FfiOpaqueHandle f6)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0), f1(f1), f2(f2), f3(f3), f4(f4), f5(f5), f6(f6) { }
     ~smoke_ListenersWithReturnValues_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_ListenersWithReturnValues");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -184,7 +185,7 @@ library_smoke_ListenersWithReturnValues_get_raw_pointer(FfiOpaqueHandle handle) 
 }
 FfiOpaqueHandle
 library_smoke_ListenersWithReturnValues_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4, FfiOpaqueHandle f5, FfiOpaqueHandle f6) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ListenersWithReturnValues_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ListenersWithReturnValues_Proxy>(token, "smoke_ListenersWithReturnValues");
     std::shared_ptr<smoke_ListenersWithReturnValues_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ListenersWithReturnValues_Proxy>(cached_proxy);
@@ -192,7 +193,7 @@ library_smoke_ListenersWithReturnValues_create_proxy(uint64_t token, int32_t iso
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ListenersWithReturnValues_Proxy>(
             new (std::nothrow) smoke_ListenersWithReturnValues_Proxy(token, isolate_id, deleter, f0, f1, f2, f3, f4, f5, f6)
         );
-        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, "smoke_ListenersWithReturnValues", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
@@ -13,6 +13,7 @@ public:
     smoke_OuterClass_InnerInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_OuterClass_InnerInterface_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_OuterClass_InnerInterface");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -112,7 +113,7 @@ library_smoke_OuterClass_InnerInterface_get_raw_pointer(FfiOpaqueHandle handle) 
 }
 FfiOpaqueHandle
 library_smoke_OuterClass_InnerInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterClass_InnerInterface_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterClass_InnerInterface_Proxy>(token, "smoke_OuterClass_InnerInterface");
     std::shared_ptr<smoke_OuterClass_InnerInterface_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterClass_InnerInterface_Proxy>(cached_proxy);
@@ -120,7 +121,7 @@ library_smoke_OuterClass_InnerInterface_create_proxy(uint64_t token, int32_t iso
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterClass_InnerInterface_Proxy>(
             new (std::nothrow) smoke_OuterClass_InnerInterface_Proxy(token, isolate_id, deleter, f0)
         );
-        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, "smoke_OuterClass_InnerInterface", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
@@ -13,6 +13,7 @@ public:
     smoke_OuterInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_OuterInterface_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_OuterInterface");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -49,6 +50,7 @@ public:
     smoke_OuterInterface_InnerInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_OuterInterface_InnerInterface_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, "smoke_OuterInterface_InnerInterface");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -148,7 +150,7 @@ library_smoke_OuterInterface_InnerInterface_get_raw_pointer(FfiOpaqueHandle hand
 }
 FfiOpaqueHandle
 library_smoke_OuterInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterInterface_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterInterface_Proxy>(token, "smoke_OuterInterface");
     std::shared_ptr<smoke_OuterInterface_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterInterface_Proxy>(cached_proxy);
@@ -156,13 +158,13 @@ library_smoke_OuterInterface_create_proxy(uint64_t token, int32_t isolate_id, Ff
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterInterface_Proxy>(
             new (std::nothrow) smoke_OuterInterface_Proxy(token, isolate_id, deleter, f0)
         );
-        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, "smoke_OuterInterface", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }
 FfiOpaqueHandle
 library_smoke_OuterInterface_InnerInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterInterface_InnerInterface_Proxy>(token);
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterInterface_InnerInterface_Proxy>(token, "smoke_OuterInterface_InnerInterface");
     std::shared_ptr<smoke_OuterInterface_InnerInterface_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterInterface_InnerInterface_Proxy>(cached_proxy);
@@ -170,7 +172,7 @@ library_smoke_OuterInterface_InnerInterface_create_proxy(uint64_t token, int32_t
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterInterface_InnerInterface_Proxy>(
             new (std::nothrow) smoke_OuterInterface_InnerInterface_Proxy(token, isolate_id, deleter, f0)
         );
-        gluecodium::ffi::cache_proxy(token, *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, "smoke_OuterInterface_InnerInterface", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }


### PR DESCRIPTION
Updated Java and Dart templates to add mangled type name to the key of
"proxy" cache. This enables the scenario where a single object on
Java/Dart side implements more than one "callback" interfaces.

Without this change there's only ever a single "proxy" for such object
(implementing whatever "callback" interface was used first). With the
fix there is now correctly one "proxy" per interface type.

Same scenario works fine in Swift without any fixes.

Added functional tests for Java, Swift, and Dart. Updated smoke tests.

Resolves: #364
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>