### PR TITLE
Fix Java compilation for methods returning nullable string

### DIFF
--- a/examples/libhello/lime/test/NullableInterface.lime
+++ b/examples/libhello/lime/test/NullableInterface.lime
@@ -121,3 +121,7 @@ struct NullableCollectionsStruct {
     dates: List<Date?>
     structs: Map<Int, NullableInterface.SomeStruct?>
 }
+
+interface InternalInterfaceWithNullable {
+    fun dummy_function(dummyVar: String): String?
+}

--- a/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsHeader.mustache
@@ -50,6 +50,8 @@ std::string convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, 
 std::string convert_from_jni( JNIEnv* env, const JniReference<jstring>& jvalue, std::string* );
 {{>common/InternalNamespace}}optional<std::string> convert_from_jni(
     JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<std::string>* );
+{{>common/InternalNamespace}}optional<std::string> convert_from_jni(
+    JNIEnv* env, const JniReference<jstring>& jvalue, {{>common/InternalNamespace}}optional<std::string>* );
 
 /**
  * Converts a jbyteArray to a byte buffer

--- a/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsImplementation.mustache
@@ -76,6 +76,14 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/In
         : {{>common/InternalNamespace}}optional<std::string>{};
 }
 
+{{>common/InternalNamespace}}optional<std::string>
+convert_from_jni( JNIEnv* env, const JniReference<jstring>& jvalue, {{>common/InternalNamespace}}optional<std::string>* )
+{
+    return jvalue
+        ? {{>common/InternalNamespace}}optional<std::string>( convert_string_from_jni( env, jvalue.get( ) ) )
+        : {{>common/InternalNamespace}}optional<std::string>{};
+}
+
 std::shared_ptr< std::vector< uint8_t > >
 convert_from_jni( JNIEnv* env, const JniReference<jbyteArray>& jvalue,
                   std::shared_ptr< std::vector< uint8_t > >* )


### PR DESCRIPTION
Added missing JNI conversion function for nullable string type to JNI
templates. This fixes a compilation issue for methods which have
nullable string as a return type.

Added compilation functional test.

Resolves: #362
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>