### PR TITLE
Move remove_cached_proxy() function body to .cpp file in Dart FFI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed compilation issue for methods returning a nullable string in Java.
+  * Fixed general compilation issue in Dart for modularized builds.
+
 ## 7.0.2
 Release date: 2020-05-27
 ### Bug fixes:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -349,14 +349,15 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
     private fun generateFfiCommonFiles(
         nameResolvers: Map<String, NameResolver>
     ): List<GeneratedFile> {
-        val headerOnly = listOf("ConversionBase", "Export", "OpaqueHandle", "ProxyCache")
+        val headerOnly = listOf("ConversionBase", "Export", "OpaqueHandle")
         val headerAndImpl = listOf(
             "StringHandle",
             "BlobHandle",
             "NullableHandles",
             "IsolateContext",
             "CallbacksQueue",
-            "CallbacksHandle"
+            "CallbacksHandle",
+            "ProxyCache"
         )
         val data = mapOf(
             "libraryName" to libraryName,

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyCacheHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyCacheHeader.mustache
@@ -75,11 +75,7 @@ cache_proxy(uint64_t token, const std::string& type_key, std::shared_ptr<T> prox
     _proxy_cache[{token, type_key}] = std::weak_ptr<void>(std::static_pointer_cast<void>(proxy));
 }
 
-void
-remove_cached_proxy(uint64_t token, const std::string& type_key) {
-    const std::lock_guard<std::mutex> lock(_cache_mutex);
-    _proxy_cache.erase({token, type_key});
-}
+void remove_cached_proxy(uint64_t token, const std::string& type_key);
 
 }
 {{#internalNamespace}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyCacheImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyCacheImpl.mustache
@@ -1,0 +1,41 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{>ffi/FfiCopyrightHeader}}
+
+#include "ProxyCache.h"
+
+{{#internalNamespace}}
+namespace {{.}}
+{
+{{/internalNamespace}}
+namespace ffi
+{
+
+void
+remove_cached_proxy(uint64_t token, const std::string& type_key) {
+    const std::lock_guard<std::mutex> lock(_cache_mutex);
+    _proxy_cache.erase({token, type_key});
+}
+
+}
+{{#internalNamespace}}
+}
+{{/internalNamespace}}


### PR DESCRIPTION
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>