### PR TITLE
Add support for Locale type to C++ generator

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -411,6 +411,12 @@ feature(CppConst cpp android swift dart SOURCES
     src/test/CppConstMethods.cpp
 )
 
+feature(Locales cpp SOURCES
+    src/test/Locales.cpp
+
+    lime/test/Locales.lime
+)
+
 if(APPLE)
     # This feature is intended for Swift only. It also does not compile outside of Apple platforms.
     feature(ObjcInterface swift SOURCES

--- a/examples/libhello/lime/test/Locales.lime
+++ b/examples/libhello/lime/test/Locales.lime
@@ -1,0 +1,23 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+class Locales {
+    static fun localeRoundTrip(input: Locale): Locale
+    static property localeProperty: Locale
+}

--- a/examples/libhello/src/test/Locales.cpp
+++ b/examples/libhello/src/test/Locales.cpp
@@ -1,0 +1,41 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/Locales.h"
+
+namespace test
+{
+lorem_ipsum::test::Locale s_locale = lorem_ipsum::test::Locale("foo", "bar", "baz");
+
+lorem_ipsum::test::Locale
+Locales::locale_round_trip(const lorem_ipsum::test::Locale& input) {
+    return input;
+}
+
+lorem_ipsum::test::Locale
+Locales::get_locale_property() {
+    return s_locale;
+}
+
+void
+Locales::set_locale_property(const lorem_ipsum::test::Locale& value) {
+    s_locale = value;
+}
+}  // namespace test

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppTypeMapper.kt
@@ -64,6 +64,10 @@ class CppTypeMapper(
             includeResolver.createInternalNamespaceInclude("TimePointHash.h")
         )
     )
+    private val localeType = CppComplexTypeRef(
+        CppNameRules.joinFullyQualifiedName(internalNamespace + "Locale"),
+        listOf(includeResolver.createInternalNamespaceInclude("Locale.h"))
+    )
 
     private fun getReturnWrapperType(outArgType: CppTypeRef, errorType: CppTypeRef): CppTypeRef =
         createTemplateTypeRef(
@@ -203,7 +207,7 @@ class CppTypeMapper(
             TypeId.STRING -> stringType
             TypeId.BLOB -> blobPointerType
             TypeId.DATE -> dateType
-            TypeId.LOCALE -> TODO()
+            TypeId.LOCALE -> localeType
         }
 
     private fun createTemplateTypeRef(

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/baseapi/BaseApiGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/baseapi/BaseApiGeneratorSuite.kt
@@ -120,7 +120,7 @@ class BaseApiGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
         val helperModel = mapOf("internalNamespace" to internalNamespace, "exportName" to exportName)
         return cppFiles.flatMap { generator.generateCode(it) } +
                 ADDITIONAL_HEADERS.map { generator.generateHelperHeader(it, helperModel) } +
-                generator.generateHelperImpl("TypeRepositoryImpl", helperModel) +
+                ADDITIONAL_IMPLS.map { generator.generateHelperImpl(it, helperModel) } +
                 generator.generateHelperHeader("Export", helperModel)
     }
 
@@ -237,6 +237,7 @@ class BaseApiGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
 
         internal val ADDITIONAL_HEADERS = listOf(
             "Hash",
+            "Locale",
             "Mutex",
             "Optional",
             "OptionalImpl",
@@ -247,6 +248,7 @@ class BaseApiGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
             "UnorderedSetHash",
             "VectorHash"
         )
+        internal val ADDITIONAL_IMPLS = listOf("LocaleImpl", "TypeRepositoryImpl")
 
         private fun flattenCppModel(members: List<CppElement>) =
             members.flatMap { it.allElementsRecursive }

--- a/gluecodium/src/main/resources/templates/cpp/Locale.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/Locale.mustache
@@ -1,0 +1,89 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "Optional.h"
+#include <string>
+
+{{#internalNamespace}}
+namespace {{.}} {
+{{/internalNamespace}}
+
+/**
+ * Represents an ISO locale, optionally with a corresponding BCP 47 language tag.
+ */
+struct Locale {
+    Locale();
+    explicit Locale(optional<std::string> language_tag);
+    Locale(optional<std::string> language_code, optional<std::string> country_code);
+    Locale(optional<std::string> language_code,
+           optional<std::string> country_code,
+           optional<std::string> script_code);
+    Locale(optional<std::string> language_code,
+           optional<std::string> country_code,
+           optional<std::string> script_code,
+           optional<std::string> language_tag);
+    explicit Locale(std::string language_tag);
+    Locale(std::string language_code, std::string country_code);
+    Locale(std::string language_code,
+           std::string country_code,
+           std::string script_code);
+    Locale(std::string language_code,
+           std::string country_code,
+           std::string script_code,
+           std::string language_tag);
+
+    /// ISO 639-1 language code (2-letter)
+    optional<std::string> language_code;
+    /// ISO 3166-1 alpha-2 country code (2-letter)
+    optional<std::string> country_code;
+    /// ISO 15924 script code (4-letter)
+    optional<std::string> script_code;
+    /// BCP 47 language tag
+    optional<std::string> language_tag;
+
+    bool operator==(const Locale& rhs) const;
+    bool operator!=(const Locale& rhs) const;
+};
+
+{{#internalNamespace}}
+}
+{{/internalNamespace}}

--- a/gluecodium/src/main/resources/templates/cpp/LocaleImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/LocaleImpl.mustache
@@ -1,0 +1,131 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "{{#internalNamespace}}{{.}}/{{/internalNamespace}}Locale.h"
+
+{{#internalNamespace}}
+namespace {{.}} {
+{{/internalNamespace}}
+
+Locale::Locale() {}
+
+Locale::Locale(optional<std::string> language_tag) : language_tag(std::move(language_tag)) {}
+
+Locale::Locale(optional<std::string> language_code, optional<std::string> country_code)
+    : language_code(std::move(language_code)),
+      country_code(std::move(country_code)) {}
+
+Locale::Locale(optional<std::string> language_code,
+               optional<std::string> country_code,
+               optional<std::string> script_code)
+    : language_code(std::move(language_code)),
+      country_code(std::move(country_code)),
+      script_code(std::move(script_code)) {}
+
+Locale::Locale(optional<std::string> language_code,
+               optional<std::string> country_code,
+               optional<std::string> script_code,
+               optional<std::string> language_tag)
+    : language_code(std::move(language_code)),
+      country_code(std::move(country_code)),
+      script_code(std::move(script_code)),
+      language_tag(std::move(language_tag)) {}
+
+Locale::Locale(std::string language_tag)
+    : language_tag(optional<std::string>(std::move(language_tag))) {}
+
+Locale::Locale(std::string language_code, std::string country_code)
+    : language_code(optional<std::string>(std::move(language_code))),
+      country_code(optional<std::string>(std::move(country_code))) {}
+
+Locale::Locale(std::string language_code,
+               std::string country_code,
+               std::string script_code)
+    : language_code(optional<std::string>(std::move(language_code))),
+      country_code(optional<std::string>(std::move(country_code))),
+      script_code(optional<std::string>(std::move(script_code))) {}
+
+Locale::Locale(std::string language_code,
+               std::string country_code,
+               std::string script_code,
+               std::string language_tag)
+    : language_code(optional<std::string>(std::move(language_code))),
+      country_code(optional<std::string>(std::move(country_code))),
+      script_code(optional<std::string>(std::move(script_code))),
+      language_tag(optional<std::string>(std::move(language_tag))) {}
+
+bool
+Locale::operator==(const Locale& rhs) const
+{
+    return
+        ((language_code && rhs.language_code)
+            ? (*language_code == *rhs.language_code)
+            : (static_cast<bool>(language_code) == static_cast<bool>(rhs.language_code))) &&
+        ((country_code && rhs.country_code)
+            ? (*country_code == *rhs.country_code)
+            : (static_cast<bool>(country_code) == static_cast<bool>(rhs.country_code))) &&
+        ((script_code && rhs.script_code)
+            ? (*script_code == *rhs.script_code)
+            : (static_cast<bool>(script_code) == static_cast<bool>(rhs.script_code))) &&
+        ((language_tag && rhs.language_tag)
+            ? (*language_tag == *rhs.language_tag)
+            : (static_cast<bool>(language_tag) == static_cast<bool>(rhs.language_tag)));
+}
+
+bool
+Locale::operator!=(const Locale& rhs) const
+{
+    return !(*this == rhs);
+}
+
+template<>
+std::size_t
+hash<Locale>::operator()(const Locale& t) const noexcept {
+    size_t hash_value = 43;
+    hash_value = (hash_value ^ hash<optional<std::string>>()(t.language_code)) << 1;
+    hash_value = (hash_value ^ hash<optional<std::string>>()(t.country_code)) << 1;
+    hash_value = (hash_value ^ hash<optional<std::string>>()(t.script_code)) << 1;
+    hash_value = (hash_value ^ hash<optional<std::string>>()(t.language_tag)) << 1;
+    return hash_value;
+}
+
+{{#internalNamespace}}
+}
+{{/internalNamespace}}

--- a/gluecodium/src/test/java/com/here/gluecodium/platform/baseapi/BaseApiGeneratorSuiteTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/platform/baseapi/BaseApiGeneratorSuiteTest.kt
@@ -43,8 +43,8 @@ class BaseApiGeneratorSuiteTest {
     fun generateFilesEmptyModel() {
         val generatedFiles = baseApiGeneratorSuite.generate(LimeModel(emptyMap(), emptyList()))
         assertNotNull(generatedFiles)
-        // + 1 for Export.h
-        val expectedGeneratedFiles = BaseApiGeneratorSuite.ADDITIONAL_HEADERS.size + 2
+        val expectedGeneratedFiles = BaseApiGeneratorSuite.ADDITIONAL_HEADERS.size +
+            BaseApiGeneratorSuite.ADDITIONAL_IMPLS.size + 1 // + 1 for Export.h
         assertEquals(
                 "Expected cpp/internal files and test generated file",
                 expectedGeneratedFiles,

--- a/gluecodium/src/test/resources/smoke/locales/output/cpp/include/smoke/Locales.h
+++ b/gluecodium/src/test/resources/smoke/locales/output/cpp/include/smoke/Locales.h
@@ -1,0 +1,32 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include "gluecodium/Locale.h"
+#include "gluecodium/UnorderedMapHash.h"
+#include "gluecodium/VectorHash.h"
+#include <string>
+#include <unordered_map>
+#include <vector>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT Locales {
+public:
+    Locales();
+    virtual ~Locales() = 0;
+public:
+    using LocaleTypeDef = ::gluecodium::Locale;
+    using LocaleArray = ::std::vector< ::gluecodium::Locale >;
+    using LocaleMap = ::std::unordered_map< ::std::string, ::gluecodium::Locale >;
+    struct _GLUECODIUM_CPP_EXPORT LocaleStruct {
+        ::gluecodium::Locale locale_field;
+        LocaleStruct( );
+        LocaleStruct( ::gluecodium::Locale locale_field );
+    };
+public:
+    virtual ::gluecodium::Locale locale_method( const ::gluecodium::Locale& input ) = 0;
+    virtual ::gluecodium::Locale get_locale_property(  ) const = 0;
+    virtual void set_locale_property( const ::gluecodium::Locale& value ) = 0;
+};
+}


### PR DESCRIPTION
Added C++ templates for custom Locale struct. The struct carries ISO and
BCP locale information supplied by the platform side. A custom struct is
needed for this as no STL type is suitable for this.

See: #372
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>