### PR TITLE
Add support for Locale type to Java generator

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -411,7 +411,7 @@ feature(CppConst cpp android swift dart SOURCES
     src/test/CppConstMethods.cpp
 )
 
-feature(Locales cpp SOURCES
+feature(Locales cpp android SOURCES
     src/test/Locales.cpp
 
     lime/test/Locales.lime

--- a/examples/libhello/lime/test/Locales.lime
+++ b/examples/libhello/lime/test/Locales.lime
@@ -19,5 +19,12 @@ package test
 
 class Locales {
     static fun localeRoundTrip(input: Locale): Locale
+    static fun localeRoundTripStripTag(input: Locale): Locale
+    static fun localeRoundTripNullable(input: Locale?): Locale?
     static property localeProperty: Locale
+
+    static property localeWithMalformedTag: Locale { get }
+    static property localeWithMalformedLanguage: Locale { get }
+    static property localeWithMalformedCountry: Locale { get }
+    static property localeWithMalformedScript: Locale { get }
 }

--- a/examples/libhello/src/test/Locales.cpp
+++ b/examples/libhello/src/test/Locales.cpp
@@ -23,9 +23,21 @@
 namespace test
 {
 lorem_ipsum::test::Locale s_locale = lorem_ipsum::test::Locale("foo", "bar", "baz");
+std::string nonsense = "@#$%";
 
 lorem_ipsum::test::Locale
 Locales::locale_round_trip(const lorem_ipsum::test::Locale& input) {
+    return input;
+}
+
+lorem_ipsum::test::Locale
+Locales::locale_round_trip_strip_tag(const lorem_ipsum::test::Locale& input) {
+    return lorem_ipsum::test::Locale(input.language_code, input.country_code, input.script_code);
+}
+
+lorem_ipsum::test::optional<lorem_ipsum::test::Locale>
+Locales::locale_round_trip_nullable(
+    const lorem_ipsum::test::optional<lorem_ipsum::test::Locale>& input) {
     return input;
 }
 
@@ -38,4 +50,29 @@ void
 Locales::set_locale_property(const lorem_ipsum::test::Locale& value) {
     s_locale = value;
 }
+
+lorem_ipsum::test::Locale
+Locales::get_locale_with_malformed_tag() {
+    return lorem_ipsum::test::Locale(nonsense);
+}
+
+lorem_ipsum::test::Locale
+Locales::get_locale_with_malformed_language() {
+    return lorem_ipsum::test::Locale(lorem_ipsum::test::optional<std::string>(nonsense),
+                                     lorem_ipsum::test::optional<std::string>());
+}
+
+lorem_ipsum::test::Locale
+Locales::get_locale_with_malformed_country() {
+    return lorem_ipsum::test::Locale(lorem_ipsum::test::optional<std::string>(),
+                                     lorem_ipsum::test::optional<std::string>(nonsense));
+}
+
+lorem_ipsum::test::Locale
+Locales::get_locale_with_malformed_script() {
+    return lorem_ipsum::test::Locale(lorem_ipsum::test::optional<std::string>(),
+                                     lorem_ipsum::test::optional<std::string>(),
+                                     lorem_ipsum::test::optional<std::string>(nonsense));
+}
+
 }  // namespace test

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/LocalesTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/LocalesTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNull;
+
+import android.os.Build;
+import com.example.here.hello.BuildConfig;
+import com.here.android.RobolectricApplication;
+import java.util.IllformedLocaleException;
+import java.util.Locale;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(
+    sdk = Build.VERSION_CODES.M,
+    application = RobolectricApplication.class,
+    constants = BuildConfig.class)
+public class LocalesTest {
+
+  @Rule public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void localeRoundTrip() {
+    Locale locale = Locale.getDefault();
+
+    Locale result = Locales.localeRoundTrip(locale);
+
+    assertEquals(locale, result);
+  }
+
+  @Test
+  public void localeRoundTripStripTag() {
+    Locale locale = Locale.getDefault();
+
+    Locale result = Locales.localeRoundTripStripTag(locale);
+
+    assertEquals(locale, result);
+  }
+
+  @Test
+  public void localeRoundTripNullable() {
+    Locale locale = Locale.getDefault();
+
+    Locale result = Locales.localeRoundTripNullable(locale);
+
+    assertEquals(locale, result);
+  }
+
+  @Test
+  public void localeRoundTripNullableNull() {
+    Locale result = Locales.localeRoundTripNullable(null);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void localePropertyRoundTrip() {
+    Locale locale = Locale.getDefault();
+
+    Locales.setLocaleProperty(locale);
+    Locale result = Locales.getLocaleProperty();
+
+    assertEquals(locale, result);
+  }
+
+  @Test
+  public void localeWithMalformedTag() {
+    expectedException.expect(IllformedLocaleException.class);
+
+    Locales.getLocaleWithMalformedTag();
+  }
+
+  @Test
+  public void localeWithMalformedLanguage() {
+    expectedException.expect(IllformedLocaleException.class);
+
+    Locales.getLocaleWithMalformedLanguage();
+  }
+
+  @Test
+  public void localeWithMalformedCountry() {
+    expectedException.expect(IllformedLocaleException.class);
+
+    Locales.getLocaleWithMalformedCountry();
+  }
+
+  @Test
+  public void localeWithMalformedScript() {
+    expectedException.expect(IllformedLocaleException.class);
+
+    Locales.getLocaleWithMalformedScript();
+  }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaTypeMapper.kt
@@ -203,7 +203,7 @@ class JavaTypeMapper(
             TypeId.STRING -> JavaReferenceTypeRef(JavaReferenceTypeRef.Type.STRING)
             TypeId.BLOB -> JavaArrayTypeRef(JavaPrimitiveTypeRef.Type.BYTE)
             TypeId.DATE -> JavaReferenceTypeRef(JavaReferenceTypeRef.Type.DATE)
-            TypeId.LOCALE -> TODO()
+            TypeId.LOCALE -> JavaReferenceTypeRef(JavaReferenceTypeRef.Type.LOCALE)
         }
 
     companion object {

--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaReferenceTypeRef.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaReferenceTypeRef.kt
@@ -41,7 +41,8 @@ class JavaReferenceTypeRef(val type: Type) :
         LONG("Long"),
         FLOAT("Float"),
         DOUBLE("Double"),
-        DATE("Date", JAVA_UTIL_PACKAGE, setOf(JavaImport("Date", JavaPackage(JAVA_UTIL_PACKAGE))))
+        DATE("Date", JAVA_UTIL_PACKAGE, setOf(JavaImport("Date", JavaPackage(JAVA_UTIL_PACKAGE)))),
+        LOCALE("Locale", JAVA_UTIL_PACKAGE, setOf(JavaImport("Locale", JavaPackage(JAVA_UTIL_PACKAGE))))
     }
 
     companion object {

--- a/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsHeader.mustache
@@ -25,6 +25,7 @@
 #include <jni.h>
 
 #include "JniReference.h"
+#include "{{>common/InternalInclude}}Locale.h"
 #include "{{>common/InternalInclude}}Optional.h"
 
 #include <chrono>
@@ -71,6 +72,15 @@ std::chrono::system_clock::time_point convert_from_jni(
     JNIEnv* env, const JniReference<jobject>& jvalue,
     {{>common/InternalNamespace}}optional<std::chrono::system_clock::time_point>* );
 
+/**
+ * Converts a Java Locale object to {{>common/InternalNamespace}}Locale.
+ */
+{{>common/InternalNamespace}}Locale convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}Locale*);
+{{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale> convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue,
+    {{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>*);
+
 // -------------------- C++ to JNI conversion functions --------------------------------------------
 
 /**
@@ -92,6 +102,13 @@ JniReference<jbyteArray> convert_to_jni(
 JniReference<jobject> convert_to_jni( JNIEnv* env, const std::chrono::system_clock::time_point& nvalue );
 JniReference<jobject> convert_to_jni(
     JNIEnv* env, const {{>common/InternalNamespace}}optional<std::chrono::system_clock::time_point>& nvalue );
+
+/**
+ * Converts {{>common/InternalNamespace}}Locale to a Java Date object.
+ */
+JniReference<jobject> convert_to_jni(JNIEnv* env, const {{>common/InternalNamespace}}Locale& nvalue);
+JniReference<jobject> convert_to_jni(
+    JNIEnv* env, const {{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>& nvalue);
 
 // -------------------- optional<std::function<>> conversion functions -----------------------------
 

--- a/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsImplementation.mustache
@@ -142,6 +142,37 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue,
         : {{>common/InternalNamespace}}optional< std::chrono::system_clock::time_point >{};
 }
 
+{{>common/InternalNamespace}}Locale
+convert_from_jni(JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}Locale*) {
+    if (!jvalue) {
+        auto exceptionClass = {{>common/InternalNamespace}}jni::find_class(env, "java/lang/NullPointerException");
+        env->ThrowNew(exceptionClass.get(), "");
+        return {{>common/InternalNamespace}}Locale();
+    }
+
+    auto languageCode = call_java_method<jstring>(env, jvalue, "getLanguage", "()Ljava/lang/String;");
+    auto countryCode = call_java_method<jstring>(env, jvalue, "getCountry", "()Ljava/lang/String;");
+    auto scriptCode = call_java_method<jstring>(env, jvalue, "getScript", "()Ljava/lang/String;");
+    auto languageTag = call_java_method<jstring>(env, jvalue, "toLanguageTag", "()Ljava/lang/String;");
+
+    return {{>common/InternalNamespace}}Locale(
+        convert_from_jni(env, languageCode, (std::string*)nullptr),
+        convert_from_jni(env, countryCode, (std::string*)nullptr),
+        convert_from_jni(env, scriptCode, (std::string*)nullptr),
+        convert_from_jni(env, languageTag, (std::string*)nullptr)
+    );
+}
+
+{{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>
+convert_from_jni(JNIEnv* env, const JniReference<jobject>& jvalue,
+                 {{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>*)
+{
+    return jvalue
+        ? {{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>(
+            convert_from_jni(env, jvalue, ({{>common/InternalNamespace}}Locale*)nullptr))
+        : {{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>{};
+}
+
 // -------------------- C++ to JNI conversion functions --------------------------------------------
 
 JniReference<jstring>
@@ -195,6 +226,46 @@ convert_to_jni( JNIEnv* env,
                 const {{>common/InternalNamespace}}optional< std::chrono::system_clock::time_point >& nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* env, const {{>common/InternalNamespace}}Locale& nvalue) {
+    auto localeBuilderClass = find_class(env, "java/util/Locale$Builder");
+    auto builder = create_object(env, localeBuilderClass);
+    if (nvalue.language_tag) {
+        // BCP 47 language tag takes precedence if present.
+        call_java_method<jobject>(
+            env, builder, "setLanguageTag", "(Ljava/lang/String;)Ljava/util/Locale$Builder;",
+            convert_to_jni(env, nvalue.language_tag)
+        );
+        if (env->ExceptionOccurred()) return {};
+    } else {
+        // java.util.Locale has no constructor that takes "script" code,
+        // so Locale.Builder has to be used instead to create a Locale from ISO codes.
+        call_java_method<jobject>(
+            env, builder, "setLanguage", "(Ljava/lang/String;)Ljava/util/Locale$Builder;",
+            convert_to_jni(env, nvalue.language_code)
+        );
+        if (env->ExceptionOccurred()) return {};
+
+        call_java_method<jobject>(
+            env, builder, "setRegion", "(Ljava/lang/String;)Ljava/util/Locale$Builder;",
+            convert_to_jni(env, nvalue.country_code)
+        );
+        if (env->ExceptionOccurred()) return {};
+
+        call_java_method<jobject>(
+            env, builder, "setScript", "(Ljava/lang/String;)Ljava/util/Locale$Builder;",
+            convert_to_jni(env, nvalue.script_code)
+        );
+        if (env->ExceptionOccurred()) return {};
+    }
+    return call_java_method<jobject>(env, builder, "build", "()Ljava/util/Locale;");
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* env, const {{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>& nvalue) {
+    return nvalue ? convert_to_jni(env, *nvalue) : JniReference<jobject>{};
 }
 
 }

--- a/gluecodium/src/test/resources/smoke/locales/output/android/com/example/smoke/Locales.java
+++ b/gluecodium/src/test/resources/smoke/locales/output/android/com/example/smoke/Locales.java
@@ -1,0 +1,34 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import com.example.NativeBase;
+import java.util.Locale;
+public final class Locales extends NativeBase {
+    public final static class LocaleStruct {
+        @NonNull
+        public Locale localeField;
+        public LocaleStruct(@NonNull final Locale localeField) {
+            this.localeField = localeField;
+        }
+    }
+    /**
+     * For internal use only.
+     * @exclude
+     */
+    protected Locales(final long nativeHandle) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+    private static native void disposeNativeHandle(long nativeHandle);
+    @NonNull
+    public native Locale localeMethod(@NonNull final Locale input);
+    @NonNull
+    public native Locale getLocaleProperty();
+    public native void setLocaleProperty(@NonNull final Locale value);
+}

--- a/gluecodium/src/test/resources/smoke/locales/output/android/jni/com_example_smoke_Locales.cpp
+++ b/gluecodium/src/test/resources/smoke/locales/output/android/jni/com_example_smoke_Locales.cpp
@@ -1,0 +1,59 @@
+/*
+ *
+ */
+#include "com_example_smoke_Locales.h"
+#include "com_example_smoke_Locales__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+#include "JniWrapperCache.h"
+extern "C" {
+jobject
+Java_com_example_smoke_Locales_localeMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    ::gluecodium::Locale input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::gluecodium::Locale*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Locales>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->locale_method(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+jobject
+Java_com_example_smoke_Locales_getLocaleProperty(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Locales>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->get_locale_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+void
+Java_com_example_smoke_Locales_setLocaleProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
+{
+    ::gluecodium::Locale value = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jvalue),
+            (::gluecodium::Locale*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Locales>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->set_locale_property(value);
+}
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Locales_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::Locales>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+}


### PR DESCRIPTION
Added java.util.Locale type support to Java generator. Added conversion
functions for this type to JNI templates. Added functional and smoke
tests.

See: #372
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>