### PR TITLE
Add support for Locale type to Swift generator

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -411,7 +411,7 @@ feature(CppConst cpp android swift dart SOURCES
     src/test/CppConstMethods.cpp
 )
 
-feature(Locales cpp android SOURCES
+feature(Locales cpp android swift SOURCES
     src/test/Locales.cpp
 
     lime/test/Locales.lime

--- a/examples/platforms/ios/Tests/main.swift
+++ b/examples/platforms/ios/Tests/main.swift
@@ -47,6 +47,7 @@ let allTests = [
     testCase(ListenersReturnValuesTests.allTests),
     testCase(ListenersTests.allTests),
     testCase(ListenersWithDictionaries.allTests),
+    testCase(LocalesTests.allTests),
     testCase(MapsTests.allTests),
     testCase(MethodOverloadsTests.allTests),
     testCase(MultiListenerTests.allTests),

--- a/examples/platforms/ios/Tests/testTests/LocalesTests.swift
+++ b/examples/platforms/ios/Tests/testTests/LocalesTests.swift
@@ -1,0 +1,100 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import hello
+
+class LocalesTests: XCTestCase {
+
+    func testLocaleRoundTrip() {
+        let locale = Locale.current
+
+        let result = Locales.localeRoundTrip(input: locale)
+
+        XCTAssertEqual(result.identifier, locale.identifier)
+    }
+
+    func testLocaleRoundTripStripTag() {
+        let locale = Locale.current
+
+        let result = Locales.localeRoundTripStripTag(input: locale)
+
+        XCTAssertEqual(result.identifier, locale.identifier)
+    }
+
+    func testLocaleRoundTripNullable() {
+        let locale = Locale.current
+
+        let result = Locales.localeRoundTripNullable(input: locale)
+
+        XCTAssertEqual(result?.identifier, locale.identifier)
+    }
+
+    func testLocaleRoundTripNullableNull() {
+        let result = Locales.localeRoundTripNullable(input: nil)
+
+        XCTAssertNil(result)
+    }
+
+    func testLocalePropertyRoundTrip() {
+        let locale = Locale.current
+
+        Locales.localeProperty = locale
+        let result = Locales.localeProperty
+
+        XCTAssertEqual(result.identifier, locale.identifier)
+    }
+
+    func testLocaleWithMalformedTag() {
+        let result = Locales.localeWithMalformedTag
+
+        XCTAssertEqual(result.identifier, "")
+    }
+
+    func testLocaleWithMalformedLanguage() {
+        let result = Locales.localeWithMalformedLanguage
+
+        XCTAssertEqual(result.identifier, "")
+    }
+
+    func testLocaleWithMalformedCountry() {
+        let result = Locales.localeWithMalformedCountry
+
+        XCTAssertEqual(result.identifier, "_")
+    }
+
+    func testLocaleWithMalformedScript() {
+        let result = Locales.localeWithMalformedScript
+
+        XCTAssertEqual(result.identifier, "_")
+    }
+
+    static var allTests = [
+        ("testLocaleRoundTrip", testLocaleRoundTrip),
+        ("testLocaleRoundTripStripTag", testLocaleRoundTripStripTag),
+        ("testLocaleRoundTripNullable", testLocaleRoundTripNullable),
+        ("testLocaleRoundTripNullableNull", testLocaleRoundTripNullableNull),
+        ("testLocalePropertyRoundTrip", testLocalePropertyRoundTrip),
+        ("testLocaleWithMalformedTag", testLocaleWithMalformedTag),
+        ("testLocaleWithMalformedLanguage", testLocaleWithMalformedLanguage),
+        ("testLocaleWithMalformedCountry", testLocaleWithMalformedCountry),
+        ("testLocaleWithMalformedScript", testLocaleWithMalformedScript)
+    ]
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
@@ -86,6 +86,10 @@ class CBridgeGenerator(
                 Paths.get(CBRIDGE_PUBLIC, SRC_DIR, "ByteArrayHandle.cpp").toString()
             ),
             generateHelperContent(
+                "LocaleHandle",
+                Paths.get(CBRIDGE_PUBLIC, SRC_DIR, "LocaleHandle.cpp").toString()
+            ),
+            generateHelperContent(
                 "DateHandle",
                 Paths.get(CBRIDGE_PUBLIC, SRC_DIR, "DateHandle.cpp").toString()
             ),
@@ -226,6 +230,9 @@ class CBridgeGenerator(
             ),
             GeneratorSuite.copyCommonFile(
                 Paths.get(CBRIDGE_PUBLIC, INCLUDE_DIR, "ByteArrayHandle.h").toString(), ""
+            ),
+            GeneratorSuite.copyCommonFile(
+                Paths.get(CBRIDGE_PUBLIC, INCLUDE_DIR, "LocaleHandle.h").toString(), ""
             ),
             GeneratorSuite.copyCommonFile(CBridgeComponents.PROXY_CACHE_FILENAME, "")
         )

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeTypeMapper.kt
@@ -64,6 +64,12 @@ class CBridgeTypeMapper(
         CType.BYTE_ARRAY_REF,
         listOf(BASE_HANDLE_IMPL_INCLUDE)
     )
+    private val localeTypeInfo = CppTypeInfo(
+        "${internalNamespace.joinToString("::")}::Locale",
+        CType(BASE_REF_NAME),
+        CType(BASE_REF_NAME),
+        listOf(BASE_HANDLE_IMPL_INCLUDE)
+    )
 
     fun mapType(limeTypeRef: LimeTypeRef, cppTypeRef: CppTypeRef): CppTypeInfo {
         val typeInfo = mapType(limeTypeRef.type, cppTypeRef)
@@ -134,7 +140,7 @@ class CBridgeTypeMapper(
             TypeId.STRING -> CppTypeInfo.STRING
             TypeId.BLOB -> byteBufferTypeInfo
             TypeId.DATE -> CppTypeInfo.DATE
-            TypeId.LOCALE -> TODO()
+            TypeId.LOCALE -> localeTypeInfo
         }
 
     private fun createMapTypeInfo(limeType: LimeMap, cppType: CppTypeRef): CppMapTypeInfo {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftTypeMapper.kt
@@ -176,7 +176,7 @@ class SwiftTypeMapper(
                 TypeId.DOUBLE -> SwiftType.DOUBLE
                 TypeId.BLOB -> SwiftType.DATA
                 TypeId.DATE -> SwiftType.DATE
-                TypeId.LOCALE -> TODO()
+                TypeId.LOCALE -> SwiftType.LOCALE
             }
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftType.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftType.kt
@@ -42,8 +42,7 @@ open class SwiftType protected constructor(
     enum class TypeCategory {
         BUILTIN_SIMPLE,
         BUILTIN_STRING,
-        BUILTIN_BYTEBUFFER,
-        BUILTIN_DATE,
+        BUILTIN_OTHER,
         STRUCT,
         ENUM,
         CLASS,
@@ -82,7 +81,8 @@ open class SwiftType protected constructor(
         val FLOAT = SwiftType("Float", "float")
         val DOUBLE = SwiftType("Double", "double")
         val STRING = SwiftType("String", "std_string", TypeCategory.BUILTIN_STRING)
-        val DATA = SwiftType("Data", "data", TypeCategory.BUILTIN_BYTEBUFFER)
-        val DATE = SwiftType("Date", "date", TypeCategory.BUILTIN_DATE)
+        val DATA = SwiftType("Data", "data", TypeCategory.BUILTIN_OTHER)
+        val DATE = SwiftType("Date", "date", TypeCategory.BUILTIN_OTHER)
+        val LOCALE = SwiftType("Locale", "locale", TypeCategory.BUILTIN_OTHER)
     }
 }

--- a/gluecodium/src/main/resources/cbridge/include/LocaleHandle.h
+++ b/gluecodium/src/main/resources/cbridge/include/LocaleHandle.h
@@ -1,0 +1,48 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "BaseHandle.h"
+#include "Export.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+_GLUECODIUM_C_EXPORT _baseRef locale_create_handle(_baseRef language_code_handle,
+                                                   _baseRef country_code_handle,
+                                                   _baseRef script_code_handle,
+                                                   _baseRef language_tag_handle);
+_GLUECODIUM_C_EXPORT void locale_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef locale_get_language_code(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef locale_get_country_code(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef locale_get_script_code(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef locale_get_language_tag(_baseRef handle);
+
+_GLUECODIUM_C_EXPORT _baseRef locale_create_optional_handle(_baseRef locale_handle);
+_GLUECODIUM_C_EXPORT void locale_release_optional_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef locale_unwrap_optional_handle(_baseRef handle);
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/main/resources/templates/cbridge/LocaleHandle.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/LocaleHandle.mustache
@@ -1,0 +1,127 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "cbridge/include/LocaleHandle.h"
+
+#include "{{>common/InternalInclude}}/Locale.h"
+#include "{{>common/InternalInclude}}/Optional.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include <new>
+#include <string>
+
+_baseRef
+locale_create_handle(_baseRef language_code_handle,
+                     _baseRef country_code_handle,
+                     _baseRef script_code_handle,
+                     _baseRef language_tag_handle)
+{
+    return reinterpret_cast<_baseRef>(
+        new (std::nothrow) {{>common/InternalNamespace}}Locale(
+            Conversion<{{>common/InternalNamespace}}optional<std::string>>::toCpp(language_code_handle),
+            Conversion<{{>common/InternalNamespace}}optional<std::string>>::toCpp(country_code_handle),
+            Conversion<{{>common/InternalNamespace}}optional<std::string>>::toCpp(script_code_handle),
+            Conversion<std::string>::toCpp(language_tag_handle)
+        )
+    );
+}
+
+void
+locale_release_handle(_baseRef handle)
+{
+    delete get_pointer<{{>common/InternalNamespace}}Locale>(handle);
+}
+
+_baseRef
+locale_get_language_code(_baseRef handle)
+{
+    return Conversion<{{>common/InternalNamespace}}optional<std::string>>::toBaseRef(
+        get_pointer<{{>common/InternalNamespace}}Locale>(handle)->language_code
+    );
+}
+
+_baseRef
+locale_get_country_code(_baseRef handle)
+{
+    return Conversion<{{>common/InternalNamespace}}optional<std::string>>::toBaseRef(
+        get_pointer<{{>common/InternalNamespace}}Locale>(handle)->country_code
+    );
+}
+
+_baseRef
+locale_get_script_code(_baseRef handle)
+{
+    return Conversion<{{>common/InternalNamespace}}optional<std::string>>::toBaseRef(
+        get_pointer<{{>common/InternalNamespace}}Locale>(handle)->script_code
+    );
+}
+
+_baseRef
+locale_get_language_tag(_baseRef handle)
+{
+    return Conversion<{{>common/InternalNamespace}}optional<std::string>>::toBaseRef(
+        get_pointer<{{>common/InternalNamespace}}Locale>(handle)->language_tag
+    );
+}
+
+_baseRef
+locale_create_optional_handle(_baseRef locale_handle)
+{
+    return reinterpret_cast<_baseRef>(
+        new (std::nothrow) {{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>(
+            *get_pointer<{{>common/InternalNamespace}}Locale>(locale_handle)
+        )
+    );
+}
+
+void
+locale_release_optional_handle(_baseRef handle)
+{
+    delete reinterpret_cast<{{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>*>(handle);
+}
+
+_baseRef
+locale_unwrap_optional_handle(_baseRef handle)
+{
+    return reinterpret_cast<_baseRef>(
+        new (std::nothrow) {{>common/InternalNamespace}}Locale(
+            **reinterpret_cast<{{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>*>(handle)
+        )
+    );
+}

--- a/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/smoke/cbridge_Locales.cpp
+++ b/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/smoke/cbridge_Locales.cpp
@@ -1,0 +1,72 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_Locales.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
+#include "gluecodium/Optional.h"
+#include "gluecodium/TypeRepository.h"
+#include "smoke/Locales.h"
+#include <memory>
+#include <new>
+void smoke_Locales_release_handle(_baseRef handle) {
+    delete get_pointer<std::shared_ptr<::smoke::Locales>>(handle);
+}
+_baseRef smoke_Locales_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Locales>>(handle)))
+        : 0;
+}
+const void* smoke_Locales_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Locales>>(handle)->get())
+        : nullptr;
+}
+void smoke_Locales_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Locales>>(handle)->get(), swift_pointer);
+}
+void smoke_Locales_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Locales>>(handle)->get());
+}
+_baseRef
+smoke_Locales_LocaleStruct_create_handle( _baseRef localeField )
+{
+    ::smoke::Locales::LocaleStruct* _struct = new ( std::nothrow ) ::smoke::Locales::LocaleStruct();
+    _struct->locale_field = Conversion<gluecodium::Locale>::toCpp( localeField );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+void
+smoke_Locales_LocaleStruct_release_handle( _baseRef handle )
+{
+    delete get_pointer<::smoke::Locales::LocaleStruct>( handle );
+}
+_baseRef
+smoke_Locales_LocaleStruct_create_optional_handle(_baseRef localeField)
+{
+    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Locales::LocaleStruct>( ::smoke::Locales::LocaleStruct( ) );
+    (*_struct)->locale_field = Conversion<gluecodium::Locale>::toCpp( localeField );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+_baseRef
+smoke_Locales_LocaleStruct_unwrap_optional_handle( _baseRef handle )
+{
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::smoke::Locales::LocaleStruct>*>( handle ) );
+}
+void smoke_Locales_LocaleStruct_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::smoke::Locales::LocaleStruct>*>( handle );
+}
+_baseRef smoke_Locales_LocaleStruct_localeField_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const ::smoke::Locales::LocaleStruct>(handle);
+return Conversion<gluecodium::Locale>::toBaseRef(struct_pointer->locale_field);
+}
+_baseRef smoke_Locales_localeMethod(_baseRef _instance, _baseRef input) {
+    return Conversion<gluecodium::Locale>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Locales>>(_instance)->get()->locale_method(Conversion<gluecodium::Locale>::toCpp(input)));
+}
+_baseRef smoke_Locales_localeProperty_get(_baseRef _instance) {
+    return Conversion<gluecodium::Locale>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Locales>>(_instance)->get()->get_locale_property());
+}
+void smoke_Locales_localeProperty_set(_baseRef _instance, _baseRef newValue) {
+    return get_pointer<std::shared_ptr<::smoke::Locales>>(_instance)->get()->set_locale_property(Conversion<gluecodium::Locale>::toCpp(newValue));
+}

--- a/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/Locales.swift
+++ b/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/Locales.swift
@@ -1,0 +1,134 @@
+//
+//
+import Foundation
+public class Locales {
+    public typealias LocaleTypeDef = Locale
+    public typealias LocaleArray = [Locale]
+    public typealias LocaleMap = [String: Locale]
+    public var localeProperty: Locale {
+        get {
+            return moveFromCType(smoke_Locales_localeProperty_get(self.c_instance))
+        }
+        set {
+            let c_newValue = moveToCType(newValue)
+            return moveFromCType(smoke_Locales_localeProperty_set(self.c_instance, c_newValue.ref))
+        }
+    }
+    let c_instance : _baseRef
+    init(cLocales: _baseRef) {
+        guard cLocales != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cLocales
+    }
+    deinit {
+        smoke_Locales_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_Locales_release_handle(c_instance)
+    }
+    public struct LocaleStruct {
+        public var localeField: Locale
+        public init(localeField: Locale) {
+            self.localeField = localeField
+        }
+        internal init(cHandle: _baseRef) {
+            localeField = moveFromCType(smoke_Locales_LocaleStruct_localeField_get(cHandle))
+        }
+    }
+    public func localeMethod(input: Locale) -> Locale {
+        let c_input = moveToCType(input)
+        return moveFromCType(smoke_Locales_localeMethod(self.c_instance, c_input.ref))
+    }
+}
+internal func getRef(_ ref: Locales?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_Locales_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_Locales_release_handle)
+        : RefHolder(handle_copy)
+}
+extension Locales: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func Locales_copyFromCType(_ handle: _baseRef) -> Locales {
+    if let swift_pointer = smoke_Locales_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Locales {
+        return re_constructed
+    }
+    let result = Locales(cLocales: smoke_Locales_copy_handle(handle))
+    smoke_Locales_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func Locales_moveFromCType(_ handle: _baseRef) -> Locales {
+    if let swift_pointer = smoke_Locales_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Locales {
+        return re_constructed
+    }
+    let result = Locales(cLocales: handle)
+    smoke_Locales_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func Locales_copyFromCType(_ handle: _baseRef) -> Locales? {
+    guard handle != 0 else {
+        return nil
+    }
+    return Locales_moveFromCType(handle) as Locales
+}
+internal func Locales_moveFromCType(_ handle: _baseRef) -> Locales? {
+    guard handle != 0 else {
+        return nil
+    }
+    return Locales_moveFromCType(handle) as Locales
+}
+internal func copyToCType(_ swiftClass: Locales) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: Locales) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: Locales?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: Locales?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyFromCType(_ handle: _baseRef) -> Locales.LocaleStruct {
+    return Locales.LocaleStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> Locales.LocaleStruct {
+    defer {
+        smoke_Locales_LocaleStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: Locales.LocaleStruct) -> RefHolder {
+    let c_localeField = moveToCType(swiftType.localeField)
+    return RefHolder(smoke_Locales_LocaleStruct_create_handle(c_localeField.ref))
+}
+internal func moveToCType(_ swiftType: Locales.LocaleStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Locales_LocaleStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> Locales.LocaleStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_Locales_LocaleStruct_unwrap_optional_handle(handle)
+    return Locales.LocaleStruct(cHandle: unwrappedHandle) as Locales.LocaleStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> Locales.LocaleStruct? {
+    defer {
+        smoke_Locales_LocaleStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: Locales.LocaleStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_localeField = moveToCType(swiftType.localeField)
+    return RefHolder(smoke_Locales_LocaleStruct_create_optional_handle(c_localeField.ref))
+}
+internal func moveToCType(_ swiftType: Locales.LocaleStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Locales_LocaleStruct_release_optional_handle)
+}


### PR DESCRIPTION
Added Locale Foundation type support to swift generator. Added
conversion functions for this type to Swift and CBridge templates. Added
functional and smoke tests.

See: #372
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>