### PR TITLE
Use try-finally for "fromFfi" conversions in Dart

### DIFF
--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -207,8 +207,11 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
     }}('{{libraryName}}_{{resolveName getter "Ffi"}}');
     final __result_handle = _{{resolveName getter}}_ffi({{!!
     }}{{#unless isStatic}}this.handle, {{/unless}}__lib.LibraryContext.isolateId);
-    _cache_{{resolveName}} = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
-    {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
+    try {
+      _cache_{{resolveName}} = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
+    } finally {
+      {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
+    }
     _is_cached_{{resolveName}} = true;
   }
   return _cache_{{resolveName}};

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
@@ -38,9 +38,11 @@
   if (_{{resolveName}}_return_has_error(__call_result_handle) != 0) {
       final __error_handle = _{{resolveName}}_return_get_error(__call_result_handle);
       _{{resolveName}}_return_release_handle(__call_result_handle);
-      final _error_value = {{#set call="fromFfi" typeRef=exception.errorType}}{{>dart/DartFfiConversionCall}}{{/set}}(__error_handle);
-      {{#set call="releaseFfiHandle" typeRef=exception.errorType}}{{>dart/DartFfiConversionCall}}{{/set}}(__error_handle);
-      throw {{resolveName exception}}(_error_value);
+      try {
+        throw {{resolveName exception}}({{#set call="fromFfi" typeRef=exception.errorType}}{{>dart/DartFfiConversionCall}}{{/set}}(__error_handle));
+      } finally {
+        {{#set call="releaseFfiHandle" typeRef=exception.errorType}}{{>dart/DartFfiConversionCall}}{{/set}}(__error_handle);
+      }
   }
   final __result_handle = _{{resolveName}}_return_get_result(__call_result_handle);
   _{{resolveName}}_return_release_handle(__call_result_handle);
@@ -60,6 +62,8 @@
 }}{{#unless isStatic}}Pointer<Void>, {{/unless}}int{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{/ffiDart}}{{!!
 
-}}{{+ffiReturnConversion}}  {{#returnType}}final _result = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
-  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);{{/returnType}}
-  return _result;{{/ffiReturnConversion}}
+}}{{+ffiReturnConversion}}  {{#returnType}}try {
+    return {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
+  } finally {
+    {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
+  }{{/returnType}}{{/ffiReturnConversion}}

--- a/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
@@ -111,15 +111,21 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
 {{#instanceOf this "LimeMap"}}
     final _key_handle = _{{resolveName "Ffi"}}_iterator_get_key(_iterator_handle);
     final _value_handle = _{{resolveName "Ffi"}}_iterator_get_value(_iterator_handle);
-    result[{{#set typeRef=keyType call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_key_handle)] =
-      {{#set typeRef=valueType call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value_handle);
-    {{#set typeRef=keyType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_key_handle);
-    {{#set typeRef=valueType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value_handle);
+    try {
+      result[{{#set typeRef=keyType call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_key_handle)] =
+        {{#set typeRef=valueType call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value_handle);
+    } finally {
+      {{#set typeRef=keyType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_key_handle);
+      {{#set typeRef=valueType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value_handle);
+    }
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
     final _element_handle = _{{resolveName "Ffi"}}_iterator_get(_iterator_handle);
-    result.add({{#set typeRef=elementType call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_element_handle));
-    {{#set typeRef=elementType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_element_handle);
+    try {
+      result.add({{#set typeRef=elementType call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_element_handle));
+    } finally {
+      {{#set typeRef=elementType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_element_handle);
+    }
 {{/notInstanceOf}}
     _{{resolveName "Ffi"}}_iterator_increment(_iterator_handle);
   }

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -203,19 +203,16 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 }}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
 }}{{#unless returnType.isVoid}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/unless}}{{!!
 }}{{#if thrownType}}, Pointer<{{resolveName exception.errorType "FfiApiTypes"}}> _error{{/if}}) {
-  {{#if thrownType}}
+{{#if thrownType}}
   bool _error_flag = false;
+{{/if}}{{#unless returnType.isVoid}}
+  {{resolveName returnType.typeRef}} _result_object = null;{{/unless}}
   try {
-  {{/if}}
-{{#parameters}}
-  final __{{resolveName}} = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
-  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
-{{/parameters}}
-  {{#unless returnType.isVoid}}final _result_object = {{/unless}}{{!!
+    {{#unless returnType.isVoid}}_result_object = {{/unless}}{{!!
   }}(__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}}({{#parameters}}{{!!
-  }}__{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{!!
+  }}{{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}}){{#if iter.hasNext}}, {{/if}}{{!!
   }}{{/parameters}});{{#unless returnType.isVoid}}
-  _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/unless}}
+    _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/unless}}
 {{#if thrownType}}
   } on {{resolveName exception}} catch(e) {
     _error_flag = true;
@@ -226,16 +223,17 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 {{/instanceOf}}{{#instanceOf exception.errorType.type.actualType "LimeInterface"}}
     if (_error_object != null) _error_object.release();
 {{/instanceOf}}
+{{/if}}
   } finally {
-  {{/if}}{{!!
+{{#parameters}}
+    {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
+{{/parameters}}{{!!
 }}{{#instanceOf returnType.typeRef.type.actualType "LimeClass"}}
-  if (_result_object != null) _result_object.release();
+    if (_result_object != null) _result_object.release();
 {{/instanceOf}}{{#instanceOf returnType.typeRef.type.actualType "LimeInterface"}}
-  if (_result_object != null) _result_object.release();
-{{/instanceOf}}{{!!
-  }}{{#if thrownType}}
+    if (_result_object != null) _result_object.release();
+{{/instanceOf}}
   }
-  {{/if}}
   return{{#if thrownType}} _error_flag ? 1 :{{/if}} 0;
 }
 {{/each}}
@@ -249,9 +247,12 @@ int _{{resolveName parent}}_{{resolveName}}_get_static(int _token, Pointer<{{res
 {{#if setter}}
 
 int _{{resolveName parent}}_{{resolveName}}_set_static(int _token, {{resolveName typeRef "FfiDartTypes"}} _value) {
-  final __value = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value);
-  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value);
-  (__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}} = __value;
+  try {
+    (__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}} =
+      {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value);
+  } finally {
+    {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value);
+  }
   return 0;
 }
 {{/if}}

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -57,18 +57,22 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 }}int _token{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
 }}{{#unless returnType.isVoid}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/unless}}) {
-  {{#unless returnType.isVoid}}final _result_object = {{/unless}}{{!!
+  {{#unless returnType.isVoid}}{{resolveName returnType.typeRef}} _result_object;{{/unless}}
+  try {
+    {{#unless returnType.isVoid}}_result_object = {{/unless}}{{!!
   }}(__lib.instanceCache[_token] as {{resolveName parent}})({{#parameters}}{{!!
   }}{{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}}){{#if iter.hasNext}}, {{/if}}{{!!
   }}{{/parameters}});{{#unless returnType.isVoid}}
-  _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/unless}}
+    _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/unless}}
+  } finally {
 {{#parameters}}
-  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
+    {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
 {{/parameters}}{{#instanceOf returnType.typeRef.type.actualType "LimeClass"}}
-  if (_result_object != null) _result_object.release();
+    if (_result_object != null) _result_object.release();
 {{/instanceOf}}{{#instanceOf returnType.typeRef.type.actualType "LimeInterface"}}
-  if (_result_object != null) _result_object.release();
+    if (_result_object != null) _result_object.release();
 {{/instanceOf}}
+  }
   return 0;
 }
 {{/asFunction}}{{/set}}

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -104,13 +104,15 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
 {{#set parent=this}}{{#fields}}
   final _{{resolveName}}_handle = _{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}}(handle);
 {{/fields}}{{/set}}
-  final _result = {{resolveName}}{{#if constructors}}._{{/if}}({{#fields}}
-    {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle){{#if iter.hasNext}}, {{/if}}
-  {{/fields}});
+  try {
+    return {{resolveName}}{{#if constructors}}._{{/if}}({{#fields}}
+      {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle){{#if iter.hasNext}}, {{/if}}
+    {{/fields}});
+  } finally {
 {{#fields}}
-  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle);
+    {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle);
 {{/fields}}
-  return _result;
+  }
 }
 
 void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveName "Ffi"}}_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -52,108 +52,132 @@ class BasicTypes$Impl implements BasicTypes {
     final _input_handle = String_toFfi(input);
     final __result_handle = _stringFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   static bool boolFunction(bool input) {
     final _boolFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_boolFunction__Boolean');
     final _input_handle = Boolean_toFfi(input);
     final __result_handle = _boolFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     Boolean_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   static double floatFunction(double input) {
     final _floatFunction_ffi = __lib.nativeLibrary.lookupFunction<Float Function(Int32, Float), double Function(int, double)>('library_smoke_BasicTypes_floatFunction__Float');
     final _input_handle = (input);
     final __result_handle = _floatFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static double doubleFunction(double input) {
     final _doubleFunction_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_BasicTypes_doubleFunction__Double');
     final _input_handle = (input);
     final __result_handle = _doubleFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static int byteFunction(int input) {
     final _byteFunction_ffi = __lib.nativeLibrary.lookupFunction<Int8 Function(Int32, Int8), int Function(int, int)>('library_smoke_BasicTypes_byteFunction__Byte');
     final _input_handle = (input);
     final __result_handle = _byteFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static int shortFunction(int input) {
     final _shortFunction_ffi = __lib.nativeLibrary.lookupFunction<Int16 Function(Int32, Int16), int Function(int, int)>('library_smoke_BasicTypes_shortFunction__Short');
     final _input_handle = (input);
     final __result_handle = _shortFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static int intFunction(int input) {
     final _intFunction_ffi = __lib.nativeLibrary.lookupFunction<Int32 Function(Int32, Int32), int Function(int, int)>('library_smoke_BasicTypes_intFunction__Int');
     final _input_handle = (input);
     final __result_handle = _intFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static int longFunction(int input) {
     final _longFunction_ffi = __lib.nativeLibrary.lookupFunction<Int64 Function(Int32, Int64), int Function(int, int)>('library_smoke_BasicTypes_longFunction__Long');
     final _input_handle = (input);
     final __result_handle = _longFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static int ubyteFunction(int input) {
     final _ubyteFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_ubyteFunction__UByte');
     final _input_handle = (input);
     final __result_handle = _ubyteFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static int ushortFunction(int input) {
     final _ushortFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint16 Function(Int32, Uint16), int Function(int, int)>('library_smoke_BasicTypes_ushortFunction__UShort');
     final _input_handle = (input);
     final __result_handle = _ushortFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static int uintFunction(int input) {
     final _uintFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_BasicTypes_uintFunction__UInt');
     final _input_handle = (input);
     final __result_handle = _uintFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static int ulongFunction(int input) {
     final _ulongFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint64 Function(Int32, Uint64), int Function(int, int)>('library_smoke_BasicTypes_ulongFunction__ULong');
     final _input_handle = (input);
     final __result_handle = _ulongFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_BasicTypes_toFfi(BasicTypes value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -156,13 +156,15 @@ Pointer<Void> smoke_Comments_SomeStruct_toFfi(Comments_SomeStruct value) {
 Comments_SomeStruct smoke_Comments_SomeStruct_fromFfi(Pointer<Void> handle) {
   final _someField_handle = _smoke_Comments_SomeStruct_get_field_someField(handle);
   final _nullableField_handle = _smoke_Comments_SomeStruct_get_field_nullableField(handle);
-  final _result = Comments_SomeStruct(
-    Boolean_fromFfi(_someField_handle),
-    String_fromFfi_nullable(_nullableField_handle)
-  );
-  Boolean_releaseFfiHandle(_someField_handle);
-  String_releaseFfiHandle_nullable(_nullableField_handle);
-  return _result;
+  try {
+    return Comments_SomeStruct(
+      Boolean_fromFfi(_someField_handle),
+      String_fromFfi_nullable(_nullableField_handle)
+    );
+  } finally {
+    Boolean_releaseFfiHandle(_someField_handle);
+    String_releaseFfiHandle_nullable(_nullableField_handle);
+  }
 }
 void smoke_Comments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Comments_SomeStruct_release_handle(handle);
 // Nullable Comments_SomeStruct
@@ -227,16 +229,22 @@ class Comments_SomeLambda$Impl {
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle, _p1_handle);
     String_releaseFfiHandle(_p0_handle);
     (_p1_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _Comments_SomeLambda_call_static(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
-  final _result_object = (__lib.instanceCache[_token] as Comments_SomeLambda)(String_fromFfi(p0), (p1));
-  _result.value = (_result_object);
-  String_releaseFfiHandle(p0);
-  (p1);
+  double _result_object;
+  try {
+    _result_object = (__lib.instanceCache[_token] as Comments_SomeLambda)(String_fromFfi(p0), (p1));
+    _result.value = (_result_object);
+  } finally {
+    String_releaseFfiHandle(p0);
+    (p1);
+  }
   return 0;
 }
 Pointer<Void> smoke_Comments_SomeLambda_toFfi(Comments_SomeLambda value) {
@@ -341,15 +349,19 @@ class Comments$Impl implements Comments {
     if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
         _someMethodWithAllComments_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Comments_SomeEnum_fromFfi(__error_handle);
-        smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
-        throw Comments_SomethingWrongException(_error_value);
+        try {
+          throw Comments_SomethingWrongException(smoke_Comments_SomeEnum_fromFfi(__error_handle));
+        } finally {
+          smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
     _someMethodWithAllComments_return_release_handle(__call_result_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool someMethodWithInputComments(String input) {
@@ -358,9 +370,11 @@ class Comments$Impl implements Comments {
     final _handle = this.handle;
     final __result_handle = _someMethodWithInputComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool someMethodWithOutputComments(String input) {
@@ -369,9 +383,11 @@ class Comments$Impl implements Comments {
     final _handle = this.handle;
     final __result_handle = _someMethodWithOutputComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool someMethodWithNoComments(String input) {
@@ -380,9 +396,11 @@ class Comments$Impl implements Comments {
     final _handle = this.handle;
     final __result_handle = _someMethodWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   someMethodWithoutReturnTypeWithAllComments(String input) {
@@ -391,9 +409,11 @@ class Comments$Impl implements Comments {
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   someMethodWithoutReturnTypeWithNoComments(String input) {
@@ -402,45 +422,55 @@ class Comments$Impl implements Comments {
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   bool someMethodWithoutInputParametersWithAllComments() {
     final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithAllComments');
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutInputParametersWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool someMethodWithoutInputParametersWithNoComments() {
     final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithNoComments');
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutInputParametersWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   someMethodWithNothing() {
     final _someMethodWithNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithNothing');
     final _handle = this.handle;
     final __result_handle = _someMethodWithNothing_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutReturnTypeOrInputParameters');
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   String oneParameterCommentOnly(String undocumented, String documented) {
@@ -451,9 +481,11 @@ class Comments$Impl implements Comments {
     final __result_handle = _oneParameterCommentOnly_ffi(_handle, __lib.LibraryContext.isolateId, _undocumented_handle, _documented_handle);
     String_releaseFfiHandle(_undocumented_handle);
     String_releaseFfiHandle(_documented_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   String returnCommentOnly(String undocumented) {
@@ -462,18 +494,22 @@ class Comments$Impl implements Comments {
     final _handle = this.handle;
     final __result_handle = _returnCommentOnly_ffi(_handle, __lib.LibraryContext.isolateId, _undocumented_handle);
     String_releaseFfiHandle(_undocumented_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool get isSomeProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_isSomeProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set isSomeProperty(bool value) {
@@ -482,9 +518,11 @@ class Comments$Impl implements Comments {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     Boolean_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_Comments_toFfi(Comments value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -161,11 +161,13 @@ Pointer<Void> smoke_CommentsInterface_SomeStruct_toFfi(CommentsInterface_SomeStr
 }
 CommentsInterface_SomeStruct smoke_CommentsInterface_SomeStruct_fromFfi(Pointer<Void> handle) {
   final _someField_handle = _smoke_CommentsInterface_SomeStruct_get_field_someField(handle);
-  final _result = CommentsInterface_SomeStruct(
-    Boolean_fromFfi(_someField_handle)
-  );
-  Boolean_releaseFfiHandle(_someField_handle);
-  return _result;
+  try {
+    return CommentsInterface_SomeStruct(
+      Boolean_fromFfi(_someField_handle)
+    );
+  } finally {
+    Boolean_releaseFfiHandle(_someField_handle);
+  }
 }
 void smoke_CommentsInterface_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_CommentsInterface_SomeStruct_release_handle(handle);
 // Nullable CommentsInterface_SomeStruct
@@ -314,9 +316,11 @@ class CommentsInterface$Impl implements CommentsInterface {
     final _handle = this.handle;
     final __result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool someMethodWithInputComments(String input) {
@@ -325,9 +329,11 @@ class CommentsInterface$Impl implements CommentsInterface {
     final _handle = this.handle;
     final __result_handle = _someMethodWithInputComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool someMethodWithOutputComments(String input) {
@@ -336,9 +342,11 @@ class CommentsInterface$Impl implements CommentsInterface {
     final _handle = this.handle;
     final __result_handle = _someMethodWithOutputComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool someMethodWithNoComments(String input) {
@@ -347,9 +355,11 @@ class CommentsInterface$Impl implements CommentsInterface {
     final _handle = this.handle;
     final __result_handle = _someMethodWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   someMethodWithoutReturnTypeWithAllComments(String input) {
@@ -358,9 +368,11 @@ class CommentsInterface$Impl implements CommentsInterface {
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   someMethodWithoutReturnTypeWithNoComments(String input) {
@@ -369,54 +381,66 @@ class CommentsInterface$Impl implements CommentsInterface {
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   bool someMethodWithoutInputParametersWithAllComments() {
     final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithAllComments');
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutInputParametersWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool someMethodWithoutInputParametersWithNoComments() {
     final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithNoComments');
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutInputParametersWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   someMethodWithNothing() {
     final _someMethodWithNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithNothing');
     final _handle = this.handle;
     final __result_handle = _someMethodWithNothing_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeOrInputParameters');
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   /// Gets some very useful property.
   bool get isSomeProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_isSomeProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   /// Sets some very useful property.
   set isSomeProperty(bool value) {
@@ -425,67 +449,99 @@ class CommentsInterface$Impl implements CommentsInterface {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     Boolean_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _CommentsInterface_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  final __input = String_fromFfi(input);
-  String_releaseFfiHandle(input);
-  final _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithAllComments(__input);
-  _result.value = Boolean_toFfi(_result_object);
+  bool _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithAllComments(String_fromFfi(input));
+    _result.value = Boolean_toFfi(_result_object);
+  } finally {
+    String_releaseFfiHandle(input);
+  }
   return 0;
 }
 int _CommentsInterface_someMethodWithInputComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  final __input = String_fromFfi(input);
-  String_releaseFfiHandle(input);
-  final _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithInputComments(__input);
-  _result.value = Boolean_toFfi(_result_object);
+  bool _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithInputComments(String_fromFfi(input));
+    _result.value = Boolean_toFfi(_result_object);
+  } finally {
+    String_releaseFfiHandle(input);
+  }
   return 0;
 }
 int _CommentsInterface_someMethodWithOutputComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  final __input = String_fromFfi(input);
-  String_releaseFfiHandle(input);
-  final _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithOutputComments(__input);
-  _result.value = Boolean_toFfi(_result_object);
+  bool _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithOutputComments(String_fromFfi(input));
+    _result.value = Boolean_toFfi(_result_object);
+  } finally {
+    String_releaseFfiHandle(input);
+  }
   return 0;
 }
 int _CommentsInterface_someMethodWithNoComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  final __input = String_fromFfi(input);
-  String_releaseFfiHandle(input);
-  final _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithNoComments(__input);
-  _result.value = Boolean_toFfi(_result_object);
+  bool _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithNoComments(String_fromFfi(input));
+    _result.value = Boolean_toFfi(_result_object);
+  } finally {
+    String_releaseFfiHandle(input);
+  }
   return 0;
 }
 int _CommentsInterface_someMethodWithoutReturnTypeWithAllComments_static(int _token, Pointer<Void> input) {
-  final __input = String_fromFfi(input);
-  String_releaseFfiHandle(input);
-  (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutReturnTypeWithAllComments(__input);
+  try {
+    (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutReturnTypeWithAllComments(String_fromFfi(input));
+  } finally {
+    String_releaseFfiHandle(input);
+  }
   return 0;
 }
 int _CommentsInterface_someMethodWithoutReturnTypeWithNoComments_static(int _token, Pointer<Void> input) {
-  final __input = String_fromFfi(input);
-  String_releaseFfiHandle(input);
-  (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutReturnTypeWithNoComments(__input);
+  try {
+    (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutReturnTypeWithNoComments(String_fromFfi(input));
+  } finally {
+    String_releaseFfiHandle(input);
+  }
   return 0;
 }
 int _CommentsInterface_someMethodWithoutInputParametersWithAllComments_static(int _token, Pointer<Uint8> _result) {
-  final _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithAllComments();
-  _result.value = Boolean_toFfi(_result_object);
+  bool _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithAllComments();
+    _result.value = Boolean_toFfi(_result_object);
+  } finally {
+  }
   return 0;
 }
 int _CommentsInterface_someMethodWithoutInputParametersWithNoComments_static(int _token, Pointer<Uint8> _result) {
-  final _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithNoComments();
-  _result.value = Boolean_toFfi(_result_object);
+  bool _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithNoComments();
+    _result.value = Boolean_toFfi(_result_object);
+  } finally {
+  }
   return 0;
 }
 int _CommentsInterface_someMethodWithNothing_static(int _token) {
-  (__lib.instanceCache[_token] as CommentsInterface).someMethodWithNothing();
+  try {
+    (__lib.instanceCache[_token] as CommentsInterface).someMethodWithNothing();
+  } finally {
+  }
   return 0;
 }
 int _CommentsInterface_someMethodWithoutReturnTypeOrInputParameters_static(int _token) {
-  (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutReturnTypeOrInputParameters();
+  try {
+    (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutReturnTypeOrInputParameters();
+  } finally {
+  }
   return 0;
 }
 int _CommentsInterface_isSomeProperty_get_static(int _token, Pointer<Uint8> _result) {
@@ -493,9 +549,12 @@ int _CommentsInterface_isSomeProperty_get_static(int _token, Pointer<Uint8> _res
   return 0;
 }
 int _CommentsInterface_isSomeProperty_set_static(int _token, int _value) {
-  final __value = Boolean_fromFfi(_value);
-  Boolean_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as CommentsInterface).isSomeProperty = __value;
+  try {
+    (__lib.instanceCache[_token] as CommentsInterface).isSomeProperty =
+      Boolean_fromFfi(_value);
+  } finally {
+    Boolean_releaseFfiHandle(_value);
+  }
   return 0;
 }
 Pointer<Void> smoke_CommentsInterface_toFfi(CommentsInterface value) {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -87,11 +87,13 @@ Pointer<Void> smoke_CommentsLinks_RandomStruct_toFfi(CommentsLinks_RandomStruct 
 }
 CommentsLinks_RandomStruct smoke_CommentsLinks_RandomStruct_fromFfi(Pointer<Void> handle) {
   final _randomField_handle = _smoke_CommentsLinks_RandomStruct_get_field_randomField(handle);
-  final _result = CommentsLinks_RandomStruct(
-    smoke_Comments_SomeStruct_fromFfi(_randomField_handle)
-  );
-  smoke_Comments_SomeStruct_releaseFfiHandle(_randomField_handle);
-  return _result;
+  try {
+    return CommentsLinks_RandomStruct(
+      smoke_Comments_SomeStruct_fromFfi(_randomField_handle)
+    );
+  } finally {
+    smoke_Comments_SomeStruct_releaseFfiHandle(_randomField_handle);
+  }
 }
 void smoke_CommentsLinks_RandomStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_CommentsLinks_RandomStruct_release_handle(handle);
 // Nullable CommentsLinks_RandomStruct
@@ -174,15 +176,19 @@ class CommentsLinks$Impl implements CommentsLinks {
     if (_randomMethod_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _randomMethod_return_get_error(__call_result_handle);
         _randomMethod_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Comments_SomeEnum_fromFfi(__error_handle);
-        smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
-        throw Comments_SomethingWrongException(_error_value);
+        try {
+          throw Comments_SomethingWrongException(smoke_Comments_SomeEnum_fromFfi(__error_handle));
+        } finally {
+          smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _randomMethod_return_get_result(__call_result_handle);
     _randomMethod_return_release_handle(__call_result_handle);
-    final _result = smoke_Comments_SomeEnum_fromFfi(__result_handle);
-    smoke_Comments_SomeEnum_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Comments_SomeEnum_fromFfi(__result_handle);
+    } finally {
+      smoke_Comments_SomeEnum_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   randomMethod2(String text, bool flag) {
@@ -193,9 +199,11 @@ class CommentsLinks$Impl implements CommentsLinks {
     final __result_handle = _randomMethod2_ffi(_handle, __lib.LibraryContext.isolateId, _text_handle, _flag_handle);
     String_releaseFfiHandle(_text_handle);
     Boolean_releaseFfiHandle(_flag_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_CommentsLinks_toFfi(CommentsLinks value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -133,11 +133,13 @@ Pointer<Void> smoke_DeprecationComments_SomeStruct_toFfi(DeprecationComments_Som
 }
 DeprecationComments_SomeStruct smoke_DeprecationComments_SomeStruct_fromFfi(Pointer<Void> handle) {
   final _someField_handle = _smoke_DeprecationComments_SomeStruct_get_field_someField(handle);
-  final _result = DeprecationComments_SomeStruct(
-    Boolean_fromFfi(_someField_handle)
-  );
-  Boolean_releaseFfiHandle(_someField_handle);
-  return _result;
+  try {
+    return DeprecationComments_SomeStruct(
+      Boolean_fromFfi(_someField_handle)
+    );
+  } finally {
+    Boolean_releaseFfiHandle(_someField_handle);
+  }
 }
 void smoke_DeprecationComments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_DeprecationComments_SomeStruct_release_handle(handle);
 // Nullable DeprecationComments_SomeStruct
@@ -232,9 +234,11 @@ class DeprecationComments$Impl implements DeprecationComments {
     final _handle = this.handle;
     final __result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   /// Gets some very useful property.
   @Deprecated("Unfortunately, this property's getter is deprecated.
@@ -243,9 +247,11 @@ class DeprecationComments$Impl implements DeprecationComments {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_isSomeProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   /// Sets some very useful property.
   @Deprecated("Unfortunately, this property's setter is deprecated.
@@ -256,16 +262,21 @@ class DeprecationComments$Impl implements DeprecationComments {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     Boolean_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _DeprecationComments_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  final __input = String_fromFfi(input);
-  String_releaseFfiHandle(input);
-  final _result_object = (__lib.instanceCache[_token] as DeprecationComments).someMethodWithAllComments(__input);
-  _result.value = Boolean_toFfi(_result_object);
+  bool _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as DeprecationComments).someMethodWithAllComments(String_fromFfi(input));
+    _result.value = Boolean_toFfi(_result_object);
+  } finally {
+    String_releaseFfiHandle(input);
+  }
   return 0;
 }
 int _DeprecationComments_isSomeProperty_get_static(int _token, Pointer<Uint8> _result) {
@@ -273,9 +284,12 @@ int _DeprecationComments_isSomeProperty_get_static(int _token, Pointer<Uint8> _r
   return 0;
 }
 int _DeprecationComments_isSomeProperty_set_static(int _token, int _value) {
-  final __value = Boolean_fromFfi(_value);
-  Boolean_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as DeprecationComments).isSomeProperty = __value;
+  try {
+    (__lib.instanceCache[_token] as DeprecationComments).isSomeProperty =
+      Boolean_fromFfi(_value);
+  } finally {
+    Boolean_releaseFfiHandle(_value);
+  }
   return 0;
 }
 Pointer<Void> smoke_DeprecationComments_toFfi(DeprecationComments value) {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -114,11 +114,13 @@ Pointer<Void> smoke_DeprecationCommentsOnly_SomeStruct_toFfi(DeprecationComments
 }
 DeprecationCommentsOnly_SomeStruct smoke_DeprecationCommentsOnly_SomeStruct_fromFfi(Pointer<Void> handle) {
   final _someField_handle = _smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField(handle);
-  final _result = DeprecationCommentsOnly_SomeStruct(
-    Boolean_fromFfi(_someField_handle)
-  );
-  Boolean_releaseFfiHandle(_someField_handle);
-  return _result;
+  try {
+    return DeprecationCommentsOnly_SomeStruct(
+      Boolean_fromFfi(_someField_handle)
+    );
+  } finally {
+    Boolean_releaseFfiHandle(_someField_handle);
+  }
 }
 void smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_DeprecationCommentsOnly_SomeStruct_release_handle(handle);
 // Nullable DeprecationCommentsOnly_SomeStruct
@@ -213,18 +215,22 @@ class DeprecationCommentsOnly$Impl implements DeprecationCommentsOnly {
     final _handle = this.handle;
     final __result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @Deprecated("Unfortunately, this property's getter is deprecated.")
   bool get isSomeProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @Deprecated("Unfortunately, this property's setter is deprecated.")
   set isSomeProperty(bool value) {
@@ -233,16 +239,21 @@ class DeprecationCommentsOnly$Impl implements DeprecationCommentsOnly {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     Boolean_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _DeprecationCommentsOnly_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  final __input = String_fromFfi(input);
-  String_releaseFfiHandle(input);
-  final _result_object = (__lib.instanceCache[_token] as DeprecationCommentsOnly).someMethodWithAllComments(__input);
-  _result.value = Boolean_toFfi(_result_object);
+  bool _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as DeprecationCommentsOnly).someMethodWithAllComments(String_fromFfi(input));
+    _result.value = Boolean_toFfi(_result_object);
+  } finally {
+    String_releaseFfiHandle(input);
+  }
   return 0;
 }
 int _DeprecationCommentsOnly_isSomeProperty_get_static(int _token, Pointer<Uint8> _result) {
@@ -250,9 +261,12 @@ int _DeprecationCommentsOnly_isSomeProperty_get_static(int _token, Pointer<Uint8
   return 0;
 }
 int _DeprecationCommentsOnly_isSomeProperty_set_static(int _token, int _value) {
-  final __value = Boolean_fromFfi(_value);
-  Boolean_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as DeprecationCommentsOnly).isSomeProperty = __value;
+  try {
+    (__lib.instanceCache[_token] as DeprecationCommentsOnly).isSomeProperty =
+      Boolean_fromFfi(_value);
+  } finally {
+    Boolean_releaseFfiHandle(_value);
+  }
   return 0;
 }
 Pointer<Void> smoke_DeprecationCommentsOnly_toFfi(DeprecationCommentsOnly value) {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -45,9 +45,11 @@ class InternalClassWithComments$Impl implements InternalClassWithComments {
     final _doNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithComments_doNothing');
     final _handle = this.handle;
     final __result_handle = _doNothing_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_InternalClassWithComments_toFfi(InternalClassWithComments value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -73,9 +73,11 @@ class MultiLineComments$Impl implements MultiLineComments {
     final __result_handle = _someMethodWithLongComment_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle, _ratio_handle);
     String_releaseFfiHandle(_input_handle);
     (_ratio_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_MultiLineComments_toFfi(MultiLineComments value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -110,11 +110,13 @@ Pointer<Void> smoke_PlatformComments_Something_toFfi(PlatformComments_Something 
 }
 PlatformComments_Something smoke_PlatformComments_Something_fromFfi(Pointer<Void> handle) {
   final _nothing_handle = _smoke_PlatformComments_Something_get_field_nothing(handle);
-  final _result = PlatformComments_Something(
-    String_fromFfi(_nothing_handle)
-  );
-  String_releaseFfiHandle(_nothing_handle);
-  return _result;
+  try {
+    return PlatformComments_Something(
+      String_fromFfi(_nothing_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_nothing_handle);
+  }
 }
 void smoke_PlatformComments_Something_releaseFfiHandle(Pointer<Void> handle) => _smoke_PlatformComments_Something_release_handle(handle);
 // Nullable PlatformComments_Something
@@ -192,18 +194,22 @@ class PlatformComments$Impl implements PlatformComments {
     final _doNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doNothing');
     final _handle = this.handle;
     final __result_handle = _doNothing_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   doMagic() {
     final _doMagic_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doMagic');
     final _handle = this.handle;
     final __result_handle = _doMagic_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   bool someMethodWithAllComments(String input) {
@@ -215,15 +221,19 @@ class PlatformComments$Impl implements PlatformComments {
     if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
         _someMethodWithAllComments_return_release_handle(__call_result_handle);
-        final _error_value = smoke_PlatformComments_SomeEnum_fromFfi(__error_handle);
-        smoke_PlatformComments_SomeEnum_releaseFfiHandle(__error_handle);
-        throw PlatformComments_SomethingWrongException(_error_value);
+        try {
+          throw PlatformComments_SomethingWrongException(smoke_PlatformComments_SomeEnum_fromFfi(__error_handle));
+        } finally {
+          smoke_PlatformComments_SomeEnum_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
     _someMethodWithAllComments_return_release_handle(__call_result_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_PlatformComments_toFfi(PlatformComments value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -67,15 +67,19 @@ class UnicodeComments$Impl implements UnicodeComments {
     if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
         _someMethodWithAllComments_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Comments_SomeEnum_fromFfi(__error_handle);
-        smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
-        throw Comments_SomethingWrongException(_error_value);
+        try {
+          throw Comments_SomethingWrongException(smoke_Comments_SomeEnum_fromFfi(__error_handle));
+        } finally {
+          smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
     _someMethodWithAllComments_return_release_handle(__call_result_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_UnicodeComments_toFfi(UnicodeComments value) =>

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
@@ -46,13 +46,15 @@ Pointer<Void> smoke_StructConstants_SomeStruct_toFfi(StructConstants_SomeStruct 
 StructConstants_SomeStruct smoke_StructConstants_SomeStruct_fromFfi(Pointer<Void> handle) {
   final _stringField_handle = _smoke_StructConstants_SomeStruct_get_field_stringField(handle);
   final _floatField_handle = _smoke_StructConstants_SomeStruct_get_field_floatField(handle);
-  final _result = StructConstants_SomeStruct(
-    String_fromFfi(_stringField_handle),
-    (_floatField_handle)
-  );
-  String_releaseFfiHandle(_stringField_handle);
-  (_floatField_handle);
-  return _result;
+  try {
+    return StructConstants_SomeStruct(
+      String_fromFfi(_stringField_handle),
+      (_floatField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_stringField_handle);
+    (_floatField_handle);
+  }
 }
 void smoke_StructConstants_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructConstants_SomeStruct_release_handle(handle);
 // Nullable StructConstants_SomeStruct
@@ -110,11 +112,13 @@ Pointer<Void> smoke_StructConstants_NestingStruct_toFfi(StructConstants_NestingS
 }
 StructConstants_NestingStruct smoke_StructConstants_NestingStruct_fromFfi(Pointer<Void> handle) {
   final _structField_handle = _smoke_StructConstants_NestingStruct_get_field_structField(handle);
-  final _result = StructConstants_NestingStruct(
-    smoke_StructConstants_SomeStruct_fromFfi(_structField_handle)
-  );
-  smoke_StructConstants_SomeStruct_releaseFfiHandle(_structField_handle);
-  return _result;
+  try {
+    return StructConstants_NestingStruct(
+      smoke_StructConstants_SomeStruct_fromFfi(_structField_handle)
+    );
+  } finally {
+    smoke_StructConstants_SomeStruct_releaseFfiHandle(_structField_handle);
+  }
 }
 void smoke_StructConstants_NestingStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructConstants_NestingStruct_release_handle(handle);
 // Nullable StructConstants_NestingStruct

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -169,9 +169,11 @@ class Constructors$Impl implements Constructors {
     if (_fromString_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _fromString_return_get_error(__call_result_handle);
         _fromString_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Constructors_ErrorEnum_fromFfi(__error_handle);
-        smoke_Constructors_ErrorEnum_releaseFfiHandle(__error_handle);
-        throw Constructors_ConstructorExplodedException(_error_value);
+        try {
+          throw Constructors_ConstructorExplodedException(smoke_Constructors_ErrorEnum_fromFfi(__error_handle));
+        } finally {
+          smoke_Constructors_ErrorEnum_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _fromString_return_get_result(__call_result_handle);
     _fromString_return_release_handle(__call_result_handle);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -39,11 +39,13 @@ Pointer<Void> smoke_Dates_DateStruct_toFfi(Dates_DateStruct value) {
 }
 Dates_DateStruct smoke_Dates_DateStruct_fromFfi(Pointer<Void> handle) {
   final _dateField_handle = _smoke_Dates_DateStruct_get_field_dateField(handle);
-  final _result = Dates_DateStruct(
-    Date_fromFfi(_dateField_handle)
-  );
-  Date_releaseFfiHandle(_dateField_handle);
-  return _result;
+  try {
+    return Dates_DateStruct(
+      Date_fromFfi(_dateField_handle)
+    );
+  } finally {
+    Date_releaseFfiHandle(_dateField_handle);
+  }
 }
 void smoke_Dates_DateStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Dates_DateStruct_release_handle(handle);
 // Nullable Dates_DateStruct
@@ -107,18 +109,22 @@ class Dates$Impl implements Dates {
     final _handle = this.handle;
     final __result_handle = _dateMethod_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     Date_releaseFfiHandle(_input_handle);
-    final _result = Date_fromFfi(__result_handle);
-    Date_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Date_fromFfi(__result_handle);
+    } finally {
+      Date_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   DateTime get dateProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Dates_dateProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Date_fromFfi(__result_handle);
-    Date_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Date_fromFfi(__result_handle);
+    } finally {
+      Date_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set dateProperty(DateTime value) {
@@ -127,9 +133,11 @@ class Dates$Impl implements Dates {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     Date_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_Dates_toFfi(Dates value) =>

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -214,25 +214,27 @@ DefaultValues_StructWithDefaults smoke_DefaultValues_StructWithDefaults_fromFfi(
   final _stringField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_stringField(handle);
   final _enumField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_enumField(handle);
   final _externalEnumField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_externalEnumField(handle);
-  final _result = DefaultValues_StructWithDefaults(
-    (_intField_handle),
-    (_uintField_handle),
-    (_floatField_handle),
-    (_doubleField_handle),
-    Boolean_fromFfi(_boolField_handle),
-    String_fromFfi(_stringField_handle),
-    smoke_DefaultValues_SomeEnum_fromFfi(_enumField_handle),
-    smoke_DefaultValues_ExternalEnum_fromFfi(_externalEnumField_handle)
-  );
-  (_intField_handle);
-  (_uintField_handle);
-  (_floatField_handle);
-  (_doubleField_handle);
-  Boolean_releaseFfiHandle(_boolField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
-  smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumField_handle);
-  return _result;
+  try {
+    return DefaultValues_StructWithDefaults(
+      (_intField_handle),
+      (_uintField_handle),
+      (_floatField_handle),
+      (_doubleField_handle),
+      Boolean_fromFfi(_boolField_handle),
+      String_fromFfi(_stringField_handle),
+      smoke_DefaultValues_SomeEnum_fromFfi(_enumField_handle),
+      smoke_DefaultValues_ExternalEnum_fromFfi(_externalEnumField_handle)
+    );
+  } finally {
+    (_intField_handle);
+    (_uintField_handle);
+    (_floatField_handle);
+    (_doubleField_handle);
+    Boolean_releaseFfiHandle(_boolField_handle);
+    String_releaseFfiHandle(_stringField_handle);
+    smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
+    smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumField_handle);
+  }
 }
 void smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithDefaults_release_handle(handle);
 // Nullable DefaultValues_StructWithDefaults
@@ -332,21 +334,23 @@ DefaultValues_NullableStructWithDefaults smoke_DefaultValues_NullableStructWithD
   final _boolField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_boolField(handle);
   final _stringField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_stringField(handle);
   final _enumField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_enumField(handle);
-  final _result = DefaultValues_NullableStructWithDefaults(
-    Int_fromFfi_nullable(_intField_handle),
-    UInt_fromFfi_nullable(_uintField_handle),
-    Float_fromFfi_nullable(_floatField_handle),
-    Boolean_fromFfi_nullable(_boolField_handle),
-    String_fromFfi_nullable(_stringField_handle),
-    smoke_DefaultValues_SomeEnum_fromFfi_nullable(_enumField_handle)
-  );
-  Int_releaseFfiHandle_nullable(_intField_handle);
-  UInt_releaseFfiHandle_nullable(_uintField_handle);
-  Float_releaseFfiHandle_nullable(_floatField_handle);
-  Boolean_releaseFfiHandle_nullable(_boolField_handle);
-  String_releaseFfiHandle_nullable(_stringField_handle);
-  smoke_DefaultValues_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
-  return _result;
+  try {
+    return DefaultValues_NullableStructWithDefaults(
+      Int_fromFfi_nullable(_intField_handle),
+      UInt_fromFfi_nullable(_uintField_handle),
+      Float_fromFfi_nullable(_floatField_handle),
+      Boolean_fromFfi_nullable(_boolField_handle),
+      String_fromFfi_nullable(_stringField_handle),
+      smoke_DefaultValues_SomeEnum_fromFfi_nullable(_enumField_handle)
+    );
+  } finally {
+    Int_releaseFfiHandle_nullable(_intField_handle);
+    UInt_releaseFfiHandle_nullable(_uintField_handle);
+    Float_releaseFfiHandle_nullable(_floatField_handle);
+    Boolean_releaseFfiHandle_nullable(_boolField_handle);
+    String_releaseFfiHandle_nullable(_stringField_handle);
+    smoke_DefaultValues_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
+  }
 }
 void smoke_DefaultValues_NullableStructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_NullableStructWithDefaults_release_handle(handle);
 // Nullable DefaultValues_NullableStructWithDefaults
@@ -446,21 +450,23 @@ DefaultValues_StructWithSpecialDefaults smoke_DefaultValues_StructWithSpecialDef
   final _doubleNanField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNanField(handle);
   final _doubleInfinityField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleInfinityField(handle);
   final _doubleNegativeInfinityField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNegativeInfinityField(handle);
-  final _result = DefaultValues_StructWithSpecialDefaults(
-    (_floatNanField_handle),
-    (_floatInfinityField_handle),
-    (_floatNegativeInfinityField_handle),
-    (_doubleNanField_handle),
-    (_doubleInfinityField_handle),
-    (_doubleNegativeInfinityField_handle)
-  );
-  (_floatNanField_handle);
-  (_floatInfinityField_handle);
-  (_floatNegativeInfinityField_handle);
-  (_doubleNanField_handle);
-  (_doubleInfinityField_handle);
-  (_doubleNegativeInfinityField_handle);
-  return _result;
+  try {
+    return DefaultValues_StructWithSpecialDefaults(
+      (_floatNanField_handle),
+      (_floatInfinityField_handle),
+      (_floatNegativeInfinityField_handle),
+      (_doubleNanField_handle),
+      (_doubleInfinityField_handle),
+      (_doubleNegativeInfinityField_handle)
+    );
+  } finally {
+    (_floatNanField_handle);
+    (_floatInfinityField_handle);
+    (_floatNegativeInfinityField_handle);
+    (_doubleNanField_handle);
+    (_doubleInfinityField_handle);
+    (_doubleNegativeInfinityField_handle);
+  }
 }
 void smoke_DefaultValues_StructWithSpecialDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithSpecialDefaults_release_handle(handle);
 // Nullable DefaultValues_StructWithSpecialDefaults
@@ -552,19 +558,21 @@ DefaultValues_StructWithEmptyDefaults smoke_DefaultValues_StructWithEmptyDefault
   final _mapField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_mapField(handle);
   final _structField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_structField(handle);
   final _setTypeField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField(handle);
-  final _result = DefaultValues_StructWithEmptyDefaults(
-    ListOf_Int_fromFfi(_intsField_handle),
-    ListOf_Float_fromFfi(_floatsField_handle),
-    MapOf_UInt_to_String_fromFfi(_mapField_handle),
-    smoke_DefaultValues_StructWithDefaults_fromFfi(_structField_handle),
-    SetOf_String_fromFfi(_setTypeField_handle)
-  );
-  ListOf_Int_releaseFfiHandle(_intsField_handle);
-  ListOf_Float_releaseFfiHandle(_floatsField_handle);
-  MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
-  smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_structField_handle);
-  SetOf_String_releaseFfiHandle(_setTypeField_handle);
-  return _result;
+  try {
+    return DefaultValues_StructWithEmptyDefaults(
+      ListOf_Int_fromFfi(_intsField_handle),
+      ListOf_Float_fromFfi(_floatsField_handle),
+      MapOf_UInt_to_String_fromFfi(_mapField_handle),
+      smoke_DefaultValues_StructWithDefaults_fromFfi(_structField_handle),
+      SetOf_String_fromFfi(_setTypeField_handle)
+    );
+  } finally {
+    ListOf_Int_releaseFfiHandle(_intsField_handle);
+    ListOf_Float_releaseFfiHandle(_floatsField_handle);
+    MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
+    smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_structField_handle);
+    SetOf_String_releaseFfiHandle(_setTypeField_handle);
+  }
 }
 void smoke_DefaultValues_StructWithEmptyDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithEmptyDefaults_release_handle(handle);
 // Nullable DefaultValues_StructWithEmptyDefaults
@@ -648,17 +656,19 @@ DefaultValues_StructWithTypedefDefaults smoke_DefaultValues_StructWithTypedefDef
   final _boolField_handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_field_boolField(handle);
   final _stringField_handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_field_stringField(handle);
   final _enumField_handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_field_enumField(handle);
-  final _result = DefaultValues_StructWithTypedefDefaults(
-    (_longField_handle),
-    Boolean_fromFfi(_boolField_handle),
-    String_fromFfi(_stringField_handle),
-    smoke_DefaultValues_SomeEnum_fromFfi(_enumField_handle)
-  );
-  (_longField_handle);
-  Boolean_releaseFfiHandle(_boolField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
-  return _result;
+  try {
+    return DefaultValues_StructWithTypedefDefaults(
+      (_longField_handle),
+      Boolean_fromFfi(_boolField_handle),
+      String_fromFfi(_stringField_handle),
+      smoke_DefaultValues_SomeEnum_fromFfi(_enumField_handle)
+    );
+  } finally {
+    (_longField_handle);
+    Boolean_releaseFfiHandle(_boolField_handle);
+    String_releaseFfiHandle(_stringField_handle);
+    smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
+  }
 }
 void smoke_DefaultValues_StructWithTypedefDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithTypedefDefaults_release_handle(handle);
 // Nullable DefaultValues_StructWithTypedefDefaults
@@ -720,9 +730,11 @@ class DefaultValues$Impl implements DefaultValues {
     final _input_handle = smoke_DefaultValues_StructWithDefaults_toFfi(input);
     final __result_handle = _processStructWithDefaults_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_input_handle);
-    final _result = smoke_DefaultValues_StructWithDefaults_fromFfi(__result_handle);
-    smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_DefaultValues_StructWithDefaults_fromFfi(__result_handle);
+    } finally {
+      smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_DefaultValues_toFfi(DefaultValues value) =>

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
@@ -64,19 +64,21 @@ StructWithInitializerDefaults smoke_StructWithInitializerDefaults_fromFfi(Pointe
   final _structField_handle = _smoke_StructWithInitializerDefaults_get_field_structField(handle);
   final _setTypeField_handle = _smoke_StructWithInitializerDefaults_get_field_setTypeField(handle);
   final _mapField_handle = _smoke_StructWithInitializerDefaults_get_field_mapField(handle);
-  final _result = StructWithInitializerDefaults(
-    ListOf_Int_fromFfi(_intsField_handle),
-    ListOf_Float_fromFfi(_floatsField_handle),
-    smoke_TypesWithDefaults_StructWithAnEnum_fromFfi(_structField_handle),
-    SetOf_String_fromFfi(_setTypeField_handle),
-    MapOf_UInt_to_String_fromFfi(_mapField_handle)
-  );
-  ListOf_Int_releaseFfiHandle(_intsField_handle);
-  ListOf_Float_releaseFfiHandle(_floatsField_handle);
-  smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_structField_handle);
-  SetOf_String_releaseFfiHandle(_setTypeField_handle);
-  MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
-  return _result;
+  try {
+    return StructWithInitializerDefaults(
+      ListOf_Int_fromFfi(_intsField_handle),
+      ListOf_Float_fromFfi(_floatsField_handle),
+      smoke_TypesWithDefaults_StructWithAnEnum_fromFfi(_structField_handle),
+      SetOf_String_fromFfi(_setTypeField_handle),
+      MapOf_UInt_to_String_fromFfi(_mapField_handle)
+    );
+  } finally {
+    ListOf_Int_releaseFfiHandle(_intsField_handle);
+    ListOf_Float_releaseFfiHandle(_floatsField_handle);
+    smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_structField_handle);
+    SetOf_String_releaseFfiHandle(_setTypeField_handle);
+    MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
+  }
 }
 void smoke_StructWithInitializerDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithInitializerDefaults_release_handle(handle);
 // Nullable StructWithInitializerDefaults

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -139,23 +139,25 @@ StructWithDefaults smoke_TypesWithDefaults_StructWithDefaults_fromFfi(Pointer<Vo
   final _boolField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_boolField(handle);
   final _stringField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_stringField(handle);
   final _enumField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_enumField(handle);
-  final _result = StructWithDefaults(
-    (_intField_handle),
-    (_uintField_handle),
-    (_floatField_handle),
-    (_doubleField_handle),
-    Boolean_fromFfi(_boolField_handle),
-    String_fromFfi(_stringField_handle),
-    smoke_TypesWithDefaults_SomeEnum_fromFfi(_enumField_handle)
-  );
-  (_intField_handle);
-  (_uintField_handle);
-  (_floatField_handle);
-  (_doubleField_handle);
-  Boolean_releaseFfiHandle(_boolField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumField_handle);
-  return _result;
+  try {
+    return StructWithDefaults(
+      (_intField_handle),
+      (_uintField_handle),
+      (_floatField_handle),
+      (_doubleField_handle),
+      Boolean_fromFfi(_boolField_handle),
+      String_fromFfi(_stringField_handle),
+      smoke_TypesWithDefaults_SomeEnum_fromFfi(_enumField_handle)
+    );
+  } finally {
+    (_intField_handle);
+    (_uintField_handle);
+    (_floatField_handle);
+    (_doubleField_handle);
+    Boolean_releaseFfiHandle(_boolField_handle);
+    String_releaseFfiHandle(_stringField_handle);
+    smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumField_handle);
+  }
 }
 void smoke_TypesWithDefaults_StructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypesWithDefaults_StructWithDefaults_release_handle(handle);
 // Nullable StructWithDefaults
@@ -271,25 +273,27 @@ ImmutableStructWithDefaults smoke_TypesWithDefaults_ImmutableStructWithDefaults_
   final _stringField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_stringField(handle);
   final _enumField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_enumField(handle);
   final _externalEnumField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_externalEnumField(handle);
-  final _result = ImmutableStructWithDefaults(
-    (_intField_handle),
-    (_uintField_handle),
-    (_floatField_handle),
-    (_doubleField_handle),
-    Boolean_fromFfi(_boolField_handle),
-    String_fromFfi(_stringField_handle),
-    smoke_TypesWithDefaults_SomeEnum_fromFfi(_enumField_handle),
-    smoke_DefaultValues_ExternalEnum_fromFfi(_externalEnumField_handle)
-  );
-  (_intField_handle);
-  (_uintField_handle);
-  (_floatField_handle);
-  (_doubleField_handle);
-  Boolean_releaseFfiHandle(_boolField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumField_handle);
-  smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumField_handle);
-  return _result;
+  try {
+    return ImmutableStructWithDefaults(
+      (_intField_handle),
+      (_uintField_handle),
+      (_floatField_handle),
+      (_doubleField_handle),
+      Boolean_fromFfi(_boolField_handle),
+      String_fromFfi(_stringField_handle),
+      smoke_TypesWithDefaults_SomeEnum_fromFfi(_enumField_handle),
+      smoke_DefaultValues_ExternalEnum_fromFfi(_externalEnumField_handle)
+    );
+  } finally {
+    (_intField_handle);
+    (_uintField_handle);
+    (_floatField_handle);
+    (_doubleField_handle);
+    Boolean_releaseFfiHandle(_boolField_handle);
+    String_releaseFfiHandle(_stringField_handle);
+    smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumField_handle);
+    smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumField_handle);
+  }
 }
 void smoke_TypesWithDefaults_ImmutableStructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle(handle);
 // Nullable ImmutableStructWithDefaults
@@ -349,11 +353,13 @@ Pointer<Void> smoke_TypesWithDefaults_StructWithAnEnum_toFfi(StructWithAnEnum va
 }
 StructWithAnEnum smoke_TypesWithDefaults_StructWithAnEnum_fromFfi(Pointer<Void> handle) {
   final _config_handle = _smoke_TypesWithDefaults_StructWithAnEnum_get_field_config(handle);
-  final _result = StructWithAnEnum(
-    smoke_AnEnum_AnEnum_fromFfi(_config_handle)
-  );
-  smoke_AnEnum_AnEnum_releaseFfiHandle(_config_handle);
-  return _result;
+  try {
+    return StructWithAnEnum(
+      smoke_AnEnum_AnEnum_fromFfi(_config_handle)
+    );
+  } finally {
+    smoke_AnEnum_AnEnum_releaseFfiHandle(_config_handle);
+  }
 }
 void smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypesWithDefaults_StructWithAnEnum_release_handle(handle);
 // Nullable StructWithAnEnum

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -285,13 +285,15 @@ Pointer<Void> smoke_Enums_ErrorStruct_toFfi(Enums_ErrorStruct value) {
 Enums_ErrorStruct smoke_Enums_ErrorStruct_fromFfi(Pointer<Void> handle) {
   final _type_handle = _smoke_Enums_ErrorStruct_get_field_type(handle);
   final _message_handle = _smoke_Enums_ErrorStruct_get_field_message(handle);
-  final _result = Enums_ErrorStruct(
-    smoke_Enums_InternalErrorCode_fromFfi(_type_handle),
-    String_fromFfi(_message_handle)
-  );
-  smoke_Enums_InternalErrorCode_releaseFfiHandle(_type_handle);
-  String_releaseFfiHandle(_message_handle);
-  return _result;
+  try {
+    return Enums_ErrorStruct(
+      smoke_Enums_InternalErrorCode_fromFfi(_type_handle),
+      String_fromFfi(_message_handle)
+    );
+  } finally {
+    smoke_Enums_InternalErrorCode_releaseFfiHandle(_type_handle);
+    String_releaseFfiHandle(_message_handle);
+  }
 }
 void smoke_Enums_ErrorStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Enums_ErrorStruct_release_handle(handle);
 // Nullable Enums_ErrorStruct
@@ -353,27 +355,33 @@ class Enums$Impl implements Enums {
     final _input_handle = smoke_Enums_SimpleEnum_toFfi(input);
     final __result_handle = _methodWithEnumeration_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Enums_SimpleEnum_releaseFfiHandle(_input_handle);
-    final _result = smoke_Enums_SimpleEnum_fromFfi(__result_handle);
-    smoke_Enums_SimpleEnum_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Enums_SimpleEnum_fromFfi(__result_handle);
+    } finally {
+      smoke_Enums_SimpleEnum_releaseFfiHandle(__result_handle);
+    }
   }
   static Enums_InternalErrorCode flipEnumValue(Enums_InternalErrorCode input) {
     final _flipEnumValue_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_Enums_flipEnumValue__InternalErrorCode');
     final _input_handle = smoke_Enums_InternalErrorCode_toFfi(input);
     final __result_handle = _flipEnumValue_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Enums_InternalErrorCode_releaseFfiHandle(_input_handle);
-    final _result = smoke_Enums_InternalErrorCode_fromFfi(__result_handle);
-    smoke_Enums_InternalErrorCode_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Enums_InternalErrorCode_fromFfi(__result_handle);
+    } finally {
+      smoke_Enums_InternalErrorCode_releaseFfiHandle(__result_handle);
+    }
   }
   static Enums_InternalErrorCode extractEnumFromStruct(Enums_ErrorStruct input) {
     final _extractEnumFromStruct_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Pointer<Void>), int Function(int, Pointer<Void>)>('library_smoke_Enums_extractEnumFromStruct__ErrorStruct');
     final _input_handle = smoke_Enums_ErrorStruct_toFfi(input);
     final __result_handle = _extractEnumFromStruct_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Enums_ErrorStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_Enums_InternalErrorCode_fromFfi(__result_handle);
-    smoke_Enums_InternalErrorCode_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Enums_InternalErrorCode_fromFfi(__result_handle);
+    } finally {
+      smoke_Enums_InternalErrorCode_releaseFfiHandle(__result_handle);
+    }
   }
   static Enums_ErrorStruct createStructWithEnumInside(Enums_InternalErrorCode type, String message) {
     final _createStructWithEnumInside_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint32, Pointer<Void>), Pointer<Void> Function(int, int, Pointer<Void>)>('library_smoke_Enums_createStructWithEnumInside__InternalErrorCode_String');
@@ -382,18 +390,22 @@ class Enums$Impl implements Enums {
     final __result_handle = _createStructWithEnumInside_ffi(__lib.LibraryContext.isolateId, _type_handle, _message_handle);
     smoke_Enums_InternalErrorCode_releaseFfiHandle(_type_handle);
     String_releaseFfiHandle(_message_handle);
-    final _result = smoke_Enums_ErrorStruct_fromFfi(__result_handle);
-    smoke_Enums_ErrorStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Enums_ErrorStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_Enums_ErrorStruct_releaseFfiHandle(__result_handle);
+    }
   }
   static methodWithExternalEnum(Enums_ExternalEnum input) {
     final _methodWithExternalEnum_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Int32, Uint32), void Function(int, int)>('library_smoke_Enums_methodWithExternalEnum__External_1Enum');
     final _input_handle = smoke_Enums_ExternalEnum_toFfi(input);
     final __result_handle = _methodWithExternalEnum_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Enums_ExternalEnum_releaseFfiHandle(_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_Enums_toFfi(Enums value) =>

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
@@ -193,29 +193,31 @@ EquatableStruct smoke_Equatable_EquatableStruct_fromFfi(Pointer<Void> handle) {
   final _enumField_handle = _smoke_Equatable_EquatableStruct_get_field_enumField(handle);
   final _arrayField_handle = _smoke_Equatable_EquatableStruct_get_field_arrayField(handle);
   final _mapField_handle = _smoke_Equatable_EquatableStruct_get_field_mapField(handle);
-  final _result = EquatableStruct(
-    Boolean_fromFfi(_boolField_handle),
-    (_intField_handle),
-    (_longField_handle),
-    (_floatField_handle),
-    (_doubleField_handle),
-    String_fromFfi(_stringField_handle),
-    smoke_Equatable_NestedEquatableStruct_fromFfi(_structField_handle),
-    smoke_Equatable_SomeEnum_fromFfi(_enumField_handle),
-    ListOf_String_fromFfi(_arrayField_handle),
-    MapOf_Int_to_String_fromFfi(_mapField_handle)
-  );
-  Boolean_releaseFfiHandle(_boolField_handle);
-  (_intField_handle);
-  (_longField_handle);
-  (_floatField_handle);
-  (_doubleField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(_structField_handle);
-  smoke_Equatable_SomeEnum_releaseFfiHandle(_enumField_handle);
-  ListOf_String_releaseFfiHandle(_arrayField_handle);
-  MapOf_Int_to_String_releaseFfiHandle(_mapField_handle);
-  return _result;
+  try {
+    return EquatableStruct(
+      Boolean_fromFfi(_boolField_handle),
+      (_intField_handle),
+      (_longField_handle),
+      (_floatField_handle),
+      (_doubleField_handle),
+      String_fromFfi(_stringField_handle),
+      smoke_Equatable_NestedEquatableStruct_fromFfi(_structField_handle),
+      smoke_Equatable_SomeEnum_fromFfi(_enumField_handle),
+      ListOf_String_fromFfi(_arrayField_handle),
+      MapOf_Int_to_String_fromFfi(_mapField_handle)
+    );
+  } finally {
+    Boolean_releaseFfiHandle(_boolField_handle);
+    (_intField_handle);
+    (_longField_handle);
+    (_floatField_handle);
+    (_doubleField_handle);
+    String_releaseFfiHandle(_stringField_handle);
+    smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(_structField_handle);
+    smoke_Equatable_SomeEnum_releaseFfiHandle(_enumField_handle);
+    ListOf_String_releaseFfiHandle(_arrayField_handle);
+    MapOf_Int_to_String_releaseFfiHandle(_mapField_handle);
+  }
 }
 void smoke_Equatable_EquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Equatable_EquatableStruct_release_handle(handle);
 // Nullable EquatableStruct
@@ -366,27 +368,29 @@ EquatableNullableStruct smoke_Equatable_EquatableNullableStruct_fromFfi(Pointer<
   final _enumField_handle = _smoke_Equatable_EquatableNullableStruct_get_field_enumField(handle);
   final _arrayField_handle = _smoke_Equatable_EquatableNullableStruct_get_field_arrayField(handle);
   final _mapField_handle = _smoke_Equatable_EquatableNullableStruct_get_field_mapField(handle);
-  final _result = EquatableNullableStruct(
-    Boolean_fromFfi_nullable(_boolField_handle),
-    Int_fromFfi_nullable(_intField_handle),
-    UShort_fromFfi_nullable(_uintField_handle),
-    Float_fromFfi_nullable(_floatField_handle),
-    String_fromFfi_nullable(_stringField_handle),
-    smoke_Equatable_NestedEquatableStruct_fromFfi_nullable(_structField_handle),
-    smoke_Equatable_SomeEnum_fromFfi_nullable(_enumField_handle),
-    ListOf_String_fromFfi_nullable(_arrayField_handle),
-    MapOf_Int_to_String_fromFfi_nullable(_mapField_handle)
-  );
-  Boolean_releaseFfiHandle_nullable(_boolField_handle);
-  Int_releaseFfiHandle_nullable(_intField_handle);
-  UShort_releaseFfiHandle_nullable(_uintField_handle);
-  Float_releaseFfiHandle_nullable(_floatField_handle);
-  String_releaseFfiHandle_nullable(_stringField_handle);
-  smoke_Equatable_NestedEquatableStruct_releaseFfiHandle_nullable(_structField_handle);
-  smoke_Equatable_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
-  ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
-  MapOf_Int_to_String_releaseFfiHandle_nullable(_mapField_handle);
-  return _result;
+  try {
+    return EquatableNullableStruct(
+      Boolean_fromFfi_nullable(_boolField_handle),
+      Int_fromFfi_nullable(_intField_handle),
+      UShort_fromFfi_nullable(_uintField_handle),
+      Float_fromFfi_nullable(_floatField_handle),
+      String_fromFfi_nullable(_stringField_handle),
+      smoke_Equatable_NestedEquatableStruct_fromFfi_nullable(_structField_handle),
+      smoke_Equatable_SomeEnum_fromFfi_nullable(_enumField_handle),
+      ListOf_String_fromFfi_nullable(_arrayField_handle),
+      MapOf_Int_to_String_fromFfi_nullable(_mapField_handle)
+    );
+  } finally {
+    Boolean_releaseFfiHandle_nullable(_boolField_handle);
+    Int_releaseFfiHandle_nullable(_intField_handle);
+    UShort_releaseFfiHandle_nullable(_uintField_handle);
+    Float_releaseFfiHandle_nullable(_floatField_handle);
+    String_releaseFfiHandle_nullable(_stringField_handle);
+    smoke_Equatable_NestedEquatableStruct_releaseFfiHandle_nullable(_structField_handle);
+    smoke_Equatable_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
+    ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
+    MapOf_Int_to_String_releaseFfiHandle_nullable(_mapField_handle);
+  }
 }
 void smoke_Equatable_EquatableNullableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Equatable_EquatableNullableStruct_release_handle(handle);
 // Nullable EquatableNullableStruct
@@ -457,11 +461,13 @@ Pointer<Void> smoke_Equatable_NestedEquatableStruct_toFfi(NestedEquatableStruct 
 }
 NestedEquatableStruct smoke_Equatable_NestedEquatableStruct_fromFfi(Pointer<Void> handle) {
   final _fooField_handle = _smoke_Equatable_NestedEquatableStruct_get_field_fooField(handle);
-  final _result = NestedEquatableStruct(
-    String_fromFfi(_fooField_handle)
-  );
-  String_releaseFfiHandle(_fooField_handle);
-  return _result;
+  try {
+    return NestedEquatableStruct(
+      String_fromFfi(_fooField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_fooField_handle);
+  }
 }
 void smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Equatable_NestedEquatableStruct_release_handle(handle);
 // Nullable NestedEquatableStruct

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
@@ -88,19 +88,21 @@ EquatableStructWithInternalFields smoke_EquatableStructWithInternalFields_fromFf
   final _internalListField_handle = _smoke_EquatableStructWithInternalFields_get_field_internalListField(handle);
   final _internalMapField_handle = _smoke_EquatableStructWithInternalFields_get_field_internalMapField(handle);
   final _internalSetField_handle = _smoke_EquatableStructWithInternalFields_get_field_internalSetField(handle);
-  final _result = EquatableStructWithInternalFields(
-    String_fromFfi(_publicField_handle),
-    String_fromFfi(_internalField_handle),
-    ListOf_String_fromFfi(_internalListField_handle),
-    MapOf_String_to_String_fromFfi(_internalMapField_handle),
-    SetOf_String_fromFfi(_internalSetField_handle)
-  );
-  String_releaseFfiHandle(_publicField_handle);
-  String_releaseFfiHandle(_internalField_handle);
-  ListOf_String_releaseFfiHandle(_internalListField_handle);
-  MapOf_String_to_String_releaseFfiHandle(_internalMapField_handle);
-  SetOf_String_releaseFfiHandle(_internalSetField_handle);
-  return _result;
+  try {
+    return EquatableStructWithInternalFields(
+      String_fromFfi(_publicField_handle),
+      String_fromFfi(_internalField_handle),
+      ListOf_String_fromFfi(_internalListField_handle),
+      MapOf_String_to_String_fromFfi(_internalMapField_handle),
+      SetOf_String_fromFfi(_internalSetField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_publicField_handle);
+    String_releaseFfiHandle(_internalField_handle);
+    ListOf_String_releaseFfiHandle(_internalListField_handle);
+    MapOf_String_to_String_releaseFfiHandle(_internalMapField_handle);
+    SetOf_String_releaseFfiHandle(_internalSetField_handle);
+  }
 }
 void smoke_EquatableStructWithInternalFields_releaseFfiHandle(Pointer<Void> handle) => _smoke_EquatableStructWithInternalFields_release_handle(handle);
 // Nullable EquatableStructWithInternalFields

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/simple_equatable_struct.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/simple_equatable_struct.dart
@@ -74,17 +74,19 @@ SimpleEquatableStruct smoke_SimpleEquatableStruct_fromFfi(Pointer<Void> handle) 
   final _interfaceField_handle = _smoke_SimpleEquatableStruct_get_field_interfaceField(handle);
   final _nullableClassField_handle = _smoke_SimpleEquatableStruct_get_field_nullableClassField(handle);
   final _nullableInterfaceField_handle = _smoke_SimpleEquatableStruct_get_field_nullableInterfaceField(handle);
-  final _result = SimpleEquatableStruct(
-    smoke_NonEquatableClass_fromFfi(_classField_handle),
-    smoke_NonEquatableInterface_fromFfi(_interfaceField_handle),
-    smoke_NonEquatableClass_fromFfi_nullable(_nullableClassField_handle),
-    smoke_NonEquatableInterface_fromFfi_nullable(_nullableInterfaceField_handle)
-  );
-  smoke_NonEquatableClass_releaseFfiHandle(_classField_handle);
-  smoke_NonEquatableInterface_releaseFfiHandle(_interfaceField_handle);
-  smoke_NonEquatableClass_releaseFfiHandle_nullable(_nullableClassField_handle);
-  smoke_NonEquatableInterface_releaseFfiHandle_nullable(_nullableInterfaceField_handle);
-  return _result;
+  try {
+    return SimpleEquatableStruct(
+      smoke_NonEquatableClass_fromFfi(_classField_handle),
+      smoke_NonEquatableInterface_fromFfi(_interfaceField_handle),
+      smoke_NonEquatableClass_fromFfi_nullable(_nullableClassField_handle),
+      smoke_NonEquatableInterface_fromFfi_nullable(_nullableInterfaceField_handle)
+    );
+  } finally {
+    smoke_NonEquatableClass_releaseFfiHandle(_classField_handle);
+    smoke_NonEquatableInterface_releaseFfiHandle(_interfaceField_handle);
+    smoke_NonEquatableClass_releaseFfiHandle_nullable(_nullableClassField_handle);
+    smoke_NonEquatableInterface_releaseFfiHandle_nullable(_nullableInterfaceField_handle);
+  }
 }
 void smoke_SimpleEquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_SimpleEquatableStruct_release_handle(handle);
 // Nullable SimpleEquatableStruct

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -252,15 +252,19 @@ class Errors$Impl implements Errors {
     if (_methodWithErrors_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithErrors_return_get_error(__call_result_handle);
         _methodWithErrors_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Errors_InternalErrorCode_fromFfi(__error_handle);
-        smoke_Errors_InternalErrorCode_releaseFfiHandle(__error_handle);
-        throw Errors_InternalException(_error_value);
+        try {
+          throw Errors_InternalException(smoke_Errors_InternalErrorCode_fromFfi(__error_handle));
+        } finally {
+          smoke_Errors_InternalErrorCode_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _methodWithErrors_return_get_result(__call_result_handle);
     _methodWithErrors_return_release_handle(__call_result_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static methodWithExternalErrors() {
     final _methodWithExternalErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithExternalErrors');
@@ -268,15 +272,19 @@ class Errors$Impl implements Errors {
     if (_methodWithExternalErrors_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithExternalErrors_return_get_error(__call_result_handle);
         _methodWithExternalErrors_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Errors_ExternalErrors_fromFfi(__error_handle);
-        smoke_Errors_ExternalErrors_releaseFfiHandle(__error_handle);
-        throw Errors_ExternalException(_error_value);
+        try {
+          throw Errors_ExternalException(smoke_Errors_ExternalErrors_fromFfi(__error_handle));
+        } finally {
+          smoke_Errors_ExternalErrors_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _methodWithExternalErrors_return_get_result(__call_result_handle);
     _methodWithExternalErrors_return_release_handle(__call_result_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static String methodWithErrorsAndReturnValue() {
     final _methodWithErrorsAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrorsAndReturnValue');
@@ -284,15 +292,19 @@ class Errors$Impl implements Errors {
     if (_methodWithErrorsAndReturnValue_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithErrorsAndReturnValue_return_get_error(__call_result_handle);
         _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Errors_InternalErrorCode_fromFfi(__error_handle);
-        smoke_Errors_InternalErrorCode_releaseFfiHandle(__error_handle);
-        throw Errors_InternalException(_error_value);
+        try {
+          throw Errors_InternalException(smoke_Errors_InternalErrorCode_fromFfi(__error_handle));
+        } finally {
+          smoke_Errors_InternalErrorCode_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _methodWithErrorsAndReturnValue_return_get_result(__call_result_handle);
     _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   static methodWithPayloadError() {
     final _methodWithPayloadError_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadError');
@@ -300,15 +312,19 @@ class Errors$Impl implements Errors {
     if (_methodWithPayloadError_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithPayloadError_return_get_error(__call_result_handle);
         _methodWithPayloadError_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Payload_fromFfi(__error_handle);
-        smoke_Payload_releaseFfiHandle(__error_handle);
-        throw WithPayloadException(_error_value);
+        try {
+          throw WithPayloadException(smoke_Payload_fromFfi(__error_handle));
+        } finally {
+          smoke_Payload_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _methodWithPayloadError_return_get_result(__call_result_handle);
     _methodWithPayloadError_return_release_handle(__call_result_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static String methodWithPayloadErrorAndReturnValue() {
     final _methodWithPayloadErrorAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadErrorAndReturnValue');
@@ -316,15 +332,19 @@ class Errors$Impl implements Errors {
     if (_methodWithPayloadErrorAndReturnValue_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithPayloadErrorAndReturnValue_return_get_error(__call_result_handle);
         _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Payload_fromFfi(__error_handle);
-        smoke_Payload_releaseFfiHandle(__error_handle);
-        throw WithPayloadException(_error_value);
+        try {
+          throw WithPayloadException(smoke_Payload_fromFfi(__error_handle));
+        } finally {
+          smoke_Payload_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _methodWithPayloadErrorAndReturnValue_return_get_result(__call_result_handle);
     _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_Errors_toFfi(Errors value) =>

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -314,15 +314,19 @@ class ErrorsInterface$Impl implements ErrorsInterface {
     if (_methodWithErrors_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithErrors_return_get_error(__call_result_handle);
         _methodWithErrors_return_release_handle(__call_result_handle);
-        final _error_value = smoke_ErrorsInterface_InternalError_fromFfi(__error_handle);
-        smoke_ErrorsInterface_InternalError_releaseFfiHandle(__error_handle);
-        throw ErrorsInterface_InternalException(_error_value);
+        try {
+          throw ErrorsInterface_InternalException(smoke_ErrorsInterface_InternalError_fromFfi(__error_handle));
+        } finally {
+          smoke_ErrorsInterface_InternalError_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _methodWithErrors_return_get_result(__call_result_handle);
     _methodWithErrors_return_release_handle(__call_result_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   methodWithExternalErrors() {
@@ -332,15 +336,19 @@ class ErrorsInterface$Impl implements ErrorsInterface {
     if (_methodWithExternalErrors_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithExternalErrors_return_get_error(__call_result_handle);
         _methodWithExternalErrors_return_release_handle(__call_result_handle);
-        final _error_value = smoke_ErrorsInterface_ExternalErrors_fromFfi(__error_handle);
-        smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(__error_handle);
-        throw ErrorsInterface_ExternalException(_error_value);
+        try {
+          throw ErrorsInterface_ExternalException(smoke_ErrorsInterface_ExternalErrors_fromFfi(__error_handle));
+        } finally {
+          smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _methodWithExternalErrors_return_get_result(__call_result_handle);
     _methodWithExternalErrors_return_release_handle(__call_result_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   String methodWithErrorsAndReturnValue() {
@@ -350,15 +358,19 @@ class ErrorsInterface$Impl implements ErrorsInterface {
     if (_methodWithErrorsAndReturnValue_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithErrorsAndReturnValue_return_get_error(__call_result_handle);
         _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
-        final _error_value = smoke_ErrorsInterface_InternalError_fromFfi(__error_handle);
-        smoke_ErrorsInterface_InternalError_releaseFfiHandle(__error_handle);
-        throw ErrorsInterface_InternalException(_error_value);
+        try {
+          throw ErrorsInterface_InternalException(smoke_ErrorsInterface_InternalError_fromFfi(__error_handle));
+        } finally {
+          smoke_ErrorsInterface_InternalError_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _methodWithErrorsAndReturnValue_return_get_result(__call_result_handle);
     _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   static methodWithPayloadError() {
@@ -367,15 +379,19 @@ class ErrorsInterface$Impl implements ErrorsInterface {
     if (_methodWithPayloadError_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithPayloadError_return_get_error(__call_result_handle);
         _methodWithPayloadError_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Payload_fromFfi(__error_handle);
-        smoke_Payload_releaseFfiHandle(__error_handle);
-        throw WithPayloadException(_error_value);
+        try {
+          throw WithPayloadException(smoke_Payload_fromFfi(__error_handle));
+        } finally {
+          smoke_Payload_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _methodWithPayloadError_return_get_result(__call_result_handle);
     _methodWithPayloadError_return_release_handle(__call_result_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   static String methodWithPayloadErrorAndReturnValue() {
@@ -384,21 +400,25 @@ class ErrorsInterface$Impl implements ErrorsInterface {
     if (_methodWithPayloadErrorAndReturnValue_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithPayloadErrorAndReturnValue_return_get_error(__call_result_handle);
         _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
-        final _error_value = smoke_Payload_fromFfi(__error_handle);
-        smoke_Payload_releaseFfiHandle(__error_handle);
-        throw WithPayloadException(_error_value);
+        try {
+          throw WithPayloadException(smoke_Payload_fromFfi(__error_handle));
+        } finally {
+          smoke_Payload_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _methodWithPayloadErrorAndReturnValue_return_get_result(__call_result_handle);
     _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 int _ErrorsInterface_methodWithErrors_static(int _token, Pointer<Uint32> _error) {
   bool _error_flag = false;
   try {
-  (__lib.instanceCache[_token] as ErrorsInterface).methodWithErrors();
+    (__lib.instanceCache[_token] as ErrorsInterface).methodWithErrors();
   } on ErrorsInterface_InternalException catch(e) {
     _error_flag = true;
     final _error_object = e.error;
@@ -410,7 +430,7 @@ int _ErrorsInterface_methodWithErrors_static(int _token, Pointer<Uint32> _error)
 int _ErrorsInterface_methodWithExternalErrors_static(int _token, Pointer<Uint32> _error) {
   bool _error_flag = false;
   try {
-  (__lib.instanceCache[_token] as ErrorsInterface).methodWithExternalErrors();
+    (__lib.instanceCache[_token] as ErrorsInterface).methodWithExternalErrors();
   } on ErrorsInterface_ExternalException catch(e) {
     _error_flag = true;
     final _error_object = e.error;
@@ -421,9 +441,10 @@ int _ErrorsInterface_methodWithExternalErrors_static(int _token, Pointer<Uint32>
 }
 int _ErrorsInterface_methodWithErrorsAndReturnValue_static(int _token, Pointer<Pointer<Void>> _result, Pointer<Uint32> _error) {
   bool _error_flag = false;
+  String _result_object = null;
   try {
-  final _result_object = (__lib.instanceCache[_token] as ErrorsInterface).methodWithErrorsAndReturnValue();
-  _result.value = String_toFfi(_result_object);
+    _result_object = (__lib.instanceCache[_token] as ErrorsInterface).methodWithErrorsAndReturnValue();
+    _result.value = String_toFfi(_result_object);
   } on ErrorsInterface_InternalException catch(e) {
     _error_flag = true;
     final _error_object = e.error;
@@ -435,7 +456,7 @@ int _ErrorsInterface_methodWithErrorsAndReturnValue_static(int _token, Pointer<P
 int _ErrorsInterface_methodWithPayloadError_static(int _token, Pointer<Pointer<Void>> _error) {
   bool _error_flag = false;
   try {
-  (__lib.instanceCache[_token] as ErrorsInterface).methodWithPayloadError();
+    (__lib.instanceCache[_token] as ErrorsInterface).methodWithPayloadError();
   } on WithPayloadException catch(e) {
     _error_flag = true;
     final _error_object = e.error;
@@ -446,9 +467,10 @@ int _ErrorsInterface_methodWithPayloadError_static(int _token, Pointer<Pointer<V
 }
 int _ErrorsInterface_methodWithPayloadErrorAndReturnValue_static(int _token, Pointer<Pointer<Void>> _result, Pointer<Pointer<Void>> _error) {
   bool _error_flag = false;
+  String _result_object = null;
   try {
-  final _result_object = (__lib.instanceCache[_token] as ErrorsInterface).methodWithPayloadErrorAndReturnValue();
-  _result.value = String_toFfi(_result_object);
+    _result_object = (__lib.instanceCache[_token] as ErrorsInterface).methodWithPayloadErrorAndReturnValue();
+    _result.value = String_toFfi(_result_object);
   } on WithPayloadException catch(e) {
     _error_flag = true;
     final _error_object = e.error;

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -81,24 +81,30 @@ class Class$Impl implements Class {
     if (_fun_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _fun_return_get_error(__call_result_handle);
         _fun_return_release_handle(__call_result_handle);
-        final _error_value = package_Types_Enum_fromFfi(__error_handle);
-        package_Types_Enum_releaseFfiHandle(__error_handle);
-        throw ExceptionException(_error_value);
+        try {
+          throw ExceptionException(package_Types_Enum_fromFfi(__error_handle));
+        } finally {
+          package_Types_Enum_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _fun_return_get_result(__call_result_handle);
     _fun_return_release_handle(__call_result_handle);
-    final _result = package_Types_Struct_fromFfi(__result_handle);
-    package_Types_Struct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return package_Types_Struct_fromFfi(__result_handle);
+    } finally {
+      package_Types_Struct_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Enum get property {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_package_Class_property_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = package_Types_Enum_fromFfi(__result_handle);
-    package_Types_Enum_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return package_Types_Enum_fromFfi(__result_handle);
+    } finally {
+      package_Types_Enum_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set property(Enum value) {
@@ -107,9 +113,11 @@ class Class$Impl implements Class {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     package_Types_Enum_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> package_Class_toFfi(Class value) =>

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
@@ -2,7 +2,6 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 enum Enum {
     naN
 }
@@ -86,11 +85,13 @@ Pointer<Void> package_Types_Struct_toFfi(Struct value) {
 }
 Struct package_Types_Struct_fromFfi(Pointer<Void> handle) {
   final _null_handle = _package_Types_Struct_get_field_null(handle);
-  final _result = Struct(
-    package_Types_Enum_fromFfi(_null_handle)
-  );
-  package_Types_Enum_releaseFfiHandle(_null_handle);
-  return _result;
+  try {
+    return Struct(
+      package_Types_Enum_fromFfi(_null_handle)
+    );
+  } finally {
+    package_Types_Enum_releaseFfiHandle(_null_handle);
+  }
 }
 void package_Types_Struct_releaseFfiHandle(Pointer<Void> handle) => _package_Types_Struct_release_handle(handle);
 // Nullable Struct

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/generic_types__conversion.dart
@@ -54,8 +54,11 @@ List<double> foobar_ListOf_Float_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_ListOf_Float_iterator(handle);
   while (_foobar_ListOf_Float_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_Float_iterator_get(_iterator_handle);
-    result.add((_element_handle));
-    (_element_handle);
+    try {
+      result.add((_element_handle));
+    } finally {
+      (_element_handle);
+    }
     _foobar_ListOf_Float_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_Float_iterator_release_handle(_iterator_handle);
@@ -136,8 +139,11 @@ List<int> foobar_ListOf_Int_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_ListOf_Int_iterator(handle);
   while (_foobar_ListOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_Int_iterator_get(_iterator_handle);
-    result.add((_element_handle));
-    (_element_handle);
+    try {
+      result.add((_element_handle));
+    } finally {
+      (_element_handle);
+    }
     _foobar_ListOf_Int_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_Int_iterator_release_handle(_iterator_handle);
@@ -218,8 +224,11 @@ List<String> foobar_ListOf_String_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_ListOf_String_iterator(handle);
   while (_foobar_ListOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_String_iterator_get(_iterator_handle);
-    result.add(String_fromFfi(_element_handle));
-    String_releaseFfiHandle(_element_handle);
+    try {
+      result.add(String_fromFfi(_element_handle));
+    } finally {
+      String_releaseFfiHandle(_element_handle);
+    }
     _foobar_ListOf_String_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_String_iterator_release_handle(_iterator_handle);
@@ -300,8 +309,11 @@ List<int> foobar_ListOf_UByte_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_ListOf_UByte_iterator(handle);
   while (_foobar_ListOf_UByte_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_UByte_iterator_get(_iterator_handle);
-    result.add((_element_handle));
-    (_element_handle);
+    try {
+      result.add((_element_handle));
+    } finally {
+      (_element_handle);
+    }
     _foobar_ListOf_UByte_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_UByte_iterator_release_handle(_iterator_handle);
@@ -382,8 +394,11 @@ List<List<int>> foobar_ListOf_foobar_ListOf_Int_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_ListOf_foobar_ListOf_Int_iterator(handle);
   while (_foobar_ListOf_foobar_ListOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_foobar_ListOf_Int_iterator_get(_iterator_handle);
-    result.add(foobar_ListOf_Int_fromFfi(_element_handle));
-    foobar_ListOf_Int_releaseFfiHandle(_element_handle);
+    try {
+      result.add(foobar_ListOf_Int_fromFfi(_element_handle));
+    } finally {
+      foobar_ListOf_Int_releaseFfiHandle(_element_handle);
+    }
     _foobar_ListOf_foobar_ListOf_Int_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_foobar_ListOf_Int_iterator_release_handle(_iterator_handle);
@@ -464,8 +479,11 @@ List<Map<int, bool>> foobar_ListOf_foobar_MapOf_Int_to_Boolean_fromFfi(Pointer<V
   final _iterator_handle = _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator(handle);
   while (_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_get(_iterator_handle);
-    result.add(foobar_MapOf_Int_to_Boolean_fromFfi(_element_handle));
-    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_element_handle);
+    try {
+      result.add(foobar_MapOf_Int_to_Boolean_fromFfi(_element_handle));
+    } finally {
+      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_element_handle);
+    }
     _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle(_iterator_handle);
@@ -546,8 +564,11 @@ List<Set<int>> foobar_ListOf_foobar_SetOf_Int_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_ListOf_foobar_SetOf_Int_iterator(handle);
   while (_foobar_ListOf_foobar_SetOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_foobar_SetOf_Int_iterator_get(_iterator_handle);
-    result.add(foobar_SetOf_Int_fromFfi(_element_handle));
-    foobar_SetOf_Int_releaseFfiHandle(_element_handle);
+    try {
+      result.add(foobar_SetOf_Int_fromFfi(_element_handle));
+    } finally {
+      foobar_SetOf_Int_releaseFfiHandle(_element_handle);
+    }
     _foobar_ListOf_foobar_SetOf_Int_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_foobar_SetOf_Int_iterator_release_handle(_iterator_handle);
@@ -628,8 +649,11 @@ List<AnotherDummyClass> foobar_ListOf_smoke_AnotherDummyClass_fromFfi(Pointer<Vo
   final _iterator_handle = _foobar_ListOf_smoke_AnotherDummyClass_iterator(handle);
   while (_foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_AnotherDummyClass_iterator_get(_iterator_handle);
-    result.add(smoke_AnotherDummyClass_fromFfi(_element_handle));
-    smoke_AnotherDummyClass_releaseFfiHandle(_element_handle);
+    try {
+      result.add(smoke_AnotherDummyClass_fromFfi(_element_handle));
+    } finally {
+      smoke_AnotherDummyClass_releaseFfiHandle(_element_handle);
+    }
     _foobar_ListOf_smoke_AnotherDummyClass_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_smoke_AnotherDummyClass_iterator_release_handle(_iterator_handle);
@@ -710,8 +734,11 @@ List<DummyClass> foobar_ListOf_smoke_DummyClass_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_ListOf_smoke_DummyClass_iterator(handle);
   while (_foobar_ListOf_smoke_DummyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_DummyClass_iterator_get(_iterator_handle);
-    result.add(smoke_DummyClass_fromFfi(_element_handle));
-    smoke_DummyClass_releaseFfiHandle(_element_handle);
+    try {
+      result.add(smoke_DummyClass_fromFfi(_element_handle));
+    } finally {
+      smoke_DummyClass_releaseFfiHandle(_element_handle);
+    }
     _foobar_ListOf_smoke_DummyClass_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_smoke_DummyClass_iterator_release_handle(_iterator_handle);
@@ -792,8 +819,11 @@ List<DummyInterface> foobar_ListOf_smoke_DummyInterface_fromFfi(Pointer<Void> ha
   final _iterator_handle = _foobar_ListOf_smoke_DummyInterface_iterator(handle);
   while (_foobar_ListOf_smoke_DummyInterface_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_DummyInterface_iterator_get(_iterator_handle);
-    result.add(smoke_DummyInterface_fromFfi(_element_handle));
-    smoke_DummyInterface_releaseFfiHandle(_element_handle);
+    try {
+      result.add(smoke_DummyInterface_fromFfi(_element_handle));
+    } finally {
+      smoke_DummyInterface_releaseFfiHandle(_element_handle);
+    }
     _foobar_ListOf_smoke_DummyInterface_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_smoke_DummyInterface_iterator_release_handle(_iterator_handle);
@@ -874,8 +904,11 @@ List<GenericTypesWithCompoundTypes_BasicStruct> foobar_ListOf_smoke_GenericTypes
   final _iterator_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator(handle);
   while (_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get(_iterator_handle);
-    result.add(smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_element_handle));
-    smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_element_handle);
+    try {
+      result.add(smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_element_handle));
+    } finally {
+      smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_element_handle);
+    }
     _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle(_iterator_handle);
@@ -956,8 +989,11 @@ List<GenericTypesWithCompoundTypes_ExternalEnum> foobar_ListOf_smoke_GenericType
   final _iterator_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(handle);
   while (_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get(_iterator_handle);
-    result.add(smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_element_handle));
-    smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_element_handle);
+    try {
+      result.add(smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_element_handle));
+    } finally {
+      smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_element_handle);
+    }
     _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(_iterator_handle);
@@ -1038,8 +1074,11 @@ List<GenericTypesWithCompoundTypes_ExternalStruct> foobar_ListOf_smoke_GenericTy
   final _iterator_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator(handle);
   while (_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get(_iterator_handle);
-    result.add(smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_element_handle));
-    smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_element_handle);
+    try {
+      result.add(smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_element_handle));
+    } finally {
+      smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_element_handle);
+    }
     _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle(_iterator_handle);
@@ -1120,8 +1159,11 @@ List<GenericTypesWithCompoundTypes_SomeEnum> foobar_ListOf_smoke_GenericTypesWit
   final _iterator_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(handle);
   while (_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get(_iterator_handle);
-    result.add(smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_element_handle));
-    smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_element_handle);
+    try {
+      result.add(smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_element_handle));
+    } finally {
+      smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_element_handle);
+    }
     _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(_iterator_handle);
@@ -1202,8 +1244,11 @@ List<YetAnotherDummyClass> foobar_ListOf_smoke_YetAnotherDummyClass_fromFfi(Poin
   final _iterator_handle = _foobar_ListOf_smoke_YetAnotherDummyClass_iterator(handle);
   while (_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_get(_iterator_handle);
-    result.add(smoke_YetAnotherDummyClass_fromFfi(_element_handle));
-    smoke_YetAnotherDummyClass_releaseFfiHandle(_element_handle);
+    try {
+      result.add(smoke_YetAnotherDummyClass_fromFfi(_element_handle));
+    } finally {
+      smoke_YetAnotherDummyClass_releaseFfiHandle(_element_handle);
+    }
     _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_increment(_iterator_handle);
   }
   _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_release_handle(_iterator_handle);
@@ -1291,10 +1336,13 @@ Map<double, double> foobar_MapOf_Float_to_Double_fromFfi(Pointer<Void> handle) {
   while (_foobar_MapOf_Float_to_Double_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_Float_to_Double_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_Float_to_Double_iterator_get_value(_iterator_handle);
-    result[(_key_handle)] =
+    try {
+      result[(_key_handle)] =
+        (_value_handle);
+    } finally {
+      (_key_handle);
       (_value_handle);
-    (_key_handle);
-    (_value_handle);
+    }
     _foobar_MapOf_Float_to_Double_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_Float_to_Double_iterator_release_handle(_iterator_handle);
@@ -1382,10 +1430,13 @@ Map<int, bool> foobar_MapOf_Int_to_Boolean_fromFfi(Pointer<Void> handle) {
   while (_foobar_MapOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_Int_to_Boolean_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_Int_to_Boolean_iterator_get_value(_iterator_handle);
-    result[(_key_handle)] =
-      Boolean_fromFfi(_value_handle);
-    (_key_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    try {
+      result[(_key_handle)] =
+        Boolean_fromFfi(_value_handle);
+    } finally {
+      (_key_handle);
+      Boolean_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_Int_to_Boolean_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_Int_to_Boolean_iterator_release_handle(_iterator_handle);
@@ -1473,10 +1524,13 @@ Map<int, List<int>> foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi(Pointer<Void> 
   while (_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_value(_iterator_handle);
-    result[(_key_handle)] =
-      foobar_ListOf_Int_fromFfi(_value_handle);
-    (_key_handle);
-    foobar_ListOf_Int_releaseFfiHandle(_value_handle);
+    try {
+      result[(_key_handle)] =
+        foobar_ListOf_Int_fromFfi(_value_handle);
+    } finally {
+      (_key_handle);
+      foobar_ListOf_Int_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_release_handle(_iterator_handle);
@@ -1564,10 +1618,13 @@ Map<int, Map<int, bool>> foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_fromFfi
   while (_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_value(_iterator_handle);
-    result[(_key_handle)] =
-      foobar_MapOf_Int_to_Boolean_fromFfi(_value_handle);
-    (_key_handle);
-    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_value_handle);
+    try {
+      result[(_key_handle)] =
+        foobar_MapOf_Int_to_Boolean_fromFfi(_value_handle);
+    } finally {
+      (_key_handle);
+      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_release_handle(_iterator_handle);
@@ -1655,10 +1712,13 @@ Map<int, Set<int>> foobar_MapOf_Int_to_foobar_SetOf_Int_fromFfi(Pointer<Void> ha
   while (_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_value(_iterator_handle);
-    result[(_key_handle)] =
-      foobar_SetOf_Int_fromFfi(_value_handle);
-    (_key_handle);
-    foobar_SetOf_Int_releaseFfiHandle(_value_handle);
+    try {
+      result[(_key_handle)] =
+        foobar_SetOf_Int_fromFfi(_value_handle);
+    } finally {
+      (_key_handle);
+      foobar_SetOf_Int_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_release_handle(_iterator_handle);
@@ -1746,10 +1806,13 @@ Map<int, DummyClass> foobar_MapOf_Int_to_smoke_DummyClass_fromFfi(Pointer<Void> 
   while (_foobar_MapOf_Int_to_smoke_DummyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_value(_iterator_handle);
-    result[(_key_handle)] =
-      smoke_DummyClass_fromFfi(_value_handle);
-    (_key_handle);
-    smoke_DummyClass_releaseFfiHandle(_value_handle);
+    try {
+      result[(_key_handle)] =
+        smoke_DummyClass_fromFfi(_value_handle);
+    } finally {
+      (_key_handle);
+      smoke_DummyClass_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_Int_to_smoke_DummyClass_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_Int_to_smoke_DummyClass_iterator_release_handle(_iterator_handle);
@@ -1837,10 +1900,13 @@ Map<int, DummyInterface> foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi(Pointe
   while (_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_value(_iterator_handle);
-    result[(_key_handle)] =
-      smoke_DummyInterface_fromFfi(_value_handle);
-    (_key_handle);
-    smoke_DummyInterface_releaseFfiHandle(_value_handle);
+    try {
+      result[(_key_handle)] =
+        smoke_DummyInterface_fromFfi(_value_handle);
+    } finally {
+      (_key_handle);
+      smoke_DummyInterface_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_release_handle(_iterator_handle);
@@ -1928,10 +1994,13 @@ Map<int, GenericTypesWithCompoundTypes_ExternalEnum> foobar_MapOf_Int_to_smoke_G
   while (_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_value(_iterator_handle);
-    result[(_key_handle)] =
-      smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_value_handle);
-    (_key_handle);
-    smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_value_handle);
+    try {
+      result[(_key_handle)] =
+        smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_value_handle);
+    } finally {
+      (_key_handle);
+      smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(_iterator_handle);
@@ -2019,10 +2088,13 @@ Map<int, GenericTypesWithCompoundTypes_SomeEnum> foobar_MapOf_Int_to_smoke_Gener
   while (_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_value(_iterator_handle);
-    result[(_key_handle)] =
-      smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_value_handle);
-    (_key_handle);
-    smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_value_handle);
+    try {
+      result[(_key_handle)] =
+        smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_value_handle);
+    } finally {
+      (_key_handle);
+      smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(_iterator_handle);
@@ -2110,10 +2182,13 @@ Map<String, String> foobar_MapOf_String_to_String_fromFfi(Pointer<Void> handle) 
   while (_foobar_MapOf_String_to_String_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_String_to_String_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_String_to_String_iterator_get_value(_iterator_handle);
-    result[String_fromFfi(_key_handle)] =
-      String_fromFfi(_value_handle);
-    String_releaseFfiHandle(_key_handle);
-    String_releaseFfiHandle(_value_handle);
+    try {
+      result[String_fromFfi(_key_handle)] =
+        String_fromFfi(_value_handle);
+    } finally {
+      String_releaseFfiHandle(_key_handle);
+      String_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_String_to_String_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_String_to_String_iterator_release_handle(_iterator_handle);
@@ -2201,10 +2276,13 @@ Map<String, GenericTypesWithCompoundTypes_BasicStruct> foobar_MapOf_String_to_sm
   while (_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_value(_iterator_handle);
-    result[String_fromFfi(_key_handle)] =
-      smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_value_handle);
-    String_releaseFfiHandle(_key_handle);
-    smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_value_handle);
+    try {
+      result[String_fromFfi(_key_handle)] =
+        smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_value_handle);
+    } finally {
+      String_releaseFfiHandle(_key_handle);
+      smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle(_iterator_handle);
@@ -2292,10 +2370,13 @@ Map<String, GenericTypesWithCompoundTypes_ExternalStruct> foobar_MapOf_String_to
   while (_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_value(_iterator_handle);
-    result[String_fromFfi(_key_handle)] =
-      smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_value_handle);
-    String_releaseFfiHandle(_key_handle);
-    smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_value_handle);
+    try {
+      result[String_fromFfi(_key_handle)] =
+        smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_value_handle);
+    } finally {
+      String_releaseFfiHandle(_key_handle);
+      smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle(_iterator_handle);
@@ -2383,10 +2464,13 @@ Map<int, String> foobar_MapOf_UByte_to_String_fromFfi(Pointer<Void> handle) {
   while (_foobar_MapOf_UByte_to_String_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_UByte_to_String_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_UByte_to_String_iterator_get_value(_iterator_handle);
-    result[(_key_handle)] =
-      String_fromFfi(_value_handle);
-    (_key_handle);
-    String_releaseFfiHandle(_value_handle);
+    try {
+      result[(_key_handle)] =
+        String_fromFfi(_value_handle);
+    } finally {
+      (_key_handle);
+      String_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_UByte_to_String_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_UByte_to_String_iterator_release_handle(_iterator_handle);
@@ -2474,10 +2558,13 @@ Map<List<int>, bool> foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi(Pointer<V
   while (_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_value(_iterator_handle);
-    result[foobar_ListOf_Int_fromFfi(_key_handle)] =
-      Boolean_fromFfi(_value_handle);
-    foobar_ListOf_Int_releaseFfiHandle(_key_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    try {
+      result[foobar_ListOf_Int_fromFfi(_key_handle)] =
+        Boolean_fromFfi(_value_handle);
+    } finally {
+      foobar_ListOf_Int_releaseFfiHandle(_key_handle);
+      Boolean_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_release_handle(_iterator_handle);
@@ -2565,10 +2652,13 @@ Map<Map<int, bool>, bool> foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fr
   while (_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_value(_iterator_handle);
-    result[foobar_MapOf_Int_to_Boolean_fromFfi(_key_handle)] =
-      Boolean_fromFfi(_value_handle);
-    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_key_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    try {
+      result[foobar_MapOf_Int_to_Boolean_fromFfi(_key_handle)] =
+        Boolean_fromFfi(_value_handle);
+    } finally {
+      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_key_handle);
+      Boolean_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_release_handle(_iterator_handle);
@@ -2656,10 +2746,13 @@ Map<Set<int>, bool> foobar_MapOf_foobar_SetOf_Int_to_Boolean_fromFfi(Pointer<Voi
   while (_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_value(_iterator_handle);
-    result[foobar_SetOf_Int_fromFfi(_key_handle)] =
-      Boolean_fromFfi(_value_handle);
-    foobar_SetOf_Int_releaseFfiHandle(_key_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    try {
+      result[foobar_SetOf_Int_fromFfi(_key_handle)] =
+        Boolean_fromFfi(_value_handle);
+    } finally {
+      foobar_SetOf_Int_releaseFfiHandle(_key_handle);
+      Boolean_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_release_handle(_iterator_handle);
@@ -2747,10 +2840,13 @@ Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> foobar_MapOf_smoke_Generic
   while (_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_value(_iterator_handle);
-    result[smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_key_handle)] =
-      Boolean_fromFfi(_value_handle);
-    smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_key_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    try {
+      result[smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_key_handle)] =
+        Boolean_fromFfi(_value_handle);
+    } finally {
+      smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_key_handle);
+      Boolean_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_release_handle(_iterator_handle);
@@ -2838,10 +2934,13 @@ Map<GenericTypesWithCompoundTypes_SomeEnum, bool> foobar_MapOf_smoke_GenericType
   while (_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_key(_iterator_handle);
     final _value_handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_value(_iterator_handle);
-    result[smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_key_handle)] =
-      Boolean_fromFfi(_value_handle);
-    smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_key_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    try {
+      result[smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_key_handle)] =
+        Boolean_fromFfi(_value_handle);
+    } finally {
+      smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_key_handle);
+      Boolean_releaseFfiHandle(_value_handle);
+    }
     _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_increment(_iterator_handle);
   }
   _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_release_handle(_iterator_handle);
@@ -2922,8 +3021,11 @@ Set<double> foobar_SetOf_Float_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_SetOf_Float_iterator(handle);
   while (_foobar_SetOf_Float_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_SetOf_Float_iterator_get(_iterator_handle);
-    result.add((_element_handle));
-    (_element_handle);
+    try {
+      result.add((_element_handle));
+    } finally {
+      (_element_handle);
+    }
     _foobar_SetOf_Float_iterator_increment(_iterator_handle);
   }
   _foobar_SetOf_Float_iterator_release_handle(_iterator_handle);
@@ -3004,8 +3106,11 @@ Set<int> foobar_SetOf_Int_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_SetOf_Int_iterator(handle);
   while (_foobar_SetOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_SetOf_Int_iterator_get(_iterator_handle);
-    result.add((_element_handle));
-    (_element_handle);
+    try {
+      result.add((_element_handle));
+    } finally {
+      (_element_handle);
+    }
     _foobar_SetOf_Int_iterator_increment(_iterator_handle);
   }
   _foobar_SetOf_Int_iterator_release_handle(_iterator_handle);
@@ -3086,8 +3191,11 @@ Set<String> foobar_SetOf_String_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_SetOf_String_iterator(handle);
   while (_foobar_SetOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_SetOf_String_iterator_get(_iterator_handle);
-    result.add(String_fromFfi(_element_handle));
-    String_releaseFfiHandle(_element_handle);
+    try {
+      result.add(String_fromFfi(_element_handle));
+    } finally {
+      String_releaseFfiHandle(_element_handle);
+    }
     _foobar_SetOf_String_iterator_increment(_iterator_handle);
   }
   _foobar_SetOf_String_iterator_release_handle(_iterator_handle);
@@ -3168,8 +3276,11 @@ Set<int> foobar_SetOf_UByte_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_SetOf_UByte_iterator(handle);
   while (_foobar_SetOf_UByte_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_SetOf_UByte_iterator_get(_iterator_handle);
-    result.add((_element_handle));
-    (_element_handle);
+    try {
+      result.add((_element_handle));
+    } finally {
+      (_element_handle);
+    }
     _foobar_SetOf_UByte_iterator_increment(_iterator_handle);
   }
   _foobar_SetOf_UByte_iterator_release_handle(_iterator_handle);
@@ -3250,8 +3361,11 @@ Set<List<int>> foobar_SetOf_foobar_ListOf_Int_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_SetOf_foobar_ListOf_Int_iterator(handle);
   while (_foobar_SetOf_foobar_ListOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_SetOf_foobar_ListOf_Int_iterator_get(_iterator_handle);
-    result.add(foobar_ListOf_Int_fromFfi(_element_handle));
-    foobar_ListOf_Int_releaseFfiHandle(_element_handle);
+    try {
+      result.add(foobar_ListOf_Int_fromFfi(_element_handle));
+    } finally {
+      foobar_ListOf_Int_releaseFfiHandle(_element_handle);
+    }
     _foobar_SetOf_foobar_ListOf_Int_iterator_increment(_iterator_handle);
   }
   _foobar_SetOf_foobar_ListOf_Int_iterator_release_handle(_iterator_handle);
@@ -3332,8 +3446,11 @@ Set<Map<int, bool>> foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi(Pointer<Voi
   final _iterator_handle = _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator(handle);
   while (_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_get(_iterator_handle);
-    result.add(foobar_MapOf_Int_to_Boolean_fromFfi(_element_handle));
-    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_element_handle);
+    try {
+      result.add(foobar_MapOf_Int_to_Boolean_fromFfi(_element_handle));
+    } finally {
+      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_element_handle);
+    }
     _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_increment(_iterator_handle);
   }
   _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle(_iterator_handle);
@@ -3414,8 +3531,11 @@ Set<Set<int>> foobar_SetOf_foobar_SetOf_Int_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _foobar_SetOf_foobar_SetOf_Int_iterator(handle);
   while (_foobar_SetOf_foobar_SetOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_SetOf_foobar_SetOf_Int_iterator_get(_iterator_handle);
-    result.add(foobar_SetOf_Int_fromFfi(_element_handle));
-    foobar_SetOf_Int_releaseFfiHandle(_element_handle);
+    try {
+      result.add(foobar_SetOf_Int_fromFfi(_element_handle));
+    } finally {
+      foobar_SetOf_Int_releaseFfiHandle(_element_handle);
+    }
     _foobar_SetOf_foobar_SetOf_Int_iterator_increment(_iterator_handle);
   }
   _foobar_SetOf_foobar_SetOf_Int_iterator_release_handle(_iterator_handle);
@@ -3496,8 +3616,11 @@ Set<GenericTypesWithCompoundTypes_ExternalEnum> foobar_SetOf_smoke_GenericTypesW
   final _iterator_handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(handle);
   while (_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get(_iterator_handle);
-    result.add(smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_element_handle));
-    smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_element_handle);
+    try {
+      result.add(smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_element_handle));
+    } finally {
+      smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_element_handle);
+    }
     _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(_iterator_handle);
   }
   _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(_iterator_handle);
@@ -3578,8 +3701,11 @@ Set<GenericTypesWithCompoundTypes_SomeEnum> foobar_SetOf_smoke_GenericTypesWithC
   final _iterator_handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(handle);
   while (_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get(_iterator_handle);
-    result.add(smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_element_handle));
-    smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_element_handle);
+    try {
+      result.add(smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_element_handle));
+    } finally {
+      smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_element_handle);
+    }
     _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(_iterator_handle);
   }
   _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(_iterator_handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -65,15 +65,17 @@ GenericTypesWithBasicTypes_StructWithGenerics smoke_GenericTypesWithBasicTypes_S
   final _numbersList_handle = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersList(handle);
   final _numbersMap_handle = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersMap(handle);
   final _numbersSet_handle = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersSet(handle);
-  final _result = GenericTypesWithBasicTypes_StructWithGenerics(
-    foobar_ListOf_UByte_fromFfi(_numbersList_handle),
-    foobar_MapOf_UByte_to_String_fromFfi(_numbersMap_handle),
-    foobar_SetOf_UByte_fromFfi(_numbersSet_handle)
-  );
-  foobar_ListOf_UByte_releaseFfiHandle(_numbersList_handle);
-  foobar_MapOf_UByte_to_String_releaseFfiHandle(_numbersMap_handle);
-  foobar_SetOf_UByte_releaseFfiHandle(_numbersSet_handle);
-  return _result;
+  try {
+    return GenericTypesWithBasicTypes_StructWithGenerics(
+      foobar_ListOf_UByte_fromFfi(_numbersList_handle),
+      foobar_MapOf_UByte_to_String_fromFfi(_numbersMap_handle),
+      foobar_SetOf_UByte_fromFfi(_numbersSet_handle)
+    );
+  } finally {
+    foobar_ListOf_UByte_releaseFfiHandle(_numbersList_handle);
+    foobar_MapOf_UByte_to_String_releaseFfiHandle(_numbersMap_handle);
+    foobar_SetOf_UByte_releaseFfiHandle(_numbersSet_handle);
+  }
 }
 void smoke_GenericTypesWithBasicTypes_StructWithGenerics_releaseFfiHandle(Pointer<Void> handle) => _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle(handle);
 // Nullable GenericTypesWithBasicTypes_StructWithGenerics
@@ -137,9 +139,11 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
     final _handle = this.handle;
     final __result_handle = _methodWithList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_ListOf_Int_releaseFfiHandle(_input_handle);
-    final _result = foobar_ListOf_Int_fromFfi(__result_handle);
-    foobar_ListOf_Int_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_ListOf_Int_fromFfi(__result_handle);
+    } finally {
+      foobar_ListOf_Int_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Map<int, bool> methodWithMap(Map<int, bool> input) {
@@ -148,9 +152,11 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
     final _handle = this.handle;
     final __result_handle = _methodWithMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
-    final _result = foobar_MapOf_Int_to_Boolean_fromFfi(__result_handle);
-    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_MapOf_Int_to_Boolean_fromFfi(__result_handle);
+    } finally {
+      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Set<int> methodWithSet(Set<int> input) {
@@ -159,9 +165,11 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
     final _handle = this.handle;
     final __result_handle = _methodWithSet_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_SetOf_Int_releaseFfiHandle(_input_handle);
-    final _result = foobar_SetOf_Int_fromFfi(__result_handle);
-    foobar_SetOf_Int_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_SetOf_Int_fromFfi(__result_handle);
+    } finally {
+      foobar_SetOf_Int_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   List<String> methodWithListTypeAlias(List<String> input) {
@@ -170,9 +178,11 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
     final _handle = this.handle;
     final __result_handle = _methodWithListTypeAlias_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_ListOf_String_releaseFfiHandle(_input_handle);
-    final _result = foobar_ListOf_String_fromFfi(__result_handle);
-    foobar_ListOf_String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_ListOf_String_fromFfi(__result_handle);
+    } finally {
+      foobar_ListOf_String_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Map<String, String> methodWithMapTypeAlias(Map<String, String> input) {
@@ -181,9 +191,11 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
     final _handle = this.handle;
     final __result_handle = _methodWithMapTypeAlias_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_MapOf_String_to_String_releaseFfiHandle(_input_handle);
-    final _result = foobar_MapOf_String_to_String_fromFfi(__result_handle);
-    foobar_MapOf_String_to_String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_MapOf_String_to_String_fromFfi(__result_handle);
+    } finally {
+      foobar_MapOf_String_to_String_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Set<String> methodWithSetTypeAlias(Set<String> input) {
@@ -192,18 +204,22 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
     final _handle = this.handle;
     final __result_handle = _methodWithSetTypeAlias_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_SetOf_String_releaseFfiHandle(_input_handle);
-    final _result = foobar_SetOf_String_fromFfi(__result_handle);
-    foobar_SetOf_String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_SetOf_String_fromFfi(__result_handle);
+    } finally {
+      foobar_SetOf_String_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   List<double> get listProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_listProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = foobar_ListOf_Float_fromFfi(__result_handle);
-    foobar_ListOf_Float_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_ListOf_Float_fromFfi(__result_handle);
+    } finally {
+      foobar_ListOf_Float_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set listProperty(List<double> value) {
@@ -212,18 +228,22 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     foobar_ListOf_Float_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   Map<double, double> get mapProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = foobar_MapOf_Float_to_Double_fromFfi(__result_handle);
-    foobar_MapOf_Float_to_Double_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_MapOf_Float_to_Double_fromFfi(__result_handle);
+    } finally {
+      foobar_MapOf_Float_to_Double_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set mapProperty(Map<double, double> value) {
@@ -232,18 +252,22 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     foobar_MapOf_Float_to_Double_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   Set<double> get setProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_setProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = foobar_SetOf_Float_fromFfi(__result_handle);
-    foobar_SetOf_Float_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_SetOf_Float_fromFfi(__result_handle);
+    } finally {
+      foobar_SetOf_Float_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set setProperty(Set<double> value) {
@@ -252,9 +276,11 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     foobar_SetOf_Float_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi(GenericTypesWithBasicTypes value) =>

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -165,11 +165,13 @@ Pointer<Void> smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(GenericTypes
 }
 GenericTypesWithCompoundTypes_BasicStruct smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(Pointer<Void> handle) {
   final _value_handle = _smoke_GenericTypesWithCompoundTypes_BasicStruct_get_field_value(handle);
-  final _result = GenericTypesWithCompoundTypes_BasicStruct(
-    (_value_handle)
-  );
-  (_value_handle);
-  return _result;
+  try {
+    return GenericTypesWithCompoundTypes_BasicStruct(
+      (_value_handle)
+    );
+  } finally {
+    (_value_handle);
+  }
 }
 void smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(handle);
 // Nullable GenericTypesWithCompoundTypes_BasicStruct
@@ -227,11 +229,13 @@ Pointer<Void> smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(GenericTy
 }
 GenericTypesWithCompoundTypes_ExternalStruct smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(Pointer<Void> handle) {
   final _string_handle = _smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_field_string(handle);
-  final _result = GenericTypesWithCompoundTypes_ExternalStruct(
-    String_fromFfi(_string_handle)
-  );
-  String_releaseFfiHandle(_string_handle);
-  return _result;
+  try {
+    return GenericTypesWithCompoundTypes_ExternalStruct(
+      String_fromFfi(_string_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_string_handle);
+  }
 }
 void smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(handle);
 // Nullable GenericTypesWithCompoundTypes_ExternalStruct
@@ -295,9 +299,11 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
     final _handle = this.handle;
     final __result_handle = _methodWithStructList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
-    final _result = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
-    foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
+    } finally {
+      foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Map<String, GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructMap(Map<String, GenericTypesWithCompoundTypes_BasicStruct> input) {
@@ -306,9 +312,11 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
     final _handle = this.handle;
     final __result_handle = _methodWithStructMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
-    final _result = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
-    foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
+    } finally {
+      foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   List<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumList(List<GenericTypesWithCompoundTypes_SomeEnum> input) {
@@ -317,9 +325,11 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
     final _handle = this.handle;
     final __result_handle = _methodWithEnumList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
-    final _result = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
-    foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
+    } finally {
+      foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> methodWithEnumMapKey(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> input) {
@@ -328,9 +338,11 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
     final _handle = this.handle;
     final __result_handle = _methodWithEnumMapKey_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(_input_handle);
-    final _result = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi(__result_handle);
-    foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi(__result_handle);
+    } finally {
+      foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Map<int, GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumMapValue(Map<int, GenericTypesWithCompoundTypes_SomeEnum> input) {
@@ -339,9 +351,11 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
     final _handle = this.handle;
     final __result_handle = _methodWithEnumMapValue_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
-    final _result = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
-    foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
+    } finally {
+      foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Set<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumSet(Set<GenericTypesWithCompoundTypes_SomeEnum> input) {
@@ -350,9 +364,11 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
     final _handle = this.handle;
     final __result_handle = _methodWithEnumSet_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
-    final _result = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
-    foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
+    } finally {
+      foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   List<DummyInterface> methodWithInstancesList(List<DummyClass> input) {
@@ -361,9 +377,11 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
     final _handle = this.handle;
     final __result_handle = _methodWithInstancesList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_ListOf_smoke_DummyClass_releaseFfiHandle(_input_handle);
-    final _result = foobar_ListOf_smoke_DummyInterface_fromFfi(__result_handle);
-    foobar_ListOf_smoke_DummyInterface_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_ListOf_smoke_DummyInterface_fromFfi(__result_handle);
+    } finally {
+      foobar_ListOf_smoke_DummyInterface_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Map<int, DummyInterface> methodWithInstancesMap(Map<int, DummyClass> input) {
@@ -372,9 +390,11 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
     final _handle = this.handle;
     final __result_handle = _methodWithInstancesMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(_input_handle);
-    final _result = foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi(__result_handle);
-    foobar_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi(__result_handle);
+    } finally {
+      foobar_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_toFfi(GenericTypesWithCompoundTypes value) =>

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -50,9 +50,11 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
     final _handle = this.handle;
     final __result_handle = _methodWithListOfLists_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(_input_handle);
-    final _result = foobar_ListOf_foobar_ListOf_Int_fromFfi(__result_handle);
-    foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_ListOf_foobar_ListOf_Int_fromFfi(__result_handle);
+    } finally {
+      foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Map<Map<int, bool>, bool> methodWithMapOfMaps(Map<int, Map<int, bool>> input) {
@@ -61,9 +63,11 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
     final _handle = this.handle;
     final __result_handle = _methodWithMapOfMaps_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
-    final _result = foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fromFfi(__result_handle);
-    foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fromFfi(__result_handle);
+    } finally {
+      foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Set<Set<int>> methodWithSetOfSets(Set<Set<int>> input) {
@@ -72,9 +76,11 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
     final _handle = this.handle;
     final __result_handle = _methodWithSetOfSets_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(_input_handle);
-    final _result = foobar_SetOf_foobar_SetOf_Int_fromFfi(__result_handle);
-    foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_SetOf_foobar_SetOf_Int_fromFfi(__result_handle);
+    } finally {
+      foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Map<int, List<int>> methodWithListAndMap(List<Map<int, bool>> input) {
@@ -83,9 +89,11 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
     final _handle = this.handle;
     final __result_handle = _methodWithListAndMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_ListOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
-    final _result = foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi(__result_handle);
-    foobar_MapOf_Int_to_foobar_ListOf_Int_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi(__result_handle);
+    } finally {
+      foobar_MapOf_Int_to_foobar_ListOf_Int_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Set<List<int>> methodWithListAndSet(List<Set<int>> input) {
@@ -94,9 +102,11 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
     final _handle = this.handle;
     final __result_handle = _methodWithListAndSet_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_ListOf_foobar_SetOf_Int_releaseFfiHandle(_input_handle);
-    final _result = foobar_SetOf_foobar_ListOf_Int_fromFfi(__result_handle);
-    foobar_SetOf_foobar_ListOf_Int_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_SetOf_foobar_ListOf_Int_fromFfi(__result_handle);
+    } finally {
+      foobar_SetOf_foobar_ListOf_Int_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Set<Map<int, bool>> methodWithMapAndSet(Map<int, Set<int>> input) {
@@ -105,9 +115,11 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
     final _handle = this.handle;
     final __result_handle = _methodWithMapAndSet_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_MapOf_Int_to_foobar_SetOf_Int_releaseFfiHandle(_input_handle);
-    final _result = foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi(__result_handle);
-    foobar_SetOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi(__result_handle);
+    } finally {
+      foobar_SetOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Map<List<int>, bool> methodWithMapGenericKeys(Map<Set<int>, bool> input) {
@@ -116,9 +128,11 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
     final _handle = this.handle;
     final __result_handle = _methodWithMapGenericKeys_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     foobar_MapOf_foobar_SetOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
-    final _result = foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi(__result_handle);
-    foobar_MapOf_foobar_ListOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi(__result_handle);
+    } finally {
+      foobar_MapOf_foobar_ListOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_GenericTypesWithGenericTypes_toFfi(GenericTypesWithGenericTypes value) =>

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -45,9 +45,11 @@ class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFro
     final _childClassMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromClass_childClassMethod');
     final _handle = this.handle;
     final __result_handle = _childClassMethod_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_ChildClassFromClass_toFfi(ChildClassFromClass value) =>

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -47,27 +47,33 @@ class ChildClassFromInterface$Impl implements ChildClassFromInterface {
     final _childClassMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_childClassMethod');
     final _handle = this.handle;
     final __result_handle = _childClassMethod_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   rootMethod() {
     final _rootMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod');
     final _handle = this.handle;
     final __result_handle = _rootMethod_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   String get rootProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set rootProperty(String value) {
@@ -76,9 +82,11 @@ class ChildClassFromInterface$Impl implements ChildClassFromInterface {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     String_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_ChildClassFromInterface_toFfi(ChildClassFromInterface value) =>

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -81,17 +81,25 @@ class ChildInterface$Impl extends ParentInterface$Impl implements ChildInterface
     final _childMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildInterface_childMethod');
     final _handle = this.handle;
     final __result_handle = _childMethod_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _ChildInterface_rootMethod_static(int _token) {
-  (__lib.instanceCache[_token] as ChildInterface).rootMethod();
+  try {
+    (__lib.instanceCache[_token] as ChildInterface).rootMethod();
+  } finally {
+  }
   return 0;
 }
 int _ChildInterface_childMethod_static(int _token) {
-  (__lib.instanceCache[_token] as ChildInterface).childMethod();
+  try {
+    (__lib.instanceCache[_token] as ChildInterface).childMethod();
+  } finally {
+  }
   return 0;
 }
 int _ChildInterface_rootProperty_get_static(int _token, Pointer<Pointer<Void>> _result) {
@@ -99,9 +107,12 @@ int _ChildInterface_rootProperty_get_static(int _token, Pointer<Pointer<Void>> _
   return 0;
 }
 int _ChildInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
-  final __value = String_fromFfi(_value);
-  String_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as ChildInterface).rootProperty = __value;
+  try {
+    (__lib.instanceCache[_token] as ChildInterface).rootProperty =
+      String_fromFfi(_value);
+  } finally {
+    String_releaseFfiHandle(_value);
+  }
   return 0;
 }
 Pointer<Void> smoke_ChildInterface_toFfi(ChildInterface value) {

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -48,18 +48,22 @@ class ChildWithParentClassReferences$Impl implements ChildWithParentClassReferen
     final _classFunction_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classFunction');
     final _handle = this.handle;
     final __result_handle = _classFunction_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_ChildClassFromClass_fromFfi(__result_handle);
-    smoke_ChildClassFromClass_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_ChildClassFromClass_fromFfi(__result_handle);
+    } finally {
+      smoke_ChildClassFromClass_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   ParentClass get classProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_ParentClass_fromFfi(__result_handle);
-    smoke_ParentClass_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_ParentClass_fromFfi(__result_handle);
+    } finally {
+      smoke_ParentClass_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set classProperty(ParentClass value) {
@@ -68,9 +72,11 @@ class ChildWithParentClassReferences$Impl implements ChildWithParentClassReferen
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     smoke_ParentClass_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_ChildWithParentClassReferences_toFfi(ChildWithParentClassReferences value) =>

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -46,9 +46,11 @@ class ParentClass$Impl implements ParentClass {
     final _rootMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentClass_rootMethod');
     final _handle = this.handle;
     final __result_handle = _rootMethod_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_ParentClass_toFfi(ParentClass value) =>

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -85,17 +85,21 @@ class ParentInterface$Impl implements ParentInterface {
     final _rootMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod');
     final _handle = this.handle;
     final __result_handle = _rootMethod_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   String get rootProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   set rootProperty(String value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String');
@@ -103,13 +107,18 @@ class ParentInterface$Impl implements ParentInterface {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     String_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _ParentInterface_rootMethod_static(int _token) {
-  (__lib.instanceCache[_token] as ParentInterface).rootMethod();
+  try {
+    (__lib.instanceCache[_token] as ParentInterface).rootMethod();
+  } finally {
+  }
   return 0;
 }
 int _ParentInterface_rootProperty_get_static(int _token, Pointer<Pointer<Void>> _result) {
@@ -117,9 +126,12 @@ int _ParentInterface_rootProperty_get_static(int _token, Pointer<Pointer<Void>> 
   return 0;
 }
 int _ParentInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
-  final __value = String_fromFfi(_value);
-  String_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as ParentInterface).rootProperty = __value;
+  try {
+    (__lib.instanceCache[_token] as ParentInterface).rootProperty =
+      String_fromFfi(_value);
+  } finally {
+    String_releaseFfiHandle(_value);
+  }
   return 0;
 }
 Pointer<Void> smoke_ParentInterface_toFfi(ParentInterface value) {

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/external_class.dart
@@ -90,11 +90,13 @@ Pointer<Void> smoke_ExternalClass_SomeStruct_toFfi(ExternalClass_SomeStruct valu
 }
 ExternalClass_SomeStruct smoke_ExternalClass_SomeStruct_fromFfi(Pointer<Void> handle) {
   final _someField_handle = _smoke_ExternalClass_SomeStruct_get_field_someField(handle);
-  final _result = ExternalClass_SomeStruct(
-    String_fromFfi(_someField_handle)
-  );
-  String_releaseFfiHandle(_someField_handle);
-  return _result;
+  try {
+    return ExternalClass_SomeStruct(
+      String_fromFfi(_someField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_someField_handle);
+  }
 }
 void smoke_ExternalClass_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ExternalClass_SomeStruct_release_handle(handle);
 // Nullable ExternalClass_SomeStruct
@@ -158,18 +160,22 @@ class ExternalClass$Impl implements ExternalClass {
     final _handle = this.handle;
     final __result_handle = _someMethod_ffi(_handle, __lib.LibraryContext.isolateId, _someParameter_handle);
     (_someParameter_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   String get someProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalClass_someProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_ExternalClass_toFfi(ExternalClass value) =>

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/external_interface.dart
@@ -99,11 +99,13 @@ Pointer<Void> smoke_ExternalInterface_SomeStruct_toFfi(ExternalInterface_SomeStr
 }
 ExternalInterface_SomeStruct smoke_ExternalInterface_SomeStruct_fromFfi(Pointer<Void> handle) {
   final _someField_handle = _smoke_ExternalInterface_SomeStruct_get_field_someField(handle);
-  final _result = ExternalInterface_SomeStruct(
-    String_fromFfi(_someField_handle)
-  );
-  String_releaseFfiHandle(_someField_handle);
-  return _result;
+  try {
+    return ExternalInterface_SomeStruct(
+      String_fromFfi(_someField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_someField_handle);
+  }
 }
 void smoke_ExternalInterface_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ExternalInterface_SomeStruct_release_handle(handle);
 // Nullable ExternalInterface_SomeStruct
@@ -193,23 +195,29 @@ class ExternalInterface$Impl implements ExternalInterface {
     final _handle = this.handle;
     final __result_handle = _someMethod_ffi(_handle, __lib.LibraryContext.isolateId, _someParameter_handle);
     (_someParameter_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   String get someProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalInterface_someProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 int _ExternalInterface_someMethod_static(int _token, int someParameter) {
-  final __someParameter = (someParameter);
-  (someParameter);
-  (__lib.instanceCache[_token] as ExternalInterface).someMethod(__someParameter);
+  try {
+    (__lib.instanceCache[_token] as ExternalInterface).someMethod((someParameter));
+  } finally {
+    (someParameter);
+  }
   return 0;
 }
 int _ExternalInterface_someProperty_get_static(int _token, Pointer<Pointer<Void>> _result) {

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
@@ -42,9 +42,11 @@ class SimpleClass$Impl implements SimpleClass {
     final _getStringValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SimpleClass_getStringValue');
     final _handle = this.handle;
     final __result_handle = _getStringValue_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   SimpleClass useSimpleClass(SimpleClass input) {
@@ -53,9 +55,11 @@ class SimpleClass$Impl implements SimpleClass {
     final _handle = this.handle;
     final __result_handle = _useSimpleClass_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     smoke_SimpleClass_releaseFfiHandle(_input_handle);
-    final _result = smoke_SimpleClass_fromFfi(__result_handle);
-    smoke_SimpleClass_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_SimpleClass_fromFfi(__result_handle);
+    } finally {
+      smoke_SimpleClass_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_SimpleClass_toFfi(SimpleClass value) =>

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -78,9 +78,11 @@ class SimpleInterface$Impl implements SimpleInterface {
     final _getStringValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SimpleInterface_getStringValue');
     final _handle = this.handle;
     final __result_handle = _getStringValue_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   SimpleInterface useSimpleInterface(SimpleInterface input) {
@@ -89,22 +91,31 @@ class SimpleInterface$Impl implements SimpleInterface {
     final _handle = this.handle;
     final __result_handle = _useSimpleInterface_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     smoke_SimpleInterface_releaseFfiHandle(_input_handle);
-    final _result = smoke_SimpleInterface_fromFfi(__result_handle);
-    smoke_SimpleInterface_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_SimpleInterface_fromFfi(__result_handle);
+    } finally {
+      smoke_SimpleInterface_releaseFfiHandle(__result_handle);
+    }
   }
 }
 int _SimpleInterface_getStringValue_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = (__lib.instanceCache[_token] as SimpleInterface).getStringValue();
-  _result.value = String_toFfi(_result_object);
+  String _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as SimpleInterface).getStringValue();
+    _result.value = String_toFfi(_result_object);
+  } finally {
+  }
   return 0;
 }
 int _SimpleInterface_useSimpleInterface_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  final __input = smoke_SimpleInterface_fromFfi(input);
-  smoke_SimpleInterface_releaseFfiHandle(input);
-  final _result_object = (__lib.instanceCache[_token] as SimpleInterface).useSimpleInterface(__input);
-  _result.value = smoke_SimpleInterface_toFfi(_result_object);
-  if (_result_object != null) _result_object.release();
+  SimpleInterface _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as SimpleInterface).useSimpleInterface(smoke_SimpleInterface_fromFfi(input));
+    _result.value = smoke_SimpleInterface_toFfi(_result_object);
+  } finally {
+    smoke_SimpleInterface_releaseFfiHandle(input);
+    if (_result_object != null) _result_object.release();
+  }
   return 0;
 }
 Pointer<Void> smoke_SimpleInterface_toFfi(SimpleInterface value) {

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_class.dart
@@ -28,11 +28,13 @@ Pointer<Void> smoke_StructWithClass_toFfi(StructWithClass value) {
 }
 StructWithClass smoke_StructWithClass_fromFfi(Pointer<Void> handle) {
   final _classInstance_handle = _smoke_StructWithClass_get_field_classInstance(handle);
-  final _result = StructWithClass(
-    smoke_SimpleClass_fromFfi(_classInstance_handle)
-  );
-  smoke_SimpleClass_releaseFfiHandle(_classInstance_handle);
-  return _result;
+  try {
+    return StructWithClass(
+      smoke_SimpleClass_fromFfi(_classInstance_handle)
+    );
+  } finally {
+    smoke_SimpleClass_releaseFfiHandle(_classInstance_handle);
+  }
 }
 void smoke_StructWithClass_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithClass_release_handle(handle);
 // Nullable StructWithClass

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_interface.dart
@@ -28,11 +28,13 @@ Pointer<Void> smoke_StructWithInterface_toFfi(StructWithInterface value) {
 }
 StructWithInterface smoke_StructWithInterface_fromFfi(Pointer<Void> handle) {
   final _interfaceInstance_handle = _smoke_StructWithInterface_get_field_interfaceInstance(handle);
-  final _result = StructWithInterface(
-    smoke_SimpleInterface_fromFfi(_interfaceInstance_handle)
-  );
-  smoke_SimpleInterface_releaseFfiHandle(_interfaceInstance_handle);
-  return _result;
+  try {
+    return StructWithInterface(
+      smoke_SimpleInterface_fromFfi(_interfaceInstance_handle)
+    );
+  } finally {
+    smoke_SimpleInterface_releaseFfiHandle(_interfaceInstance_handle);
+  }
 }
 void smoke_StructWithInterface_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithInterface_release_handle(handle);
 // Nullable StructWithInterface

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -42,15 +42,21 @@ class ClassWithInternalLambda_InternalLambda$Impl {
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
     String_releaseFfiHandle(_p0_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
 }
 int _ClassWithInternalLambda_InternalLambda_call_static(int _token, Pointer<Void> p0, Pointer<Uint8> _result) {
-  final _result_object = (__lib.instanceCache[_token] as ClassWithInternalLambda_InternalLambda)(String_fromFfi(p0));
-  _result.value = Boolean_toFfi(_result_object);
-  String_releaseFfiHandle(p0);
+  bool _result_object;
+  try {
+    _result_object = (__lib.instanceCache[_token] as ClassWithInternalLambda_InternalLambda)(String_fromFfi(p0));
+    _result.value = Boolean_toFfi(_result_object);
+  } finally {
+    String_releaseFfiHandle(p0);
+  }
   return 0;
 }
 Pointer<Void> smoke_ClassWithInternalLambda_InternalLambda_toFfi(ClassWithInternalLambda_InternalLambda value) {
@@ -136,9 +142,11 @@ class ClassWithInternalLambda$Impl implements ClassWithInternalLambda {
     final __result_handle = _invokeInternalLambda_ffi(__lib.LibraryContext.isolateId, _lambda_handle, _value_handle);
     smoke_ClassWithInternalLambda_InternalLambda_releaseFfiHandle(_lambda_handle);
     String_releaseFfiHandle(_value_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_ClassWithInternalLambda_toFfi(ClassWithInternalLambda value) =>

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -41,14 +41,20 @@ class Lambdas_Producer$Impl {
     final _call_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Lambdas_Producer_call');
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 int _Lambdas_Producer_call_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = (__lib.instanceCache[_token] as Lambdas_Producer)();
-  _result.value = String_toFfi(_result_object);
+  String _result_object;
+  try {
+    _result_object = (__lib.instanceCache[_token] as Lambdas_Producer)();
+    _result.value = String_toFfi(_result_object);
+  } finally {
+  }
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Producer_toFfi(Lambdas_Producer value) {
@@ -133,15 +139,21 @@ class Lambdas_Confuser$Impl {
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
     String_releaseFfiHandle(_p0_handle);
-    final _result = smoke_Lambdas_Producer_fromFfi(__result_handle);
-    smoke_Lambdas_Producer_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Lambdas_Producer_fromFfi(__result_handle);
+    } finally {
+      smoke_Lambdas_Producer_releaseFfiHandle(__result_handle);
+    }
   }
 }
 int _Lambdas_Confuser_call_static(int _token, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
-  final _result_object = (__lib.instanceCache[_token] as Lambdas_Confuser)(String_fromFfi(p0));
-  _result.value = smoke_Lambdas_Producer_toFfi(_result_object);
-  String_releaseFfiHandle(p0);
+  Lambdas_Producer _result_object;
+  try {
+    _result_object = (__lib.instanceCache[_token] as Lambdas_Confuser)(String_fromFfi(p0));
+    _result.value = smoke_Lambdas_Producer_toFfi(_result_object);
+  } finally {
+    String_releaseFfiHandle(p0);
+  }
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Confuser_toFfi(Lambdas_Confuser value) {
@@ -225,14 +237,19 @@ class Lambdas_Consumer$Impl {
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
     String_releaseFfiHandle(_p0_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _Lambdas_Consumer_call_static(int _token, Pointer<Void> p0) {
-  (__lib.instanceCache[_token] as Lambdas_Consumer)(String_fromFfi(p0));
-  String_releaseFfiHandle(p0);
+  try {
+    (__lib.instanceCache[_token] as Lambdas_Consumer)(String_fromFfi(p0));
+  } finally {
+    String_releaseFfiHandle(p0);
+  }
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Consumer_toFfi(Lambdas_Consumer value) {
@@ -318,16 +335,22 @@ class Lambdas_Indexer$Impl {
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle, _p1_handle);
     String_releaseFfiHandle(_p0_handle);
     (_p1_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _Lambdas_Indexer_call_static(int _token, Pointer<Void> p0, double p1, Pointer<Int32> _result) {
-  final _result_object = (__lib.instanceCache[_token] as Lambdas_Indexer)(String_fromFfi(p0), (p1));
-  _result.value = (_result_object);
-  String_releaseFfiHandle(p0);
-  (p1);
+  int _result_object;
+  try {
+    _result_object = (__lib.instanceCache[_token] as Lambdas_Indexer)(String_fromFfi(p0), (p1));
+    _result.value = (_result_object);
+  } finally {
+    String_releaseFfiHandle(p0);
+    (p1);
+  }
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Indexer_toFfi(Lambdas_Indexer value) {
@@ -411,15 +434,21 @@ class Lambdas_NullableConfuser$Impl {
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
     String_releaseFfiHandle_nullable(_p0_handle);
-    final _result = smoke_Lambdas_Producer_fromFfi_nullable(__result_handle);
-    smoke_Lambdas_Producer_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return smoke_Lambdas_Producer_fromFfi_nullable(__result_handle);
+    } finally {
+      smoke_Lambdas_Producer_releaseFfiHandle_nullable(__result_handle);
+    }
   }
 }
 int _Lambdas_NullableConfuser_call_static(int _token, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
-  final _result_object = (__lib.instanceCache[_token] as Lambdas_NullableConfuser)(String_fromFfi_nullable(p0));
-  _result.value = smoke_Lambdas_Producer_toFfi_nullable(_result_object);
-  String_releaseFfiHandle_nullable(p0);
+  Lambdas_Producer _result_object;
+  try {
+    _result_object = (__lib.instanceCache[_token] as Lambdas_NullableConfuser)(String_fromFfi_nullable(p0));
+    _result.value = smoke_Lambdas_Producer_toFfi_nullable(_result_object);
+  } finally {
+    String_releaseFfiHandle_nullable(p0);
+  }
   return 0;
 }
 Pointer<Void> smoke_Lambdas_NullableConfuser_toFfi(Lambdas_NullableConfuser value) {
@@ -507,9 +536,11 @@ class Lambdas$Impl implements Lambdas {
     final __result_handle = _deconfuse_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle, _confuser_handle);
     String_releaseFfiHandle(_value_handle);
     smoke_Lambdas_Confuser_releaseFfiHandle(_confuser_handle);
-    final _result = smoke_Lambdas_Producer_fromFfi(__result_handle);
-    smoke_Lambdas_Producer_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Lambdas_Producer_fromFfi(__result_handle);
+    } finally {
+      smoke_Lambdas_Producer_releaseFfiHandle(__result_handle);
+    }
   }
   static Map<int, String> fuse(List<String> items, Lambdas_Indexer callback) {
     final _fuse_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_fuse__ListOf_1String_Indexer');
@@ -518,9 +549,11 @@ class Lambdas$Impl implements Lambdas {
     final __result_handle = _fuse_ffi(__lib.LibraryContext.isolateId, _items_handle, _callback_handle);
     ListOf_String_releaseFfiHandle(_items_handle);
     smoke_Lambdas_Indexer_releaseFfiHandle(_callback_handle);
-    final _result = MapOf_Int_to_String_fromFfi(__result_handle);
-    MapOf_Int_to_String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return MapOf_Int_to_String_fromFfi(__result_handle);
+    } finally {
+      MapOf_Int_to_String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_Lambdas_toFfi(Lambdas value) =>

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -44,14 +44,19 @@ class LambdasWithStructuredTypes_ClassCallback$Impl {
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
     smoke_LambdasInterface_releaseFfiHandle(_p0_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _LambdasWithStructuredTypes_ClassCallback_call_static(int _token, Pointer<Void> p0) {
-  (__lib.instanceCache[_token] as LambdasWithStructuredTypes_ClassCallback)(smoke_LambdasInterface_fromFfi(p0));
-  smoke_LambdasInterface_releaseFfiHandle(p0);
+  try {
+    (__lib.instanceCache[_token] as LambdasWithStructuredTypes_ClassCallback)(smoke_LambdasInterface_fromFfi(p0));
+  } finally {
+    smoke_LambdasInterface_releaseFfiHandle(p0);
+  }
   return 0;
 }
 Pointer<Void> smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(LambdasWithStructuredTypes_ClassCallback value) {
@@ -135,14 +140,19 @@ class LambdasWithStructuredTypes_StructCallback$Impl {
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
     smoke_LambdasDeclarationOrder_SomeStruct_releaseFfiHandle(_p0_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _LambdasWithStructuredTypes_StructCallback_call_static(int _token, Pointer<Void> p0) {
-  (__lib.instanceCache[_token] as LambdasWithStructuredTypes_StructCallback)(smoke_LambdasDeclarationOrder_SomeStruct_fromFfi(p0));
-  smoke_LambdasDeclarationOrder_SomeStruct_releaseFfiHandle(p0);
+  try {
+    (__lib.instanceCache[_token] as LambdasWithStructuredTypes_StructCallback)(smoke_LambdasDeclarationOrder_SomeStruct_fromFfi(p0));
+  } finally {
+    smoke_LambdasDeclarationOrder_SomeStruct_releaseFfiHandle(p0);
+  }
   return 0;
 }
 Pointer<Void> smoke_LambdasWithStructuredTypes_StructCallback_toFfi(LambdasWithStructuredTypes_StructCallback value) {
@@ -228,9 +238,11 @@ class LambdasWithStructuredTypes$Impl implements LambdasWithStructuredTypes {
     final _handle = this.handle;
     final __result_handle = _doClassStuff_ffi(_handle, __lib.LibraryContext.isolateId, _callback_handle);
     smoke_LambdasWithStructuredTypes_ClassCallback_releaseFfiHandle(_callback_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   doStructStuff(LambdasWithStructuredTypes_StructCallback callback) {
@@ -239,9 +251,11 @@ class LambdasWithStructuredTypes$Impl implements LambdasWithStructuredTypes {
     final _handle = this.handle;
     final __result_handle = _doStructStuff_ffi(_handle, __lib.LibraryContext.isolateId, _callback_handle);
     smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle(_callback_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_LambdasWithStructuredTypes_toFfi(LambdasWithStructuredTypes value) =>

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
@@ -4,7 +4,6 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 typedef StandaloneProducer = String Function();
 // StandaloneProducer "private" section, not exported.
 final _smoke_StandaloneProducer_copy_handle = __lib.nativeLibrary.lookupFunction<
@@ -32,14 +31,20 @@ class StandaloneProducer$Impl {
     final _call_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_StandaloneProducer_call');
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 int _StandaloneProducer_call_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = (__lib.instanceCache[_token] as StandaloneProducer)();
-  _result.value = String_toFfi(_result_object);
+  String _result_object;
+  try {
+    _result_object = (__lib.instanceCache[_token] as StandaloneProducer)();
+    _result.value = String_toFfi(_result_object);
+  } finally {
+  }
   return 0;
 }
 Pointer<Void> smoke_StandaloneProducer_toFfi(StandaloneProducer value) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -61,11 +61,13 @@ Pointer<Void> smoke_CalculatorListener_ResultStruct_toFfi(CalculatorListener_Res
 }
 CalculatorListener_ResultStruct smoke_CalculatorListener_ResultStruct_fromFfi(Pointer<Void> handle) {
   final _result_handle = _smoke_CalculatorListener_ResultStruct_get_field_result(handle);
-  final _result = CalculatorListener_ResultStruct(
-    (_result_handle)
-  );
-  (_result_handle);
-  return _result;
+  try {
+    return CalculatorListener_ResultStruct(
+      (_result_handle)
+    );
+  } finally {
+    (_result_handle);
+  }
 }
 void smoke_CalculatorListener_ResultStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_CalculatorListener_ResultStruct_release_handle(handle);
 // Nullable CalculatorListener_ResultStruct
@@ -180,9 +182,11 @@ class CalculatorListener$Impl implements CalculatorListener {
     final _handle = this.handle;
     final __result_handle = _onCalculationResult_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
     (_calculationResult_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   onCalculationResultConst(double calculationResult) {
@@ -191,9 +195,11 @@ class CalculatorListener$Impl implements CalculatorListener {
     final _handle = this.handle;
     final __result_handle = _onCalculationResultConst_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
     (_calculationResult_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult) {
@@ -202,9 +208,11 @@ class CalculatorListener$Impl implements CalculatorListener {
     final _handle = this.handle;
     final __result_handle = _onCalculationResultStruct_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
     smoke_CalculatorListener_ResultStruct_releaseFfiHandle(_calculationResult_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   onCalculationResultArray(List<double> calculationResult) {
@@ -213,9 +221,11 @@ class CalculatorListener$Impl implements CalculatorListener {
     final _handle = this.handle;
     final __result_handle = _onCalculationResultArray_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
     ListOf_Double_releaseFfiHandle(_calculationResult_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   onCalculationResultMap(Map<String, double> calculationResults) {
@@ -224,9 +234,11 @@ class CalculatorListener$Impl implements CalculatorListener {
     final _handle = this.handle;
     final __result_handle = _onCalculationResultMap_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResults_handle);
     MapOf_String_to_Double_releaseFfiHandle(_calculationResults_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   onCalculationResultInstance(CalculationResult calculationResult) {
@@ -235,45 +247,59 @@ class CalculatorListener$Impl implements CalculatorListener {
     final _handle = this.handle;
     final __result_handle = _onCalculationResultInstance_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
     smoke_CalculationResult_releaseFfiHandle(_calculationResult_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _CalculatorListener_onCalculationResult_static(int _token, double calculationResult) {
-  final __calculationResult = (calculationResult);
-  (calculationResult);
-  (__lib.instanceCache[_token] as CalculatorListener).onCalculationResult(__calculationResult);
+  try {
+    (__lib.instanceCache[_token] as CalculatorListener).onCalculationResult((calculationResult));
+  } finally {
+    (calculationResult);
+  }
   return 0;
 }
 int _CalculatorListener_onCalculationResultConst_static(int _token, double calculationResult) {
-  final __calculationResult = (calculationResult);
-  (calculationResult);
-  (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultConst(__calculationResult);
+  try {
+    (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultConst((calculationResult));
+  } finally {
+    (calculationResult);
+  }
   return 0;
 }
 int _CalculatorListener_onCalculationResultStruct_static(int _token, Pointer<Void> calculationResult) {
-  final __calculationResult = smoke_CalculatorListener_ResultStruct_fromFfi(calculationResult);
-  smoke_CalculatorListener_ResultStruct_releaseFfiHandle(calculationResult);
-  (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultStruct(__calculationResult);
+  try {
+    (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultStruct(smoke_CalculatorListener_ResultStruct_fromFfi(calculationResult));
+  } finally {
+    smoke_CalculatorListener_ResultStruct_releaseFfiHandle(calculationResult);
+  }
   return 0;
 }
 int _CalculatorListener_onCalculationResultArray_static(int _token, Pointer<Void> calculationResult) {
-  final __calculationResult = ListOf_Double_fromFfi(calculationResult);
-  ListOf_Double_releaseFfiHandle(calculationResult);
-  (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultArray(__calculationResult);
+  try {
+    (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultArray(ListOf_Double_fromFfi(calculationResult));
+  } finally {
+    ListOf_Double_releaseFfiHandle(calculationResult);
+  }
   return 0;
 }
 int _CalculatorListener_onCalculationResultMap_static(int _token, Pointer<Void> calculationResults) {
-  final __calculationResults = MapOf_String_to_Double_fromFfi(calculationResults);
-  MapOf_String_to_Double_releaseFfiHandle(calculationResults);
-  (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultMap(__calculationResults);
+  try {
+    (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultMap(MapOf_String_to_Double_fromFfi(calculationResults));
+  } finally {
+    MapOf_String_to_Double_releaseFfiHandle(calculationResults);
+  }
   return 0;
 }
 int _CalculatorListener_onCalculationResultInstance_static(int _token, Pointer<Void> calculationResult) {
-  final __calculationResult = smoke_CalculationResult_fromFfi(calculationResult);
-  smoke_CalculationResult_releaseFfiHandle(calculationResult);
-  (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultInstance(__calculationResult);
+  try {
+    (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultInstance(smoke_CalculationResult_fromFfi(calculationResult));
+  } finally {
+    smoke_CalculationResult_releaseFfiHandle(calculationResult);
+  }
   return 0;
 }
 Pointer<Void> smoke_CalculatorListener_toFfi(CalculatorListener value) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -145,11 +145,13 @@ Pointer<Void> smoke_ListenerWithProperties_ResultStruct_toFfi(ListenerWithProper
 }
 ListenerWithProperties_ResultStruct smoke_ListenerWithProperties_ResultStruct_fromFfi(Pointer<Void> handle) {
   final _result_handle = _smoke_ListenerWithProperties_ResultStruct_get_field_result(handle);
-  final _result = ListenerWithProperties_ResultStruct(
-    (_result_handle)
-  );
-  (_result_handle);
-  return _result;
+  try {
+    return ListenerWithProperties_ResultStruct(
+      (_result_handle)
+    );
+  } finally {
+    (_result_handle);
+  }
 }
 void smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ListenerWithProperties_ResultStruct_release_handle(handle);
 // Nullable ListenerWithProperties_ResultStruct
@@ -295,9 +297,11 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_message_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   set message(String value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_message_set__String');
@@ -305,17 +309,21 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     String_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   CalculationResult get packedMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_packedMessage_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_CalculationResult_fromFfi(__result_handle);
-    smoke_CalculationResult_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_CalculationResult_fromFfi(__result_handle);
+    } finally {
+      smoke_CalculationResult_releaseFfiHandle(__result_handle);
+    }
   }
   set packedMessage(CalculationResult value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_packedMessage_set__CalculationResult');
@@ -323,17 +331,21 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     smoke_CalculationResult_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   ListenerWithProperties_ResultStruct get structuredMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_structuredMessage_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_ListenerWithProperties_ResultStruct_fromFfi(__result_handle);
-    smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_ListenerWithProperties_ResultStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(__result_handle);
+    }
   }
   set structuredMessage(ListenerWithProperties_ResultStruct value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_structuredMessage_set__ResultStruct');
@@ -341,17 +353,21 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   ListenerWithProperties_ResultEnum get enumeratedMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_ListenerWithProperties_ResultEnum_fromFfi(__result_handle);
-    smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_ListenerWithProperties_ResultEnum_fromFfi(__result_handle);
+    } finally {
+      smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(__result_handle);
+    }
   }
   set enumeratedMessage(ListenerWithProperties_ResultEnum value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_set__ResultEnum');
@@ -359,17 +375,21 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   List<String> get arrayedMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_arrayedMessage_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = ListOf_String_fromFfi(__result_handle);
-    ListOf_String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return ListOf_String_fromFfi(__result_handle);
+    } finally {
+      ListOf_String_releaseFfiHandle(__result_handle);
+    }
   }
   set arrayedMessage(List<String> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_arrayedMessage_set__ListOf_1String');
@@ -377,17 +397,21 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     ListOf_String_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   Map<String, double> get mappedMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_mappedMessage_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = MapOf_String_to_Double_fromFfi(__result_handle);
-    MapOf_String_to_Double_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return MapOf_String_to_Double_fromFfi(__result_handle);
+    } finally {
+      MapOf_String_to_Double_releaseFfiHandle(__result_handle);
+    }
   }
   set mappedMessage(Map<String, double> value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_mappedMessage_set__MapOf_1String_1to_1Double');
@@ -395,17 +419,21 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     MapOf_String_to_Double_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   Uint8List get bufferedMessage {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_bufferedMessage_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Blob_fromFfi(__result_handle);
-    Blob_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Blob_fromFfi(__result_handle);
+    } finally {
+      Blob_releaseFfiHandle(__result_handle);
+    }
   }
   set bufferedMessage(Uint8List value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_bufferedMessage_set__Blob');
@@ -413,9 +441,11 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     Blob_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _ListenerWithProperties_message_get_static(int _token, Pointer<Pointer<Void>> _result) {
@@ -423,9 +453,12 @@ int _ListenerWithProperties_message_get_static(int _token, Pointer<Pointer<Void>
   return 0;
 }
 int _ListenerWithProperties_message_set_static(int _token, Pointer<Void> _value) {
-  final __value = String_fromFfi(_value);
-  String_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as ListenerWithProperties).message = __value;
+  try {
+    (__lib.instanceCache[_token] as ListenerWithProperties).message =
+      String_fromFfi(_value);
+  } finally {
+    String_releaseFfiHandle(_value);
+  }
   return 0;
 }
 int _ListenerWithProperties_packedMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {
@@ -433,9 +466,12 @@ int _ListenerWithProperties_packedMessage_get_static(int _token, Pointer<Pointer
   return 0;
 }
 int _ListenerWithProperties_packedMessage_set_static(int _token, Pointer<Void> _value) {
-  final __value = smoke_CalculationResult_fromFfi(_value);
-  smoke_CalculationResult_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as ListenerWithProperties).packedMessage = __value;
+  try {
+    (__lib.instanceCache[_token] as ListenerWithProperties).packedMessage =
+      smoke_CalculationResult_fromFfi(_value);
+  } finally {
+    smoke_CalculationResult_releaseFfiHandle(_value);
+  }
   return 0;
 }
 int _ListenerWithProperties_structuredMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {
@@ -443,9 +479,12 @@ int _ListenerWithProperties_structuredMessage_get_static(int _token, Pointer<Poi
   return 0;
 }
 int _ListenerWithProperties_structuredMessage_set_static(int _token, Pointer<Void> _value) {
-  final __value = smoke_ListenerWithProperties_ResultStruct_fromFfi(_value);
-  smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as ListenerWithProperties).structuredMessage = __value;
+  try {
+    (__lib.instanceCache[_token] as ListenerWithProperties).structuredMessage =
+      smoke_ListenerWithProperties_ResultStruct_fromFfi(_value);
+  } finally {
+    smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(_value);
+  }
   return 0;
 }
 int _ListenerWithProperties_enumeratedMessage_get_static(int _token, Pointer<Uint32> _result) {
@@ -453,9 +492,12 @@ int _ListenerWithProperties_enumeratedMessage_get_static(int _token, Pointer<Uin
   return 0;
 }
 int _ListenerWithProperties_enumeratedMessage_set_static(int _token, int _value) {
-  final __value = smoke_ListenerWithProperties_ResultEnum_fromFfi(_value);
-  smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as ListenerWithProperties).enumeratedMessage = __value;
+  try {
+    (__lib.instanceCache[_token] as ListenerWithProperties).enumeratedMessage =
+      smoke_ListenerWithProperties_ResultEnum_fromFfi(_value);
+  } finally {
+    smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(_value);
+  }
   return 0;
 }
 int _ListenerWithProperties_arrayedMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {
@@ -463,9 +505,12 @@ int _ListenerWithProperties_arrayedMessage_get_static(int _token, Pointer<Pointe
   return 0;
 }
 int _ListenerWithProperties_arrayedMessage_set_static(int _token, Pointer<Void> _value) {
-  final __value = ListOf_String_fromFfi(_value);
-  ListOf_String_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as ListenerWithProperties).arrayedMessage = __value;
+  try {
+    (__lib.instanceCache[_token] as ListenerWithProperties).arrayedMessage =
+      ListOf_String_fromFfi(_value);
+  } finally {
+    ListOf_String_releaseFfiHandle(_value);
+  }
   return 0;
 }
 int _ListenerWithProperties_mappedMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {
@@ -473,9 +518,12 @@ int _ListenerWithProperties_mappedMessage_get_static(int _token, Pointer<Pointer
   return 0;
 }
 int _ListenerWithProperties_mappedMessage_set_static(int _token, Pointer<Void> _value) {
-  final __value = MapOf_String_to_Double_fromFfi(_value);
-  MapOf_String_to_Double_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as ListenerWithProperties).mappedMessage = __value;
+  try {
+    (__lib.instanceCache[_token] as ListenerWithProperties).mappedMessage =
+      MapOf_String_to_Double_fromFfi(_value);
+  } finally {
+    MapOf_String_to_Double_releaseFfiHandle(_value);
+  }
   return 0;
 }
 int _ListenerWithProperties_bufferedMessage_get_static(int _token, Pointer<Pointer<Void>> _result) {
@@ -483,9 +531,12 @@ int _ListenerWithProperties_bufferedMessage_get_static(int _token, Pointer<Point
   return 0;
 }
 int _ListenerWithProperties_bufferedMessage_set_static(int _token, Pointer<Void> _value) {
-  final __value = Blob_fromFfi(_value);
-  Blob_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as ListenerWithProperties).bufferedMessage = __value;
+  try {
+    (__lib.instanceCache[_token] as ListenerWithProperties).bufferedMessage =
+      Blob_fromFfi(_value);
+  } finally {
+    Blob_releaseFfiHandle(_value);
+  }
   return 0;
 }
 Pointer<Void> smoke_ListenerWithProperties_toFfi(ListenerWithProperties value) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -123,11 +123,13 @@ Pointer<Void> smoke_ListenersWithReturnValues_ResultStruct_toFfi(ListenersWithRe
 }
 ListenersWithReturnValues_ResultStruct smoke_ListenersWithReturnValues_ResultStruct_fromFfi(Pointer<Void> handle) {
   final _result_handle = _smoke_ListenersWithReturnValues_ResultStruct_get_field_result(handle);
-  final _result = ListenersWithReturnValues_ResultStruct(
-    (_result_handle)
-  );
-  (_result_handle);
-  return _result;
+  try {
+    return ListenersWithReturnValues_ResultStruct(
+      (_result_handle)
+    );
+  } finally {
+    (_result_handle);
+  }
 }
 void smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ListenersWithReturnValues_ResultStruct_release_handle(handle);
 // Nullable ListenersWithReturnValues_ResultStruct
@@ -246,99 +248,141 @@ class ListenersWithReturnValues$Impl implements ListenersWithReturnValues {
     final _fetchDataDouble_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataDouble');
     final _handle = this.handle;
     final __result_handle = _fetchDataDouble_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   String fetchDataString() {
     final _fetchDataString_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataString');
     final _handle = this.handle;
     final __result_handle = _fetchDataString_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   ListenersWithReturnValues_ResultStruct fetchDataStruct() {
     final _fetchDataStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataStruct');
     final _handle = this.handle;
     final __result_handle = _fetchDataStruct_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_ListenersWithReturnValues_ResultStruct_fromFfi(__result_handle);
-    smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_ListenersWithReturnValues_ResultStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   ListenersWithReturnValues_ResultEnum fetchDataEnum() {
     final _fetchDataEnum_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataEnum');
     final _handle = this.handle;
     final __result_handle = _fetchDataEnum_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_ListenersWithReturnValues_ResultEnum_fromFfi(__result_handle);
-    smoke_ListenersWithReturnValues_ResultEnum_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_ListenersWithReturnValues_ResultEnum_fromFfi(__result_handle);
+    } finally {
+      smoke_ListenersWithReturnValues_ResultEnum_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   List<double> fetchDataArray() {
     final _fetchDataArray_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataArray');
     final _handle = this.handle;
     final __result_handle = _fetchDataArray_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = ListOf_Double_fromFfi(__result_handle);
-    ListOf_Double_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return ListOf_Double_fromFfi(__result_handle);
+    } finally {
+      ListOf_Double_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   Map<String, double> fetchDataMap() {
     final _fetchDataMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataMap');
     final _handle = this.handle;
     final __result_handle = _fetchDataMap_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = MapOf_String_to_Double_fromFfi(__result_handle);
-    MapOf_String_to_Double_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return MapOf_String_to_Double_fromFfi(__result_handle);
+    } finally {
+      MapOf_String_to_Double_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   CalculationResult fetchDataInstance() {
     final _fetchDataInstance_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataInstance');
     final _handle = this.handle;
     final __result_handle = _fetchDataInstance_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_CalculationResult_fromFfi(__result_handle);
-    smoke_CalculationResult_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_CalculationResult_fromFfi(__result_handle);
+    } finally {
+      smoke_CalculationResult_releaseFfiHandle(__result_handle);
+    }
   }
 }
 int _ListenersWithReturnValues_fetchDataDouble_static(int _token, Pointer<Double> _result) {
-  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataDouble();
-  _result.value = (_result_object);
+  double _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataDouble();
+    _result.value = (_result_object);
+  } finally {
+  }
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataString_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataString();
-  _result.value = String_toFfi(_result_object);
+  String _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataString();
+    _result.value = String_toFfi(_result_object);
+  } finally {
+  }
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataStruct_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataStruct();
-  _result.value = smoke_ListenersWithReturnValues_ResultStruct_toFfi(_result_object);
+  ListenersWithReturnValues_ResultStruct _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataStruct();
+    _result.value = smoke_ListenersWithReturnValues_ResultStruct_toFfi(_result_object);
+  } finally {
+  }
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataEnum_static(int _token, Pointer<Uint32> _result) {
-  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataEnum();
-  _result.value = smoke_ListenersWithReturnValues_ResultEnum_toFfi(_result_object);
+  ListenersWithReturnValues_ResultEnum _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataEnum();
+    _result.value = smoke_ListenersWithReturnValues_ResultEnum_toFfi(_result_object);
+  } finally {
+  }
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataArray_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataArray();
-  _result.value = ListOf_Double_toFfi(_result_object);
+  List<double> _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataArray();
+    _result.value = ListOf_Double_toFfi(_result_object);
+  } finally {
+  }
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataMap_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataMap();
-  _result.value = MapOf_String_to_Double_toFfi(_result_object);
+  Map<String, double> _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataMap();
+    _result.value = MapOf_String_to_Double_toFfi(_result_object);
+  } finally {
+  }
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataInstance_static(int _token, Pointer<Pointer<Void>> _result) {
-  final _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataInstance();
-  _result.value = smoke_CalculationResult_toFfi(_result_object);
-  if (_result_object != null) _result_object.release();
+  CalculationResult _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataInstance();
+    _result.value = smoke_CalculationResult_toFfi(_result_object);
+  } finally {
+    if (_result_object != null) _result_object.release();
+  }
   return 0;
 }
 Pointer<Void> smoke_ListenersWithReturnValues_toFfi(ListenersWithReturnValues value) {

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -55,13 +55,15 @@ Pointer<Void> smoke_MethodOverloads_Point_toFfi(MethodOverloads_Point value) {
 MethodOverloads_Point smoke_MethodOverloads_Point_fromFfi(Pointer<Void> handle) {
   final _x_handle = _smoke_MethodOverloads_Point_get_field_x(handle);
   final _y_handle = _smoke_MethodOverloads_Point_get_field_y(handle);
-  final _result = MethodOverloads_Point(
-    (_x_handle),
-    (_y_handle)
-  );
-  (_x_handle);
-  (_y_handle);
-  return _result;
+  try {
+    return MethodOverloads_Point(
+      (_x_handle),
+      (_y_handle)
+    );
+  } finally {
+    (_x_handle);
+    (_y_handle);
+  }
 }
 void smoke_MethodOverloads_Point_releaseFfiHandle(Pointer<Void> handle) => _smoke_MethodOverloads_Point_release_handle(handle);
 // Nullable MethodOverloads_Point
@@ -125,9 +127,11 @@ class MethodOverloads$Impl implements MethodOverloads {
     final _handle = this.handle;
     final __result_handle = _isBoolean_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     Boolean_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool isBooleanByte(int input) {
@@ -136,9 +140,11 @@ class MethodOverloads$Impl implements MethodOverloads {
     final _handle = this.handle;
     final __result_handle = _isBooleanByte_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool isBooleanString(String input) {
@@ -147,9 +153,11 @@ class MethodOverloads$Impl implements MethodOverloads {
     final _handle = this.handle;
     final __result_handle = _isBooleanString_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool isBooleanPoint(MethodOverloads_Point input) {
@@ -158,9 +166,11 @@ class MethodOverloads$Impl implements MethodOverloads {
     final _handle = this.handle;
     final __result_handle = _isBooleanPoint_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     smoke_MethodOverloads_Point_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool isBooleanMulti(bool input1, int input2, String input3, MethodOverloads_Point input4) {
@@ -175,9 +185,11 @@ class MethodOverloads$Impl implements MethodOverloads {
     (_input2_handle);
     String_releaseFfiHandle(_input3_handle);
     smoke_MethodOverloads_Point_releaseFfiHandle(_input4_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool isBooleanStringArray(List<String> input) {
@@ -186,9 +198,11 @@ class MethodOverloads$Impl implements MethodOverloads {
     final _handle = this.handle;
     final __result_handle = _isBooleanStringArray_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     ListOf_String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool isBooleanIntArray(List<int> input) {
@@ -197,18 +211,22 @@ class MethodOverloads$Impl implements MethodOverloads {
     final _handle = this.handle;
     final __result_handle = _isBooleanIntArray_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     ListOf_Byte_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool isBooleanConst() {
     final _isBooleanConst_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_MethodOverloads_isBoolean');
     final _handle = this.handle;
     final __result_handle = _isBooleanConst_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool isFloatString(String input) {
@@ -217,9 +235,11 @@ class MethodOverloads$Impl implements MethodOverloads {
     final _handle = this.handle;
     final __result_handle = _isFloatString_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   bool isFloatList(List<int> input) {
@@ -228,9 +248,11 @@ class MethodOverloads$Impl implements MethodOverloads {
     final _handle = this.handle;
     final __result_handle = _isFloatList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     ListOf_Byte_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_MethodOverloads_toFfi(MethodOverloads value) =>

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -44,36 +44,44 @@ class SpecialNames$Impl implements SpecialNames {
     final _create_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_create');
     final _handle = this.handle;
     final __result_handle = _create_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   reallyRelease() {
     final _reallyRelease_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_release');
     final _handle = this.handle;
     final __result_handle = _reallyRelease_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   createProxy() {
     final _createProxy_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_createProxy');
     final _handle = this.handle;
     final __result_handle = _createProxy_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   Uppercase() {
     final _Uppercase_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_Uppercase');
     final _handle = this.handle;
     final __result_handle = _Uppercase_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_SpecialNames_toFfi(SpecialNames value) =>

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_point.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_point.dart
@@ -14,9 +14,11 @@ class FreePoint {
     final _handle = smoke_FreePoint_toFfi(this);
     final __result_handle = _flip_ffi(_handle, __lib.LibraryContext.isolateId);
     smoke_FreePoint_releaseFfiHandle(_handle);
-    final _result = smoke_FreePoint_fromFfi(__result_handle);
-    smoke_FreePoint_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_FreePoint_fromFfi(__result_handle);
+    } finally {
+      smoke_FreePoint_releaseFfiHandle(__result_handle);
+    }
   }
 }
 // FreePoint "private" section, not exported.
@@ -47,13 +49,15 @@ Pointer<Void> smoke_FreePoint_toFfi(FreePoint value) {
 FreePoint smoke_FreePoint_fromFfi(Pointer<Void> handle) {
   final _x_handle = _smoke_FreePoint_get_field_x(handle);
   final _y_handle = _smoke_FreePoint_get_field_y(handle);
-  final _result = FreePoint(
-    (_x_handle),
-    (_y_handle)
-  );
-  (_x_handle);
-  (_y_handle);
-  return _result;
+  try {
+    return FreePoint(
+      (_x_handle),
+      (_y_handle)
+    );
+  } finally {
+    (_x_handle);
+    (_y_handle);
+  }
 }
 void smoke_FreePoint_releaseFfiHandle(Pointer<Void> handle) => _smoke_FreePoint_release_handle(handle);
 // Nullable FreePoint

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -87,9 +87,11 @@ class LevelOne_LevelTwo_LevelThree_LevelFour {
   static LevelOne_LevelTwo_LevelThree_LevelFour fooFactory() {
     final _fooFactory_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fooFactory');
     final __result_handle = _fooFactory_ffi(__lib.LibraryContext.isolateId);
-    final _result = smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi(__result_handle);
-    smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi(__result_handle);
+    } finally {
+      smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(__result_handle);
+    }
   }
 }
 // LevelOne_LevelTwo_LevelThree_LevelFour "private" section, not exported.
@@ -113,11 +115,13 @@ Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi(LevelOne_LevelT
 }
 LevelOne_LevelTwo_LevelThree_LevelFour smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi(Pointer<Void> handle) {
   final _stringField_handle = _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField(handle);
-  final _result = LevelOne_LevelTwo_LevelThree_LevelFour(
-    String_fromFfi(_stringField_handle)
-  );
-  String_releaseFfiHandle(_stringField_handle);
-  return _result;
+  try {
+    return LevelOne_LevelTwo_LevelThree_LevelFour(
+      String_fromFfi(_stringField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_stringField_handle);
+  }
 }
 void smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(Pointer<Void> handle) => _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle(handle);
 // Nullable LevelOne_LevelTwo_LevelThree_LevelFour
@@ -181,9 +185,11 @@ class LevelOne_LevelTwo_LevelThree$Impl implements LevelOne_LevelTwo_LevelThree 
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     smoke_OuterClass_InnerInterface_releaseFfiHandle(_input_handle);
-    final _result = smoke_OuterInterface_InnerClass_fromFfi(__result_handle);
-    smoke_OuterInterface_InnerClass_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_OuterInterface_InnerClass_fromFfi(__result_handle);
+    } finally {
+      smoke_OuterInterface_InnerClass_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi(LevelOne_LevelTwo_LevelThree value) =>

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -52,9 +52,11 @@ class OuterClass_InnerClass$Impl implements OuterClass_InnerClass {
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_OuterClass_InnerClass_toFfi(OuterClass_InnerClass value) =>
@@ -143,16 +145,21 @@ class OuterClass_InnerInterface$Impl implements OuterClass_InnerInterface {
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 int _OuterClass_InnerInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  final __input = String_fromFfi(input);
-  String_releaseFfiHandle(input);
-  final _result_object = (__lib.instanceCache[_token] as OuterClass_InnerInterface).foo(__input);
-  _result.value = String_toFfi(_result_object);
+  String _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as OuterClass_InnerInterface).foo(String_fromFfi(input));
+    _result.value = String_toFfi(_result_object);
+  } finally {
+    String_releaseFfiHandle(input);
+  }
   return 0;
 }
 Pointer<Void> smoke_OuterClass_InnerInterface_toFfi(OuterClass_InnerInterface value) {
@@ -220,9 +227,11 @@ class OuterClass$Impl implements OuterClass {
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_OuterClass_toFfi(OuterClass value) =>

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -58,9 +58,11 @@ class OuterInterface_InnerClass$Impl implements OuterInterface_InnerClass {
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_OuterInterface_InnerClass_toFfi(OuterInterface_InnerClass value) =>
@@ -149,16 +151,21 @@ class OuterInterface_InnerInterface$Impl implements OuterInterface_InnerInterfac
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 int _OuterInterface_InnerInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  final __input = String_fromFfi(input);
-  String_releaseFfiHandle(input);
-  final _result_object = (__lib.instanceCache[_token] as OuterInterface_InnerInterface).foo(__input);
-  _result.value = String_toFfi(_result_object);
+  String _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as OuterInterface_InnerInterface).foo(String_fromFfi(input));
+    _result.value = String_toFfi(_result_object);
+  } finally {
+    String_releaseFfiHandle(input);
+  }
   return 0;
 }
 Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi(OuterInterface_InnerInterface value) {
@@ -247,16 +254,21 @@ class OuterInterface$Impl implements OuterInterface {
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
 }
 int _OuterInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  final __input = String_fromFfi(input);
-  String_releaseFfiHandle(input);
-  final _result_object = (__lib.instanceCache[_token] as OuterInterface).foo(__input);
-  _result.value = String_toFfi(_result_object);
+  String _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as OuterInterface).foo(String_fromFfi(input));
+    _result.value = String_toFfi(_result_object);
+  } finally {
+    String_releaseFfiHandle(input);
+  }
   return 0;
 }
 Pointer<Void> smoke_OuterInterface_toFfi(OuterInterface value) {

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -67,15 +67,19 @@ class UseFreeTypes$Impl implements UseFreeTypes {
     if (_doStuff_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _doStuff_return_get_error(__call_result_handle);
         _doStuff_return_release_handle(__call_result_handle);
-        final _error_value = smoke_FreeEnum_fromFfi(__error_handle);
-        smoke_FreeEnum_releaseFfiHandle(__error_handle);
-        throw FreeException(_error_value);
+        try {
+          throw FreeException(smoke_FreeEnum_fromFfi(__error_handle));
+        } finally {
+          smoke_FreeEnum_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _doStuff_return_get_result(__call_result_handle);
     _doStuff_return_release_handle(__call_result_handle);
-    final _result = Date_fromFfi(__result_handle);
-    Date_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Date_fromFfi(__result_handle);
+    } finally {
+      Date_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_UseFreeTypes_toFfi(UseFreeTypes value) =>

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/generic_types__conversion.dart
@@ -50,8 +50,11 @@ List<DateTime> ListOf_Nullable_Date_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _ListOf_Nullable_Date_iterator(handle);
   while (_ListOf_Nullable_Date_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _ListOf_Nullable_Date_iterator_get(_iterator_handle);
-    result.add(Date_fromFfi_nullable(_element_handle));
-    Date_releaseFfiHandle_nullable(_element_handle);
+    try {
+      result.add(Date_fromFfi_nullable(_element_handle));
+    } finally {
+      Date_releaseFfiHandle_nullable(_element_handle);
+    }
     _ListOf_Nullable_Date_iterator_increment(_iterator_handle);
   }
   _ListOf_Nullable_Date_iterator_release_handle(_iterator_handle);
@@ -132,8 +135,11 @@ List<String> ListOf_String_fromFfi(Pointer<Void> handle) {
   final _iterator_handle = _ListOf_String_iterator(handle);
   while (_ListOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _ListOf_String_iterator_get(_iterator_handle);
-    result.add(String_fromFfi(_element_handle));
-    String_releaseFfiHandle(_element_handle);
+    try {
+      result.add(String_fromFfi(_element_handle));
+    } finally {
+      String_releaseFfiHandle(_element_handle);
+    }
     _ListOf_String_iterator_increment(_iterator_handle);
   }
   _ListOf_String_iterator_release_handle(_iterator_handle);
@@ -221,10 +227,13 @@ Map<int, Nullable_SomeStruct> MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fr
   while (_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key(_iterator_handle);
     final _value_handle = _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value(_iterator_handle);
-    result[(_key_handle)] =
-      smoke_Nullable_SomeStruct_fromFfi_nullable(_value_handle);
-    (_key_handle);
-    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_value_handle);
+    try {
+      result[(_key_handle)] =
+        smoke_Nullable_SomeStruct_fromFfi_nullable(_value_handle);
+    } finally {
+      (_key_handle);
+      smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_value_handle);
+    }
     _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment(_iterator_handle);
   }
   _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle(_iterator_handle);
@@ -312,10 +321,13 @@ Map<int, String> MapOf_Long_to_String_fromFfi(Pointer<Void> handle) {
   while (_MapOf_Long_to_String_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _MapOf_Long_to_String_iterator_get_key(_iterator_handle);
     final _value_handle = _MapOf_Long_to_String_iterator_get_value(_iterator_handle);
-    result[(_key_handle)] =
-      String_fromFfi(_value_handle);
-    (_key_handle);
-    String_releaseFfiHandle(_value_handle);
+    try {
+      result[(_key_handle)] =
+        String_fromFfi(_value_handle);
+    } finally {
+      (_key_handle);
+      String_releaseFfiHandle(_value_handle);
+    }
     _MapOf_Long_to_String_iterator_increment(_iterator_handle);
   }
   _MapOf_Long_to_String_iterator_release_handle(_iterator_handle);

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -127,11 +127,13 @@ Pointer<Void> smoke_Nullable_SomeStruct_toFfi(Nullable_SomeStruct value) {
 }
 Nullable_SomeStruct smoke_Nullable_SomeStruct_fromFfi(Pointer<Void> handle) {
   final _stringField_handle = _smoke_Nullable_SomeStruct_get_field_stringField(handle);
-  final _result = Nullable_SomeStruct(
-    String_fromFfi(_stringField_handle)
-  );
-  String_releaseFfiHandle(_stringField_handle);
-  return _result;
+  try {
+    return Nullable_SomeStruct(
+      String_fromFfi(_stringField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_stringField_handle);
+  }
 }
 void smoke_Nullable_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Nullable_SomeStruct_release_handle(handle);
 // Nullable Nullable_SomeStruct
@@ -253,27 +255,29 @@ Nullable_NullableStruct smoke_Nullable_NullableStruct_fromFfi(Pointer<Void> hand
   final _inlineArrayField_handle = _smoke_Nullable_NullableStruct_get_field_inlineArrayField(handle);
   final _mapField_handle = _smoke_Nullable_NullableStruct_get_field_mapField(handle);
   final _instanceField_handle = _smoke_Nullable_NullableStruct_get_field_instanceField(handle);
-  final _result = Nullable_NullableStruct(
-    String_fromFfi_nullable(_stringField_handle),
-    Boolean_fromFfi_nullable(_boolField_handle),
-    Double_fromFfi_nullable(_doubleField_handle),
-    smoke_Nullable_SomeStruct_fromFfi_nullable(_structField_handle),
-    smoke_Nullable_SomeEnum_fromFfi_nullable(_enumField_handle),
-    ListOf_String_fromFfi_nullable(_arrayField_handle),
-    ListOf_String_fromFfi_nullable(_inlineArrayField_handle),
-    MapOf_Long_to_String_fromFfi_nullable(_mapField_handle),
-    smoke_SomeInterface_fromFfi_nullable(_instanceField_handle)
-  );
-  String_releaseFfiHandle_nullable(_stringField_handle);
-  Boolean_releaseFfiHandle_nullable(_boolField_handle);
-  Double_releaseFfiHandle_nullable(_doubleField_handle);
-  smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_structField_handle);
-  smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
-  ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
-  ListOf_String_releaseFfiHandle_nullable(_inlineArrayField_handle);
-  MapOf_Long_to_String_releaseFfiHandle_nullable(_mapField_handle);
-  smoke_SomeInterface_releaseFfiHandle_nullable(_instanceField_handle);
-  return _result;
+  try {
+    return Nullable_NullableStruct(
+      String_fromFfi_nullable(_stringField_handle),
+      Boolean_fromFfi_nullable(_boolField_handle),
+      Double_fromFfi_nullable(_doubleField_handle),
+      smoke_Nullable_SomeStruct_fromFfi_nullable(_structField_handle),
+      smoke_Nullable_SomeEnum_fromFfi_nullable(_enumField_handle),
+      ListOf_String_fromFfi_nullable(_arrayField_handle),
+      ListOf_String_fromFfi_nullable(_inlineArrayField_handle),
+      MapOf_Long_to_String_fromFfi_nullable(_mapField_handle),
+      smoke_SomeInterface_fromFfi_nullable(_instanceField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle_nullable(_stringField_handle);
+    Boolean_releaseFfiHandle_nullable(_boolField_handle);
+    Double_releaseFfiHandle_nullable(_doubleField_handle);
+    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_structField_handle);
+    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
+    ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
+    ListOf_String_releaseFfiHandle_nullable(_inlineArrayField_handle);
+    MapOf_Long_to_String_releaseFfiHandle_nullable(_mapField_handle);
+    smoke_SomeInterface_releaseFfiHandle_nullable(_instanceField_handle);
+  }
 }
 void smoke_Nullable_NullableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Nullable_NullableStruct_release_handle(handle);
 // Nullable Nullable_NullableStruct
@@ -387,25 +391,27 @@ Nullable_NullableIntsStruct smoke_Nullable_NullableIntsStruct_fromFfi(Pointer<Vo
   final _uint16Field_handle = _smoke_Nullable_NullableIntsStruct_get_field_uint16Field(handle);
   final _uint32Field_handle = _smoke_Nullable_NullableIntsStruct_get_field_uint32Field(handle);
   final _uint64Field_handle = _smoke_Nullable_NullableIntsStruct_get_field_uint64Field(handle);
-  final _result = Nullable_NullableIntsStruct(
-    Byte_fromFfi_nullable(_int8Field_handle),
-    Short_fromFfi_nullable(_int16Field_handle),
-    Int_fromFfi_nullable(_int32Field_handle),
-    Long_fromFfi_nullable(_int64Field_handle),
-    UByte_fromFfi_nullable(_uint8Field_handle),
-    UShort_fromFfi_nullable(_uint16Field_handle),
-    UInt_fromFfi_nullable(_uint32Field_handle),
-    ULong_fromFfi_nullable(_uint64Field_handle)
-  );
-  Byte_releaseFfiHandle_nullable(_int8Field_handle);
-  Short_releaseFfiHandle_nullable(_int16Field_handle);
-  Int_releaseFfiHandle_nullable(_int32Field_handle);
-  Long_releaseFfiHandle_nullable(_int64Field_handle);
-  UByte_releaseFfiHandle_nullable(_uint8Field_handle);
-  UShort_releaseFfiHandle_nullable(_uint16Field_handle);
-  UInt_releaseFfiHandle_nullable(_uint32Field_handle);
-  ULong_releaseFfiHandle_nullable(_uint64Field_handle);
-  return _result;
+  try {
+    return Nullable_NullableIntsStruct(
+      Byte_fromFfi_nullable(_int8Field_handle),
+      Short_fromFfi_nullable(_int16Field_handle),
+      Int_fromFfi_nullable(_int32Field_handle),
+      Long_fromFfi_nullable(_int64Field_handle),
+      UByte_fromFfi_nullable(_uint8Field_handle),
+      UShort_fromFfi_nullable(_uint16Field_handle),
+      UInt_fromFfi_nullable(_uint32Field_handle),
+      ULong_fromFfi_nullable(_uint64Field_handle)
+    );
+  } finally {
+    Byte_releaseFfiHandle_nullable(_int8Field_handle);
+    Short_releaseFfiHandle_nullable(_int16Field_handle);
+    Int_releaseFfiHandle_nullable(_int32Field_handle);
+    Long_releaseFfiHandle_nullable(_int64Field_handle);
+    UByte_releaseFfiHandle_nullable(_uint8Field_handle);
+    UShort_releaseFfiHandle_nullable(_uint16Field_handle);
+    UInt_releaseFfiHandle_nullable(_uint32Field_handle);
+    ULong_releaseFfiHandle_nullable(_uint64Field_handle);
+  }
 }
 void smoke_Nullable_NullableIntsStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Nullable_NullableIntsStruct_release_handle(handle);
 // Nullable Nullable_NullableIntsStruct
@@ -469,9 +475,11 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _methodWithString_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle_nullable(_input_handle);
-    final _result = String_fromFfi_nullable(__result_handle);
-    String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi_nullable(__result_handle);
+    } finally {
+      String_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   bool methodWithBoolean(bool input) {
@@ -480,9 +488,11 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _methodWithBoolean_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     Boolean_releaseFfiHandle_nullable(_input_handle);
-    final _result = Boolean_fromFfi_nullable(__result_handle);
-    Boolean_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi_nullable(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   double methodWithDouble(double input) {
@@ -491,9 +501,11 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _methodWithDouble_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     Double_releaseFfiHandle_nullable(_input_handle);
-    final _result = Double_fromFfi_nullable(__result_handle);
-    Double_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return Double_fromFfi_nullable(__result_handle);
+    } finally {
+      Double_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   int methodWithInt(int input) {
@@ -502,9 +514,11 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _methodWithInt_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     Long_releaseFfiHandle_nullable(_input_handle);
-    final _result = Long_fromFfi_nullable(__result_handle);
-    Long_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return Long_fromFfi_nullable(__result_handle);
+    } finally {
+      Long_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   Nullable_SomeStruct methodWithSomeStruct(Nullable_SomeStruct input) {
@@ -513,9 +527,11 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _methodWithSomeStruct_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_input_handle);
-    final _result = smoke_Nullable_SomeStruct_fromFfi_nullable(__result_handle);
-    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return smoke_Nullable_SomeStruct_fromFfi_nullable(__result_handle);
+    } finally {
+      smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   Nullable_SomeEnum methodWithSomeEnum(Nullable_SomeEnum input) {
@@ -524,9 +540,11 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _methodWithSomeEnum_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_input_handle);
-    final _result = smoke_Nullable_SomeEnum_fromFfi_nullable(__result_handle);
-    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return smoke_Nullable_SomeEnum_fromFfi_nullable(__result_handle);
+    } finally {
+      smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   List<String> methodWithSomeArray(List<String> input) {
@@ -535,9 +553,11 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _methodWithSomeArray_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     ListOf_String_releaseFfiHandle_nullable(_input_handle);
-    final _result = ListOf_String_fromFfi_nullable(__result_handle);
-    ListOf_String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return ListOf_String_fromFfi_nullable(__result_handle);
+    } finally {
+      ListOf_String_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   List<String> methodWithInlineArray(List<String> input) {
@@ -546,9 +566,11 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _methodWithInlineArray_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     ListOf_String_releaseFfiHandle_nullable(_input_handle);
-    final _result = ListOf_String_fromFfi_nullable(__result_handle);
-    ListOf_String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return ListOf_String_fromFfi_nullable(__result_handle);
+    } finally {
+      ListOf_String_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   Map<int, String> methodWithSomeMap(Map<int, String> input) {
@@ -557,9 +579,11 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _methodWithSomeMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     MapOf_Long_to_String_releaseFfiHandle_nullable(_input_handle);
-    final _result = MapOf_Long_to_String_fromFfi_nullable(__result_handle);
-    MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return MapOf_Long_to_String_fromFfi_nullable(__result_handle);
+    } finally {
+      MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   SomeInterface methodWithInstance(SomeInterface input) {
@@ -568,18 +592,22 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _methodWithInstance_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     smoke_SomeInterface_releaseFfiHandle_nullable(_input_handle);
-    final _result = smoke_SomeInterface_fromFfi_nullable(__result_handle);
-    smoke_SomeInterface_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return smoke_SomeInterface_fromFfi_nullable(__result_handle);
+    } finally {
+      smoke_SomeInterface_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   String get stringProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_stringProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = String_fromFfi_nullable(__result_handle);
-    String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi_nullable(__result_handle);
+    } finally {
+      String_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   set stringProperty(String value) {
@@ -588,18 +616,22 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     String_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   bool get isBoolProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_isBoolProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Boolean_fromFfi_nullable(__result_handle);
-    Boolean_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi_nullable(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   set isBoolProperty(bool value) {
@@ -608,18 +640,22 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     Boolean_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   double get doubleProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_doubleProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Double_fromFfi_nullable(__result_handle);
-    Double_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return Double_fromFfi_nullable(__result_handle);
+    } finally {
+      Double_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   set doubleProperty(double value) {
@@ -628,18 +664,22 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     Double_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   int get intProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_intProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Long_fromFfi_nullable(__result_handle);
-    Long_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return Long_fromFfi_nullable(__result_handle);
+    } finally {
+      Long_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   set intProperty(int value) {
@@ -648,18 +688,22 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     Long_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   Nullable_SomeStruct get structProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_structProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_Nullable_SomeStruct_fromFfi_nullable(__result_handle);
-    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return smoke_Nullable_SomeStruct_fromFfi_nullable(__result_handle);
+    } finally {
+      smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   set structProperty(Nullable_SomeStruct value) {
@@ -668,18 +712,22 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   Nullable_SomeEnum get enumProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_enumProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_Nullable_SomeEnum_fromFfi_nullable(__result_handle);
-    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return smoke_Nullable_SomeEnum_fromFfi_nullable(__result_handle);
+    } finally {
+      smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   set enumProperty(Nullable_SomeEnum value) {
@@ -688,18 +736,22 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   List<String> get arrayProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_arrayProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = ListOf_String_fromFfi_nullable(__result_handle);
-    ListOf_String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return ListOf_String_fromFfi_nullable(__result_handle);
+    } finally {
+      ListOf_String_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   set arrayProperty(List<String> value) {
@@ -708,18 +760,22 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     ListOf_String_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   List<String> get inlineArrayProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_inlineArrayProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = ListOf_String_fromFfi_nullable(__result_handle);
-    ListOf_String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return ListOf_String_fromFfi_nullable(__result_handle);
+    } finally {
+      ListOf_String_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   set inlineArrayProperty(List<String> value) {
@@ -728,18 +784,22 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     ListOf_String_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   Map<int, String> get mapProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_mapProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = MapOf_Long_to_String_fromFfi_nullable(__result_handle);
-    MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return MapOf_Long_to_String_fromFfi_nullable(__result_handle);
+    } finally {
+      MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   set mapProperty(Map<int, String> value) {
@@ -748,18 +808,22 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     MapOf_Long_to_String_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   SomeInterface get instanceProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_instanceProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_SomeInterface_fromFfi_nullable(__result_handle);
-    smoke_SomeInterface_releaseFfiHandle_nullable(__result_handle);
-    return _result;
+    try {
+      return smoke_SomeInterface_fromFfi_nullable(__result_handle);
+    } finally {
+      smoke_SomeInterface_releaseFfiHandle_nullable(__result_handle);
+    }
   }
   @override
   set instanceProperty(SomeInterface value) {
@@ -768,9 +832,11 @@ class Nullable$Impl implements Nullable {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     smoke_SomeInterface_releaseFfiHandle_nullable(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_Nullable_toFfi(Nullable value) =>

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
@@ -37,11 +37,13 @@ Pointer<Void> smoke_off_NestedPackages_SomeStruct_toFfi(NestedPackages_SomeStruc
 }
 NestedPackages_SomeStruct smoke_off_NestedPackages_SomeStruct_fromFfi(Pointer<Void> handle) {
   final _someField_handle = _smoke_off_NestedPackages_SomeStruct_get_field_someField(handle);
-  final _result = NestedPackages_SomeStruct(
-    String_fromFfi(_someField_handle)
-  );
-  String_releaseFfiHandle(_someField_handle);
-  return _result;
+  try {
+    return NestedPackages_SomeStruct(
+      String_fromFfi(_someField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_someField_handle);
+  }
 }
 void smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_off_NestedPackages_SomeStruct_release_handle(handle);
 // Nullable NestedPackages_SomeStruct
@@ -103,9 +105,11 @@ class NestedPackages$Impl implements NestedPackages {
     final _input_handle = smoke_off_NestedPackages_SomeStruct_toFfi(input);
     final __result_handle = _basicMethod_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_off_NestedPackages_SomeStruct_fromFfi(__result_handle);
-    smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_off_NestedPackages_SomeStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_off_NestedPackages_toFfi(NestedPackages value) =>

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -50,9 +50,11 @@ class weeInterface$Impl implements weeInterface {
     final _handle = this.handle;
     final __result_handle = _WeeMethod_ffi(_handle, __lib.LibraryContext.isolateId, _WeeParameter_handle);
     String_releaseFfiHandle(_WeeParameter_handle);
-    final _result = smoke_PlatformNames_BasicStruct_fromFfi(__result_handle);
-    smoke_PlatformNames_BasicStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_PlatformNames_BasicStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_PlatformNames_BasicStruct_releaseFfiHandle(__result_handle);
+    }
   }
   static Pointer<Void> _make(String makeParameter) {
     final _make_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_PlatformNamesInterface_create__String');
@@ -66,9 +68,11 @@ class weeInterface$Impl implements weeInterface {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_PlatformNamesInterface_basicProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   set WEE_PROPERTY(int value) {
@@ -77,9 +81,11 @@ class weeInterface$Impl implements weeInterface {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     (_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_PlatformNamesInterface_toFfi(weeInterface value) =>

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -71,15 +71,19 @@ class weeListener$Impl implements weeListener {
     final _handle = this.handle;
     final __result_handle = _WeeMethod_ffi(_handle, __lib.LibraryContext.isolateId, _WeeParameter_handle);
     String_releaseFfiHandle(_WeeParameter_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _weeListener_WeeMethod_static(int _token, Pointer<Void> WeeParameter) {
-  final __WeeParameter = String_fromFfi(WeeParameter);
-  String_releaseFfiHandle(WeeParameter);
-  (__lib.instanceCache[_token] as weeListener).WeeMethod(__WeeParameter);
+  try {
+    (__lib.instanceCache[_token] as weeListener).WeeMethod(String_fromFfi(WeeParameter));
+  } finally {
+    String_releaseFfiHandle(WeeParameter);
+  }
   return 0;
 }
 Pointer<Void> smoke_PlatformNamesListener_toFfi(weeListener value) {

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
@@ -3,7 +3,6 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 enum werrEnum {
     WEE_ITEM
 }
@@ -66,9 +65,11 @@ class weeStruct {
     final _WeeParameter_handle = String_toFfi(WeeParameter);
     final __result_handle = _WeeCreate_ffi(__lib.LibraryContext.isolateId, _WeeParameter_handle);
     String_releaseFfiHandle(_WeeParameter_handle);
-    final _result = smoke_PlatformNames_BasicStruct_fromFfi(__result_handle);
-    smoke_PlatformNames_BasicStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_PlatformNames_BasicStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_PlatformNames_BasicStruct_releaseFfiHandle(__result_handle);
+    }
   }
 }
 // weeStruct "private" section, not exported.
@@ -92,11 +93,13 @@ Pointer<Void> smoke_PlatformNames_BasicStruct_toFfi(weeStruct value) {
 }
 weeStruct smoke_PlatformNames_BasicStruct_fromFfi(Pointer<Void> handle) {
   final _WEE_FIELD_handle = _smoke_PlatformNames_BasicStruct_get_field_stringField(handle);
-  final _result = weeStruct._(
-    String_fromFfi(_WEE_FIELD_handle)
-  );
-  String_releaseFfiHandle(_WEE_FIELD_handle);
-  return _result;
+  try {
+    return weeStruct._(
+      String_fromFfi(_WEE_FIELD_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_WEE_FIELD_handle);
+  }
 }
 void smoke_PlatformNames_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PlatformNames_BasicStruct_release_handle(handle);
 // Nullable weeStruct

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
@@ -46,8 +46,11 @@ class CachedProperties$Impl implements CachedProperties {
     if (!_is_cached_cachedProperty) {
       final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_CachedProperties_cachedProperty_get');
       final __result_handle = _get_ffi(this.handle, __lib.LibraryContext.isolateId);
-      _cache_cachedProperty = ListOf_String_fromFfi(__result_handle);
-      ListOf_String_releaseFfiHandle(__result_handle);
+      try {
+        _cache_cachedProperty = ListOf_String_fromFfi(__result_handle);
+      } finally {
+        ListOf_String_releaseFfiHandle(__result_handle);
+      }
       _is_cached_cachedProperty = true;
     }
     return _cache_cachedProperty;
@@ -58,8 +61,11 @@ class CachedProperties$Impl implements CachedProperties {
     if (!_is_cached_staticCachedProperty) {
       final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_CachedProperties_staticCachedProperty_get');
       final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
-      _cache_staticCachedProperty = Blob_fromFfi(__result_handle);
-      Blob_releaseFfiHandle(__result_handle);
+      try {
+        _cache_staticCachedProperty = Blob_fromFfi(__result_handle);
+      } finally {
+        Blob_releaseFfiHandle(__result_handle);
+      }
       _is_cached_staticCachedProperty = true;
     }
     return _cache_staticCachedProperty;

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -116,11 +116,13 @@ Pointer<Void> smoke_Properties_ExampleStruct_toFfi(Properties_ExampleStruct valu
 }
 Properties_ExampleStruct smoke_Properties_ExampleStruct_fromFfi(Pointer<Void> handle) {
   final _value_handle = _smoke_Properties_ExampleStruct_get_field_value(handle);
-  final _result = Properties_ExampleStruct(
-    (_value_handle)
-  );
-  (_value_handle);
-  return _result;
+  try {
+    return Properties_ExampleStruct(
+      (_value_handle)
+    );
+  } finally {
+    (_value_handle);
+  }
 }
 void smoke_Properties_ExampleStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Properties_ExampleStruct_release_handle(handle);
 // Nullable Properties_ExampleStruct
@@ -182,9 +184,11 @@ class Properties$Impl implements Properties {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_builtInTypeProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   set builtInTypeProperty(int value) {
@@ -193,27 +197,33 @@ class Properties$Impl implements Properties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     (_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   double get readonlyProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_Properties_readonlyProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   Properties_ExampleStruct get structProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_structProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_Properties_ExampleStruct_fromFfi(__result_handle);
-    smoke_Properties_ExampleStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Properties_ExampleStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_Properties_ExampleStruct_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set structProperty(Properties_ExampleStruct value) {
@@ -222,18 +232,22 @@ class Properties$Impl implements Properties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     smoke_Properties_ExampleStruct_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   List<String> get arrayProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_arrayProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = ListOf_String_fromFfi(__result_handle);
-    ListOf_String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return ListOf_String_fromFfi(__result_handle);
+    } finally {
+      ListOf_String_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set arrayProperty(List<String> value) {
@@ -242,18 +256,22 @@ class Properties$Impl implements Properties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     ListOf_String_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   Properties_InternalErrorCode get complexTypeProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_complexTypeProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_Properties_InternalErrorCode_fromFfi(__result_handle);
-    smoke_Properties_InternalErrorCode_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Properties_InternalErrorCode_fromFfi(__result_handle);
+    } finally {
+      smoke_Properties_InternalErrorCode_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set complexTypeProperty(Properties_InternalErrorCode value) {
@@ -262,18 +280,22 @@ class Properties$Impl implements Properties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     smoke_Properties_InternalErrorCode_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   Uint8List get byteBufferProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_byteBufferProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Blob_fromFfi(__result_handle);
-    Blob_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Blob_fromFfi(__result_handle);
+    } finally {
+      Blob_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set byteBufferProperty(Uint8List value) {
@@ -282,18 +304,22 @@ class Properties$Impl implements Properties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     Blob_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   PropertiesInterface get instanceProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_instanceProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_PropertiesInterface_fromFfi(__result_handle);
-    smoke_PropertiesInterface_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_PropertiesInterface_fromFfi(__result_handle);
+    } finally {
+      smoke_PropertiesInterface_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set instanceProperty(PropertiesInterface value) {
@@ -302,18 +328,22 @@ class Properties$Impl implements Properties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     smoke_PropertiesInterface_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   bool get isBooleanProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_isBooleanProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set isBooleanProperty(bool value) {
@@ -322,32 +352,40 @@ class Properties$Impl implements Properties {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     Boolean_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static String get staticProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticProperty_get');
     final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   static set staticProperty(String value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_Properties_staticProperty_set__String');
     final _value_handle = String_toFfi(value);
     final __result_handle = _set_ffi(__lib.LibraryContext.isolateId, _value_handle);
     String_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static Properties_ExampleStruct get staticReadonlyProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticReadonlyProperty_get');
     final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
-    final _result = smoke_Properties_ExampleStruct_fromFfi(__result_handle);
-    smoke_Properties_ExampleStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Properties_ExampleStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_Properties_ExampleStruct_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_Properties_toFfi(Properties value) =>

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -47,11 +47,13 @@ Pointer<Void> smoke_PropertiesInterface_ExampleStruct_toFfi(PropertiesInterface_
 }
 PropertiesInterface_ExampleStruct smoke_PropertiesInterface_ExampleStruct_fromFfi(Pointer<Void> handle) {
   final _value_handle = _smoke_PropertiesInterface_ExampleStruct_get_field_value(handle);
-  final _result = PropertiesInterface_ExampleStruct(
-    (_value_handle)
-  );
-  (_value_handle);
-  return _result;
+  try {
+    return PropertiesInterface_ExampleStruct(
+      (_value_handle)
+    );
+  } finally {
+    (_value_handle);
+  }
 }
 void smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PropertiesInterface_ExampleStruct_release_handle(handle);
 // Nullable PropertiesInterface_ExampleStruct
@@ -137,9 +139,11 @@ class PropertiesInterface$Impl implements PropertiesInterface {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PropertiesInterface_structProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_PropertiesInterface_ExampleStruct_fromFfi(__result_handle);
-    smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_PropertiesInterface_ExampleStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(__result_handle);
+    }
   }
   set structProperty(PropertiesInterface_ExampleStruct value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PropertiesInterface_structProperty_set__ExampleStruct');
@@ -147,9 +151,11 @@ class PropertiesInterface$Impl implements PropertiesInterface {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 int _PropertiesInterface_structProperty_get_static(int _token, Pointer<Pointer<Void>> _result) {
@@ -157,9 +163,12 @@ int _PropertiesInterface_structProperty_get_static(int _token, Pointer<Pointer<V
   return 0;
 }
 int _PropertiesInterface_structProperty_set_static(int _token, Pointer<Void> _value) {
-  final __value = smoke_PropertiesInterface_ExampleStruct_fromFfi(_value);
-  smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(_value);
-  (__lib.instanceCache[_token] as PropertiesInterface).structProperty = __value;
+  try {
+    (__lib.instanceCache[_token] as PropertiesInterface).structProperty =
+      smoke_PropertiesInterface_ExampleStruct_fromFfi(_value);
+  } finally {
+    smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(_value);
+  }
   return 0;
 }
 Pointer<Void> smoke_PropertiesInterface_toFfi(PropertiesInterface value) {

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -42,18 +42,22 @@ class SkipFunctions$Impl implements SkipFunctions {
     final _input_handle = String_toFfi(input);
     final __result_handle = _notInJava_ffi(__lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   static bool notInSwift(bool input) {
     final _notInSwift_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_SkipFunctions_notInSwift__Boolean');
     final _input_handle = Boolean_toFfi(input);
     final __result_handle = _notInSwift_ffi(__lib.LibraryContext.isolateId, _input_handle);
     Boolean_releaseFfiHandle(_input_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_SkipFunctions_toFfi(SkipFunctions value) =>

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -36,11 +36,13 @@ Pointer<Void> smoke_SkipTypes_NotInJava_toFfi(SkipTypes_NotInJava value) {
 }
 SkipTypes_NotInJava smoke_SkipTypes_NotInJava_fromFfi(Pointer<Void> handle) {
   final _fooField_handle = _smoke_SkipTypes_NotInJava_get_field_fooField(handle);
-  final _result = SkipTypes_NotInJava(
-    String_fromFfi(_fooField_handle)
-  );
-  String_releaseFfiHandle(_fooField_handle);
-  return _result;
+  try {
+    return SkipTypes_NotInJava(
+      String_fromFfi(_fooField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_fooField_handle);
+  }
 }
 void smoke_SkipTypes_NotInJava_releaseFfiHandle(Pointer<Void> handle) => _smoke_SkipTypes_NotInJava_release_handle(handle);
 // Nullable SkipTypes_NotInJava
@@ -98,11 +100,13 @@ Pointer<Void> smoke_SkipTypes_NotInSwift_toFfi(SkipTypes_NotInSwift value) {
 }
 SkipTypes_NotInSwift smoke_SkipTypes_NotInSwift_fromFfi(Pointer<Void> handle) {
   final _fooField_handle = _smoke_SkipTypes_NotInSwift_get_field_fooField(handle);
-  final _result = SkipTypes_NotInSwift(
-    String_fromFfi(_fooField_handle)
-  );
-  String_releaseFfiHandle(_fooField_handle);
-  return _result;
+  try {
+    return SkipTypes_NotInSwift(
+      String_fromFfi(_fooField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_fooField_handle);
+  }
 }
 void smoke_SkipTypes_NotInSwift_releaseFfiHandle(Pointer<Void> handle) => _smoke_SkipTypes_NotInSwift_release_handle(handle);
 // Nullable SkipTypes_NotInSwift

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -113,13 +113,15 @@ Pointer<Void> smoke_Structs_Point_toFfi(Structs_Point value) {
 Structs_Point smoke_Structs_Point_fromFfi(Pointer<Void> handle) {
   final _x_handle = _smoke_Structs_Point_get_field_x(handle);
   final _y_handle = _smoke_Structs_Point_get_field_y(handle);
-  final _result = Structs_Point(
-    (_x_handle),
-    (_y_handle)
-  );
-  (_x_handle);
-  (_y_handle);
-  return _result;
+  try {
+    return Structs_Point(
+      (_x_handle),
+      (_y_handle)
+    );
+  } finally {
+    (_x_handle);
+    (_y_handle);
+  }
 }
 void smoke_Structs_Point_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_Point_release_handle(handle);
 // Nullable Structs_Point
@@ -185,13 +187,15 @@ Pointer<Void> smoke_Structs_Line_toFfi(Structs_Line value) {
 Structs_Line smoke_Structs_Line_fromFfi(Pointer<Void> handle) {
   final _a_handle = _smoke_Structs_Line_get_field_a(handle);
   final _b_handle = _smoke_Structs_Line_get_field_b(handle);
-  final _result = Structs_Line(
-    smoke_Structs_Point_fromFfi(_a_handle),
-    smoke_Structs_Point_fromFfi(_b_handle)
-  );
-  smoke_Structs_Point_releaseFfiHandle(_a_handle);
-  smoke_Structs_Point_releaseFfiHandle(_b_handle);
-  return _result;
+  try {
+    return Structs_Line(
+      smoke_Structs_Point_fromFfi(_a_handle),
+      smoke_Structs_Point_fromFfi(_b_handle)
+    );
+  } finally {
+    smoke_Structs_Point_releaseFfiHandle(_a_handle);
+    smoke_Structs_Point_releaseFfiHandle(_b_handle);
+  }
 }
 void smoke_Structs_Line_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_Line_release_handle(handle);
 // Nullable Structs_Line
@@ -353,37 +357,39 @@ Structs_AllTypesStruct smoke_Structs_AllTypesStruct_fromFfi(Pointer<Void> handle
   final _booleanField_handle = _smoke_Structs_AllTypesStruct_get_field_booleanField(handle);
   final _bytesField_handle = _smoke_Structs_AllTypesStruct_get_field_bytesField(handle);
   final _pointField_handle = _smoke_Structs_AllTypesStruct_get_field_pointField(handle);
-  final _result = Structs_AllTypesStruct(
-    (_int8Field_handle),
-    (_uint8Field_handle),
-    (_int16Field_handle),
-    (_uint16Field_handle),
-    (_int32Field_handle),
-    (_uint32Field_handle),
-    (_int64Field_handle),
-    (_uint64Field_handle),
-    (_floatField_handle),
-    (_doubleField_handle),
-    String_fromFfi(_stringField_handle),
-    Boolean_fromFfi(_booleanField_handle),
-    Blob_fromFfi(_bytesField_handle),
-    smoke_Structs_Point_fromFfi(_pointField_handle)
-  );
-  (_int8Field_handle);
-  (_uint8Field_handle);
-  (_int16Field_handle);
-  (_uint16Field_handle);
-  (_int32Field_handle);
-  (_uint32Field_handle);
-  (_int64Field_handle);
-  (_uint64Field_handle);
-  (_floatField_handle);
-  (_doubleField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  Boolean_releaseFfiHandle(_booleanField_handle);
-  Blob_releaseFfiHandle(_bytesField_handle);
-  smoke_Structs_Point_releaseFfiHandle(_pointField_handle);
-  return _result;
+  try {
+    return Structs_AllTypesStruct(
+      (_int8Field_handle),
+      (_uint8Field_handle),
+      (_int16Field_handle),
+      (_uint16Field_handle),
+      (_int32Field_handle),
+      (_uint32Field_handle),
+      (_int64Field_handle),
+      (_uint64Field_handle),
+      (_floatField_handle),
+      (_doubleField_handle),
+      String_fromFfi(_stringField_handle),
+      Boolean_fromFfi(_booleanField_handle),
+      Blob_fromFfi(_bytesField_handle),
+      smoke_Structs_Point_fromFfi(_pointField_handle)
+    );
+  } finally {
+    (_int8Field_handle);
+    (_uint8Field_handle);
+    (_int16Field_handle);
+    (_uint16Field_handle);
+    (_int32Field_handle);
+    (_uint32Field_handle);
+    (_int64Field_handle);
+    (_uint64Field_handle);
+    (_floatField_handle);
+    (_doubleField_handle);
+    String_releaseFfiHandle(_stringField_handle);
+    Boolean_releaseFfiHandle(_booleanField_handle);
+    Blob_releaseFfiHandle(_bytesField_handle);
+    smoke_Structs_Point_releaseFfiHandle(_pointField_handle);
+  }
 }
 void smoke_Structs_AllTypesStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_AllTypesStruct_release_handle(handle);
 // Nullable Structs_AllTypesStruct
@@ -465,17 +471,19 @@ Structs_ExternalStruct smoke_Structs_ExternalStruct_fromFfi(Pointer<Void> handle
   final _externalStringField_handle = _smoke_Structs_ExternalStruct_get_field_externalStringField(handle);
   final _externalArrayField_handle = _smoke_Structs_ExternalStruct_get_field_externalArrayField(handle);
   final _externalStructField_handle = _smoke_Structs_ExternalStruct_get_field_externalStructField(handle);
-  final _result = Structs_ExternalStruct(
-    String_fromFfi(_stringField_handle),
-    String_fromFfi(_externalStringField_handle),
-    ListOf_Byte_fromFfi(_externalArrayField_handle),
-    smoke_Structs_AnotherExternalStruct_fromFfi(_externalStructField_handle)
-  );
-  String_releaseFfiHandle(_stringField_handle);
-  String_releaseFfiHandle(_externalStringField_handle);
-  ListOf_Byte_releaseFfiHandle(_externalArrayField_handle);
-  smoke_Structs_AnotherExternalStruct_releaseFfiHandle(_externalStructField_handle);
-  return _result;
+  try {
+    return Structs_ExternalStruct(
+      String_fromFfi(_stringField_handle),
+      String_fromFfi(_externalStringField_handle),
+      ListOf_Byte_fromFfi(_externalArrayField_handle),
+      smoke_Structs_AnotherExternalStruct_fromFfi(_externalStructField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_stringField_handle);
+    String_releaseFfiHandle(_externalStringField_handle);
+    ListOf_Byte_releaseFfiHandle(_externalArrayField_handle);
+    smoke_Structs_AnotherExternalStruct_releaseFfiHandle(_externalStructField_handle);
+  }
 }
 void smoke_Structs_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_ExternalStruct_release_handle(handle);
 // Nullable Structs_ExternalStruct
@@ -533,11 +541,13 @@ Pointer<Void> smoke_Structs_AnotherExternalStruct_toFfi(Structs_AnotherExternalS
 }
 Structs_AnotherExternalStruct smoke_Structs_AnotherExternalStruct_fromFfi(Pointer<Void> handle) {
   final _intField_handle = _smoke_Structs_AnotherExternalStruct_get_field_intField(handle);
-  final _result = Structs_AnotherExternalStruct(
-    (_intField_handle)
-  );
-  (_intField_handle);
-  return _result;
+  try {
+    return Structs_AnotherExternalStruct(
+      (_intField_handle)
+    );
+  } finally {
+    (_intField_handle);
+  }
 }
 void smoke_Structs_AnotherExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_AnotherExternalStruct_release_handle(handle);
 // Nullable Structs_AnotherExternalStruct
@@ -595,11 +605,13 @@ Pointer<Void> smoke_Structs_YetAnotherExternalStruct_toFfi(Structs_YetAnotherExt
 }
 Structs_YetAnotherExternalStruct smoke_Structs_YetAnotherExternalStruct_fromFfi(Pointer<Void> handle) {
   final _stringField_handle = _smoke_Structs_YetAnotherExternalStruct_get_field_stringField(handle);
-  final _result = Structs_YetAnotherExternalStruct(
-    String_fromFfi(_stringField_handle)
-  );
-  String_releaseFfiHandle(_stringField_handle);
-  return _result;
+  try {
+    return Structs_YetAnotherExternalStruct(
+      String_fromFfi(_stringField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_stringField_handle);
+  }
 }
 void smoke_Structs_YetAnotherExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_YetAnotherExternalStruct_release_handle(handle);
 // Nullable Structs_YetAnotherExternalStruct
@@ -657,11 +669,13 @@ Pointer<Void> smoke_Structs_NestingImmutableStruct_toFfi(Structs_NestingImmutabl
 }
 Structs_NestingImmutableStruct smoke_Structs_NestingImmutableStruct_fromFfi(Pointer<Void> handle) {
   final _structField_handle = _smoke_Structs_NestingImmutableStruct_get_field_structField(handle);
-  final _result = Structs_NestingImmutableStruct(
-    smoke_Structs_AllTypesStruct_fromFfi(_structField_handle)
-  );
-  smoke_Structs_AllTypesStruct_releaseFfiHandle(_structField_handle);
-  return _result;
+  try {
+    return Structs_NestingImmutableStruct(
+      smoke_Structs_AllTypesStruct_fromFfi(_structField_handle)
+    );
+  } finally {
+    smoke_Structs_AllTypesStruct_releaseFfiHandle(_structField_handle);
+  }
 }
 void smoke_Structs_NestingImmutableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_NestingImmutableStruct_release_handle(handle);
 // Nullable Structs_NestingImmutableStruct
@@ -719,11 +733,13 @@ Pointer<Void> smoke_Structs_DoubleNestingImmutableStruct_toFfi(Structs_DoubleNes
 }
 Structs_DoubleNestingImmutableStruct smoke_Structs_DoubleNestingImmutableStruct_fromFfi(Pointer<Void> handle) {
   final _nestingStructField_handle = _smoke_Structs_DoubleNestingImmutableStruct_get_field_nestingStructField(handle);
-  final _result = Structs_DoubleNestingImmutableStruct(
-    smoke_Structs_NestingImmutableStruct_fromFfi(_nestingStructField_handle)
-  );
-  smoke_Structs_NestingImmutableStruct_releaseFfiHandle(_nestingStructField_handle);
-  return _result;
+  try {
+    return Structs_DoubleNestingImmutableStruct(
+      smoke_Structs_NestingImmutableStruct_fromFfi(_nestingStructField_handle)
+    );
+  } finally {
+    smoke_Structs_NestingImmutableStruct_releaseFfiHandle(_nestingStructField_handle);
+  }
 }
 void smoke_Structs_DoubleNestingImmutableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_DoubleNestingImmutableStruct_release_handle(handle);
 // Nullable Structs_DoubleNestingImmutableStruct
@@ -781,11 +797,13 @@ Pointer<Void> smoke_Structs_StructWithArrayOfImmutable_toFfi(Structs_StructWithA
 }
 Structs_StructWithArrayOfImmutable smoke_Structs_StructWithArrayOfImmutable_fromFfi(Pointer<Void> handle) {
   final _arrayField_handle = _smoke_Structs_StructWithArrayOfImmutable_get_field_arrayField(handle);
-  final _result = Structs_StructWithArrayOfImmutable(
-    ListOf_smoke_Structs_AllTypesStruct_fromFfi(_arrayField_handle)
-  );
-  ListOf_smoke_Structs_AllTypesStruct_releaseFfiHandle(_arrayField_handle);
-  return _result;
+  try {
+    return Structs_StructWithArrayOfImmutable(
+      ListOf_smoke_Structs_AllTypesStruct_fromFfi(_arrayField_handle)
+    );
+  } finally {
+    ListOf_smoke_Structs_AllTypesStruct_releaseFfiHandle(_arrayField_handle);
+  }
 }
 void smoke_Structs_StructWithArrayOfImmutable_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_StructWithArrayOfImmutable_release_handle(handle);
 // Nullable Structs_StructWithArrayOfImmutable
@@ -843,11 +861,13 @@ Pointer<Void> smoke_Structs_ImmutableStructWithCppAccessors_toFfi(Structs_Immuta
 }
 Structs_ImmutableStructWithCppAccessors smoke_Structs_ImmutableStructWithCppAccessors_fromFfi(Pointer<Void> handle) {
   final _stringField_handle = _smoke_Structs_ImmutableStructWithCppAccessors_get_field_stringField(handle);
-  final _result = Structs_ImmutableStructWithCppAccessors(
-    String_fromFfi(_stringField_handle)
-  );
-  String_releaseFfiHandle(_stringField_handle);
-  return _result;
+  try {
+    return Structs_ImmutableStructWithCppAccessors(
+      String_fromFfi(_stringField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_stringField_handle);
+  }
 }
 void smoke_Structs_ImmutableStructWithCppAccessors_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_ImmutableStructWithCppAccessors_release_handle(handle);
 // Nullable Structs_ImmutableStructWithCppAccessors
@@ -905,11 +925,13 @@ Pointer<Void> smoke_Structs_MutableStructWithCppAccessors_toFfi(Structs_MutableS
 }
 Structs_MutableStructWithCppAccessors smoke_Structs_MutableStructWithCppAccessors_fromFfi(Pointer<Void> handle) {
   final _stringField_handle = _smoke_Structs_MutableStructWithCppAccessors_get_field_stringField(handle);
-  final _result = Structs_MutableStructWithCppAccessors(
-    String_fromFfi(_stringField_handle)
-  );
-  String_releaseFfiHandle(_stringField_handle);
-  return _result;
+  try {
+    return Structs_MutableStructWithCppAccessors(
+      String_fromFfi(_stringField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_stringField_handle);
+  }
 }
 void smoke_Structs_MutableStructWithCppAccessors_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_MutableStructWithCppAccessors_release_handle(handle);
 // Nullable Structs_MutableStructWithCppAccessors
@@ -971,39 +993,49 @@ class Structs$Impl implements Structs {
     final _input_handle = smoke_Structs_Point_toFfi(input);
     final __result_handle = _swapPointCoordinates_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Structs_Point_releaseFfiHandle(_input_handle);
-    final _result = smoke_Structs_Point_fromFfi(__result_handle);
-    smoke_Structs_Point_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Structs_Point_fromFfi(__result_handle);
+    } finally {
+      smoke_Structs_Point_releaseFfiHandle(__result_handle);
+    }
   }
   static Structs_AllTypesStruct returnAllTypesStruct(Structs_AllTypesStruct input) {
     final _returnAllTypesStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_returnAllTypesStruct__AllTypesStruct');
     final _input_handle = smoke_Structs_AllTypesStruct_toFfi(input);
     final __result_handle = _returnAllTypesStruct_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Structs_AllTypesStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_Structs_AllTypesStruct_fromFfi(__result_handle);
-    smoke_Structs_AllTypesStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Structs_AllTypesStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_Structs_AllTypesStruct_releaseFfiHandle(__result_handle);
+    }
   }
   static Structs_ExternalStruct getExternalStruct() {
     final _getExternalStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getExternalStruct');
     final __result_handle = _getExternalStruct_ffi(__lib.LibraryContext.isolateId);
-    final _result = smoke_Structs_ExternalStruct_fromFfi(__result_handle);
-    smoke_Structs_ExternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Structs_ExternalStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_Structs_ExternalStruct_releaseFfiHandle(__result_handle);
+    }
   }
   static Structs_AnotherExternalStruct getAnotherExternalStruct() {
     final _getAnotherExternalStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getAnotherExternalStruct');
     final __result_handle = _getAnotherExternalStruct_ffi(__lib.LibraryContext.isolateId);
-    final _result = smoke_Structs_AnotherExternalStruct_fromFfi(__result_handle);
-    smoke_Structs_AnotherExternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Structs_AnotherExternalStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_Structs_AnotherExternalStruct_releaseFfiHandle(__result_handle);
+    }
   }
   static Structs_YetAnotherExternalStruct getYetAnotherExternalStruct() {
     final _getYetAnotherExternalStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getYetAnotherExternalStruct');
     final __result_handle = _getYetAnotherExternalStruct_ffi(__lib.LibraryContext.isolateId);
-    final _result = smoke_Structs_YetAnotherExternalStruct_fromFfi(__result_handle);
-    smoke_Structs_YetAnotherExternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_Structs_YetAnotherExternalStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_Structs_YetAnotherExternalStruct_releaseFfiHandle(__result_handle);
+    }
   }
   static Point createPoint(double x, double y) {
     final _createPoint_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Double, Double), Pointer<Void> Function(int, double, double)>('library_smoke_Structs_createPoint__Double_Double');
@@ -1012,18 +1044,22 @@ class Structs$Impl implements Structs {
     final __result_handle = _createPoint_ffi(__lib.LibraryContext.isolateId, _x_handle, _y_handle);
     (_x_handle);
     (_y_handle);
-    final _result = smoke_TypeCollection_Point_fromFfi(__result_handle);
-    smoke_TypeCollection_Point_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_TypeCollection_Point_fromFfi(__result_handle);
+    } finally {
+      smoke_TypeCollection_Point_releaseFfiHandle(__result_handle);
+    }
   }
   static AllTypesStruct modifyAllTypesStruct(AllTypesStruct input) {
     final _modifyAllTypesStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_modifyAllTypesStruct__AllTypesStruct');
     final _input_handle = smoke_TypeCollection_AllTypesStruct_toFfi(input);
     final __result_handle = _modifyAllTypesStruct_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_TypeCollection_AllTypesStruct_fromFfi(__result_handle);
-    smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_TypeCollection_AllTypesStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_Structs_toFfi(Structs value) =>

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_constants.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_constants.dart
@@ -39,13 +39,15 @@ Pointer<Void> smoke_StructsWithConstants_Route_toFfi(Route value) {
 Route smoke_StructsWithConstants_Route_fromFfi(Pointer<Void> handle) {
   final _description_handle = _smoke_StructsWithConstants_Route_get_field_description(handle);
   final _type_handle = _smoke_StructsWithConstants_Route_get_field_type(handle);
-  final _result = Route(
-    String_fromFfi(_description_handle),
-    smoke_RouteUtils_RouteType_fromFfi(_type_handle)
-  );
-  String_releaseFfiHandle(_description_handle);
-  smoke_RouteUtils_RouteType_releaseFfiHandle(_type_handle);
-  return _result;
+  try {
+    return Route(
+      String_fromFfi(_description_handle),
+      smoke_RouteUtils_RouteType_fromFfi(_type_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_description_handle);
+    smoke_RouteUtils_RouteType_releaseFfiHandle(_type_handle);
+  }
 }
 void smoke_StructsWithConstants_Route_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructsWithConstants_Route_release_handle(handle);
 // Nullable Route

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
@@ -34,9 +34,11 @@ class Vector {
     final __result_handle = _distanceTo_ffi(_handle, __lib.LibraryContext.isolateId, _other_handle);
     smoke_StructsWithMethods_Vector_releaseFfiHandle(_handle);
     smoke_StructsWithMethods_Vector_releaseFfiHandle(_other_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   Vector add(Vector other) {
     final _add_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_add__Vector');
@@ -45,9 +47,11 @@ class Vector {
     final __result_handle = _add_ffi(_handle, __lib.LibraryContext.isolateId, _other_handle);
     smoke_StructsWithMethods_Vector_releaseFfiHandle(_handle);
     smoke_StructsWithMethods_Vector_releaseFfiHandle(_other_handle);
-    final _result = smoke_StructsWithMethods_Vector_fromFfi(__result_handle);
-    smoke_StructsWithMethods_Vector_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_StructsWithMethods_Vector_fromFfi(__result_handle);
+    } finally {
+      smoke_StructsWithMethods_Vector_releaseFfiHandle(__result_handle);
+    }
   }
   static bool validate(double x, double y) {
     final _validate_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Double, Double), int Function(int, double, double)>('library_smoke_StructsWithMethods_Vector_validate__Double_Double');
@@ -56,9 +60,11 @@ class Vector {
     final __result_handle = _validate_ffi(__lib.LibraryContext.isolateId, _x_handle, _y_handle);
     (_x_handle);
     (_y_handle);
-    final _result = Boolean_fromFfi(__result_handle);
-    Boolean_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return Boolean_fromFfi(__result_handle);
+    } finally {
+      Boolean_releaseFfiHandle(__result_handle);
+    }
   }
   static Vector _create(double x, double y) {
     final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Double, Double), Pointer<Void> Function(int, double, double)>('library_smoke_StructsWithMethods_Vector_create__Double_Double');
@@ -67,9 +73,11 @@ class Vector {
     final __result_handle = _create_ffi(__lib.LibraryContext.isolateId, _x_handle, _y_handle);
     (_x_handle);
     (_y_handle);
-    final _result = smoke_StructsWithMethods_Vector_fromFfi(__result_handle);
-    smoke_StructsWithMethods_Vector_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_StructsWithMethods_Vector_fromFfi(__result_handle);
+    } finally {
+      smoke_StructsWithMethods_Vector_releaseFfiHandle(__result_handle);
+    }
   }
   static Vector _copy(Vector other) {
     final _copy_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_create__Vector');
@@ -79,15 +87,19 @@ class Vector {
     if (_copy_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _copy_return_get_error(__call_result_handle);
         _copy_return_release_handle(__call_result_handle);
-        final _error_value = smoke_ValidationUtils_ValidationErrorCode_fromFfi(__error_handle);
-        smoke_ValidationUtils_ValidationErrorCode_releaseFfiHandle(__error_handle);
-        throw ValidationException(_error_value);
+        try {
+          throw ValidationException(smoke_ValidationUtils_ValidationErrorCode_fromFfi(__error_handle));
+        } finally {
+          smoke_ValidationUtils_ValidationErrorCode_releaseFfiHandle(__error_handle);
+        }
     }
     final __result_handle = _copy_return_get_result(__call_result_handle);
     _copy_return_release_handle(__call_result_handle);
-    final _result = smoke_StructsWithMethods_Vector_fromFfi(__result_handle);
-    smoke_StructsWithMethods_Vector_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_StructsWithMethods_Vector_fromFfi(__result_handle);
+    } finally {
+      smoke_StructsWithMethods_Vector_releaseFfiHandle(__result_handle);
+    }
   }
 }
 // Vector "private" section, not exported.
@@ -118,13 +130,15 @@ Pointer<Void> smoke_StructsWithMethods_Vector_toFfi(Vector value) {
 Vector smoke_StructsWithMethods_Vector_fromFfi(Pointer<Void> handle) {
   final _x_handle = _smoke_StructsWithMethods_Vector_get_field_x(handle);
   final _y_handle = _smoke_StructsWithMethods_Vector_get_field_y(handle);
-  final _result = Vector._(
-    (_x_handle),
-    (_y_handle)
-  );
-  (_x_handle);
-  (_y_handle);
-  return _result;
+  try {
+    return Vector._(
+      (_x_handle),
+      (_y_handle)
+    );
+  } finally {
+    (_x_handle);
+    (_y_handle);
+  }
 }
 void smoke_StructsWithMethods_Vector_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructsWithMethods_Vector_release_handle(handle);
 // Nullable Vector

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -46,11 +46,13 @@ Pointer<Void> smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_toFfi(TypeDefs_S
 }
 TypeDefs_StructHavingAliasFieldDefinedBelow smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_fromFfi(Pointer<Void> handle) {
   final _field_handle = _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_field_field(handle);
-  final _result = TypeDefs_StructHavingAliasFieldDefinedBelow(
-    (_field_handle)
-  );
-  (_field_handle);
-  return _result;
+  try {
+    return TypeDefs_StructHavingAliasFieldDefinedBelow(
+      (_field_handle)
+    );
+  } finally {
+    (_field_handle);
+  }
 }
 void smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle(handle);
 // Nullable TypeDefs_StructHavingAliasFieldDefinedBelow
@@ -108,11 +110,13 @@ Pointer<Void> smoke_TypeDefs_TestStruct_toFfi(TypeDefs_TestStruct value) {
 }
 TypeDefs_TestStruct smoke_TypeDefs_TestStruct_fromFfi(Pointer<Void> handle) {
   final _something_handle = _smoke_TypeDefs_TestStruct_get_field_something(handle);
-  final _result = TypeDefs_TestStruct(
-    String_fromFfi(_something_handle)
-  );
-  String_releaseFfiHandle(_something_handle);
-  return _result;
+  try {
+    return TypeDefs_TestStruct(
+      String_fromFfi(_something_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_something_handle);
+  }
 }
 void smoke_TypeDefs_TestStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypeDefs_TestStruct_release_handle(handle);
 // Nullable TypeDefs_TestStruct
@@ -174,63 +178,77 @@ class TypeDefs$Impl implements TypeDefs {
     final _input_handle = (input);
     final __result_handle = _methodWithPrimitiveTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) {
     final _methodWithComplexTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_methodWithComplexTypeDef__ListOf_1smoke_1TypeDefs_1TestStruct');
     final _input_handle = ListOf_smoke_TypeDefs_TestStruct_toFfi(input);
     final __result_handle = _methodWithComplexTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
     ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
-    final _result = ListOf_smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
-    ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return ListOf_smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
+    } finally {
+      ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
+    }
   }
   static double returnNestedIntTypeDef(double input) {
     final _returnNestedIntTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_returnNestedIntTypeDef__Double');
     final _input_handle = (input);
     final __result_handle = _returnNestedIntTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) {
     final _returnTestStructTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTestStructTypeDef__TestStruct');
     final _input_handle = smoke_TypeDefs_TestStruct_toFfi(input);
     final __result_handle = _returnTestStructTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
-    smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
+    }
   }
   static TypeDefs_TestStruct returnNestedStructTypeDef(TypeDefs_TestStruct input) {
     final _returnNestedStructTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnNestedStructTypeDef__TestStruct');
     final _input_handle = smoke_TypeDefs_TestStruct_toFfi(input);
     final __result_handle = _returnNestedStructTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
-    smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
+    }
   }
   static Point returnTypeDefPointFromTypeCollection(Point input) {
     final _returnTypeDefPointFromTypeCollection_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTypeDefPointFromTypeCollection__Point');
     final _input_handle = smoke_TypeCollection_Point_toFfi(input);
     final __result_handle = _returnTypeDefPointFromTypeCollection_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_TypeCollection_Point_releaseFfiHandle(_input_handle);
-    final _result = smoke_TypeCollection_Point_fromFfi(__result_handle);
-    smoke_TypeCollection_Point_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_TypeCollection_Point_fromFfi(__result_handle);
+    } finally {
+      smoke_TypeCollection_Point_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   List<double> get primitiveTypeProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_TypeDefs_primitiveTypeProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = ListOf_Double_fromFfi(__result_handle);
-    ListOf_Double_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return ListOf_Double_fromFfi(__result_handle);
+    } finally {
+      ListOf_Double_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set primitiveTypeProperty(List<double> value) {
@@ -239,9 +257,11 @@ class TypeDefs$Impl implements TypeDefs {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     ListOf_Double_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_TypeDefs_toFfi(TypeDefs value) =>

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -53,9 +53,11 @@ class InternalClassWithFunctions$Impl implements InternalClassWithFunctions {
     final _fooBar_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithFunctions_fooBar');
     final _handle = this.handle;
     final __result_handle = _fooBar_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   static Pointer<Void> _make() {
     final _make_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithFunctions_make');

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -43,18 +43,22 @@ class InternalClassWithStaticProperty$Impl implements InternalClassWithStaticPro
   static String get internal_fooBar {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithStaticProperty_fooBar_get');
     final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   static set internal_fooBar(String value) {
     final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InternalClassWithStaticProperty_fooBar_set__String');
     final _value_handle = String_toFfi(value);
     final __result_handle = _set_ffi(__lib.LibraryContext.isolateId, _value_handle);
     String_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_InternalClassWithStaticProperty_toFfi(InternalClassWithStaticProperty value) =>

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -107,11 +107,13 @@ Pointer<Void> smoke_PublicClass_InternalStruct_toFfi(PublicClass_InternalStruct 
 }
 PublicClass_InternalStruct smoke_PublicClass_InternalStruct_fromFfi(Pointer<Void> handle) {
   final _stringField_handle = _smoke_PublicClass_InternalStruct_get_field_stringField(handle);
-  final _result = PublicClass_InternalStruct(
-    String_fromFfi(_stringField_handle)
-  );
-  String_releaseFfiHandle(_stringField_handle);
-  return _result;
+  try {
+    return PublicClass_InternalStruct(
+      String_fromFfi(_stringField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_stringField_handle);
+  }
 }
 void smoke_PublicClass_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicClass_InternalStruct_release_handle(handle);
 // Nullable PublicClass_InternalStruct
@@ -170,11 +172,13 @@ Pointer<Void> smoke_PublicClass_PublicStruct_toFfi(PublicClass_PublicStruct valu
 }
 PublicClass_PublicStruct smoke_PublicClass_PublicStruct_fromFfi(Pointer<Void> handle) {
   final _internalField_handle = _smoke_PublicClass_PublicStruct_get_field_internalField(handle);
-  final _result = PublicClass_PublicStruct(
-    smoke_PublicClass_InternalStruct_fromFfi(_internalField_handle)
-  );
-  smoke_PublicClass_InternalStruct_releaseFfiHandle(_internalField_handle);
-  return _result;
+  try {
+    return PublicClass_PublicStruct(
+      smoke_PublicClass_InternalStruct_fromFfi(_internalField_handle)
+    );
+  } finally {
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(_internalField_handle);
+  }
 }
 void smoke_PublicClass_PublicStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicClass_PublicStruct_release_handle(handle);
 // Nullable PublicClass_PublicStruct
@@ -243,13 +247,15 @@ Pointer<Void> smoke_PublicClass_PublicStructWithInternalDefaults_toFfi(PublicCla
 PublicClass_PublicStructWithInternalDefaults smoke_PublicClass_PublicStructWithInternalDefaults_fromFfi(Pointer<Void> handle) {
   final _internalField_handle = _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_internalField(handle);
   final _publicField_handle = _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField(handle);
-  final _result = PublicClass_PublicStructWithInternalDefaults(
-    String_fromFfi(_internalField_handle),
-    (_publicField_handle)
-  );
-  String_releaseFfiHandle(_internalField_handle);
-  (_publicField_handle);
-  return _result;
+  try {
+    return PublicClass_PublicStructWithInternalDefaults(
+      String_fromFfi(_internalField_handle),
+      (_publicField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_internalField_handle);
+    (_publicField_handle);
+  }
 }
 void smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle(handle);
 // Nullable PublicClass_PublicStructWithInternalDefaults
@@ -313,18 +319,22 @@ class PublicClass$Impl implements PublicClass {
     final _handle = this.handle;
     final __result_handle = _internalMethod_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
     smoke_PublicClass_InternalStruct_releaseFfiHandle(_input_handle);
-    final _result = smoke_PublicClass_InternalStruct_fromFfi(__result_handle);
-    smoke_PublicClass_InternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_PublicClass_InternalStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_PublicClass_InternalStruct_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   PublicClass_InternalStruct get internal_internalStructProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PublicClass_internalStructProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = smoke_PublicClass_InternalStruct_fromFfi(__result_handle);
-    smoke_PublicClass_InternalStruct_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return smoke_PublicClass_InternalStruct_fromFfi(__result_handle);
+    } finally {
+      smoke_PublicClass_InternalStruct_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set internal_internalStructProperty(PublicClass_InternalStruct value) {
@@ -333,18 +343,22 @@ class PublicClass$Impl implements PublicClass {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     smoke_PublicClass_InternalStruct_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
   @override
   String get internalSetterProperty {
     final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PublicClass_internalSetterProperty_get');
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
-    final _result = String_fromFfi(__result_handle);
-    String_releaseFfiHandle(__result_handle);
-    return _result;
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
   }
   @override
   set internal_internalSetterProperty(String value) {
@@ -353,9 +367,11 @@ class PublicClass$Impl implements PublicClass {
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
     String_releaseFfiHandle(_value_handle);
-    final _result = (__result_handle);
-    (__result_handle);
-    return _result;
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_PublicClass_toFfi(PublicClass value) =>

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
@@ -40,11 +40,13 @@ Pointer<Void> smoke_PublicInterface_InternalStruct_toFfi(PublicInterface_Interna
 }
 PublicInterface_InternalStruct smoke_PublicInterface_InternalStruct_fromFfi(Pointer<Void> handle) {
   final _fieldOfInternalType_handle = _smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType(handle);
-  final _result = PublicInterface_InternalStruct(
-    smoke_PublicClass_InternalStruct_fromFfi(_fieldOfInternalType_handle)
-  );
-  smoke_PublicClass_InternalStruct_releaseFfiHandle(_fieldOfInternalType_handle);
-  return _result;
+  try {
+    return PublicInterface_InternalStruct(
+      smoke_PublicClass_InternalStruct_fromFfi(_fieldOfInternalType_handle)
+    );
+  } finally {
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(_fieldOfInternalType_handle);
+  }
 }
 void smoke_PublicInterface_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicInterface_InternalStruct_release_handle(handle);
 // Nullable PublicInterface_InternalStruct

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
@@ -47,15 +47,17 @@ PublicStructWithNonDefaultInternalField smoke_PublicStructWithNonDefaultInternal
   final _defaultedField_handle = _smoke_PublicStructWithNonDefaultInternalField_get_field_defaultedField(handle);
   final _internalField_handle = _smoke_PublicStructWithNonDefaultInternalField_get_field_internalField(handle);
   final _publicField_handle = _smoke_PublicStructWithNonDefaultInternalField_get_field_publicField(handle);
-  final _result = PublicStructWithNonDefaultInternalField(
-    (_defaultedField_handle),
-    String_fromFfi(_internalField_handle),
-    Boolean_fromFfi(_publicField_handle)
-  );
-  (_defaultedField_handle);
-  String_releaseFfiHandle(_internalField_handle);
-  Boolean_releaseFfiHandle(_publicField_handle);
-  return _result;
+  try {
+    return PublicStructWithNonDefaultInternalField(
+      (_defaultedField_handle),
+      String_fromFfi(_internalField_handle),
+      Boolean_fromFfi(_publicField_handle)
+    );
+  } finally {
+    (_defaultedField_handle);
+    String_releaseFfiHandle(_internalField_handle);
+    Boolean_releaseFfiHandle(_publicField_handle);
+  }
 }
 void smoke_PublicStructWithNonDefaultInternalField_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicStructWithNonDefaultInternalField_release_handle(handle);
 // Nullable PublicStructWithNonDefaultInternalField

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
@@ -30,11 +30,13 @@ Pointer<Void> smoke_PublicTypeCollection_InternalStruct_toFfi(InternalStruct val
 }
 InternalStruct smoke_PublicTypeCollection_InternalStruct_fromFfi(Pointer<Void> handle) {
   final _stringField_handle = _smoke_PublicTypeCollection_InternalStruct_get_field_stringField(handle);
-  final _result = InternalStruct(
-    String_fromFfi(_stringField_handle)
-  );
-  String_releaseFfiHandle(_stringField_handle);
-  return _result;
+  try {
+    return InternalStruct(
+      String_fromFfi(_stringField_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_stringField_handle);
+  }
 }
 void smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicTypeCollection_InternalStruct_release_handle(handle);
 // Nullable InternalStruct


### PR DESCRIPTION
Updated Dart templates to wrap "fromFfi" conversion calls in
`try-finally` construct, releasing the handle in the `finally` block.
This way the handle is released even if the conversion function throws.

No conversion function is expected to throw normally, but they can throw
if malformed data is passed from C++ code. The upcoming Locale type
implementation is especially sensitive to malformed data (but in general
this can happen to most supported types).

See: #372
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>