### PR TITLE
Fix error handling in Dart FFI proxies

### DIFF
--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
@@ -135,7 +135,8 @@ return _result;{{/proxyReturnResult}}{{!!
 
 }}{{+proxyReturnError}}{{#instanceOf exception.errorType.type.actualType "LimeEnumeration"}}{{!!
 }}return make_error_code({{>ffi/FfiInternal}}::Conversion<{{resolveName exception.errorType "C++"}}>::toCpp({{!!
-}}(uint32_t)_error_handle));{{/instanceOf}}{{#notInstanceOf exception.errorType.type.actualType "LimeEnumeration"}}{{!!
+}}_error_flag ? (uint32_t)_error_handle : 0));{{/instanceOf}}{{!!
+}}{{#notInstanceOf exception.errorType.type.actualType "LimeEnumeration"}}{{!!
 }}auto _error_result = {{>ffi/FfiInternal}}::Conversion<{{resolveName exception.errorType "C++"}}>::toCpp(_error_handle);
 {{#set typeRef=exception.errorType handle="_error_handle"}}{{>ffiReleaseHandle}}{{/set}};
 return _error_result;{{!!

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
@@ -31,7 +31,7 @@ public:
         dispatch([&]() { _error_flag = (*reinterpret_cast<bool (*)(uint64_t, uint32_t*)>(f0))(token,
             &_error_handle
         ); });
-        return make_error_code(gluecodium::ffi::Conversion<::smoke::ErrorsInterface::InternalError>::toCpp((uint32_t)_error_handle));
+        return make_error_code(gluecodium::ffi::Conversion<::smoke::ErrorsInterface::InternalError>::toCpp(_error_flag ? (uint32_t)_error_handle : 0));
     }
     std::error_code
     method_with_external_errors() override {
@@ -40,7 +40,7 @@ public:
         dispatch([&]() { _error_flag = (*reinterpret_cast<bool (*)(uint64_t, uint32_t*)>(f1))(token,
             &_error_handle
         ); });
-        return make_error_code(gluecodium::ffi::Conversion<::smoke::ErrorsInterface::ExternalErrors>::toCpp((uint32_t)_error_handle));
+        return make_error_code(gluecodium::ffi::Conversion<::smoke::ErrorsInterface::ExternalErrors>::toCpp(_error_flag ? (uint32_t)_error_handle : 0));
     }
     gluecodium::Return<std::string, std::error_code>
     method_with_errors_and_return_value() override {
@@ -52,7 +52,7 @@ public:
             &_error_handle
         ); });
         if (_error_flag) {
-            return make_error_code(gluecodium::ffi::Conversion<::smoke::ErrorsInterface::InternalError>::toCpp((uint32_t)_error_handle));
+            return make_error_code(gluecodium::ffi::Conversion<::smoke::ErrorsInterface::InternalError>::toCpp(_error_flag ? (uint32_t)_error_handle : 0));
         } else {
             auto _result = gluecodium::ffi::Conversion<std::string>::toCpp(_result_handle);
             delete reinterpret_cast<std::string*>(_result_handle);


### PR DESCRIPTION
Updated Dart FFI template to correctly return a "0" error value in case
of no error from functions declared in IDL as both `void` and `throws`
with an enum-based exception type.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>