### PR TITLE
Add support for Locale type to Dart generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for system Locale type in Java/Swift/Dart.
+
 ## 7.0.5
 Release date: 2020-06-04
 ### Bug fixes:

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -411,7 +411,7 @@ feature(CppConst cpp android swift dart SOURCES
     src/test/CppConstMethods.cpp
 )
 
-feature(Locales cpp android swift SOURCES
+feature(Locales cpp android swift dart SOURCES
     src/test/Locales.cpp
 
     lime/test/Locales.lime

--- a/examples/libhello/src/test/Locales.cpp
+++ b/examples/libhello/src/test/Locales.cpp
@@ -58,21 +58,17 @@ Locales::get_locale_with_malformed_tag() {
 
 lorem_ipsum::test::Locale
 Locales::get_locale_with_malformed_language() {
-    return lorem_ipsum::test::Locale(lorem_ipsum::test::optional<std::string>(nonsense),
-                                     lorem_ipsum::test::optional<std::string>());
+    return lorem_ipsum::test::Locale(nonsense, "bar", "baz");
 }
 
 lorem_ipsum::test::Locale
 Locales::get_locale_with_malformed_country() {
-    return lorem_ipsum::test::Locale(lorem_ipsum::test::optional<std::string>(),
-                                     lorem_ipsum::test::optional<std::string>(nonsense));
+    return lorem_ipsum::test::Locale("foo", nonsense, "baz");
 }
 
 lorem_ipsum::test::Locale
 Locales::get_locale_with_malformed_script() {
-    return lorem_ipsum::test::Locale(lorem_ipsum::test::optional<std::string>(),
-                                     lorem_ipsum::test::optional<std::string>(),
-                                     lorem_ipsum::test::optional<std::string>(nonsense));
+    return lorem_ipsum::test::Locale("foo", "bar", nonsense);
 }
 
 }  // namespace test

--- a/examples/platforms/dart/main.dart
+++ b/examples/platforms/dart/main.dart
@@ -38,6 +38,7 @@ import "test/Listeners_test.dart" as ListenersTests;
 import "test/ListenersWithAttributes_test.dart" as ListenersWithAttributesTests;
 import "test/ListenersWithErrors_test.dart" as ListenersWithErrorsTests;
 import "test/ListenersWithReturnValues_test.dart" as ListenersWithReturnValuesTests;
+import "test/Locales_test.dart" as LocalesTests;
 import "test/Maps_test.dart" as MapsTests;
 import "test/MethodOverloads_test.dart" as MethodOverloadsTests;
 import "test/MultiListener_test.dart" as MultiListenerTests;
@@ -77,6 +78,7 @@ final _allTests = [
   ListenersWithAttributesTests.main,
   ListenersWithErrorsTests.main,
   ListenersWithReturnValuesTests.main,
+  LocalesTests.main,
   MapsTests.main,
   MethodOverloadsTests.main,
   MultiListenerTests.main,

--- a/examples/platforms/dart/test/Locales_test.dart
+++ b/examples/platforms/dart/test/Locales_test.dart
@@ -1,0 +1,76 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:intl/intl.dart";
+import "package:intl/locale.dart";
+import "package:test/test.dart";
+import "package:hello/test.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("Locales");
+
+void main() {
+  _testSuite.test("Locale method round trip", () {
+    final input = Locale.parse(Intl.systemLocale);
+
+    final result = Locales.localeRoundTrip(input);
+
+    expect(result, input);
+  });
+  _testSuite.test("Locale method round trip stip tag", () {
+    final input = Locale.parse(Intl.systemLocale);
+
+    final result = Locales.localeRoundTripStripTag(input);
+
+    expect(result, input);
+  });
+  _testSuite.test("Locale property round trip", () {
+    final input = Locale.parse(Intl.systemLocale);
+
+    Locales.localeProperty = input;
+    final result = Locales.localeProperty;
+
+    expect(result, input);
+  });
+  _testSuite.test("Nullable Locale null round trip", () {
+    final result = Locales.localeRoundTripNullable(null);
+
+    expect(result, isNull);
+  });
+  _testSuite.test("Nullable Locale non-null round trip", () {
+    final input = Locale.parse(Intl.systemLocale);
+
+    final result = Locales.localeRoundTripNullable(input);
+
+    expect(result, input);
+  });
+  _testSuite.test("Locale with malformed tag", () {
+    expect(() => Locales.localeWithMalformedTag, throwsFormatException);
+  });
+  _testSuite.test("Locale with malformed language", () {
+    expect(() => Locales.localeWithMalformedLanguage, throwsFormatException);
+  });
+  _testSuite.test("Locale with malformed country", () {
+    expect(() => Locales.localeWithMalformedCountry, throwsFormatException);
+  });
+  _testSuite.test("Locale with malformed script", () {
+    expect(() => Locales.localeWithMalformedScript, throwsFormatException);
+  });
+}

--- a/examples/platforms/ios/Tests/testTests/LocalesTests.swift
+++ b/examples/platforms/ios/Tests/testTests/LocalesTests.swift
@@ -77,13 +77,13 @@ class LocalesTests: XCTestCase {
     func testLocaleWithMalformedCountry() {
         let result = Locales.localeWithMalformedCountry
 
-        XCTAssertEqual(result.identifier, "_")
+        XCTAssertEqual(result.identifier, "foo-baz_")
     }
 
     func testLocaleWithMalformedScript() {
         let result = Locales.localeWithMalformedScript
 
-        XCTAssertEqual(result.identifier, "_")
+        XCTAssertEqual(result.identifier, "foo_")
     }
 
     static var allTests = [

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -173,7 +173,6 @@ class Gluecodium(
         ) && saveToDirectory(options.commonOutputDir, commonFiles)
     }
 
-    // TODO: #329 move all model validation here
     private fun validateModel(limeModel: LimeModel): Boolean {
         val limeLogger = LimeLogger(LOGGER, limeModel.fileNameMap)
         val typeRefsValidationResult = LimeTypeRefsValidator(limeLogger).validate(limeModel)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -307,8 +307,7 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
         val templateData = mapOf(
             "libraryName" to libraryName,
             "builtInTypes" to
-                LimeBasicType.TypeId.values().filterNot { it == LimeBasicType.TypeId.VOID }
-                    .filterNot { it == LimeBasicType.TypeId.LOCALE /* TODO */ },
+                LimeBasicType.TypeId.values().filterNot { it == LimeBasicType.TypeId.VOID },
             "typeRepositories" to typeRepositories,
             "imports" to
                 typeRepositories.flatMap { importResolver.resolveImports(it) }.distinct().sorted()
@@ -352,13 +351,14 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
     ): List<GeneratedFile> {
         val headerOnly = listOf("ConversionBase", "Export", "OpaqueHandle")
         val headerAndImpl = listOf(
-            "StringHandle",
             "BlobHandle",
-            "NullableHandles",
-            "IsolateContext",
             "CallbacksQueue",
             "CallbacksHandle",
-            "ProxyCache"
+            "IsolateContext",
+            "LocaleHandle",
+            "NullableHandles",
+            "ProxyCache",
+            "StringHandle"
         )
         val data = mapOf(
             "libraryName" to libraryName,
@@ -366,7 +366,6 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
             "internalNamespace" to internalNamespace,
             "builtInTypes" to
                 LimeBasicType.TypeId.values().filterNot { it == LimeBasicType.TypeId.VOID }
-                    .filterNot { it == LimeBasicType.TypeId.LOCALE /* TODO */ }
         )
 
         return headerOnly.map {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
@@ -84,6 +84,7 @@ internal class DartImportResolver(
         listOf(builtInTypesConversionImport) +
             when (limeType.typeId) {
                 LimeBasicType.TypeId.BLOB -> listOf(DartImport("typed_data", isSystem = true))
+                LimeBasicType.TypeId.LOCALE -> listOf(DartImport("intl/locale"))
                 else -> emptyList()
             }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/FfiApiTypeNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/FfiApiTypeNameResolver.kt
@@ -70,7 +70,7 @@ internal class FfiApiTypeNameResolver : NameResolver {
             TypeId.STRING -> OPAQUE_HANDLE_TYPE
             TypeId.BLOB -> OPAQUE_HANDLE_TYPE
             TypeId.DATE -> "Uint64"
-            TypeId.LOCALE -> TODO()
+            TypeId.LOCALE -> OPAQUE_HANDLE_TYPE
         }
 
     companion object {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/FfiDartTypeNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/FfiDartTypeNameResolver.kt
@@ -70,7 +70,7 @@ internal class FfiDartTypeNameResolver : NameResolver {
             TypeId.STRING -> OPAQUE_HANDLE_TYPE
             TypeId.BLOB -> OPAQUE_HANDLE_TYPE
             TypeId.DATE -> "int"
-            TypeId.LOCALE -> TODO()
+            TypeId.LOCALE -> OPAQUE_HANDLE_TYPE
         }
 
     companion object {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppNameResolver.kt
@@ -122,7 +122,7 @@ internal class FfiCppNameResolver(
             TypeId.STRING -> "std::string"
             TypeId.BLOB -> "std::shared_ptr<std::vector<uint8_t>>"
             TypeId.DATE -> "std::chrono::system_clock::time_point"
-            TypeId.LOCALE -> TODO()
+            TypeId.LOCALE -> "$internalNamespace::Locale"
         }
 
     private fun getFieldName(limeField: LimeField) =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiNameResolver.kt
@@ -102,7 +102,7 @@ internal class FfiNameResolver(
             TypeId.STRING -> OPAQUE_HANDLE_TYPE
             TypeId.BLOB -> OPAQUE_HANDLE_TYPE
             TypeId.DATE -> "uint64_t"
-            TypeId.LOCALE -> TODO()
+            TypeId.LOCALE -> OPAQUE_HANDLE_TYPE
         }
 
     private fun getListName(elementType: LimeTypeRef) =

--- a/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
@@ -23,6 +23,7 @@
 import 'dart:ffi';
 import 'dart:typed_data';
 import 'package:ffi/ffi.dart';
+import 'package:intl/locale.dart';
 
 import 'package:{{libraryName}}/src/_library_context.dart' as __lib;
 
@@ -53,7 +54,6 @@ Pointer<Void> Blob_toFfi(Uint8List list) {
 
 Uint8List Blob_fromFfi(Pointer<Void> handle) =>
   Uint8List.fromList(_Blob_get_data_pointer(handle).asTypedList(_Blob_get_length(handle)));
-
 
 void Blob_releaseFfiHandle(Pointer<Void> handle) => _Blob_release_handle(handle);
 
@@ -98,6 +98,71 @@ Pointer<Void> String_toFfi(String value) {
 String String_fromFfi(Pointer<Void> handle) => Utf8.fromUtf8(_String_get_value(handle));
 
 void String_releaseFfiHandle(Pointer<Void> handle) => _String_release_handle(handle);
+
+// Locale
+
+final _Locale_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+    Pointer<Void> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  >('{{libraryName}}_locale_create_handle');
+final _Locale_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('{{libraryName}}_locale_release_handle');
+final _Locale_get_language_code = __lib.nativeLibrary.lookupFunction<
+    Pointer<Utf8> Function(Pointer<Void>),
+    Pointer<Utf8> Function(Pointer<Void>)
+>('{{libraryName}}_locale_get_language_code');
+final _Locale_get_country_code = __lib.nativeLibrary.lookupFunction<
+    Pointer<Utf8> Function(Pointer<Void>),
+    Pointer<Utf8> Function(Pointer<Void>)
+>('{{libraryName}}_locale_get_country_code');
+final _Locale_get_script_code = __lib.nativeLibrary.lookupFunction<
+    Pointer<Utf8> Function(Pointer<Void>),
+    Pointer<Utf8> Function(Pointer<Void>)
+>('{{libraryName}}_locale_get_script_code');
+final _Locale_get_language_tag = __lib.nativeLibrary.lookupFunction<
+    Pointer<Utf8> Function(Pointer<Void>),
+    Pointer<Utf8> Function(Pointer<Void>)
+>('{{libraryName}}_locale_get_language_tag');
+
+Pointer<Void> Locale_toFfi(Locale locale) {
+  final cLanguageCode = Utf8.toUtf8(locale.languageCode);
+  final cCountryCode =
+    locale.countryCode != null ? Utf8.toUtf8(locale.countryCode) : Pointer<Utf8>.fromAddress(0);
+  final cScriptCode =
+    locale.scriptCode != null ? Utf8.toUtf8(locale.scriptCode) : Pointer<Utf8>.fromAddress(0);
+  final cLanguageTag = Utf8.toUtf8(locale.toLanguageTag());
+
+  final result = _Locale_create_handle(cLanguageCode, cCountryCode, cScriptCode, cLanguageTag);
+
+  free(cLanguageCode);
+  if (cCountryCode.address != 0) free(cCountryCode);
+  if (cScriptCode.address != 0) free(cScriptCode);
+  free(cLanguageTag);
+
+  return result;
+}
+
+Locale Locale_fromFfi(Pointer<Void> handle) {
+  final languageTagCstring = _Locale_get_language_tag(handle);
+  if (languageTagCstring.address != 0) {
+    // BCP 47 language tag takes precedence if present.
+    return Locale.parse(Utf8.fromUtf8(languageTagCstring));
+  }
+
+  final languageCodeCstring = _Locale_get_language_code(handle);
+  final countryCodeCstring = _Locale_get_country_code(handle);
+  final scriptCodeCstring = _Locale_get_script_code(handle);
+
+  return Locale.fromSubtags(
+    languageCode: languageCodeCstring.address != 0 ? Utf8.fromUtf8(languageCodeCstring) : null,
+    countryCode: countryCodeCstring.address != 0 ? Utf8.fromUtf8(countryCodeCstring) : null,
+    scriptCode: scriptCodeCstring.address != 0 ? Utf8.fromUtf8(scriptCodeCstring) : null
+  );
+}
+
+void Locale_releaseFfiHandle(Pointer<Void> handle) => _Locale_release_handle(handle);
 
 {{#builtInTypes}}
 // Nullable {{this}}

--- a/gluecodium/src/main/resources/templates/dart/DartPubspec.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartPubspec.mustache
@@ -23,4 +23,5 @@ environment:
   sdk: '>=2.5.0 <3.0.0'
 dependencies:
   ffi:
+  intl:
   meta:

--- a/gluecodium/src/main/resources/templates/ffi/FfiLocaleHandleHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiLocaleHandleHeader.mustache
@@ -1,0 +1,46 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{>ffi/FfiCopyrightHeader}}
+
+#pragma once
+
+#include "Export.h"
+#include "OpaqueHandle.h"
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_locale_create_handle(
+    const char* language_code,
+    const char* country_code,
+    const char* script_code,
+    const char* language_tag);
+_GLUECODIUM_FFI_EXPORT void {{libraryName}}_locale_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT const char* {{libraryName}}_locale_get_language_code(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT const char* {{libraryName}}_locale_get_country_code(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT const char* {{libraryName}}_locale_get_script_code(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT const char* {{libraryName}}_locale_get_language_tag(FfiOpaqueHandle handle);
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/main/resources/templates/ffi/FfiLocaleHandleImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiLocaleHandleImpl.mustache
@@ -1,0 +1,94 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{>ffi/FfiCopyrightHeader}}
+
+#include "LocaleHandle.h"
+
+#include "{{>common/InternalInclude}}Locale.h"
+#include "{{>common/InternalInclude}}Optional.h"
+#include <new>
+#include <string>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+FfiOpaqueHandle
+{{libraryName}}_locale_create_handle(const char* language_code,
+                                     const char* country_code,
+                                     const char* script_code,
+                                     const char* language_tag) {
+    auto language_code_optional = language_code != nullptr
+        ? {{>common/InternalNamespace}}optional<std::string>(std::string(language_code))
+        : {{>common/InternalNamespace}}optional<std::string>();
+    auto country_code_optional = country_code != nullptr
+        ? {{>common/InternalNamespace}}optional<std::string>(std::string(country_code))
+        : {{>common/InternalNamespace}}optional<std::string>();
+    auto script_code_optional = script_code != nullptr
+        ? {{>common/InternalNamespace}}optional<std::string>(std::string(script_code))
+        : {{>common/InternalNamespace}}optional<std::string>();
+    auto language_tag_optional = language_tag != nullptr
+        ? {{>common/InternalNamespace}}optional<std::string>(std::string(language_tag))
+        : {{>common/InternalNamespace}}optional<std::string>();
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) {{>common/InternalNamespace}}Locale(language_code_optional,
+                                                               country_code_optional,
+                                                               script_code_optional,
+                                                               language_tag_optional)
+    );
+}
+
+void
+{{libraryName}}_locale_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<{{>common/InternalNamespace}}Locale*>(handle);
+}
+
+const char*
+{{libraryName}}_locale_get_language_code(FfiOpaqueHandle handle) {
+    auto& language_code =
+        reinterpret_cast<{{>common/InternalNamespace}}Locale*>(handle)->language_code;
+    return language_code ? (*language_code).c_str() : nullptr;
+}
+
+const char*
+{{libraryName}}_locale_get_country_code(FfiOpaqueHandle handle) {
+    auto& country_code =
+        reinterpret_cast<{{>common/InternalNamespace}}Locale*>(handle)->country_code;
+    return country_code ? (*country_code).c_str() : nullptr;
+}
+
+const char*
+{{libraryName}}_locale_get_script_code(FfiOpaqueHandle handle) {
+    auto& script_code =
+        reinterpret_cast<{{>common/InternalNamespace}}Locale*>(handle)->script_code;
+    return script_code ? (*script_code).c_str() : nullptr;
+}
+
+const char*
+{{libraryName}}_locale_get_language_tag(FfiOpaqueHandle handle) {
+    auto& language_tag =
+        reinterpret_cast<{{>common/InternalNamespace}}Locale*>(handle)->language_tag;
+    return language_tag ? (*language_tag).c_str() : nullptr;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/main/resources/templates/ffi/FfiNullableHandlesImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiNullableHandlesImpl.mustache
@@ -23,6 +23,7 @@
 #include "NullableHandles.h"
 
 #include "ConversionBase.h"
+#include "{{>common/InternalInclude}}Locale.h"
 #include "{{>common/InternalInclude}}Optional.h"
 #include <chrono>
 #include <memory>

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/builtin_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/builtin_types__conversion.dart
@@ -1,6 +1,7 @@
 import 'dart:ffi';
 import 'dart:typed_data';
 import 'package:ffi/ffi.dart';
+import 'package:intl/locale.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 // Blob
 final _Blob_create_handle = __lib.nativeLibrary.lookupFunction<
@@ -56,6 +57,61 @@ Pointer<Void> String_toFfi(String value) {
 }
 String String_fromFfi(Pointer<Void> handle) => Utf8.fromUtf8(_String_get_value(handle));
 void String_releaseFfiHandle(Pointer<Void> handle) => _String_release_handle(handle);
+// Locale
+final _Locale_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+    Pointer<Void> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  >('library_locale_create_handle');
+final _Locale_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_locale_release_handle');
+final _Locale_get_language_code = __lib.nativeLibrary.lookupFunction<
+    Pointer<Utf8> Function(Pointer<Void>),
+    Pointer<Utf8> Function(Pointer<Void>)
+>('library_locale_get_language_code');
+final _Locale_get_country_code = __lib.nativeLibrary.lookupFunction<
+    Pointer<Utf8> Function(Pointer<Void>),
+    Pointer<Utf8> Function(Pointer<Void>)
+>('library_locale_get_country_code');
+final _Locale_get_script_code = __lib.nativeLibrary.lookupFunction<
+    Pointer<Utf8> Function(Pointer<Void>),
+    Pointer<Utf8> Function(Pointer<Void>)
+>('library_locale_get_script_code');
+final _Locale_get_language_tag = __lib.nativeLibrary.lookupFunction<
+    Pointer<Utf8> Function(Pointer<Void>),
+    Pointer<Utf8> Function(Pointer<Void>)
+>('library_locale_get_language_tag');
+Pointer<Void> Locale_toFfi(Locale locale) {
+  final cLanguageCode = Utf8.toUtf8(locale.languageCode);
+  final cCountryCode =
+    locale.countryCode != null ? Utf8.toUtf8(locale.countryCode) : Pointer<Utf8>.fromAddress(0);
+  final cScriptCode =
+    locale.scriptCode != null ? Utf8.toUtf8(locale.scriptCode) : Pointer<Utf8>.fromAddress(0);
+  final cLanguageTag = Utf8.toUtf8(locale.toLanguageTag());
+  final result = _Locale_create_handle(cLanguageCode, cCountryCode, cScriptCode, cLanguageTag);
+  free(cLanguageCode);
+  if (cCountryCode.address != 0) free(cCountryCode);
+  if (cScriptCode.address != 0) free(cScriptCode);
+  free(cLanguageTag);
+  return result;
+}
+Locale Locale_fromFfi(Pointer<Void> handle) {
+  final languageTagCstring = _Locale_get_language_tag(handle);
+  if (languageTagCstring.address != 0) {
+    // BCP 47 language tag takes precedence if present.
+    return Locale.parse(Utf8.fromUtf8(languageTagCstring));
+  }
+  final languageCodeCstring = _Locale_get_language_code(handle);
+  final countryCodeCstring = _Locale_get_country_code(handle);
+  final scriptCodeCstring = _Locale_get_script_code(handle);
+  return Locale.fromSubtags(
+    languageCode: languageCodeCstring.address != 0 ? Utf8.fromUtf8(languageCodeCstring) : null,
+    countryCode: countryCodeCstring.address != 0 ? Utf8.fromUtf8(countryCodeCstring) : null,
+    scriptCode: scriptCodeCstring.address != 0 ? Utf8.fromUtf8(scriptCodeCstring) : null
+  );
+}
+void Locale_releaseFfiHandle(Pointer<Void> handle) => _Locale_release_handle(handle);
 // Nullable Byte
 final _Byte_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int8),
@@ -428,3 +484,31 @@ DateTime Date_fromFfi_nullable(Pointer<Void> handle) {
   return result;
 }
 void Date_releaseFfiHandle_nullable(Pointer<Void> handle) => _Date_release_handle_nullable(handle);
+// Nullable Locale
+final _Locale_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_Locale_create_handle_nullable');
+final _Locale_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_Locale_release_handle_nullable');
+final _Locale_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_Locale_get_value_nullable');
+Pointer<Void> Locale_toFfi_nullable(Locale value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = Locale_toFfi(value);
+  final result = _Locale_create_handle_nullable(_handle);
+  Locale_releaseFfiHandle(_handle);
+  return result;
+}
+Locale Locale_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _Locale_get_value_nullable(handle);
+  final result = Locale_fromFfi(_handle);
+  Locale_releaseFfiHandle(_handle);
+  return result;
+}
+void Locale_releaseFfiHandle_nullable(Pointer<Void> handle) => _Locale_release_handle_nullable(handle);

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/ffi/ffi_smoke_Locales.cpp
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/ffi/ffi_smoke_Locales.cpp
@@ -1,0 +1,91 @@
+#include "ffi_smoke_Locales.h"
+#include "ConversionBase.h"
+#include "IsolateContext.h"
+#include "smoke/Locales.h"
+#include <cstdint>
+#include <memory>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+library_smoke_Locales_localeMethod__Locale(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<gluecodium::Locale>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<::smoke::Locales>>::toCpp(_self)).locale_method(
+            gluecodium::ffi::Conversion<gluecodium::Locale>::toCpp(input)
+        )
+    );
+}
+FfiOpaqueHandle
+library_smoke_Locales_localeProperty_get(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<gluecodium::Locale>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<::smoke::Locales>>::toCpp(_self)).get_locale_property()
+    );
+}
+void
+library_smoke_Locales_localeProperty_set__Locale(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle value) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<::smoke::Locales>>::toCpp(_self)).set_locale_property(
+            gluecodium::ffi::Conversion<gluecodium::Locale>::toCpp(value)
+        );
+}
+FfiOpaqueHandle
+library_smoke_Locales_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::Locales>(
+            *reinterpret_cast<std::shared_ptr<::smoke::Locales>*>(handle)
+        )
+    );
+}
+void
+library_smoke_Locales_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::Locales>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_Locales_get_raw_pointer(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        reinterpret_cast<std::shared_ptr<::smoke::Locales>*>(handle)->get()
+    );
+}
+FfiOpaqueHandle
+library_smoke_Locales_LocaleStruct_create_handle(FfiOpaqueHandle localeField) {
+    auto _result = new (std::nothrow) ::smoke::Locales::LocaleStruct(gluecodium::ffi::Conversion<gluecodium::Locale>::toCpp(localeField));
+    return reinterpret_cast<FfiOpaqueHandle>(_result);
+}
+void
+library_smoke_Locales_LocaleStruct_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<::smoke::Locales::LocaleStruct*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_Locales_LocaleStruct_get_field_localeField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<gluecodium::Locale>::toFfi(
+        reinterpret_cast<::smoke::Locales::LocaleStruct*>(handle)->locale_field
+    );
+}
+FfiOpaqueHandle
+library_smoke_Locales_LocaleStruct_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<::smoke::Locales::LocaleStruct>(
+            gluecodium::ffi::Conversion<::smoke::Locales::LocaleStruct>::toCpp(value)
+        )
+    );
+}
+void
+library_smoke_Locales_LocaleStruct_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<::smoke::Locales::LocaleStruct>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_Locales_LocaleStruct_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<::smoke::Locales::LocaleStruct>::toFfi(
+        **reinterpret_cast<gluecodium::optional<::smoke::Locales::LocaleStruct>*>(handle)
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -1,0 +1,163 @@
+import 'package:intl/locale.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+abstract class Locales {
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+  Locale localeMethod(Locale input);
+  Locale get localeProperty;
+  set localeProperty(Locale value);
+}
+class Locales_LocaleStruct {
+  Locale localeField;
+  Locales_LocaleStruct(this.localeField);
+}
+// Locales_LocaleStruct "private" section, not exported.
+final _smoke_Locales_LocaleStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Locales_LocaleStruct_create_handle');
+final _smoke_Locales_LocaleStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Locales_LocaleStruct_release_handle');
+final _smoke_Locales_LocaleStruct_get_field_localeField = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Locales_LocaleStruct_get_field_localeField');
+Pointer<Void> smoke_Locales_LocaleStruct_toFfi(Locales_LocaleStruct value) {
+  final _localeField_handle = Locale_toFfi(value.localeField);
+  final _result = _smoke_Locales_LocaleStruct_create_handle(_localeField_handle);
+  Locale_releaseFfiHandle(_localeField_handle);
+  return _result;
+}
+Locales_LocaleStruct smoke_Locales_LocaleStruct_fromFfi(Pointer<Void> handle) {
+  final _localeField_handle = _smoke_Locales_LocaleStruct_get_field_localeField(handle);
+  try {
+    return Locales_LocaleStruct(
+      Locale_fromFfi(_localeField_handle)
+    );
+  } finally {
+    Locale_releaseFfiHandle(_localeField_handle);
+  }
+}
+void smoke_Locales_LocaleStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Locales_LocaleStruct_release_handle(handle);
+// Nullable Locales_LocaleStruct
+final _smoke_Locales_LocaleStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Locales_LocaleStruct_create_handle_nullable');
+final _smoke_Locales_LocaleStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Locales_LocaleStruct_release_handle_nullable');
+final _smoke_Locales_LocaleStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Locales_LocaleStruct_get_value_nullable');
+Pointer<Void> smoke_Locales_LocaleStruct_toFfi_nullable(Locales_LocaleStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_Locales_LocaleStruct_toFfi(value);
+  final result = _smoke_Locales_LocaleStruct_create_handle_nullable(_handle);
+  smoke_Locales_LocaleStruct_releaseFfiHandle(_handle);
+  return result;
+}
+Locales_LocaleStruct smoke_Locales_LocaleStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_Locales_LocaleStruct_get_value_nullable(handle);
+  final result = smoke_Locales_LocaleStruct_fromFfi(_handle);
+  smoke_Locales_LocaleStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_Locales_LocaleStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Locales_LocaleStruct_release_handle_nullable(handle);
+// End of Locales_LocaleStruct "private" section.
+// Locales "private" section, not exported.
+final _smoke_Locales_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Locales_copy_handle');
+final _smoke_Locales_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Locales_release_handle');
+final _smoke_Locales_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_Locales_get_raw_pointer');
+class Locales$Impl implements Locales {
+  @protected
+  Pointer<Void> handle;
+  Locales$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.reverseCache.remove(_smoke_Locales_get_raw_pointer(handle));
+    _smoke_Locales_release_handle(handle);
+    handle = null;
+  }
+  @override
+  Locale localeMethod(Locale input) {
+    final _localeMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeMethod__Locale');
+    final _input_handle = Locale_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _localeMethod_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
+    Locale_releaseFfiHandle(_input_handle);
+    try {
+      return Locale_fromFfi(__result_handle);
+    } finally {
+      Locale_releaseFfiHandle(__result_handle);
+    }
+  }
+  @override
+  Locale get localeProperty {
+    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Locales_localeProperty_get');
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return Locale_fromFfi(__result_handle);
+    } finally {
+      Locale_releaseFfiHandle(__result_handle);
+    }
+  }
+  @override
+  set localeProperty(Locale value) {
+    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeProperty_set__Locale');
+    final _value_handle = Locale_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
+    Locale_releaseFfiHandle(_value_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+}
+Pointer<Void> smoke_Locales_toFfi(Locales value) =>
+  _smoke_Locales_copy_handle((value as Locales$Impl).handle);
+Locales smoke_Locales_fromFfi(Pointer<Void> handle) {
+  final raw_handle = _smoke_Locales_get_raw_pointer(handle);
+  final instance = __lib.reverseCache[raw_handle] as Locales;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_Locales_copy_handle(handle);
+  final result = Locales$Impl(_copied_handle);
+  __lib.reverseCache[raw_handle] = result;
+  return result;
+}
+void smoke_Locales_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_Locales_release_handle(handle);
+Pointer<Void> smoke_Locales_toFfi_nullable(Locales value) =>
+  value != null ? smoke_Locales_toFfi(value) : Pointer<Void>.fromAddress(0);
+Locales smoke_Locales_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_Locales_fromFfi(handle) : null;
+void smoke_Locales_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Locales_release_handle(handle);
+// End of Locales "private" section.

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/ffi/NullableHandles.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/ffi/NullableHandles.cpp
@@ -1,5 +1,6 @@
 #include "NullableHandles.h"
 #include "ConversionBase.h"
+#include "gluecodium/Locale.h"
 #include "gluecodium/Optional.h"
 #include <chrono>
 #include <memory>
@@ -301,6 +302,27 @@ library_Date_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::chrono::system_clock::time_point>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_Locale_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<gluecodium::Locale>(
+            gluecodium::ffi::Conversion<gluecodium::Locale>::toCpp(value)
+        )
+    );
+}
+void
+library_Locale_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<gluecodium::Locale>*>(handle);
+}
+FfiOpaqueHandle
+library_Locale_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<gluecodium::Locale>::toFfi(
+        **reinterpret_cast<gluecodium::optional<gluecodium::Locale>*>(handle)
     );
 }
 #ifdef __cplusplus

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/ffi/NullableHandles.h
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/ffi/NullableHandles.h
@@ -47,6 +47,9 @@ _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_Blob_get_value_nullable(FfiOpaque
 _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_Date_create_handle_nullable(uint64_t value);
 _GLUECODIUM_FFI_EXPORT void library_Date_release_handle_nullable(FfiOpaqueHandle handle);
 _GLUECODIUM_FFI_EXPORT uint64_t library_Date_get_value_nullable(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_Locale_create_handle_nullable(FfiOpaqueHandle value);
+_GLUECODIUM_FFI_EXPORT void library_Locale_release_handle_nullable(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_Locale_get_value_nullable(FfiOpaqueHandle handle);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Added support for Locale type for system `intl` package to Dart
generator. Added conversion functions for this type to Dart and FFI
templates. Added functional and smoke tests.

Resolves: #372
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>