### PR TITLE
Fix disambiguation of method parameters in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Features:
   * Added support for system Locale type in Java/Swift/Dart.
+### Bug fixes:
+  * Fixed resolution of doc comment links to method parameters of overloaded methods in Dart.
 
 ## 7.0.5
 Release date: 2020-06-04

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/cpp/CppModelBuilderCommentsTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/cpp/CppModelBuilderCommentsTest.kt
@@ -46,6 +46,7 @@ import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeParameter
+import com.here.gluecodium.model.lime.LimePath
 import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
 import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeReturnType
@@ -157,7 +158,7 @@ class CppModelBuilderCommentsTest {
     fun finishBuildingParameterReadsComment() {
         contextStack.injectResult(CppPrimitiveTypeRef.BOOL)
         val limeElement = LimeParameter(
-            EMPTY_PATH,
+            LimePath(emptyList(), listOf("foo")),
             typeRef = LimeBasicTypeRef.DOUBLE,
             comment = LimeComment("Foo"),
             attributes = deprecatedAttributes
@@ -173,7 +174,8 @@ class CppModelBuilderCommentsTest {
     @Test
     fun finishBuildingParameterReadsNotNull() {
         contextStack.injectResult(CppPrimitiveTypeRef.BOOL)
-        val limeElement = LimeParameter(EMPTY_PATH, typeRef = limeContainerTypeRef)
+        val limeElement =
+            LimeParameter(LimePath(emptyList(), listOf("foo")), typeRef = limeContainerTypeRef)
 
         modelBuilder.finishBuilding(limeElement)
 

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/cpp/CppModelBuilderTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/cpp/CppModelBuilderTest.kt
@@ -272,7 +272,8 @@ class CppModelBuilderTest {
     @Test
     fun finishBuildingParameterReadsNameAndType() {
         contextStack.injectResult(cppTypeRef)
-        val limeParameter = LimeParameter(EMPTY_PATH, typeRef = LimeBasicTypeRef.DOUBLE)
+        val limeParameter =
+            LimeParameter(LimePath(emptyList(), listOf("foo")), typeRef = LimeBasicTypeRef.DOUBLE)
 
         modelBuilder.finishBuilding(limeParameter)
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -30,7 +30,7 @@ abstract class CommentsLinks {
   /// * method: [someMethodWithAllComments]
   /// * method with signature: [oneParameterCommentOnly]
   /// * method with signature with no spaces: [oneParameterCommentOnly]
-  /// * parameter: [inputParameter]
+  /// * parameter: [CommentsLinks.randomMethod.inputParameter]
   /// * top level constant: [CommentsTypeCollection.typeCollectionConstant]
   /// * top level struct: [TypeCollectionStruct]
   /// * top level struct field: [TypeCollectionStruct.field]

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -501,7 +501,7 @@ internal class AntlrLimeModelBuilder(
     private fun pushPathAndVisibility(
         simpleId: LimeParser.SimpleIdContext,
         visibility: LimeParser.VisibilityContext?,
-        suffix: String = ""
+        suffix: String? = null
     ) {
         pathStack.push(currentPath.child(convertSimpleId(simpleId), suffix))
         visibilityStack.push(convertVisibility(visibility, visibilityStack.peek()))

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeBasicType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeBasicType.kt
@@ -47,6 +47,9 @@ class LimeBasicType(val typeId: TypeId) : LimeType(path = LimePath.EMPTY_PATH) {
     override val name
         get() = typeId.toString()
 
+    override val fullName: String
+        get() = name
+
     override val escapedName
         get() = name
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeParameter.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeParameter.kt
@@ -24,4 +24,7 @@ class LimeParameter(
     comment: LimeComment = LimeComment(),
     attributes: LimeAttributes? = null,
     typeRef: LimeTypeRef
-) : LimeTypedElement(path, LimeVisibility.PUBLIC, comment, attributes, typeRef)
+) : LimeTypedElement(path, LimeVisibility.PUBLIC, comment, attributes, typeRef) {
+    override val fullName: String
+        get() = "${path.parent.withSuffix(path.disambiguator)}.${path.name}"
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimePath.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimePath.kt
@@ -32,7 +32,7 @@ package com.here.gluecodium.model.lime
 data class LimePath(
     val head: List<String>,
     val tail: List<String>,
-    private val disambiguationSuffix: String = ""
+    val disambiguator: String = ""
 ) {
     val container
         get() = tail.first()
@@ -50,15 +50,16 @@ data class LimePath(
     val hasParent
         get() = tail.size > 1
 
-    fun child(childName: String, disambiguationSuffix: String = "") =
-        LimePath(head, tail + childName, disambiguationSuffix)
+    fun child(childName: String, disambiguator: String? = null) =
+        LimePath(head, tail + childName, disambiguator ?: this.disambiguator)
 
-    fun child(childNames: List<String>, disambiguationSuffix: String = "") =
-        LimePath(head, tail + childNames, disambiguationSuffix)
+    fun child(childNames: List<String>, disambiguator: String? = null) =
+        LimePath(head, tail + childNames, disambiguator ?: this.disambiguator)
 
-    fun withSuffix(disambiguationSuffix: String) = LimePath(head, tail, disambiguationSuffix)
+    fun withSuffix(disambiguator: String) = LimePath(head, tail, disambiguator)
 
-    override fun toString() = (head + tail).joinToString(separator = ".") + disambiguationSuffix
+    override fun toString() = (head + tail).joinToString(separator = ".") +
+        if (disambiguator.isNotEmpty()) ":$disambiguator" else ""
 
     companion object {
         val EMPTY_PATH = LimePath(emptyList(), emptyList())


### PR DESCRIPTION
Updated LimePath class to expose "disambiguator" (user-invisible tag
that disambiguates method overloads) as public. Also changed `child()`
methods of LimePath to "inherit" the disambiguator when a child path is
created.

Updated DartNameResolver to use this new functionality to correctly
determine which method a parameter belongs to, in case of method
overloads (previously it was impossible due to disambiguation
information being lost in `LimeParameter.path`). This fixes doc comment
links to such parameters in Dart (as seen in the updated smoke test).

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>