### PR TITLE
Adds workaround for Flutter's bug to perform hot restart.

### DIFF
--- a/gluecodium/src/main/resources/templates/dart/DartLibraryContext.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLibraryContext.mustache
@@ -71,6 +71,12 @@ enum IsolateOrigin {
   spawned
 }
 
+enum WaitCallbackResult {
+  stopped,
+  hasIncoming,
+  timedOut
+}
+
 class LibraryContext {
   static int get isolateId => _isolateId;
 
@@ -96,9 +102,14 @@ class LibraryContext {
 
   static void _slaveIsolate(_SlaveIsolateMessage message) {
     _loadCustomLibrary(message.nativeLibraryPath);
-    while (_library_wait_for_callbacks(message.isolateId) != 0) {
-      message.port.send(1);
-    }
+
+    WaitCallbackResult waitResult = WaitCallbackResult.stopped;
+    do {
+      waitResult = WaitCallbackResult.values[_library_wait_for_callbacks(message.isolateId)];
+      if (waitResult == WaitCallbackResult.hasIncoming) {
+        message.port.send(1);
+      }
+    } while (waitResult != WaitCallbackResult.stopped);
     message.port.send(0);
   }
 

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksHandleHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksHandleHeader.mustache
@@ -31,7 +31,7 @@ extern "C" {
 
 _GLUECODIUM_FFI_EXPORT int32_t {{libraryName}}_library_callbacks_queue_init(bool is_main_isolate);
 _GLUECODIUM_FFI_EXPORT void {{libraryName}}_library_callbacks_queue_release(int32_t isolate_id);
-_GLUECODIUM_FFI_EXPORT bool {{libraryName}}_library_wait_for_callbacks(int32_t isolate_id);
+_GLUECODIUM_FFI_EXPORT uint8_t {{libraryName}}_library_wait_for_callbacks(int32_t isolate_id);
 _GLUECODIUM_FFI_EXPORT void {{libraryName}}_library_execute_callbacks(int32_t isolate_id);
 
 #ifdef __cplusplus

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksHandleImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksHandleImpl.mustache
@@ -24,16 +24,27 @@
 
 #include "CallbacksQueue.h"
 
+namespace {
+// Due to the bug in Flutter (https://github.com/flutter/flutter/issues/58987)
+// any hot restart which follows the first hangs if isolate is waiting
+// for event in C++. This workaround makes waiting for callback non blocking
+// so execution periodically returns to Flutter and the issue is eliminated.
+std::chrono::milliseconds g_wait_timeout = std::chrono::milliseconds::zero();
+bool g_is_first_init = true;
+}
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int32_t
 {{libraryName}}_library_callbacks_queue_init(bool is_main_isolate) {
-    if (is_main_isolate) {
+    if (is_main_isolate && !g_is_first_init) {
         // This is required to clean up after hot restart.
         {{>ffi/FfiInternal}}::cbqm.closeAllQueues();
+        g_wait_timeout = std::chrono::seconds(1);
     }
+    g_is_first_init = false;
     return {{>ffi/FfiInternal}}::cbqm.createQueue();
 }
 
@@ -42,10 +53,12 @@ void
     {{>ffi/FfiInternal}}::cbqm.closeQueue(isolate_id);
 }
 
-bool
+uint8_t
 {{libraryName}}_library_wait_for_callbacks(int32_t isolate_id) {
-    auto queue = {{>ffi/FfiInternal}}::cbqm.getQueue(isolate_id);
-    return queue && queue->waitForIncoming();
+    if (auto queue = {{>ffi/FfiInternal}}::cbqm.getQueue(isolate_id)) {
+      return static_cast<uint8_t>(queue->waitForIncoming(g_wait_timeout));
+    }
+    return static_cast<uint8_t>({{>ffi/FfiInternal}}::CallbackQueue::WaitResult::Stopped);
 }
 
 void

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <future>
 #include <memory>
@@ -56,13 +57,21 @@ private:
     std::condition_variable m_notified;
 
 public:
+    enum class WaitResult {
+        Stopped,      // Queue is stopped
+        HasIncoming,  // Queue has incomming messages
+        TimedOut      // Wait operation is timed out
+    };
+
     /**
-     * Block until there is a callback in incoming or the queue is closed.
+     * Block until there is a callback in incoming or the queue is closed
+     * or given timeout is over.
      * The incoming callbacks are moved to scheduled.
      *
-     * Returns false if queue was closed.
+     * Returns result of operation as value of WaitResult enumeration.  
      */
-    bool waitForIncoming();
+
+    WaitResult waitForIncoming(const std::chrono::milliseconds& timeout);
 
     /**
      * Execute scheduled callbacks on current thread.

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueImpl.mustache
@@ -51,19 +51,25 @@ CallbackQueue::enqueueIncoming(std::function<void()> func)
     return m_queue.back().done.get_future();
 }
 
-bool
-CallbackQueue::waitForIncoming()
+CallbackQueue::WaitResult
+CallbackQueue::waitForIncoming(const std::chrono::milliseconds& timeout)
 {
     std::unique_lock<std::mutex> lock(m_mutex);
 
-    m_notified.wait(lock, [this] { return m_has_incoming || m_is_closed; });
+    auto check_condition = [this] { return m_has_incoming || m_is_closed; };
+
+    if (timeout == std::chrono::milliseconds::zero()) {
+        m_notified.wait(lock, check_condition);
+    } else if (!m_notified.wait_for(lock, timeout, check_condition)) {
+        return WaitResult::TimedOut;
+    }
 
     if (m_is_closed) {
-        return false;
+        return WaitResult::Stopped;
     }
 
     m_has_incoming = false;
-    return true;
+    return WaitResult::HasIncoming;
 }
 
 void


### PR DESCRIPTION
The bug is registered: https://github.com/flutter/flutter/issues/58987
Workarounds makes wait to callbacks with timeout so
execution returns to Flutter periodically and Flutter is
able to process hot restart.