### PR TITLE
Include isolate ID in proxy cache key in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Added support for system Locale type in Java/Swift/Dart.
 ### Bug fixes:
   * Fixed resolution of doc comment links to method parameters of overloaded methods in Dart.
+  * Fixed runtime issue with stale cache entries in Dart.
 
 ## 7.0.5
 Release date: 2020-06-04

--- a/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
@@ -114,7 +114,7 @@ FfiOpaqueHandle
 }}{{#if inheritedProperties properties logic="or"}}, {{!!
 }}{{#each inheritedProperties properties}}FfiOpaqueHandle p{{iter.position}}g{{!!
 }}{{#if setter}}, FfiOpaqueHandle p{{iter.position}}s{{/if}}{{#if iter.hasNext}}, {{/if}}{{/each}}{{/if}}) {
-    auto cached_proxy = {{>ffi/FfiInternal}}::get_cached_proxy<{{resolveName}}_Proxy>(token, "{{resolveName}}");
+    auto cached_proxy = {{>ffi/FfiInternal}}::get_cached_proxy<{{resolveName}}_Proxy>(token, isolate_id, "{{resolveName}}");
     std::shared_ptr<{{resolveName}}_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<{{resolveName}}_Proxy>(cached_proxy);
@@ -126,7 +126,7 @@ FfiOpaqueHandle
             }}{{#each inheritedProperties properties}}p{{iter.position}}g{{!!
             }}{{#if setter}}, p{{iter.position}}s{{/if}}{{#if iter.hasNext}}, {{/if}}{{/each}}{{/if}})
         );
-        {{>ffi/FfiInternal}}::cache_proxy(token, "{{resolveName}}", *proxy_ptr);
+        {{>ffi/FfiInternal}}::cache_proxy(token, isolate_id, "{{resolveName}}", *proxy_ptr);
     }
 
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
@@ -137,10 +137,10 @@ FfiOpaqueHandle
 FfiOpaqueHandle
 {{libraryName}}_{{resolveName}}_create_proxy({{!!
 }}uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = {{>ffi/FfiInternal}}::get_cached_proxy<{{resolveName}}_Proxy>(token, "{{resolveName}}");
+    auto cached_proxy = {{>ffi/FfiInternal}}::get_cached_proxy<{{resolveName}}_Proxy>(token, isolate_id, "{{resolveName}}");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<{{resolveName}}_Proxy>(token, isolate_id, deleter, f0);
-        {{>ffi/FfiInternal}}::cache_proxy(token, "{{resolveName}}", cached_proxy);
+        {{>ffi/FfiInternal}}::cache_proxy(token, isolate_id, "{{resolveName}}", cached_proxy);
     }
 
     return reinterpret_cast<FfiOpaqueHandle>(

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyCacheHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyCacheHeader.mustache
@@ -36,11 +36,12 @@ namespace ffi
 struct ProxyCacheKey
 {
     uint64_t token;
+    int32_t isolate_id;
     std::string type_key;
 
     bool
     operator==(const ProxyCacheKey& other) const {
-        return token == other.token && type_key == other.type_key;
+        return token == other.token && isolate_id == other.isolate_id && type_key == other.type_key;
     }
 };
 
@@ -50,6 +51,7 @@ struct ProxyCacheKeyHash
     operator()(const ProxyCacheKey& key) const {
         size_t result = 7;
         result = 31 * result + key.token;
+        result = 31 * result + key.isolate_id;
         result = 31 * result + std::hash<::std::string>{}(key.type_key);
         return result;
     }
@@ -60,9 +62,9 @@ extern std::mutex _cache_mutex;
 
 template<class T>
 std::shared_ptr<T>
-get_cached_proxy(uint64_t token, const std::string& type_key) {
+get_cached_proxy(uint64_t token, int32_t isolate_id, const std::string& type_key) {
     const std::lock_guard<std::mutex> lock(_cache_mutex);
-    auto iter = _proxy_cache.find({token, type_key});
+    auto iter = _proxy_cache.find({token, isolate_id, type_key});
     return (iter != _proxy_cache.end())
         ? std::static_pointer_cast<T>(iter->second.lock())
         : std::shared_ptr<T>{};
@@ -70,12 +72,13 @@ get_cached_proxy(uint64_t token, const std::string& type_key) {
 
 template<class T>
 void
-cache_proxy(uint64_t token, const std::string& type_key, std::shared_ptr<T> proxy) {
+cache_proxy(uint64_t token, int32_t isolate_id, const std::string& type_key, std::shared_ptr<T> proxy) {
     const std::lock_guard<std::mutex> lock(_cache_mutex);
-    _proxy_cache[{token, type_key}] = std::weak_ptr<void>(std::static_pointer_cast<void>(proxy));
+    _proxy_cache[{token, isolate_id, type_key}] =
+        std::weak_ptr<void>(std::static_pointer_cast<void>(proxy));
 }
 
-void remove_cached_proxy(uint64_t token, const std::string& type_key);
+void remove_cached_proxy(uint64_t token, int32_t isolate_id, const std::string& type_key);
 
 }
 {{#internalNamespace}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyCacheImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyCacheImpl.mustache
@@ -33,9 +33,9 @@ std::unordered_map<ProxyCacheKey, std::weak_ptr<void>, ProxyCacheKeyHash> _proxy
 std::mutex _cache_mutex{};
 
 void
-remove_cached_proxy(uint64_t token, const std::string& type_key) {
+remove_cached_proxy(uint64_t token, int32_t isolate_id, const std::string& type_key) {
     const std::lock_guard<std::mutex> lock(_cache_mutex);
-    _proxy_cache.erase({token, type_key});
+    _proxy_cache.erase({token, isolate_id, type_key});
 }
 
 }

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
@@ -33,7 +33,7 @@ public:
         }}{{#if setter}}, p{{iter.position}}s(p{{iter.position}}s){{/if}}{{#if iter.hasNext}}, {{/if}}{{/each}}{{/if}} { }
 
     ~{{resolveName}}_Proxy() {
-        {{>ffi/FfiInternal}}::remove_cached_proxy(token, "{{resolveName}}");
+        {{>ffi/FfiInternal}}::remove_cached_proxy(token, isolate_id, "{{resolveName}}");
 
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/ffi/ffi_smoke_EquatableInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/ffi/ffi_smoke_EquatableInterface.cpp
@@ -11,7 +11,7 @@ public:
     smoke_EquatableInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter)
         : token(token), isolate_id(isolate_id), deleter(deleter) { }
     ~smoke_EquatableInterface_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_EquatableInterface");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_EquatableInterface");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -63,7 +63,7 @@ library_smoke_EquatableInterface_are_equal(FfiOpaqueHandle handle1, FfiOpaqueHan
 }
 FfiOpaqueHandle
 library_smoke_EquatableInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_EquatableInterface_Proxy>(token, "smoke_EquatableInterface");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_EquatableInterface_Proxy>(token, isolate_id, "smoke_EquatableInterface");
     std::shared_ptr<smoke_EquatableInterface_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_EquatableInterface_Proxy>(cached_proxy);
@@ -71,7 +71,7 @@ library_smoke_EquatableInterface_create_proxy(uint64_t token, int32_t isolate_id
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_EquatableInterface_Proxy>(
             new (std::nothrow) smoke_EquatableInterface_Proxy(token, isolate_id, deleter)
         );
-        gluecodium::ffi::cache_proxy(token, "smoke_EquatableInterface", *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_EquatableInterface", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/ffi/ffi_smoke_ErrorsInterface.cpp
@@ -15,7 +15,7 @@ public:
     smoke_ErrorsInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0), f1(f1), f2(f2), f3(f3), f4(f4) { }
     ~smoke_ErrorsInterface_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_ErrorsInterface");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_ErrorsInterface");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -264,7 +264,7 @@ library_smoke_ErrorsInterface_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_ErrorsInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ErrorsInterface_Proxy>(token, "smoke_ErrorsInterface");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ErrorsInterface_Proxy>(token, isolate_id, "smoke_ErrorsInterface");
     std::shared_ptr<smoke_ErrorsInterface_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ErrorsInterface_Proxy>(cached_proxy);
@@ -272,7 +272,7 @@ library_smoke_ErrorsInterface_create_proxy(uint64_t token, int32_t isolate_id, F
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ErrorsInterface_Proxy>(
             new (std::nothrow) smoke_ErrorsInterface_Proxy(token, isolate_id, deleter, f0, f1, f2, f3, f4)
         );
-        gluecodium::ffi::cache_proxy(token, "smoke_ErrorsInterface", *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_ErrorsInterface", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/ffi/ffi_smoke_SimpleInterface.cpp
@@ -13,7 +13,7 @@ public:
     smoke_SimpleInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0), f1(f1) { }
     ~smoke_SimpleInterface_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_SimpleInterface");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_SimpleInterface");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -95,7 +95,7 @@ library_smoke_SimpleInterface_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_SimpleInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_SimpleInterface_Proxy>(token, "smoke_SimpleInterface");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_SimpleInterface_Proxy>(token, isolate_id, "smoke_SimpleInterface");
     std::shared_ptr<smoke_SimpleInterface_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_SimpleInterface_Proxy>(cached_proxy);
@@ -103,7 +103,7 @@ library_smoke_SimpleInterface_create_proxy(uint64_t token, int32_t isolate_id, F
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_SimpleInterface_Proxy>(
             new (std::nothrow) smoke_SimpleInterface_Proxy(token, isolate_id, deleter, f0, f1)
         );
-        gluecodium::ffi::cache_proxy(token, "smoke_SimpleInterface", *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_SimpleInterface", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_Lambdas.cpp
@@ -20,7 +20,7 @@ public:
     smoke_Lambdas_Producer_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_Producer_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_Lambdas_Producer");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_Lambdas_Producer");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -56,7 +56,7 @@ public:
     smoke_Lambdas_Confuser_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_Confuser_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_Lambdas_Confuser");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_Lambdas_Confuser");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -93,7 +93,7 @@ public:
     smoke_Lambdas_Consumer_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_Consumer_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_Lambdas_Consumer");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_Lambdas_Consumer");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -125,7 +125,7 @@ public:
     smoke_Lambdas_Indexer_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_Indexer_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_Lambdas_Indexer");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_Lambdas_Indexer");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -163,7 +163,7 @@ public:
     smoke_Lambdas_NullableConfuser_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_Lambdas_NullableConfuser_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_Lambdas_NullableConfuser");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_Lambdas_NullableConfuser");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -445,10 +445,10 @@ library_smoke_Lambdas_NullableConfuser_get_value_nullable(FfiOpaqueHandle handle
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_Producer_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Producer_Proxy>(token, "smoke_Lambdas_Producer");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Producer_Proxy>(token, isolate_id, "smoke_Lambdas_Producer");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_Lambdas_Producer_Proxy>(token, isolate_id, deleter, f0);
-        gluecodium::ffi::cache_proxy(token, "smoke_Lambdas_Producer", cached_proxy);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_Lambdas_Producer", cached_proxy);
     }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::Producer(
@@ -462,10 +462,10 @@ library_smoke_Lambdas_Producer_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_Confuser_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Confuser_Proxy>(token, "smoke_Lambdas_Confuser");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Confuser_Proxy>(token, isolate_id, "smoke_Lambdas_Confuser");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_Lambdas_Confuser_Proxy>(token, isolate_id, deleter, f0);
-        gluecodium::ffi::cache_proxy(token, "smoke_Lambdas_Confuser", cached_proxy);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_Lambdas_Confuser", cached_proxy);
     }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::Confuser(
@@ -479,10 +479,10 @@ library_smoke_Lambdas_Confuser_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_Consumer_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Consumer_Proxy>(token, "smoke_Lambdas_Consumer");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Consumer_Proxy>(token, isolate_id, "smoke_Lambdas_Consumer");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_Lambdas_Consumer_Proxy>(token, isolate_id, deleter, f0);
-        gluecodium::ffi::cache_proxy(token, "smoke_Lambdas_Consumer", cached_proxy);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_Lambdas_Consumer", cached_proxy);
     }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::Consumer(
@@ -496,10 +496,10 @@ library_smoke_Lambdas_Consumer_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_Indexer_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Indexer_Proxy>(token, "smoke_Lambdas_Indexer");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_Indexer_Proxy>(token, isolate_id, "smoke_Lambdas_Indexer");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_Lambdas_Indexer_Proxy>(token, isolate_id, deleter, f0);
-        gluecodium::ffi::cache_proxy(token, "smoke_Lambdas_Indexer", cached_proxy);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_Lambdas_Indexer", cached_proxy);
     }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::Indexer(
@@ -513,10 +513,10 @@ library_smoke_Lambdas_Indexer_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_Lambdas_NullableConfuser_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_NullableConfuser_Proxy>(token, "smoke_Lambdas_NullableConfuser");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_Lambdas_NullableConfuser_Proxy>(token, isolate_id, "smoke_Lambdas_NullableConfuser");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_Lambdas_NullableConfuser_Proxy>(token, isolate_id, deleter, f0);
-        gluecodium::ffi::cache_proxy(token, "smoke_Lambdas_NullableConfuser", cached_proxy);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_Lambdas_NullableConfuser", cached_proxy);
     }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::Lambdas::NullableConfuser(

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
@@ -13,7 +13,7 @@ public:
     smoke_StandaloneProducer_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_StandaloneProducer_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_StandaloneProducer");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_StandaloneProducer");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -89,10 +89,10 @@ library_smoke_StandaloneProducer_get_value_nullable(FfiOpaqueHandle handle)
 }
 FfiOpaqueHandle
 library_smoke_StandaloneProducer_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_StandaloneProducer_Proxy>(token, "smoke_StandaloneProducer");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_StandaloneProducer_Proxy>(token, isolate_id, "smoke_StandaloneProducer");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_StandaloneProducer_Proxy>(token, isolate_id, deleter, f0);
-        gluecodium::ffi::cache_proxy(token, "smoke_StandaloneProducer", cached_proxy);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_StandaloneProducer", cached_proxy);
     }
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::smoke::StandaloneProducer(

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_CalculatorListener.cpp
@@ -15,7 +15,7 @@ public:
     smoke_CalculatorListener_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4, FfiOpaqueHandle f5)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0), f1(f1), f2(f2), f3(f3), f4(f4), f5(f5) { }
     ~smoke_CalculatorListener_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_CalculatorListener");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_CalculatorListener");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -142,7 +142,7 @@ library_smoke_CalculatorListener_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_CalculatorListener_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4, FfiOpaqueHandle f5) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_CalculatorListener_Proxy>(token, "smoke_CalculatorListener");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_CalculatorListener_Proxy>(token, isolate_id, "smoke_CalculatorListener");
     std::shared_ptr<smoke_CalculatorListener_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_CalculatorListener_Proxy>(cached_proxy);
@@ -150,7 +150,7 @@ library_smoke_CalculatorListener_create_proxy(uint64_t token, int32_t isolate_id
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_CalculatorListener_Proxy>(
             new (std::nothrow) smoke_CalculatorListener_Proxy(token, isolate_id, deleter, f0, f1, f2, f3, f4, f5)
         );
-        gluecodium::ffi::cache_proxy(token, "smoke_CalculatorListener", *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_CalculatorListener", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenerWithProperties.cpp
@@ -17,7 +17,7 @@ public:
     smoke_ListenerWithProperties_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s, FfiOpaqueHandle p1g, FfiOpaqueHandle p1s, FfiOpaqueHandle p2g, FfiOpaqueHandle p2s, FfiOpaqueHandle p3g, FfiOpaqueHandle p3s, FfiOpaqueHandle p4g, FfiOpaqueHandle p4s, FfiOpaqueHandle p5g, FfiOpaqueHandle p5s, FfiOpaqueHandle p6g, FfiOpaqueHandle p6s)
         : token(token), isolate_id(isolate_id), deleter(deleter), p0g(p0g), p0s(p0s), p1g(p1g), p1s(p1s), p2g(p2g), p2s(p2s), p3g(p3g), p3s(p3s), p4g(p4g), p4s(p4s), p5g(p5g), p5s(p5s), p6g(p6g), p6s(p6s) { }
     ~smoke_ListenerWithProperties_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_ListenerWithProperties");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_ListenerWithProperties");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -270,7 +270,7 @@ library_smoke_ListenerWithProperties_get_raw_pointer(FfiOpaqueHandle handle) {
 }
 FfiOpaqueHandle
 library_smoke_ListenerWithProperties_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s, FfiOpaqueHandle p1g, FfiOpaqueHandle p1s, FfiOpaqueHandle p2g, FfiOpaqueHandle p2s, FfiOpaqueHandle p3g, FfiOpaqueHandle p3s, FfiOpaqueHandle p4g, FfiOpaqueHandle p4s, FfiOpaqueHandle p5g, FfiOpaqueHandle p5s, FfiOpaqueHandle p6g, FfiOpaqueHandle p6s) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ListenerWithProperties_Proxy>(token, "smoke_ListenerWithProperties");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ListenerWithProperties_Proxy>(token, isolate_id, "smoke_ListenerWithProperties");
     std::shared_ptr<smoke_ListenerWithProperties_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ListenerWithProperties_Proxy>(cached_proxy);
@@ -278,7 +278,7 @@ library_smoke_ListenerWithProperties_create_proxy(uint64_t token, int32_t isolat
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ListenerWithProperties_Proxy>(
             new (std::nothrow) smoke_ListenerWithProperties_Proxy(token, isolate_id, deleter, p0g, p0s, p1g, p1s, p2g, p2s, p3g, p3s, p4g, p4s, p5g, p5s, p6g, p6s)
         );
-        gluecodium::ffi::cache_proxy(token, "smoke_ListenerWithProperties", *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_ListenerWithProperties", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/ffi/ffi_smoke_ListenersWithReturnValues.cpp
@@ -16,7 +16,7 @@ public:
     smoke_ListenersWithReturnValues_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4, FfiOpaqueHandle f5, FfiOpaqueHandle f6)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0), f1(f1), f2(f2), f3(f3), f4(f4), f5(f5), f6(f6) { }
     ~smoke_ListenersWithReturnValues_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_ListenersWithReturnValues");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_ListenersWithReturnValues");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -185,7 +185,7 @@ library_smoke_ListenersWithReturnValues_get_raw_pointer(FfiOpaqueHandle handle) 
 }
 FfiOpaqueHandle
 library_smoke_ListenersWithReturnValues_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f2, FfiOpaqueHandle f3, FfiOpaqueHandle f4, FfiOpaqueHandle f5, FfiOpaqueHandle f6) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ListenersWithReturnValues_Proxy>(token, "smoke_ListenersWithReturnValues");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_ListenersWithReturnValues_Proxy>(token, isolate_id, "smoke_ListenersWithReturnValues");
     std::shared_ptr<smoke_ListenersWithReturnValues_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ListenersWithReturnValues_Proxy>(cached_proxy);
@@ -193,7 +193,7 @@ library_smoke_ListenersWithReturnValues_create_proxy(uint64_t token, int32_t iso
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_ListenersWithReturnValues_Proxy>(
             new (std::nothrow) smoke_ListenersWithReturnValues_Proxy(token, isolate_id, deleter, f0, f1, f2, f3, f4, f5, f6)
         );
-        gluecodium::ffi::cache_proxy(token, "smoke_ListenersWithReturnValues", *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_ListenersWithReturnValues", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterClass.cpp
@@ -13,7 +13,7 @@ public:
     smoke_OuterClass_InnerInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_OuterClass_InnerInterface_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_OuterClass_InnerInterface");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_OuterClass_InnerInterface");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -113,7 +113,7 @@ library_smoke_OuterClass_InnerInterface_get_raw_pointer(FfiOpaqueHandle handle) 
 }
 FfiOpaqueHandle
 library_smoke_OuterClass_InnerInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterClass_InnerInterface_Proxy>(token, "smoke_OuterClass_InnerInterface");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterClass_InnerInterface_Proxy>(token, isolate_id, "smoke_OuterClass_InnerInterface");
     std::shared_ptr<smoke_OuterClass_InnerInterface_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterClass_InnerInterface_Proxy>(cached_proxy);
@@ -121,7 +121,7 @@ library_smoke_OuterClass_InnerInterface_create_proxy(uint64_t token, int32_t iso
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterClass_InnerInterface_Proxy>(
             new (std::nothrow) smoke_OuterClass_InnerInterface_Proxy(token, isolate_id, deleter, f0)
         );
-        gluecodium::ffi::cache_proxy(token, "smoke_OuterClass_InnerInterface", *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_OuterClass_InnerInterface", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterInterface.cpp
@@ -13,7 +13,7 @@ public:
     smoke_OuterInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_OuterInterface_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_OuterInterface");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_OuterInterface");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -50,7 +50,7 @@ public:
     smoke_OuterInterface_InnerInterface_Proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), deleter(deleter), f0(f0) { }
     ~smoke_OuterInterface_InnerInterface_Proxy() {
-        gluecodium::ffi::remove_cached_proxy(token, "smoke_OuterInterface_InnerInterface");
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_OuterInterface_InnerInterface");
         auto token_local = token;
         auto deleter_local = reinterpret_cast<void (*)(uint64_t, FfiOpaqueHandle)>(deleter);
         gluecodium::ffi::cbqm.enqueueCallback(isolate_id, [this, token_local, deleter_local]() {
@@ -150,7 +150,7 @@ library_smoke_OuterInterface_InnerInterface_get_raw_pointer(FfiOpaqueHandle hand
 }
 FfiOpaqueHandle
 library_smoke_OuterInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterInterface_Proxy>(token, "smoke_OuterInterface");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterInterface_Proxy>(token, isolate_id, "smoke_OuterInterface");
     std::shared_ptr<smoke_OuterInterface_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterInterface_Proxy>(cached_proxy);
@@ -158,13 +158,13 @@ library_smoke_OuterInterface_create_proxy(uint64_t token, int32_t isolate_id, Ff
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterInterface_Proxy>(
             new (std::nothrow) smoke_OuterInterface_Proxy(token, isolate_id, deleter, f0)
         );
-        gluecodium::ffi::cache_proxy(token, "smoke_OuterInterface", *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_OuterInterface", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }
 FfiOpaqueHandle
 library_smoke_OuterInterface_InnerInterface_create_proxy(uint64_t token, int32_t isolate_id, FfiOpaqueHandle deleter, FfiOpaqueHandle f0) {
-    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterInterface_InnerInterface_Proxy>(token, "smoke_OuterInterface_InnerInterface");
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_OuterInterface_InnerInterface_Proxy>(token, isolate_id, "smoke_OuterInterface_InnerInterface");
     std::shared_ptr<smoke_OuterInterface_InnerInterface_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterInterface_InnerInterface_Proxy>(cached_proxy);
@@ -172,7 +172,7 @@ library_smoke_OuterInterface_InnerInterface_create_proxy(uint64_t token, int32_t
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_OuterInterface_InnerInterface_Proxy>(
             new (std::nothrow) smoke_OuterInterface_InnerInterface_Proxy(token, isolate_id, deleter, f0)
         );
-        gluecodium::ffi::cache_proxy(token, "smoke_OuterInterface_InnerInterface", *proxy_ptr);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_OuterInterface_InnerInterface", *proxy_ptr);
     }
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }


### PR DESCRIPTION
Updated Dart FFI templates to include "isolate_id" value as a part of
cache key for the proxy cache. This circumvents the issue of stale cache
entries for some scenarios of Flutter app restarts.

Updated smoke tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>