### PR TITLE
Fix doc links to lambdas in C++ and Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed resolution of doc comment links to lambdas in C++ and Swift.
+
 ## 7.1.0
 Release date: 2020-06-10
 ### Features:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppModelBuilder.kt
@@ -417,7 +417,7 @@ class CppModelBuilder(
             definition = typeMapper.mapLambda(limeLambda)
         )
 
-        storeResult(cppElement)
+        storeNamedResult(limeLambda, cppElement)
         closeContext()
     }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftClass.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftClass.kt
@@ -59,7 +59,7 @@ class SwiftClass(
         get() = methods.filter { it.isConstructor }
 
     override val childElements
-        get() = properties + methods + structs + enums + typedefs + constants
+        get() = properties + methods + structs + enums + typedefs + constants + closures
 
     override val simpleName: String
         get() = nestedNames.last()

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -171,6 +171,7 @@ class CommentsLinks {
     // * top level enum: [CommentsTypeCollection.TypeCollectionEnum]
     // * top level enum item: [CommentsTypeCollection.TypeCollectionEnum.item]
     // * error: [comments.SomethingWrong]
+    // * lambda: [comments.SomeLambda]
     // * type from aux sources, same package: [AuxClass]
     // * type from aux sources, different package: [fire.AuxStruct]
     //   * we can also have

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
@@ -62,6 +62,7 @@ public final class CommentsLinks extends NativeBase {
      * <li>top level enum: {@link com.example.smoke.TypeCollectionEnum}</li>
      * <li>top level enum item: {@link com.example.smoke.TypeCollectionEnum#ITEM}</li>
      * <li>error: {@link com.example.smoke.Comments.SomethingWrongException}</li>
+     * <li>lambda: {@link com.example.smoke.SomeLambda}</li>
      * <li>type from aux sources, same package: {@link com.example.smoke.AuxClass}</li>
      * <li>type from aux sources, different package: {@link com.example.fire.AuxStruct}
      * <ul>

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
@@ -62,6 +62,7 @@ public:
      * * top level enum: ::smoke::TypeCollectionEnum
      * * top level enum item: ::smoke::TypeCollectionEnum::ITEM
      * * error: ::smoke::Comments::SomeEnum
+     * * lambda: ::smoke::Comments::SomeLambda
      * * type from aux sources, same package: ::smoke::AuxClass
      * * type from aux sources, different package: ::fire::AuxStruct
      *   * we can also have

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -37,6 +37,7 @@ abstract class CommentsLinks {
   /// * top level enum: [TypeCollectionEnum]
   /// * top level enum item: [TypeCollectionEnum.item]
   /// * error: [Comments_SomethingWrongException]
+  /// * lambda: [Comments_SomeLambda]
   /// * type from aux sources, same package: [AuxClass]
   /// * type from aux sources, different package: [AuxStruct]
   ///   * we can also have

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
@@ -35,6 +35,7 @@ class CommentsLinks {
     // * top level enum: [CommentsTypeCollection.TypeCollectionEnum]
     // * top level enum item: [CommentsTypeCollection.TypeCollectionEnum.item]
     // * error: [comments.SomethingWrong]
+    // * lambda: [comments.SomeLambda]
     // * type from aux sources, same package: [AuxClass]
     // * type from aux sources, different package: [fire.AuxStruct]
     //   * we can also have

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
@@ -53,6 +53,7 @@ public class CommentsLinks {
     /// * top level enum: `TypeCollectionEnum`
     /// * top level enum item: `TypeCollectionEnum.item`
     /// * error: `Comments.SomethingWrongError`
+    /// * lambda: `Comments.SomeLambda`
     /// * type from aux sources, same package: `AuxClass`
     /// * type from aux sources, different package: `AuxStruct`
     ///     * we can also have


### PR DESCRIPTION
Updated CppModelBuilder and SwiftClass classes to properly include
lambdas in documentation links resolution process.

Added smoke test use case for a doc link to a lambda.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>