### PR TITLE
Fix cross-package inheritance from interfaces in Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed compilation issue for cross-package inheritance from an interface in Java.
+
 ## 7.1.1
 Release date: 2020-06-11
 ### Bug fixes:

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -284,6 +284,7 @@ feature(Inheritance cpp android swift dart SOURCES
     lime/test/Inheritance.lime
     lime/test/ListenerInheritance.lime
     lime/test/ListenerInheritanceArrays.lime
+    lime/test/CrossPackageInheritance.lime
 )
 
 feature(Serialization android swift SOURCES

--- a/examples/libhello/lime/test/CrossPackageInheritance.lime
+++ b/examples/libhello/lime/test/CrossPackageInheritance.lime
@@ -1,0 +1,23 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package foobar
+
+import test.ParentInterface
+
+class CrossPackageChildClass : ParentInterface {
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGenerator.kt
@@ -74,7 +74,8 @@ class JniGenerator(
             typeMapper = javaTypeMapper,
             valueMapper = JavaValueMapper(limeReferenceMap, javaNameRules, javaTypeMapper),
             nameRules = javaNameRules,
-            nameResolver = javaNameResolver
+            nameResolver = javaNameResolver,
+            buildTransientModel = { generateModel(it).javaElements }
         )
 
         val includeResolver = CppIncludeResolver(limeReferenceMap, cppNameRules, internalNamespace)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniModelBuilder.kt
@@ -101,6 +101,7 @@ class JniModelBuilder(
         val cppClass = cppBuilder.getFinalResult(CppClass::class.java)
         val javaTopLevelElement = javaBuilder.getFinalResult(JavaTopLevelElement::class.java)
         val javaClass = javaBuilder.getFinalResult(JavaClass::class.java)
+        val limeParent = limeContainer.parent?.type
 
         val jniContainer = JniContainer(
             javaPackage = javaTopLevelElement.javaPackage,
@@ -117,10 +118,11 @@ class JniModelBuilder(
             isEquatable = limeContainer.attributes.have(LimeAttributeType.EQUATABLE),
             isPointerEquatable = limeContainer.attributes.have(LimeAttributeType.POINTER_EQUATABLE),
             hasTypeRepository = cppClass.isInheritable || cppClass.inheritances.isNotEmpty(),
-            hasConstructors = limeContainer.constructors.isNotEmpty()
+            hasConstructors = limeContainer.constructors.isNotEmpty(),
+            hasInterfaceParent = limeParent is LimeInterface
         )
 
-        limeContainer.parent?.type?.let {
+        limeParent?.let {
             val transientParent = buildTransientModel(it).first()
             jniContainer.parentMethods += transientParent.parentMethods
             jniContainer.parentMethods += transientParent.methods

--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaInterface.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaInterface.kt
@@ -21,5 +21,6 @@ package com.here.gluecodium.model.java
 
 class JavaInterface(
     name: String,
-    classNames: List<String> = listOf(name)
+    classNames: List<String> = listOf(name),
+    val parentMethods: Set<JavaMethod> = emptySet()
 ) : JavaTopLevelElement(name, classNames)

--- a/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniContainer.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniContainer.kt
@@ -43,7 +43,8 @@ class JniContainer(
     val isPointerEquatable: Boolean = false,
     @Suppress("unused") val hasTypeRepository: Boolean = false,
     @Suppress("unused") val isFunctionalInterface: Boolean = false,
-    @Suppress("unused") val hasConstructors: Boolean = false
+    @Suppress("unused") val hasConstructors: Boolean = false,
+    @Suppress("unused") val hasInterfaceParent: Boolean = false
 ) : JniElement {
     val methods: MutableList<JniMethod> = mutableListOf()
     val parentMethods: MutableList<JniMethod> = mutableListOf()

--- a/gluecodium/src/main/resources/templates/jni/Header.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Header.mustache
@@ -33,6 +33,11 @@ JNIEXPORT {{returnType.name}} JNICALL
 {{>jni/FunctionSignature}};
 
 {{/methods}}
+{{#if hasInterfaceParent}}{{#parentMethods}}
+JNIEXPORT {{returnType.name}} JNICALL
+{{>jni/FunctionSignature}};
+
+{{/parentMethods}}{{/if}}
 {{#hasNativeEquatable}}
 JNIEXPORT jboolean JNICALL
 {{#set javaMethodName="equals"}}{{>jni/FunctionSignaturePrefix}}{{/set}}, jobject jrhs);

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -31,35 +31,13 @@
 extern "C" {
 
 {{#container}}{{#methods}}
-{{returnType.name}}
-{{>jni/FunctionSignature}}
-
-{
-{{#parameters}}
-{{#if type.isComplex}}
-    {{type.cppName}} {{name}} = {{>common/InternalNamespace}}jni::convert_from_jni(_jenv,
-            {{>common/InternalNamespace}}jni::make_non_releasing_ref(j{{name}}),
-            ({{type.cppName}}*)nullptr);
-{{/if}}
-{{#unless type.isComplex}}
-    {{type.cppName}} {{name}} = j{{name}};
-{{/unless}}
-{{/parameters}}
-{{#unless isStatic}}{{#instanceOf container "JniContainer"}}{{#unless isFunctionalInterface}}
-    auto pInstanceSharedPointer = {{#set jobjectName="_jinstance"}}{{>sharedInstance}}{{/set}}
-{{/unless}}{{#if isFunctionalInterface}}
-    auto pInstanceSharedPointer = reinterpret_cast<{{cppFullyQualifiedName}}*>(
-{{#set jobjectName="_jinstance"}}{{>getNativeHandle}}{{/set}});
-{{/if}}{{/instanceOf}}{{!!
-}}{{#notInstanceOf container "JniContainer"}}
-    auto _ninstance = {{>common/InternalNamespace}}jni::convert_from_jni(_jenv,
-        {{>common/InternalNamespace}}jni::make_non_releasing_ref(_jinstance),
-        ({{container.cppFullyQualifiedName}}*)nullptr);
-{{/notInstanceOf}}{{/unless}}
-{{>jni/ReturnTypeConversion}}
-}
+{{>jniMethod}}
 
 {{/methods}}
+{{#if hasInterfaceParent}}{{#parentMethods}}
+{{>jniMethod}}
+
+{{/parentMethods}}{{/if}}
 {{#instanceOf container "JniContainer"}}
 JNIEXPORT void JNICALL
 Java_{{mangledName}}_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
@@ -132,4 +110,34 @@ jint
             {{>common/InternalNamespace}}jni::make_non_releasing_ref({{jobjectName}}),
             "nativeHandle",
             (int64_t*)nullptr){{!!
-}}{{/getNativeHandle}}
+}}{{/getNativeHandle}}{{!!
+
+}}{{+jniMethod}}
+{{returnType.name}}
+{{>jni/FunctionSignature}}
+
+{
+{{#parameters}}
+{{#if type.isComplex}}
+    {{type.cppName}} {{name}} = {{>common/InternalNamespace}}jni::convert_from_jni(_jenv,
+            {{>common/InternalNamespace}}jni::make_non_releasing_ref(j{{name}}),
+            ({{type.cppName}}*)nullptr);
+{{/if}}
+{{#unless type.isComplex}}
+    {{type.cppName}} {{name}} = j{{name}};
+{{/unless}}
+{{/parameters}}
+{{#unless isStatic}}{{#instanceOf container "JniContainer"}}{{#unless isFunctionalInterface}}
+    auto pInstanceSharedPointer = {{#set jobjectName="_jinstance"}}{{>sharedInstance}}{{/set}}
+{{/unless}}{{#if isFunctionalInterface}}
+    auto pInstanceSharedPointer = reinterpret_cast<{{cppFullyQualifiedName}}*>(
+{{#set jobjectName="_jinstance"}}{{>getNativeHandle}}{{/set}});
+{{/if}}{{/instanceOf}}{{!!
+}}{{#notInstanceOf container "JniContainer"}}
+    auto _ninstance = {{>common/InternalNamespace}}jni::convert_from_jni(_jenv,
+        {{>common/InternalNamespace}}jni::make_non_releasing_ref(_jinstance),
+        ({{container.cppFullyQualifiedName}}*)nullptr);
+{{/notInstanceOf}}{{/unless}}
+{{>jni/ReturnTypeConversion}}
+}
+{{/jniMethod}}

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/java/JavaModelBuilderContainersTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/java/JavaModelBuilderContainersTest.kt
@@ -99,7 +99,8 @@ class JavaModelBuilderContainersTest {
             valueMapper = valueMapper,
             nameRules = nameRules,
             nameResolver = JavaNameResolver(nameRules, emptyMap()),
-            contextStack = contextStack
+            contextStack = contextStack,
+            buildTransientModel = { listOf(JavaInterface("")) }
         )
     }
 
@@ -382,13 +383,14 @@ class JavaModelBuilderContainersTest {
             parent = LimeDirectTypeRef(parentContainer)
         )
         val javaType = object : JavaTypeRef("") {}
-        every { typeMapper.mapInheritanceParent(parentContainer, "BarImpl") } returns javaType
+        every { typeMapper.mapInheritanceParent(any(), any()) } returns javaType
 
         modelBuilder.finishBuilding(limeElement)
 
         val result = modelBuilder.getFinalResult(JavaClass::class.java)
-        assertEquals(javaType, result.extendedClass)
-        assertFalse(result.needsDisposer)
+        assertEquals(typeMapper.nativeBase, result.extendedClass)
+        assertEquals(javaType, result.parentInterfaces.first())
+        assertTrue(result.needsDisposer)
     }
 
     @Test

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/java/JavaModelBuilderTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/java/JavaModelBuilderTest.kt
@@ -112,7 +112,8 @@ class JavaModelBuilderTest {
             typeMapper = typeMapper,
             valueMapper = valueMapper,
             nameRules = nameRules,
-            nameResolver = JavaNameResolver(nameRules, emptyMap())
+            nameResolver = JavaNameResolver(nameRules, emptyMap()),
+            buildTransientModel = { emptyList() }
         )
     }
 

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android/com/example/package/Class.java
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android/com/example/package/Class.java
@@ -3,8 +3,9 @@
  */
 package com.example.package;
 import android.support.annotation.NonNull;
+import com.example.NativeBase;
 import java.util.List;
-public final class Class extends InterfaceImpl {
+public final class Class extends NativeBase implements Interface {
     public Class() {
         this(constructor());
         cacheThisInstance();
@@ -14,8 +15,14 @@ public final class Class extends InterfaceImpl {
      * @exclude
      */
     protected Class(final long nativeHandle) {
-        super(nativeHandle);
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
     }
+    private static native void disposeNativeHandle(long nativeHandle);
     private native void cacheThisInstance();
     private static native long constructor();
     @NonNull

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/com/example/smoke/ChildClassFromInterface.java
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/com/example/smoke/ChildClassFromInterface.java
@@ -1,15 +1,29 @@
 /*
  *
-
  */
 package com.example.smoke;
-public final class ChildClassFromInterface extends ParentInterfaceImpl {
+import android.support.annotation.NonNull;
+import com.example.NativeBase;
+public final class ChildClassFromInterface extends NativeBase implements ParentInterface {
     /**
      * For internal use only.
      * @exclude
      */
     protected ChildClassFromInterface(final long nativeHandle) {
-        super(nativeHandle);
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
     }
+    private static native void disposeNativeHandle(long nativeHandle);
     public native void childClassMethod();
+    @Override
+    public native void rootMethod();
+    @NonNull
+    @Override
+    public native String getRootProperty();
+    @Override
+    public native void setRootProperty(@NonNull final String value);
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromInterface.cpp
@@ -19,6 +19,43 @@ Java_com_example_smoke_ChildClassFromInterface_childClassMethod(JNIEnv* _jenv, j
             (int64_t*)nullptr));
     (*pInstanceSharedPointer)->child_class_method();
 }
+void
+Java_com_example_smoke_ChildClassFromInterface_rootMethod(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::ChildClassFromInterface>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->root_method();
+}
+jstring
+Java_com_example_smoke_ChildClassFromInterface_getRootProperty(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::ChildClassFromInterface>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->get_root_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+void
+Java_com_example_smoke_ChildClassFromInterface_setRootProperty(JNIEnv* _jenv, jobject _jinstance, jstring jvalue)
+{
+    ::std::string value = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jvalue),
+            (::std::string*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::ChildClassFromInterface>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->set_root_property(value);
+}
 JNIEXPORT void JNICALL
 Java_com_example_smoke_ChildClassFromInterface_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {


### PR DESCRIPTION
Updated Java and JNI model builders and templates to make classes that
inherit from interfaces to implement those interfaces directly instead
of reusing the internal "Impl" classes. This fixes the compilation issue
that arises when the class and the interface are in different packages.

Added functional test. Updated smoke tests.

Resolves: #394
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>