### PR TITLE
Fix parent interface resolution in JNI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed compilation issue for interfaces containing a lambda declaration in Java.
+
 ## 7.1.2
 Release date: 2020-06-16
 ### Bug fixes:

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -285,6 +285,7 @@ feature(Inheritance cpp android swift dart SOURCES
     lime/test/ListenerInheritance.lime
     lime/test/ListenerInheritanceArrays.lime
     lime/test/CrossPackageInheritance.lime
+    lime/test/InterfaceWithLambda.lime
 )
 
 feature(Serialization android swift SOURCES

--- a/examples/libhello/lime/test/InterfaceWithLambda.lime
+++ b/examples/libhello/lime/test/InterfaceWithLambda.lime
@@ -1,0 +1,25 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+interface InterfaceWithLambda {
+    lambda FooBar = () -> Void
+}
+
+class ChildClassWithLambda : InterfaceWithLambda {
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -308,7 +308,7 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
             "libraryName" to libraryName,
             "builtInTypes" to
                 LimeBasicType.TypeId.values().filterNot { it == LimeBasicType.TypeId.VOID },
-            "typeRepositories" to typeRepositories,
+            "typeRepositories" to typeRepositories.sortedBy { it.fullName },
             "imports" to
                 typeRepositories.flatMap { importResolver.resolveImports(it) }.distinct().sorted()
         )

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/jni/JniModelBuilderTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/jni/JniModelBuilderTest.kt
@@ -265,20 +265,6 @@ class JniModelBuilderTest {
     }
 
     @Test
-    fun finishBuildingInterfaceReadsParentMethods() {
-        val parentContainer = JniContainer()
-        parentContainer.parentMethods.add(JniMethod())
-        parentContainer.methods.add(JniMethod())
-        transientModel += parentContainer
-        val limeElement = LimeInterface(fooPath, parent = LimeBasicTypeRef.INT)
-
-        modelBuilder.finishBuilding(limeElement)
-
-        val jniContainer = modelBuilder.getFinalResult(JniContainer::class.java)
-        assertEquals(2, jniContainer.parentMethods.size)
-    }
-
-    @Test
     fun finishBuildingInterfaceReadsInterfaceInclude() {
         modelBuilder.finishBuilding(limeInterface)
 

--- a/gluecodium/src/test/resources/smoke/inheritance/input/InterfaceWithLambda.lime
+++ b/gluecodium/src/test/resources/smoke/inheritance/input/InterfaceWithLambda.lime
@@ -1,0 +1,25 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+interface InterfaceWithLambda {
+    lambda FooBar = () -> Void
+}
+
+class ChildClassWithLambda : InterfaceWithLambda {
+}

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassWithLambda.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassWithLambda.cpp
@@ -1,0 +1,18 @@
+/*
+ *
+ */
+#include "com_example_smoke_ChildClassWithLambda.h"
+#include "com_example_smoke_ChildClassWithLambda__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+#include "JniWrapperCache.h"
+extern "C" {
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildClassWithLambda_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::ChildClassWithLambda>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+}

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
@@ -1,7 +1,9 @@
 import 'package:library/src/smoke/child_class_from_class.dart';
 import 'package:library/src/smoke/child_class_from_interface.dart';
+import 'package:library/src/smoke/child_class_with_lambda.dart';
 import 'package:library/src/smoke/child_interface.dart';
 import 'package:library/src/smoke/child_with_parent_class_references.dart';
+import 'package:library/src/smoke/interface_with_lambda.dart';
 import 'package:library/src/smoke/internal_child.dart';
 import 'package:library/src/smoke/internal_parent.dart';
 import 'package:library/src/smoke/parent_class.dart';
@@ -10,13 +12,15 @@ import 'package:library/src/smoke/parent_with_class_references.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 final Map<String, Function> typeRepository = {
-  "smoke_ParentInterface": (handle) => ParentInterface$Impl(handle),
-  "smoke_ChildInterface": (handle) => ChildInterface$Impl(handle),
-  "smoke_ChildClassFromInterface": (handle) => ChildClassFromInterface$Impl(handle),
-  "smoke_ParentClass": (handle) => ParentClass$Impl(handle),
   "smoke_ChildClassFromClass": (handle) => ChildClassFromClass$Impl(handle),
-  "smoke_InternalParent": (handle) => InternalParent$Impl(handle),
-  "smoke_InternalChild": (handle) => InternalChild$Impl(handle),
-  "smoke_ParentWithClassReferences": (handle) => ParentWithClassReferences$Impl(handle),
+  "smoke_ChildClassFromInterface": (handle) => ChildClassFromInterface$Impl(handle),
+  "smoke_ChildClassWithLambda": (handle) => ChildClassWithLambda$Impl(handle),
+  "smoke_ChildInterface": (handle) => ChildInterface$Impl(handle),
   "smoke_ChildWithParentClassReferences": (handle) => ChildWithParentClassReferences$Impl(handle),
+  "smoke_InterfaceWithLambda": (handle) => InterfaceWithLambda$Impl(handle),
+  "smoke_InternalChild": (handle) => InternalChild$Impl(handle),
+  "smoke_InternalParent": (handle) => InternalParent$Impl(handle),
+  "smoke_ParentClass": (handle) => ParentClass$Impl(handle),
+  "smoke_ParentInterface": (handle) => ParentInterface$Impl(handle),
+  "smoke_ParentWithClassReferences": (handle) => ParentWithClassReferences$Impl(handle),
  };


### PR DESCRIPTION
Updated JNI model builder to correctly resolve a parent interface for a
class/interface. Previously the parent interface was resolved
incorrectly in case of parent interface having a nested interface or a
nested lambda.

Added smoke test and regression functional test. Removed one related
unit test that was incorrect.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>