### PR TITLE
Allow name resolvers to return `null` accessor names

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/NameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/NameResolver.kt
@@ -21,6 +21,6 @@ package com.here.gluecodium.generator.common
 
 interface NameResolver {
     fun resolveName(element: Any): String
-    fun resolveGetterName(element: Any): String { throw IllegalArgumentException() }
-    fun resolveSetterName(element: Any): String { throw IllegalArgumentException() }
+    fun resolveGetterName(element: Any): String? { throw IllegalArgumentException() }
+    fun resolveSetterName(element: Any): String? { throw IllegalArgumentException() }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/NameResolverHelper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/NameResolverHelper.kt
@@ -73,7 +73,7 @@ internal class NameResolverHelper : BasicHelper() {
             "getter" -> resolver.resolveGetterName(element)
             "setter" -> resolver.resolveSetterName(element)
             else -> resolver.resolveName(element)
-        }
+        } ?: return
 
         if (isSection(options)) {
             options.push(name)

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/NameResolverHelperTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/NameResolverHelperTest.kt
@@ -170,4 +170,34 @@ class NameResolverHelperTest {
 
         verify(exactly = 1) { options.append("baz") }
     }
+
+    @Test
+    fun executeThreeParametersGetterSubKeyReturnsNull() {
+        parameters.add(genericElement)
+        parameters.add("nonsense")
+        parameters.add("getter")
+        helper.nameResolvers["nonsense"] = object : NameResolver {
+            override fun resolveName(element: Any) = throw IllegalArgumentException()
+            override fun resolveGetterName(element: Any): String? = null
+        }
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.append(any()) }
+    }
+
+    @Test
+    fun executeThreeParametersSetterSubKeyReturnsNull() {
+        parameters.add(genericElement)
+        parameters.add("nonsense")
+        parameters.add("setter")
+        helper.nameResolvers["nonsense"] = object : NameResolver {
+            override fun resolveName(element: Any) = throw IllegalArgumentException()
+            override fun resolveSetterName(element: Any): String? = null
+        }
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.append(any()) }
+    }
 }


### PR DESCRIPTION
Updated NameResolver interface to change resolveGetterName() and
resolveSetterName() return type from `String` to `String?`. This adds a
failure mode to accessor name resolution (needed for the new C++
generator).

Updated NameResolverHelper to handle this failure mode in templates.
Added new unit tests for NameResolverHelper.

See: #353
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>