### PR TITLE
Add PredicateHelper and SortHelper

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/PredicateHelper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/PredicateHelper.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.common.templates
+
+import org.trimou.handlebars.BasicSectionHelper
+import org.trimou.handlebars.Options
+
+/**
+ * ifPredicate: Evaluate the (pre-registered) unary predicate with a given name on the given element
+ * and execute the section if it evaluates to `true`. If the element is omitted, `this` is taken
+ * instead.<br/>
+ * Usage: {{#ifPredicate \[element\] "predicateName"}}...{{/ifPredicate}}<br/>
+ * Example: {{#ifPredicate "fooPredicate"}}...{{/ifPredicate}}<br/>
+ * Example: {{#ifPredicate type "fooPredicate"}}...{{/ifPredicate}}<br/>
+ * unlessPredicate: same as above, except the the section is executed only if the predicate
+ * evaluates to `false`.
+ */
+internal class PredicateHelper(private val equality: Boolean) : BasicSectionHelper() {
+    val predicates = mutableMapOf<String, (Any) -> Boolean>()
+
+    override fun execute(options: Options) {
+        val element: Any
+        val predicateName: String
+        when (val firstParameter = options.parameters.firstOrNull()) {
+            is String -> {
+                element = options.peek() ?: return
+                predicateName = firstParameter
+            }
+            else -> {
+                element = firstParameter ?: return
+                predicateName = options.parameters.getOrNull(1)?.toString() ?: return
+            }
+        }
+
+        val predicate = predicates[predicateName] ?: return
+        if (predicate(element) == equality) {
+            options.fn()
+        }
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/SortHelper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/SortHelper.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.common.templates
+
+import org.trimou.handlebars.BasicSectionHelper
+import org.trimou.handlebars.Options
+
+/**
+ * Section helper that concatenates the given collections and sorts the combined collection with the
+ * given sorter (or the default sorter is none is specified). The section is then applied
+ * sequentially to each element of the sorted combined collection, in order.<br/>
+ * Usage: {{#sort collection1 collection2 ... \[sorter="sorterName"\]}}...{{/sort}}<br/>
+ * Example: {{#sort classes structs}}...{{/sort}}
+ * Example: {{#sort events sorter="sortByDate"}}...{{/sort}}
+ */
+internal class SortHelper : BasicSectionHelper() {
+    val sorters = mutableMapOf<String, (List<Any>) -> List<Any>>()
+
+    override fun execute(options: Options) {
+        val sorterName = options.hash[SORTER]?.let { convertValue(it) } ?: ""
+        val sorter = sorters[sorterName] ?: return
+        val collection =
+            options.parameters.mapNotNull { it as? List<*> }.flatten().filterNotNull()
+
+        for (element in sorter(collection)) {
+            options.push(element)
+            options.fn()
+            options.pop()
+        }
+    }
+
+    companion object {
+        private const val SORTER = "sorter"
+    }
+}

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/PredicateHelperTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/PredicateHelperTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.common.templates
+
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimePath
+import io.mockk.every
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.trimou.handlebars.Options
+
+@RunWith(Parameterized::class)
+class PredicateHelperTest(equality: Boolean) {
+    private val parameters = mutableListOf<Any>()
+    private val options = spyk<Options>()
+    private val limeElement = object : LimeNamedElement(LimePath.EMPTY_PATH) {}
+    private val otherLimeNamedElement = object : LimeNamedElement(LimePath.EMPTY_PATH) {}
+
+    private val helper = PredicateHelper(equality)
+    private val correctElementExpected = if (equality) 1 else 0
+    private val incorrectElementExpected = if (equality) 0 else 1
+
+    @Before
+    fun setUp() {
+        helper.predicates["foo"] = { it === limeElement }
+        every { options.parameters } returns parameters
+    }
+
+    @Test
+    fun executeNoParameters() {
+        every { options.peek() } returns limeElement
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.fn() }
+    }
+
+    @Test
+    fun executeOneParameterInvalidPredicateName() {
+        every { options.peek() } returns limeElement
+        parameters.add("foobar")
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.fn() }
+    }
+
+    @Test
+    fun executeOneParameterCorrectElement() {
+        every { options.peek() } returns limeElement
+        parameters.add("foo")
+
+        helper.execute(options)
+
+        verify(exactly = correctElementExpected) { options.fn() }
+    }
+
+    @Test
+    fun executeOneParameterIncorrectElement() {
+        every { options.peek() } returns otherLimeNamedElement
+        parameters.add("foo")
+
+        helper.execute(options)
+
+        verify(exactly = incorrectElementExpected) { options.fn() }
+    }
+
+    @Test
+    fun executeTwoParametersInvalidPredicateName() {
+        parameters.add(limeElement)
+        parameters.add("foobar")
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.fn() }
+    }
+
+    @Test
+    fun executeTwoParametersCorrectElement() {
+        parameters.add(limeElement)
+        parameters.add("foo")
+
+        helper.execute(options)
+
+        verify(exactly = correctElementExpected) { options.fn() }
+    }
+
+    @Test
+    fun executeTwoParametersIncorrectElement() {
+        parameters.add(otherLimeNamedElement)
+        parameters.add("foo")
+
+        helper.execute(options)
+
+        verify(exactly = incorrectElementExpected) { options.fn() }
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun testData(): Collection<Array<Any>> = listOf(arrayOf<Any>(false), arrayOf<Any>(true))
+    }
+}

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/SortHelperTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/SortHelperTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.common.templates
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.trimou.handlebars.Options
+
+@RunWith(JUnit4::class)
+class SortHelperTest {
+    private val parameters = mutableListOf<Any>()
+    private val hash = mutableMapOf<String, Any>()
+    private val options = spyk<Options>()
+
+    private val stringList = listOf("foo", "bar")
+    private val sorter = { list: List<Any> -> list.filterIsInstance<String>().sorted() }
+
+    private val helper = SortHelper()
+
+    @Before
+    fun setUp() {
+        helper.init(mockk(relaxed = true))
+        helper.sorters[""] = sorter
+
+        every { options.parameters } returns parameters
+        every { options.hash } returns hash
+    }
+
+    @Test
+    fun executeNoParameters() {
+        helper.execute(options)
+
+        verify(exactly = 0) { options.fn() }
+    }
+
+    @Test
+    fun executeOneParameter() {
+        parameters.add(stringList)
+
+        helper.execute(options)
+
+        verifyOrder {
+            options.push("bar")
+            options.push("foo")
+        }
+        verify(exactly = 2) { options.fn() }
+    }
+
+    @Test
+    fun executeTwoParameters() {
+        parameters.add(stringList)
+        parameters.add(listOf("car"))
+
+        helper.execute(options)
+
+        verifyOrder {
+            options.push("bar")
+            options.push("car")
+            options.push("foo")
+        }
+        verify(exactly = 3) { options.fn() }
+    }
+
+    @Test
+    fun executeTwoParametersOneInvalid() {
+        parameters.add(stringList)
+        parameters.add("jar")
+
+        helper.execute(options)
+
+        verifyOrder {
+            options.push("bar")
+            options.push("foo")
+        }
+        verify(exactly = 2) { options.fn() }
+    }
+
+    @Test
+    fun executeWithInvalidSorter() {
+        parameters.add(stringList)
+        hash["sorter"] = "wee"
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.fn() }
+    }
+
+    @Test
+    fun executeWithValidSorter() {
+        parameters.add(stringList)
+        hash["sorter"] = "wee"
+        helper.sorters["wee"] = sorter
+        helper.sorters.remove("")
+
+        helper.execute(options)
+
+        verifyOrder {
+            options.push("bar")
+            options.push("foo")
+        }
+        verify(exactly = 2) { options.fn() }
+    }
+}


### PR DESCRIPTION
Added PredicateHelper to facilitate complex "if/unless" checks in
Mustache templates. Added SortHelper to facilitate collection sorting in
Mustache templates. Both helpers are needed for the new C++ generator
implementation (based directly on LIME model).

Added unit tests for the new helpers.

See: #353
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>