### PR TITLE
Add missing tests for external types with methods

### DIFF
--- a/examples/libhello/lime/test/ExternalTypes.lime
+++ b/examples/libhello/lime/test/ExternalTypes.lime
@@ -80,6 +80,8 @@ class ClassWithOverloads {
     fun allOverloadsExposed(input: String): String
     @Dart("allOverloadsExposedList")
     fun allOverloadsExposed(inputList: List<String>): String
+    @Dart("allOverloadsExposedTwo")
+    fun allOverloadsExposed(inputString: String, inputBool: Boolean): String
 }
 
 @Cpp(

--- a/examples/libhello/lime/test/StructsWithMethods.lime
+++ b/examples/libhello/lime/test/StructsWithMethods.lime
@@ -96,6 +96,8 @@ struct StructWithOverloads {
     fun overloadedMethod(): String
     @Dart("overloadedMethodString")
     fun overloadedMethod(input: String): String
+    @Dart("overloadedMethodTwo")
+    fun overloadedMethod(inputString: String, inputBool: Boolean): String
 
     @Cpp(ExternalGetter = "overloadedAccessors", ExternalSetter = "overloadedAccessors")
     overloadedAccessors: Int

--- a/examples/libhello/src/test/include/ExternalTypes.h
+++ b/examples/libhello/src/test/include/ExternalTypes.h
@@ -111,6 +111,7 @@ public:
     struct StructWithOverloads {
         const std::string& overloadedMethod( );
         std::string overloadedMethod( const std::string& input );
+        std::string overloadedMethod( const std::string&, const bool );
 
         void overloadedAccessors( int32_t value );
         const int32_t& overloadedAccessors( ) const;
@@ -123,6 +124,7 @@ public:
 
     virtual const std::string& allOverloadsExposed( const std::string& ) = 0;
     virtual std::string allOverloadsExposed( const std::vector<std::string>& ) = 0;
+    virtual std::string allOverloadsExposed( const std::string&, const bool ) = 0;
 };
 
 class external_Interface

--- a/examples/libhello/src/test/src/ExternalTypes.cpp
+++ b/examples/libhello/src/test/src/ExternalTypes.cpp
@@ -79,6 +79,13 @@ ClassWithOverloads::StructWithOverloads::overloadedMethod( const std::string& in
     return input;
 }
 
+std::string
+ClassWithOverloads::StructWithOverloads::overloadedMethod(
+    const std::string& input_string, const bool input_bool )
+{
+    return input_string;
+}
+
 void
 ClassWithOverloads::StructWithOverloads::overloadedAccessors( int32_t value ) {
     m_someField = value;

--- a/gluecodium/src/test/resources/smoke/instances/input/Classes.lime
+++ b/gluecodium/src/test/resources/smoke/instances/input/Classes.lime
@@ -43,3 +43,13 @@ class ExternalClass {
         get
     }
 }
+
+@Cpp(ExternalType = "include/ExternalTypes.h")
+class ClassWithOverloads {
+    fun oneOverloadNotExposed(): String
+    fun allOverloadsExposed(input: String): String
+    @Dart("allOverloadsExposedList")
+    fun allOverloadsExposed(inputList: List<String>): String
+    @Dart("allOverloadsExposedTwo")
+    fun allOverloadsExposed(inputString: String, inputBool: Boolean): String
+}

--- a/gluecodium/src/test/resources/smoke/instances/output/cpp/src/smoke/ClassWithOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cpp/src/smoke/ClassWithOverloads.cpp
@@ -1,0 +1,40 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#include "include/ExternalTypes.h"
+#include <type_traits>
+namespace smoke {
+static_assert(
+    std::is_same<
+        ::std::string,
+        std::remove_cv<std::remove_reference<decltype(((::smoke::ClassWithOverloads*)nullptr)->oneOverloadNotExposed())>::type>::type
+    >::value,
+    "Expected '::std::string' return type for '::smoke::ClassWithOverloads::oneOverloadNotExposed'."
+);
+static_assert(
+    std::is_same<
+        ::std::string,
+        std::remove_cv<std::remove_reference<decltype(((::smoke::ClassWithOverloads*)nullptr)->allOverloadsExposed(
+            *((::std::string*)nullptr)))>::type>::type
+    >::value,
+    "Expected '::std::string' return type for '::smoke::ClassWithOverloads::allOverloadsExposed'."
+);
+static_assert(
+    std::is_same<
+        ::std::string,
+        std::remove_cv<std::remove_reference<decltype(((::smoke::ClassWithOverloads*)nullptr)->allOverloadsExposed(
+            *((::std::vector< ::std::string >*)nullptr)))>::type>::type
+    >::value,
+    "Expected '::std::string' return type for '::smoke::ClassWithOverloads::allOverloadsExposed'."
+);
+static_assert(
+    std::is_same<
+        ::std::string,
+        std::remove_cv<std::remove_reference<decltype(((::smoke::ClassWithOverloads*)nullptr)->allOverloadsExposed(
+            *((::std::string*)nullptr),
+            *((bool*)nullptr)))>::type>::type
+    >::value,
+    "Expected '::std::string' return type for '::smoke::ClassWithOverloads::allOverloadsExposed'."
+);
+}

--- a/gluecodium/src/test/resources/smoke/structs/input/StructsWithMethods.lime
+++ b/gluecodium/src/test/resources/smoke/structs/input/StructsWithMethods.lime
@@ -71,3 +71,18 @@ class StructsWithMethodsInterface {
         static fun doStuff()
     }
 }
+
+@Cpp(
+    ExternalType = "include/ExternalTypes.h",
+    ExternalName = "external::ClassWithOverloads::StructWithOverloads"
+)
+struct StructWithOverloads {
+    fun overloadedMethod(): String
+    @Dart("overloadedMethodString")
+    fun overloadedMethod(input: String): String
+    @Dart("overloadedMethodTwo")
+    fun overloadedMethod(inputString: String, inputBool: Boolean): String
+
+    @Cpp(ExternalGetter = "overloadedAccessors", ExternalSetter = "overloadedAccessors")
+    overloadedAccessors: Int
+}

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/src/smoke/StructWithOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/src/smoke/StructWithOverloads.cpp
@@ -1,0 +1,47 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#include "include/ExternalTypes.h"
+#include <type_traits>
+#include <utility>
+namespace smoke {
+static_assert(
+    std::is_same<
+        int32_t,
+        std::remove_cv<std::remove_reference<decltype(((const external::ClassWithOverloads::StructWithOverloads*)nullptr)->overloadedAccessors())>::type>::type
+    >::value,
+    "Expected 'int32_t' return type for 'external::ClassWithOverloads::StructWithOverloads::overloadedAccessors'."
+);
+static_assert(
+    std::is_same<
+        void,
+        decltype(((external::ClassWithOverloads::StructWithOverloads*)nullptr)->overloadedAccessors(*((int32_t*)nullptr)))
+    >::value,
+    "Expected 'void' return type for 'external::ClassWithOverloads::StructWithOverloads::overloadedAccessors'."
+);
+static_assert(
+    std::is_same<
+        ::std::string,
+        std::remove_cv<std::remove_reference<decltype(((external::ClassWithOverloads::StructWithOverloads*)nullptr)->overloadedMethod())>::type>::type
+    >::value,
+    "Expected '::std::string' return type for 'external::ClassWithOverloads::StructWithOverloads::overloadedMethod'."
+);
+static_assert(
+    std::is_same<
+        ::std::string,
+        std::remove_cv<std::remove_reference<decltype(((external::ClassWithOverloads::StructWithOverloads*)nullptr)->overloadedMethod(
+            *((::std::string*)nullptr)))>::type>::type
+    >::value,
+    "Expected '::std::string' return type for 'external::ClassWithOverloads::StructWithOverloads::overloadedMethod'."
+);
+static_assert(
+    std::is_same<
+        ::std::string,
+        std::remove_cv<std::remove_reference<decltype(((external::ClassWithOverloads::StructWithOverloads*)nullptr)->overloadedMethod(
+            *((::std::string*)nullptr),
+            *((bool*)nullptr)))>::type>::type
+    >::value,
+    "Expected '::std::string' return type for 'external::ClassWithOverloads::StructWithOverloads::overloadedMethod'."
+);
+}


### PR DESCRIPTION
Added smoke tests for classes and structs marked with "ExternalType".
Functional tests for these were already in place, but the smoke tests
were missing.

To the corresponding functional test, added a test case for a method with multiple parameters (before only single-parameter methods were tested).

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>