### PR TITLE
Upgrade MockK version to 1.10.0

### DIFF
--- a/gluecodium-gradle/build.gradle
+++ b/gluecodium-gradle/build.gradle
@@ -14,8 +14,8 @@ dependencies {
         exclude group: 'net.sf.proguard', module: 'proguard-gradle'
     }
 
-    testCompile 'io.mockk:mockk-dsl-jvm:1.9.3'
-    testCompile 'io.mockk:mockk:1.9.3'
+    testCompile 'io.mockk:mockk-dsl-jvm:1.10.0'
+    testCompile 'io.mockk:mockk:1.10.0'
     testCompile 'junit:junit:4.12'
 }
 

--- a/gluecodium/build.gradle
+++ b/gluecodium/build.gradle
@@ -43,8 +43,8 @@ dependencies {
     compile 'org.trimou:trimou-core:2.2.0.Final'
 
     testCompile files({ project(":lime-runtime").sourceSets.test.output })
-    testCompile 'io.mockk:mockk-dsl-jvm:1.9.3'
-    testCompile 'io.mockk:mockk:1.9.3'
+    testCompile 'io.mockk:mockk-dsl-jvm:1.10.0'
+    testCompile 'io.mockk:mockk:1.10.0'
     testCompile 'junit:junit:4.12'
 }
 

--- a/lime-loader/build.gradle
+++ b/lime-loader/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     compile "org.antlr:antlr4-runtime:4.7.2"
 
     testCompile files({ project(":lime-runtime").sourceSets.test.output })
-    testCompile 'io.mockk:mockk-dsl-jvm:1.9.3'
-    testCompile 'io.mockk:mockk:1.9.3'
+    testCompile 'io.mockk:mockk-dsl-jvm:1.10.0'
+    testCompile 'io.mockk:mockk:1.10.0'
     testCompile 'junit:junit:4.12'
 }
 

--- a/lime-runtime/build.gradle
+++ b/lime-runtime/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     compile 'org.jetbrains.kotlin:kotlin-stdlib:1.3.72'
     compile 'org.jetbrains:annotations:13.0'
 
-    testCompile 'io.mockk:mockk-dsl-jvm:1.9.3'
-    testCompile 'io.mockk:mockk:1.9.3'
+    testCompile 'io.mockk:mockk-dsl-jvm:1.10.0'
+    testCompile 'io.mockk:mockk:1.10.0'
     testCompile 'junit:junit:4.12'
 }
 


### PR DESCRIPTION
Updated MockK version to 1.10.0. The new version adds compatibility with
Java 13/14.

See: #30
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>