### PR TITLE
Include function thrown type in dependency sorting in C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Features:
   * Slightly improved logging for unhandled exceptions when calling Java code from C++.
+### Bug fixes:
+  * Fixed dependency sorting logic for thrown types in C++.
 
 ## 7.1.3
 Release date: 2020-06-16

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -353,9 +353,11 @@ feature(Dates cpp android swift dart SOURCES
 feature(StructsWithCompanion cpp android swift dart SOURCES
     src/test/StructsWithMethods.cpp
     src/test/StructsWithConstants.cpp
+    src/test/StructsWithMethodsDeclarationOrder.cpp
 
     lime/test/StructsWithMethods.lime
     lime/test/StructsWithConstants.lime
+    lime/test/StructsWithMethodsDeclarationOrder.lime
 )
 
 feature(Comments cpp android swift dart SOURCES

--- a/examples/libhello/lime/test/StructsWithMethodsDeclarationOrder.lime
+++ b/examples/libhello/lime/test/StructsWithMethodsDeclarationOrder.lime
@@ -1,50 +1,28 @@
-# Copyright (C) 2016-2019 HERE Europe B.V.
-#
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+# 
 #     http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+# 
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-package smoke
-
-types DeclarationOrder {
-    struct MainStruct {
-        structField: NestedStruct
-        typeDefField: SomeTypeDef
-        structArrayField: NestedStructArray
-        mapField: ErrorCodeToMessageMap
-        enumField: SomeEnum
-    }
-    struct NestedStruct {
-        someField: String
-    }
-
-    enum SomeEnum {
-        FOO,
-        BAR = 7
-    }
-
-    typealias SomeTypeDef = Int
-    typealias ErrorCodeToMessageMap = Map<Int, NestedStructArray>
-    typealias NestedStructArray = List<NestedStruct>
-}
+package test
 
 types DeclarationOrderWithFunctions {
     struct MainStructWithFunctions {
         structField: FieldStruct
         fun withParameter(input: ParameterStruct)
         fun withReturn(): ReturnStruct
-        fun withThrown() throws FooBar
+        fun withThrown() throws SomethingToThrow
     }
     struct FieldStruct {
         someField: String
@@ -58,5 +36,5 @@ types DeclarationOrderWithFunctions {
     struct ThrownStruct {
         someField: String
     }
-    exception FooBar(ThrownStruct)
+    exception SomethingToThrow(ThrownStruct)
 }

--- a/examples/libhello/src/test/StructsWithMethodsDeclarationOrder.cpp
+++ b/examples/libhello/src/test/StructsWithMethodsDeclarationOrder.cpp
@@ -1,0 +1,32 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/DeclarationOrderWithFunctions.h"
+
+namespace test
+{
+void
+MainStructWithFunctions::with_parameter(const ParameterStruct& input) const { }
+
+ReturnStruct
+MainStructWithFunctions::with_return() const { return {}; }
+
+lorem_ipsum::test::Return<void, ThrownStruct>
+MainStructWithFunctions::with_thrown() const { return {}; }
+}  // namespace test

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/TopologicalSort.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/TopologicalSort.kt
@@ -76,7 +76,8 @@ internal class TopologicalSort(private val elements: List<LimeNamedElement>) {
             is LimeStruct -> (limeElement.fields + limeElement.functions + limeElement.constants)
                 .flatMap { getElementDependencies(it) }
             is LimeTypeAlias -> getTypeRefDependencies(limeElement.typeRef)
-            is LimeFunction -> (limeElement.parameters.map { it.typeRef } + limeElement.returnType.typeRef)
+            is LimeFunction -> (limeElement.parameters.map { it.typeRef } +
+                    listOfNotNull(limeElement.returnType.typeRef, limeElement.exception?.errorType))
                 .flatMap { getTypeRefDependencies(it) }
             is LimeLambda -> (limeElement.parameters.map { it.typeRef } + limeElement.returnType.typeRef)
                 .flatMap { getTypeRefDependencies(it) }

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/cpp/TopologicalSortTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/cpp/TopologicalSortTest.kt
@@ -27,12 +27,15 @@ import com.here.gluecodium.generator.cpp.TopologicalSortTestHelper.createTypeAli
 import com.here.gluecodium.generator.cpp.TopologicalSortTestHelper.createTypeRef
 import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeEnumeration
+import com.here.gluecodium.model.lime.LimeException
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeParameter
+import com.here.gluecodium.model.lime.LimePath
 import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeThrownType
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -209,6 +212,21 @@ class TopologicalSortTest(
                                             createPath("x"),
                                             typeRef = createTypeRef(SECOND_STRUCT_NAME)
                                         ))
+                                )
+                            )
+                        ),
+                        createStruct(SECOND_STRUCT_NAME, TYPE_B, TYPE_C)
+                    ), listOf(1, 0)
+                ), arrayOf(
+                    "sortStructsDependentThroughMethodThrownType", listOf(
+                        LimeStruct(
+                            path = createPath(FIRST_STRUCT_NAME),
+                            functions = listOf(
+                                LimeFunction(
+                                    createPath("x"),
+                                    thrownType = LimeThrownType(LimeDirectTypeRef(LimeException(
+                                        LimePath.EMPTY_PATH, errorType = createTypeRef(SECOND_STRUCT_NAME)
+                                    )))
                                 )
                             )
                         ),

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/DeclarationOrderWithFunctions.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/DeclarationOrderWithFunctions.h
@@ -1,0 +1,38 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include "gluecodium/Return.h"
+#include <string>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT FieldStruct {
+    ::std::string some_field;
+    FieldStruct( );
+    FieldStruct( ::std::string some_field );
+};
+struct _GLUECODIUM_CPP_EXPORT ParameterStruct {
+    ::std::string some_field;
+    ParameterStruct( );
+    ParameterStruct( ::std::string some_field );
+};
+struct _GLUECODIUM_CPP_EXPORT ReturnStruct {
+    ::std::string some_field;
+    ReturnStruct( );
+    ReturnStruct( ::std::string some_field );
+};
+struct _GLUECODIUM_CPP_EXPORT ThrownStruct {
+    ::std::string some_field;
+    ThrownStruct( );
+    ThrownStruct( ::std::string some_field );
+};
+struct _GLUECODIUM_CPP_EXPORT MainStructWithFunctions {
+    ::smoke::FieldStruct struct_field;
+    MainStructWithFunctions( );
+    MainStructWithFunctions( ::smoke::FieldStruct struct_field );
+    void with_parameter( const ::smoke::ParameterStruct& input ) const;
+    ::smoke::ReturnStruct with_return(  ) const;
+    ::gluecodium::Return< void, ::smoke::ThrownStruct > with_thrown(  ) const;
+};
+}


### PR DESCRIPTION
Updated TopologicalSort algorithm to take function thrown types into
account.

Added corresponding unit, smoke, and functional tests.

Resolves: #392
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>