### PR TITLE
Fix redundant "const" modifiers for methods in C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed compilation issue in C++ caused by redundant "const" modifiers on methods.
+
 ## 7.1.4
 Release date: 2020-07-06
 ### Features:

--- a/examples/libhello/lime/test/StructsWithMethods.lime
+++ b/examples/libhello/lime/test/StructsWithMethods.lime
@@ -88,6 +88,12 @@ class StructsWithMethodsInterface {
     }
 }
 
+struct StructWithConstMethod {
+    stringField: String
+    @Cpp(Const)
+    fun doubleConst(): Double
+}
+
 @Cpp(
     ExternalType = "include/ExternalTypes.h",
     ExternalName = "external::ClassWithOverloads::StructWithOverloads"

--- a/examples/libhello/src/test/StructsWithMethods.cpp
+++ b/examples/libhello/src/test/StructsWithMethods.cpp
@@ -18,6 +18,7 @@
 //
 // -------------------------------------------------------------------------------------------------
 
+#include "test/StructWithConstMethod.h"
 #include "test/StructsWithMethods.h"
 #include "test/StructsWithMethodsInterface.h"
 #include "test/ValidationUtils.h"
@@ -101,6 +102,12 @@ StructsWithMethodsInterface::Vector3::create( const StructsWithMethodsInterface:
 void
 StructsWithMethodsInterface::StructWithStaticMethodsOnly::do_stuff( )
 {
+}
+
+double
+StructWithConstMethod::double_const( ) const
+{
+    return 0;
 }
 
 }  // namespace test

--- a/gluecodium/src/main/resources/templates/cpp/CppFunctionSignature.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppFunctionSignature.mustache
@@ -22,7 +22,7 @@
 {{#if isStatic}}static {{/if}}{{#unless isStatic}}{{#if isVirtual}}virtual {{/if}}{{/unless}}{{!!
 }}{{>resolveReturnType}} {{resolveName}}{{!!
 }}( {{#parameters}}const {{>resolveTypeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}} ){{!!
-}}{{#unless isStatic}}{{#if attributes.cpp.Const}} const{{/if}}{{#if isConst}} const{{/if}}{{!!
+}}{{#unless isStatic}}{{#if isConst attributes.cpp.const logic="or"}} const{{/if}}{{!!
 }}{{#if isVirtual}} = 0{{/if}}{{/unless}}{{!!
 
 }}{{+resolveTypeRef}}{{#if useCstring}}{{#if attributes.cpp.cstring}}char*{{/if}}{{!!

--- a/gluecodium/src/test/resources/smoke/structs/input/StructsWithMethods.lime
+++ b/gluecodium/src/test/resources/smoke/structs/input/StructsWithMethods.lime
@@ -72,6 +72,12 @@ class StructsWithMethodsInterface {
     }
 }
 
+struct StructWithConstMethod {
+    stringField: String
+    @Cpp(Const)
+    fun doubleConst(): Double
+}
+
 @Cpp(
     ExternalType = "include/ExternalTypes.h",
     ExternalName = "external::ClassWithOverloads::StructWithOverloads"

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/StructWithConstMethod.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/StructWithConstMethod.h
@@ -1,0 +1,15 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include <string>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT StructWithConstMethod {
+    ::std::string string_field;
+    StructWithConstMethod( );
+    StructWithConstMethod( ::std::string string_field );
+    double double_const(  ) const;
+};
+}


### PR DESCRIPTION
Updated C++ templates to avoid adding "const" modifier to methods twice.
Previously this could happen for methods on structs (these are always
"const") which also had `@Cpp(Const)` attribute.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>