### PR TITLE
Add support for Java "external" types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Features:
   * Introduced "external descriptors", new IDL syntax for declaring "external" types. This syntax
     replaces `@Cpp(External*)` group of IDL attributes.
+  * Added support for "external" structs and enums in Java.
 
 ## 7.1.6
 Release date: 2020-07-09

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -312,6 +312,13 @@ names are case-insensitive. Supported platform tags:
     one-to-one correspondence between IDL types and "external" C++ types is supported.
     * **getterName**, **setterName**: marks a field in a struct type that is already marked as
     external to be accessed through given getter/setter functions instead of directly in C++.
+  * **java**: describes "external" behavior for Java. Currently only supported for structs and
+  enums. Supported value names:
+    * **name**: *mandatory value*. Specifies a full Java name for the pre-existing type (i.e.
+    including package names and names of outer classes, as it would appear in an `import`
+    statement).
+    * **getterName**, **setterName**: marks a field in a struct type that is already marked as
+    external to be accessed through given getter/setter functions instead of directly in Java.
 
 ### Type references
 

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -306,6 +306,12 @@ feature(ExternalTypes cpp android swift dart SOURCES
     lime/test/UseExternalTypes.lime
 )
 
+feature(JavaExternalTypes android SOURCES
+    src/test/JavaExternalTypes.cpp
+
+    lime/test/JavaExternalTypes.lime
+)
+
 feature(UnderscorePackage cpp android swift dart SOURCES
     src/test/UseUnderscorePackage.cpp
 

--- a/examples/libhello/lime/test/JavaExternalTypes.lime
+++ b/examples/libhello/lime/test/JavaExternalTypes.lime
@@ -1,0 +1,55 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+@Immutable
+struct Currency {
+    external {
+        java name "java.util.Currency"
+    }
+
+    currencyCode: String external { java getterName "getCurrencyCode" }
+    numericCode: Int external { java getterName "getNumericCode" }
+}
+
+struct TimeZone {
+    external {
+        java name "java.util.SimpleTimeZone"
+    }
+
+    rawOffset: Int external {
+        java getterName "getRawOffset"
+        java setterName "setRawOffset"
+    }
+}
+
+enum Month {
+    external {
+        java name "java.time.Month"
+    }
+
+    JANUARY = 1,
+    FEBRUARY,
+    MARCH
+}
+
+class UseJavaExternalTypes {
+    static fun currencyRoundTrip(input: Currency): Currency
+    static fun timeZoneRoundTrip(input: TimeZone): TimeZone
+    static fun monthRoundTrip(input: Month): Month
+}

--- a/examples/libhello/src/test/JavaExternalTypes.cpp
+++ b/examples/libhello/src/test/JavaExternalTypes.cpp
@@ -1,0 +1,39 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/UseJavaExternalTypes.h"
+
+namespace test
+{
+Currency
+UseJavaExternalTypes::currency_round_trip(const Currency& input) {
+    return input;
+}
+
+TimeZone
+UseJavaExternalTypes::time_zone_round_trip(const TimeZone& input) {
+    return input;
+}
+
+Month
+UseJavaExternalTypes::month_round_trip(const Month input) {
+    return input;
+}
+}

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/ExternalTypesTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/ExternalTypesTest.java
@@ -27,6 +27,9 @@ import com.here.android.RobolectricApplication;
 import com.here.android.external.AnotherExternalStruct;
 import com.here.android.external.ExternalEnum;
 import com.here.android.external.ExternalStruct;
+import java.time.Month;
+import java.util.Currency;
+import java.util.SimpleTimeZone;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -70,5 +73,34 @@ public final class ExternalTypesTest {
 
     assertNotNull(resultEnum);
     assertEquals(ExternalEnum.BAR, resultEnum);
+  }
+
+  @Test
+  public void useJavaExternalStructCurrency() {
+    Currency currency = Currency.getInstance("EUR");
+
+    Currency result = UseJavaExternalTypes.currencyRoundTrip(currency);
+
+    assertEquals(currency.getCurrencyCode(), result.getCurrencyCode());
+    assertEquals(currency.getNumericCode(), result.getNumericCode());
+  }
+
+  @Test
+  public void useJavaExternalStructTimeZone() {
+    SimpleTimeZone timeZone = new SimpleTimeZone(2, "foobar");
+    timeZone.setRawOffset(42);
+
+    SimpleTimeZone result = UseJavaExternalTypes.timeZoneRoundTrip(timeZone);
+
+    assertEquals(timeZone.getRawOffset(), result.getRawOffset());
+  }
+
+  @Test
+  public void useJavaExternalEnum() {
+    Month month = Month.of(2);
+
+    Month result = UseJavaExternalTypes.monthRoundTrip(month);
+
+    assertEquals(month, result);
   }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameRules.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameRules.kt
@@ -48,4 +48,12 @@ class JavaNameRules(nameRuleSet: NameRuleSet) : NameRules(nameRuleSet) {
 
     private fun getPlatformName(limeElement: LimeNamedElement?) =
         limeElement?.attributes?.get(JAVA, NAME)
+
+    companion object {
+        fun getPackageFromImportString(importString: String) =
+            importString.split('.').takeWhile { it.first().isLowerCase() }
+
+        fun getClassNamesFromImportString(importString: String) =
+            importString.split('.').dropWhile { it.first().isLowerCase() }
+    }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaTypeMapper.kt
@@ -37,6 +37,7 @@ import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeException
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.NAME_NAME
 import com.here.gluecodium.model.lime.LimeLazyTypeRef
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
@@ -152,8 +153,12 @@ class JavaTypeMapper(
     }
 
     fun mapCustomType(limeType: LimeType): JavaTypeRef {
-        val classNames = nameResolver.getClassNames(limeType)
-        val javaPackage = basePackage.createChildPackage(limeType.path.head)
+        val externalImport = limeType.external?.java?.get(NAME_NAME)
+        val javaPackage = externalImport?.let {
+            JavaPackage(JavaNameRules.getPackageFromImportString(it))
+        } ?: basePackage.createChildPackage(limeType.path.head)
+        val classNames = externalImport?.let { JavaNameRules.getClassNamesFromImportString(it) }
+            ?: nameResolver.getClassNames(limeType)
 
         val javaImport = JavaImport(classNames.first(), javaPackage)
         val typeName = classNames.joinToString(".")

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniModelBuilder.kt
@@ -65,6 +65,8 @@ import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeEnumerator
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.GETTER_NAME_NAME
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.SETTER_NAME_NAME
 import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeInterface
@@ -252,7 +254,9 @@ class JniModelBuilder(
                 (javaField.type as? JavaCustomTypeRef)?.let { JniNameRules.getFullClassName(it) },
             cppField = cppField,
             cppGetterName = cppField.getterName,
-            cppSetterName = cppField.setterName
+            cppSetterName = cppField.setterName,
+            javaGetterName = limeField.external?.java?.get(GETTER_NAME_NAME),
+            javaSetterName = limeField.external?.java?.get(SETTER_NAME_NAME)
         )
 
         storeResult(jniField)
@@ -266,7 +270,8 @@ class JniModelBuilder(
             javaName = javaEnum.classNames.joinToString("$"),
             cppFullyQualifiedName = cppEnum.fullyQualifiedName,
             javaPackage = javaEnum.javaPackage,
-            enumerators = getPreviousResults(JniEnumerator::class.java)
+            enumerators = getPreviousResults(JniEnumerator::class.java),
+            isExternal = javaEnum.isExternal
         )
 
         storeNamedResult(limeEnumeration, jniEnum)

--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaClass.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaClass.kt
@@ -33,8 +33,9 @@ class JavaClass(
     val hasNativeEquatable: Boolean = false,
     val isImmutable: Boolean = false,
     val needsBuilder: Boolean = false,
-    var generatedConstructorComment: String? = null
-) : JavaTopLevelElement(name, classNames) {
+    var generatedConstructorComment: String? = null,
+    isExternal: Boolean = false
+) : JavaTopLevelElement(name, classNames, isExternal) {
 
     init {
         this.methods += methods

--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaEnum.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaEnum.kt
@@ -22,8 +22,9 @@ package com.here.gluecodium.model.java
 class JavaEnum(
     name: String,
     classNames: List<String> = listOf(name),
-    val items: List<JavaEnumItem> = emptyList()
-) : JavaTopLevelElement(name, classNames) {
+    val items: List<JavaEnumItem> = emptyList(),
+    isExternal: Boolean = false
+) : JavaTopLevelElement(name, classNames, isExternal) {
 
     override val childElements
         get() = super.childElements + items

--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaTopLevelElement.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaTopLevelElement.kt
@@ -19,7 +19,11 @@
 
 package com.here.gluecodium.model.java
 
-abstract class JavaTopLevelElement(name: String, val classNames: List<String>) : JavaElement(name) {
+abstract class JavaTopLevelElement(
+    name: String,
+    val classNames: List<String>,
+    val isExternal: Boolean = false
+) : JavaElement(name) {
 
     var javaPackage = JavaPackage.DEFAULT
     val methods: MutableSet<JavaMethod> = mutableSetOf()

--- a/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniEnum.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniEnum.kt
@@ -25,7 +25,8 @@ class JniEnum(
     javaName: String,
     cppFullyQualifiedName: String,
     javaPackage: JavaPackage,
-    val enumerators: List<JniEnumerator> = emptyList()
+    val enumerators: List<JniEnumerator> = emptyList(),
+    val isExternal: Boolean = false
 ) : JniTopLevelElement(javaName, cppFullyQualifiedName, javaPackage) {
     @Suppress("unused")
     val jniTypeSignature

--- a/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniField.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniField.kt
@@ -27,5 +27,7 @@ class JniField(
     val javaCustomType: String?,
     val cppField: CppField,
     val cppGetterName: String? = null,
-    val cppSetterName: String? = null
+    val cppSetterName: String? = null,
+    val javaGetterName: String? = null,
+    val javaSetterName: String? = null
 ) : JniElement

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
@@ -111,7 +111,10 @@ open class JavaGeneratorSuite protected constructor(
         }
 
         val javaTemplates = JavaTemplates(generatorName)
-        val javaFiles = javaTemplates.generateFiles(combinedModel.javaElements).toMutableList()
+        val nonExternalElements = combinedModel.javaElements.filter {
+            it !is JavaTopLevelElement || !it.isExternal
+        }
+        val javaFiles = javaTemplates.generateFiles(nonExternalElements).toMutableList()
 
         val nativeBasePath = listOf(generatorName) + internalPackageList + NATIVE_BASE_JAVA
         javaFiles.add(

--- a/gluecodium/src/main/resources/templates/jni/EnumConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/EnumConversionImplementation.mustache
@@ -37,8 +37,21 @@ namespace jni
 {{cppFullyQualifiedName}}
 convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, {{cppFullyQualifiedName}}*)
 {
+{{#if isExternal}}
+    auto ordinal = call_java_method<jint>(_jenv, _jinput, "ordinal", "()I");
+    switch(ordinal) {
+{{#enumerators}}
+        case {{iter.position}}:
+            return {{cppFullyQualifiedName}}::{{cppName}};
+{{/enumerators}}
+        default:
+            return {};
+    }
+{{/if}}{{!!
+}}{{#unless isExternal}}
     return {{cppFullyQualifiedName}}(
         {{>common/InternalNamespace}}jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+{{/unless}}
 }
 
 {{>common/InternalNamespace}}optional<{{cppFullyQualifiedName}}>

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -115,7 +115,6 @@ jint
 }}{{+jniMethod}}
 {{returnType.name}}
 {{>jni/FunctionSignature}}
-
 {
 {{#parameters}}
 {{#if type.isComplex}}

--- a/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
@@ -25,6 +25,7 @@
 {{/includes}}
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 
 {{#internalNamespace}}
@@ -38,7 +39,13 @@ namespace jni
 convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, {{cppFullyQualifiedName}}*)
 {
     {{#unless hasImmutableFields}}{{cppFullyQualifiedName}} _nout{};{{/unless}}
-{{#fields}}{{#if javaCustomType}}
+{{#fields}}{{#if javaGetterName}}{{#if type.isComplex}}
+    auto j_{{cppField.name}} = call_java_method<{{type.name}}>(_jenv, _jinput, "{{javaGetterName}}", "(){{type.jniTypeSignature}}");
+    auto n_{{cppField.name}} = convert_from_jni(_jenv, j_{{cppField.name}}, ({{cppField.type.name}}*)nullptr);
+{{/if}}{{#unless type.isComplex}}
+    auto n_{{cppField.name}} = call_java_method<{{type.name}}>(_jenv, _jinput, "{{javaGetterName}}", "(){{type.jniTypeSignature}}");
+{{/unless}}{{/if}}{{!!
+}}{{#unless javaGetterName}}{{#if javaCustomType}}
     {{cppField.type.name}} n_{{cppField.name}} = convert_from_jni(
         _jenv,
         {{>common/InternalNamespace}}jni::get_object_field_value(_jenv, _jinput, "{{javaName}}", "L{{javaCustomType}};"),
@@ -49,7 +56,7 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, {{cppFully
         _jinput,
         "{{javaName}}",
         ({{cppField.type.name}}*)nullptr );
-{{/unless}}
+{{/unless}}{{/unless}}
     {{#unless hasImmutableFields}}_nout.{{#if cppSetterName}}{{cppSetterName}}({{/if}}{{#unless cppSetterName}}{{cppField.name}} = {{/unless}}n_{{cppField.name}}{{#if cppSetterName}}){{/if}};{{/unless}}
 {{/fields}}
     {{#if hasImmutableFields}}return {{cppFullyQualifiedName}}({{#fields}}std::move(n_{{cppField.name}}){{#if iter.hasNext}}, {{/if}}{{/fields}});{{/if}}{{!!
@@ -71,12 +78,18 @@ convert_to_jni(JNIEnv* _jenv, const {{cppFullyQualifiedName}}& _ninput)
 {
     auto& javaClass = CachedJavaClass<{{cppFullyQualifiedName}}>::java_class;
     auto _jresult = {{>common/InternalNamespace}}jni::alloc_object(_jenv, javaClass);
-{{#fields}}{{#if javaCustomType}}
+{{#fields}}{{#if javaSetterName}}{{#if type.isComplex}}
+    auto j{{cppField.name}} = convert_to_jni(_jenv, {{>getCppFieldValue}});
+    call_java_method<void>(_jenv, _jresult, "{{javaSetterName}}", "({{type.jniTypeSignature}})V", j{{cppField.name}});
+{{/if}}{{#unless type.isComplex}}
+    call_java_method<void>(_jenv, _jresult, "{{javaSetterName}}", "({{type.jniTypeSignature}})V", {{>getCppFieldValue}});
+{{/unless}}{{/if}}{{!!
+}}{{#unless javaSetterName}}{{#if javaCustomType}}
     auto j{{cppField.name}} = convert_to_jni(_jenv, {{>getCppFieldValue}});
     {{>common/InternalNamespace}}jni::set_object_field_value(_jenv, _jresult, "{{javaName}}", "L{{javaCustomType}};", j{{cppField.name}});
 {{/if}}{{#unless javaCustomType}}
     {{>common/InternalNamespace}}jni::set_field_value(_jenv, _jresult, "{{javaName}}", {{>getCppFieldValue}});
-{{/unless}}{{/fields}}
+{{/unless}}{{/unless}}{{/fields}}
     return _jresult;
 }
 

--- a/gluecodium/src/test/resources/namespace_smoke/basic/output/android/jni/com_example_smoke_SomeStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/namespace_smoke/basic/output/android/jni/com_example_smoke_SomeStruct__Conversion.cpp
@@ -4,6 +4,7 @@
 #include "com_example_smoke_SomeStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 namespace gluecodium
 {

--- a/gluecodium/src/test/resources/smoke/external_types/input/JavaExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/JavaExternalTypes.lime
@@ -1,0 +1,55 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Immutable
+struct Currency {
+    external {
+        java name "java.util.Currency"
+    }
+
+    currencyCode: String external { java getterName "getCurrencyCode" }
+    numericCode: Int external { java getterName "getNumericCode" }
+}
+
+struct TimeZone {
+    external {
+        java name "java.util.SimpleTimeZone"
+    }
+
+    rawOffset: Int external {
+        java getterName "getRawOffset"
+        java setterName "setRawOffset"
+    }
+}
+
+enum Month {
+    external {
+        java name "java.time.Month"
+    }
+
+    JANUARY = 1,
+    FEBRUARY,
+    MARCH
+}
+
+class UseJavaExternalTypes {
+    static fun currencyRoundTrip(input: Currency): Currency
+    static fun timeZoneRoundTrip(input: TimeZone): TimeZone
+    static fun monthRoundTrip(input: Month): Month
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/UseJavaExternalTypes.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/UseJavaExternalTypes.java
@@ -1,0 +1,30 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import com.example.NativeBase;
+import java.time.Month;
+import java.util.Currency;
+import java.util.SimpleTimeZone;
+public final class UseJavaExternalTypes extends NativeBase {
+    /**
+     * For internal use only.
+     * @exclude
+     */
+    protected UseJavaExternalTypes(final long nativeHandle) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+    private static native void disposeNativeHandle(long nativeHandle);
+    @NonNull
+    public static native Currency currencyRoundTrip(@NonNull final Currency input);
+    @NonNull
+    public static native SimpleTimeZone timeZoneRoundTrip(@NonNull final SimpleTimeZone input);
+    @NonNull
+    public static native Month monthRoundTrip(@NonNull final Month input);
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Structs_ExternalStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Structs_ExternalStruct__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "com_example_smoke_Structs_ExternalStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 namespace gluecodium
 {

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_time_Month__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_time_Month__Conversion.cpp
@@ -1,0 +1,60 @@
+/*
+ *
+ */
+#include "java_time_Month__Conversion.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+namespace gluecodium
+{
+namespace jni
+{
+::smoke::Month
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Month*)
+{
+    auto ordinal = call_java_method<jint>(_jenv, _jinput, "ordinal", "()I");
+    switch(ordinal) {
+        case 0:
+            return ::smoke::Month::JANUARY;
+        case 1:
+            return ::smoke::Month::FEBRUARY;
+        case 2:
+            return ::smoke::Month::MARCH;
+        default:
+            return {};
+    }
+}
+::gluecodium::optional<::smoke::Month>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<::smoke::Month>*)
+{
+    return _jinput
+        ? ::gluecodium::optional<::smoke::Month>(convert_from_jni(_jenv, _jinput, (::smoke::Month*)nullptr))
+        : ::gluecodium::optional<::smoke::Month>{};
+}
+REGISTER_JNI_CLASS_CACHE("java/time/Month", java_time_Month, ::smoke::Month)
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::Month _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::Month>::java_class;
+    const char* enumeratorName = nullptr;
+    switch(_ninput) {
+        case(::smoke::Month::JANUARY):
+            enumeratorName = "JANUARY";
+            break;
+        case(::smoke::Month::FEBRUARY):
+            enumeratorName = "FEBRUARY";
+            break;
+        case(::smoke::Month::MARCH):
+            enumeratorName = "MARCH";
+            break;
+    }
+    jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Ljava/time/Month;");
+    return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<::smoke::Month> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_util_Currency__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_util_Currency__Conversion.cpp
@@ -1,0 +1,44 @@
+/*
+ *
+ */
+#include "java_util_Currency__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+namespace gluecodium
+{
+namespace jni
+{
+::smoke::Currency
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Currency*)
+{
+    auto j_currency_code = call_java_method<jstring>(_jenv, _jinput, "getCurrencyCode", "()Ljava/lang/String;");
+    auto n_currency_code = convert_from_jni(_jenv, j_currency_code, (::std::string*)nullptr);
+    auto n_numeric_code = call_java_method<jint>(_jenv, _jinput, "getNumericCode", "()I");
+    return ::smoke::Currency(std::move(n_currency_code), std::move(n_numeric_code));
+}
+::gluecodium::optional<::smoke::Currency>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<::smoke::Currency>*)
+{
+    return _jinput
+        ? ::gluecodium::optional<::smoke::Currency>(convert_from_jni(_jenv, _jinput, (::smoke::Currency*)nullptr))
+        : ::gluecodium::optional<::smoke::Currency>{};
+}
+REGISTER_JNI_CLASS_CACHE("java/util/Currency", java_util_Currency, ::smoke::Currency)
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::Currency& _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::Currency>::java_class;
+    auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "currencyCode", _ninput.currency_code);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "numericCode", _ninput.numeric_code);
+    return _jresult;
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<::smoke::Currency> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_util_SimpleTimeZone__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_util_SimpleTimeZone__Conversion.cpp
@@ -1,0 +1,43 @@
+/*
+ *
+ */
+#include "java_util_SimpleTimeZone__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+namespace gluecodium
+{
+namespace jni
+{
+::smoke::TimeZone
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::TimeZone*)
+{
+    ::smoke::TimeZone _nout{};
+    auto n_raw_offset = call_java_method<jint>(_jenv, _jinput, "getRawOffset", "()I");
+    _nout.raw_offset = n_raw_offset;
+    return _nout;
+}
+::gluecodium::optional<::smoke::TimeZone>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<::smoke::TimeZone>*)
+{
+    return _jinput
+        ? ::gluecodium::optional<::smoke::TimeZone>(convert_from_jni(_jenv, _jinput, (::smoke::TimeZone*)nullptr))
+        : ::gluecodium::optional<::smoke::TimeZone>{};
+}
+REGISTER_JNI_CLASS_CACHE("java/util/SimpleTimeZone", java_util_SimpleTimeZone, ::smoke::TimeZone)
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::TimeZone& _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::TimeZone>::java_class;
+    auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+    call_java_method<void>(_jenv, _jresult, "setRawOffset", "(I)V", _ninput.raw_offset);
+    return _jresult;
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<::smoke::TimeZone> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithBasicTypes_StructWithGenerics__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithBasicTypes_StructWithGenerics__Conversion.cpp
@@ -4,6 +4,7 @@
 #include "com_example_smoke_GenericTypesWithBasicTypes_StructWithGenerics__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 namespace gluecodium
 {

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_StructWithClass__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_StructWithClass__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "com_example_smoke_StructWithClass__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 namespace gluecodium
 {

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_StructWithInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_StructWithInterface__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "com_example_smoke_StructWithInterface__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 namespace gluecodium
 {

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID_EXAMPLE_STRUCT_DROID__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID_EXAMPLE_STRUCT_DROID__Conversion.cpp
@@ -4,6 +4,7 @@
 #include "com_example_namerules_NAME_RULES_DROID_EXAMPLE_STRUCT_DROID__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 namespace jni
 {

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree_LevelFour__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree_LevelFour__Conversion.cpp
@@ -4,6 +4,7 @@
 #include "com_example_smoke_LevelOne_LevelTwo_LevelThree_LevelFour__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 namespace gluecodium
 {

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_NullableCollectionsStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_NullableCollectionsStruct__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "com_example_smoke_NullableCollectionsStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 namespace gluecodium
 {

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable_NullableIntsStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable_NullableIntsStruct__Conversion.cpp
@@ -4,6 +4,7 @@
 #include "com_example_smoke_Nullable_NullableIntsStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 namespace gluecodium
 {

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable_NullableStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable_NullableStruct__Conversion.cpp
@@ -7,6 +7,7 @@
 #include "com_example_smoke_Nullable_NullableStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 namespace gluecodium
 {

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_AllTypesStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_AllTypesStruct__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "com_example_smoke_Structs_AllTypesStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 namespace gluecodium
 {

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_NestingImmutableStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_NestingImmutableStruct__Conversion.cpp
@@ -5,6 +5,7 @@
 #include "com_example_smoke_Structs_NestingImmutableStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
 namespace gluecodium
 {

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
@@ -26,6 +26,8 @@ class LimeExternalDescriptor private constructor(
 ) {
     val cpp
         get() = descriptors[CPP_TAG]
+    val java
+        get() = descriptors[JAVA_TAG]
 
     operator fun plus(other: LimeExternalDescriptor) =
         LimeExternalDescriptor(descriptors + other.descriptors)
@@ -48,6 +50,8 @@ class LimeExternalDescriptor private constructor(
 
     companion object {
         const val CPP_TAG = "cpp"
+        const val JAVA_TAG = "java"
+
         const val INCLUDE_NAME = "include"
         const val NAME_NAME = "name"
         const val GETTER_NAME_NAME = "getterName"


### PR DESCRIPTION
Updated Java and models to support "external" structs and enums. Java
code is not generated for "external" types, the given pre-existing type
is used instead. JNI conversion functions are still generated.

Updated JNI templates to support accessor (getter and setter) names for
conversion of fields of "external" structs, as well as ordinal-based
conversion of "external" enums.

Added functional tests. Added/updated smoke tests.

See: #408
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>