### PR TITLE
Add support for Swift "external" types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ jobs:
       addons:
         apt:
           packages:
+            - libcurl3
             - ninja-build
             - valgrind
       install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Features:
   * Introduced "external descriptors", new IDL syntax for declaring "external" types. This syntax
     replaces `@Cpp(External*)` group of IDL attributes.
-  * Added support for "external" structs and enums in Java.
+  * Added support for "external" structs and enums in Java and Swift.
 
 ## 7.1.6
 Release date: 2020-07-09

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -319,6 +319,11 @@ names are case-insensitive. Supported platform tags:
     statement).
     * **getterName**, **setterName**: marks a field in a struct type that is already marked as
     external to be accessed through given getter/setter functions instead of directly in Java.
+  * **swift**: describes "external" behavior for Swift. Currently only supported for structs and
+  enums. Supported value names:
+    * **framework**: *mandatory value*. Specifies a name of a Swift framework that needs to be
+    imported for the pre-existing type. The value can be an empty string **""** if the type resides
+    in the current framework or in the "Foundation" framework.
 
 ### Type references
 

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -312,6 +312,12 @@ feature(JavaExternalTypes android SOURCES
     lime/test/JavaExternalTypes.lime
 )
 
+feature(SwiftExternalTypes swift SOURCES
+    src/test/SwiftExternalTypes.cpp
+
+    lime/test/SwiftExternalTypes.lime
+)
+
 feature(UnderscorePackage cpp android swift dart SOURCES
     src/test/UseUnderscorePackage.cpp
 

--- a/examples/libhello/lime/test/SwiftExternalTypes.lime
+++ b/examples/libhello/lime/test/SwiftExternalTypes.lime
@@ -1,0 +1,43 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+struct DateInterval {
+    external {
+        swift framework "Foundation"
+    }
+
+    start: Date
+    end: Date
+}
+
+@Swift("URLCredential.Persistence")
+enum Persistence {
+    external {
+        swift framework "FoundationNetworking"
+    }
+
+    none,
+    forSession,
+    permanent
+}
+
+class UseSwiftExternalTypes {
+    static fun dateIntervalRoundTrip(input: DateInterval): DateInterval
+    static fun persistenceRoundTrip(input: Persistence): Persistence
+}

--- a/examples/libhello/src/test/SwiftExternalTypes.cpp
+++ b/examples/libhello/src/test/SwiftExternalTypes.cpp
@@ -1,0 +1,34 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/UseSwiftExternalTypes.h"
+
+namespace test
+{
+DateInterval
+UseSwiftExternalTypes::date_interval_round_trip(const DateInterval& input) {
+    return input;
+}
+
+Persistence
+UseSwiftExternalTypes::persistence_round_trip(const Persistence input) {
+    return input;
+}
+}

--- a/examples/platforms/ios/Tests/testTests/ExternalTypesTests.swift
+++ b/examples/platforms/ios/Tests/testTests/ExternalTypesTests.swift
@@ -20,6 +20,7 @@
 
 import XCTest
 import hello
+import FoundationNetworking
 
 class ExternalTypesTests: XCTestCase {
 
@@ -53,8 +54,29 @@ class ExternalTypesTests: XCTestCase {
         XCTAssertEqual(ExternalEnum.bar, resultEnum)
     }
 
+    func testSwiftExternalTypeDateInterval() {
+        let interval = DateInterval(start: Date(), duration: 60)
+
+        let result = UseSwiftExternalTypes.dateIntervalRoundTrip(input: interval)
+
+        XCTAssertEqual(interval.start.timeIntervalSinceReferenceDate,
+            result.start.timeIntervalSinceReferenceDate, accuracy: 1e-6)
+        XCTAssertEqual(interval.end.timeIntervalSinceReferenceDate,
+            result.end.timeIntervalSinceReferenceDate, accuracy: 1e-6)
+    }
+
+    func testSwiftExternalTypePersistence() {
+        let persistence = URLCredential.Persistence.forSession
+
+        let result = UseSwiftExternalTypes.persistenceRoundTrip(input: persistence)
+
+        XCTAssertEqual(persistence, result)
+    }
+
     static var allTests = [
         ("testUseExternalTypesExternalStruct", testUseExternalTypesExternalStruct),
-        ("testUseExternalTypesExternalEnum", testUseExternalTypesExternalEnum)
+        ("testUseExternalTypesExternalEnum", testUseExternalTypesExternalEnum),
+        ("testSwiftExternalTypeDateInterval", testSwiftExternalTypeDateInterval),
+        ("testSwiftExternalTypePersistence", testSwiftExternalTypePersistence)
     ]
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeNameRules.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeNameRules.kt
@@ -53,7 +53,7 @@ object CBridgeNameRules {
     const val SRC_DIR = "src"
 
     fun getName(limeElement: LimeNamedElement) =
-        getPlatformName(limeElement) ?: NameHelper.toUpperCamelCase(limeElement.name)
+        mangleName(getPlatformName(limeElement) ?: NameHelper.toUpperCamelCase(limeElement.name))
 
     fun getFunctionTableName(limeElement: LimeNamedElement) =
         getInterfaceName(limeElement) + "_FunctionTable"
@@ -76,11 +76,13 @@ object CBridgeNameRules {
             else -> ""
         }
         val methodName = getPlatformName(limeMethod) ?: NameHelper.toLowerCamelCase(limeMethod.name)
-        return prefix + methodName + suffix
+        return prefix + mangleName(methodName) + suffix
     }
 
     private fun mangleSignature(name: String) =
         name.replace("_", "_1").replace(":", "_2").replace("[", "_3").replace("]", "_4")
+
+    private fun mangleName(name: String) = name.replace(".", "_1")
 
     private fun getNestedNames(limeElement: LimeNamedElement) =
         limeElement.path.head + limeElement.path.tail.map { NameHelper.toUpperCamelCase(it) }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenericsGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenericsGenerator.kt
@@ -25,6 +25,7 @@ import com.here.gluecodium.model.swift.SwiftArray
 import com.here.gluecodium.model.swift.SwiftDictionary
 import com.here.gluecodium.model.swift.SwiftSet
 import com.here.gluecodium.model.swift.SwiftType
+import com.here.gluecodium.platform.swift.SwiftTypeRefsCollector
 import java.util.TreeMap
 
 class SwiftGenericsGenerator(private val internalPrefix: String?) {
@@ -42,7 +43,11 @@ class SwiftGenericsGenerator(private val internalPrefix: String?) {
 
     private fun generateArrays(swiftTypes: Collection<SwiftType>): List<GeneratedFile> {
         val arrays = swiftTypes.filterIsInstance<SwiftArray>()
-        val data = mapOf("arrays" to arrays, "internalPrefix" to internalPrefix)
+        val data = mapOf(
+            "arrays" to arrays,
+            "internalPrefix" to internalPrefix,
+            "imports" to collectImports(arrays)
+        )
         return when {
             arrays.isEmpty() -> emptyList()
             else -> listOf(GeneratedFile(
@@ -54,7 +59,11 @@ class SwiftGenericsGenerator(private val internalPrefix: String?) {
 
     private fun generateDictionaries(swiftTypes: Collection<SwiftType>): List<GeneratedFile> {
         val dictionaries = swiftTypes.filterIsInstance<SwiftDictionary>()
-        val data = mapOf("dictionaries" to dictionaries, "internalPrefix" to internalPrefix)
+        val data = mapOf(
+            "dictionaries" to dictionaries,
+            "internalPrefix" to internalPrefix,
+            "imports" to collectImports(dictionaries)
+        )
         return when {
             dictionaries.isEmpty() -> emptyList()
             else -> listOf(GeneratedFile(
@@ -66,7 +75,11 @@ class SwiftGenericsGenerator(private val internalPrefix: String?) {
 
     private fun generateSets(swiftTypes: Collection<SwiftType>): List<GeneratedFile> {
         val sets = swiftTypes.filterIsInstance<SwiftSet>()
-        val data = mapOf("sets" to sets, "internalPrefix" to internalPrefix)
+        val data = mapOf(
+            "sets" to sets,
+            "internalPrefix" to internalPrefix,
+            "imports" to collectImports(sets)
+        )
         return when {
             sets.isEmpty() -> emptyList()
             else -> listOf(GeneratedFile(
@@ -75,4 +88,11 @@ class SwiftGenericsGenerator(private val internalPrefix: String?) {
             ))
         }
     }
+
+    private fun collectImports(collections: List<SwiftType>) =
+        collections.flatMap { SwiftTypeRefsCollector.expandCollectionTypeRefs(it) }
+            .mapNotNull { it.externalFramework }
+            .filter { it.isNotEmpty() }
+            .distinct()
+            .sorted()
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
@@ -36,6 +36,7 @@ import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeEnumerator
 import com.here.gluecodium.model.lime.LimeException
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.FRAMEWORK_NAME
 import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeInterface
@@ -262,7 +263,8 @@ class SwiftModelBuilder(
             fields = getPreviousResults(SwiftField::class.java),
             constants = getPreviousResults(SwiftConstant::class.java),
             methods = getPreviousResults(SwiftMethod::class.java),
-            generatedConstructorComment = limeStruct.constructorComment.getFor(PLATFORM_TAG)
+            generatedConstructorComment = limeStruct.constructorComment.getFor(PLATFORM_TAG),
+            externalFramework = limeStruct.external?.swift?.get(FRAMEWORK_NAME)
         )
         swiftStruct.comment = createComments(limeStruct)
 
@@ -294,9 +296,10 @@ class SwiftModelBuilder(
 
     override fun finishBuilding(limeEnumeration: LimeEnumeration) {
         val swiftEnum = SwiftEnum(
-            nameResolver.getFullName(limeEnumeration),
-            getVisibility(limeEnumeration),
-            getPreviousResults(SwiftEnumItem::class.java)
+            name = nameResolver.getFullName(limeEnumeration),
+            visibility = getVisibility(limeEnumeration),
+            items = getPreviousResults(SwiftEnumItem::class.java),
+            externalFramework = limeEnumeration.external?.swift?.get(FRAMEWORK_NAME)
         )
         swiftEnum.comment = createComments(limeEnumeration)
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftTypeMapper.kt
@@ -27,6 +27,7 @@ import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeException
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.FRAMEWORK_NAME
 import com.here.gluecodium.model.lime.LimeGenericType
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
@@ -65,9 +66,13 @@ class SwiftTypeMapper(
             is LimeBasicType -> mapBasicType(limeType)
             is LimeStruct -> SwiftStruct(
                 nameResolver.getFullName(limeType),
-                CBridgeNameRules.getTypeName(limeType)
+                CBridgeNameRules.getTypeName(limeType),
+                externalFramework = limeType.external?.swift?.get(FRAMEWORK_NAME)
             )
-            is LimeEnumeration -> SwiftEnum(nameResolver.getFullName(limeType))
+            is LimeEnumeration -> SwiftEnum(
+                nameResolver.getFullName(limeType),
+                externalFramework = limeType.external?.swift?.get(FRAMEWORK_NAME)
+            )
             is LimeTypeAlias ->
                 mapType(limeType.typeRef.type, collectGenerics)
                     .withAlias(nameResolver.getFullName(limeType))

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftEnum.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftEnum.kt
@@ -22,12 +22,14 @@ package com.here.gluecodium.model.swift
 class SwiftEnum(
     name: String,
     visibility: SwiftVisibility? = null,
-    val items: List<SwiftEnumItem> = emptyList()
+    val items: List<SwiftEnumItem> = emptyList(),
+    externalFramework: String? = null
 ) : SwiftType(
     name = name,
     visibility = visibility,
     category = TypeCategory.ENUM,
-    publicName = name
+    publicName = name,
+    externalFramework = externalFramework
 ) {
     override val childElements
         get() = items

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftStruct.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftStruct.kt
@@ -33,8 +33,9 @@ class SwiftStruct(
     val fields: List<SwiftField> = emptyList(),
     val constants: List<SwiftConstant> = emptyList(),
     val methods: List<SwiftMethod> = emptyList(),
-    var generatedConstructorComment: String? = null
-) : SwiftType(name, cPrefix, visibility, category, publicName ?: name, optional) {
+    var generatedConstructorComment: String? = null,
+    externalFramework: String? = null
+) : SwiftType(name, cPrefix, visibility, category, publicName ?: name, optional, externalFramework) {
 
     @Suppress("unused")
     val constructors
@@ -73,7 +74,9 @@ class SwiftStruct(
             isCodable,
             fields,
             constants,
-            methods
+            methods,
+            generatedConstructorComment,
+            externalFramework
         )
         swiftStruct.comment = this.comment
         return swiftStruct
@@ -97,7 +100,9 @@ class SwiftStruct(
             isCodable,
             fields,
             constants,
-            methods
+            methods,
+            generatedConstructorComment,
+            externalFramework
         )
         swiftStruct.comment = comment
         return swiftStruct

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftType.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftType.kt
@@ -25,7 +25,8 @@ open class SwiftType protected constructor(
     visibility: SwiftVisibility? = null,
     val category: TypeCategory,
     val publicName: String = name,
-    val optional: Boolean = false
+    val optional: Boolean = false,
+    val externalFramework: String? = null
 ) : SwiftModelElement(name, visibility) {
     val className
         get() = if (category == TypeCategory.CLASS) mangledName else ""
@@ -57,13 +58,17 @@ open class SwiftType protected constructor(
     @Suppress("unused")
     fun getcPrefix() = cPrefix
 
+    @Suppress("unused")
+    val isExternal
+        get() = externalFramework != null
+
     open fun withAlias(aliasName: String) =
-        SwiftType(name, cPrefix, visibility, category, aliasName, optional)
+        SwiftType(name, cPrefix, visibility, category, aliasName, optional, externalFramework)
 
     open fun withOptional(optional: Boolean) =
         when (optional) {
             this.optional -> this
-            else -> SwiftType(name, cPrefix, visibility, category, publicName, optional)
+            else -> SwiftType(name, cPrefix, visibility, category, publicName, optional, externalFramework)
         }
 
     companion object {

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftTypeRefsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftTypeRefsCollector.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.platform.swift
+
+import com.here.gluecodium.model.swift.SwiftArray
+import com.here.gluecodium.model.swift.SwiftClass
+import com.here.gluecodium.model.swift.SwiftClosure
+import com.here.gluecodium.model.swift.SwiftDictionary
+import com.here.gluecodium.model.swift.SwiftExtension
+import com.here.gluecodium.model.swift.SwiftMethod
+import com.here.gluecodium.model.swift.SwiftModelElement
+import com.here.gluecodium.model.swift.SwiftSet
+import com.here.gluecodium.model.swift.SwiftStruct
+import com.here.gluecodium.model.swift.SwiftType
+import com.here.gluecodium.model.swift.SwiftTypedModelElement
+
+internal object SwiftTypeRefsCollector {
+    fun expandCollectionTypeRefs(swiftType: SwiftType): List<SwiftType> =
+        when (swiftType) {
+            is SwiftArray -> expandCollectionTypeRefs(swiftType.elementType)
+            is SwiftSet -> expandCollectionTypeRefs(swiftType.elementType)
+            is SwiftDictionary -> expandCollectionTypeRefs(swiftType.keyType) +
+                expandCollectionTypeRefs(swiftType.valueType)
+            else -> listOf(swiftType)
+        }
+
+    fun collectTypeRefs(element: SwiftModelElement): List<SwiftType> =
+        when (element) {
+            is SwiftClass, is SwiftStruct, is SwiftExtension ->
+                element.childElements.flatMap { collectTypeRefs(it) }
+            is SwiftMethod -> element.parameters.flatMap { collectTypeRefs(it) } + element.returnType
+            is SwiftClosure -> element.parameters + element.returnType
+            is SwiftTypedModelElement -> listOf(element.type)
+            else -> emptyList()
+        }
+}

--- a/gluecodium/src/main/resources/templates/swift/Array.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Array.mustache
@@ -23,6 +23,9 @@
 //
 
 import Foundation
+{{#imports}}
+import {{this}}
+{{/imports}}
 
 {{#arrays}}
 internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{publicName}} {

--- a/gluecodium/src/main/resources/templates/swift/Dictionary.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Dictionary.mustache
@@ -19,6 +19,9 @@
   !
   !}}
 import Foundation
+{{#imports}}
+import {{this}}
+{{/imports}}
 
 {{#dictionaries}}
 internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{publicName}} {

--- a/gluecodium/src/main/resources/templates/swift/Enum.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Enum.mustache
@@ -18,12 +18,11 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>swift/Comment}}
+{{#unless isExternal}}{{>swift/Comment}}
 {{visibility}} enum {{simpleName}} : UInt32, CaseIterable, Codable {
 {{#items}}{{prefixPartial "enumItem" "    "}}
 {{/items}}
 }
-
-{{+enumItem}}{{>swift/Comment}}
+{{/unless}}{{!!
+}}{{+enumItem}}{{>swift/Comment}}
 case {{name}}{{#if value}} = {{value}}{{/if}}{{/enumItem}}
-

--- a/gluecodium/src/main/resources/templates/swift/EnumConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/EnumConversion.mustache
@@ -19,21 +19,37 @@
   !
   !}}
 internal func copyToCType(_ swiftEnum: {{name}}) -> PrimitiveHolder<UInt32> {
-    return PrimitiveHolder(swiftEnum.rawValue)
+    return PrimitiveHolder({{#if isExternal}}UInt32({{/if}}swiftEnum.rawValue{{#if isExternal}}){{/if}})
 }
 internal func moveToCType(_ swiftEnum: {{name}}) -> PrimitiveHolder<UInt32> {
     return copyToCType(swiftEnum)
 }
 
 internal func copyToCType(_ swiftEnum: {{name}}?) -> RefHolder {
+{{#if isExternal}}
+    if let rawValue = swiftEnum?.rawValue {
+        return copyToCType(UInt32(rawValue) as UInt32?)
+    } else {
+        return RefHolder(0)
+    }
+{{/if}}{{#unless isExternal}}
     return copyToCType(swiftEnum?.rawValue)
+{{/unless}}
 }
 internal func moveToCType(_ swiftEnum: {{name}}?) -> RefHolder {
+{{#if isExternal}}
+    if let rawValue = swiftEnum?.rawValue {
+        return moveToCType(UInt32(rawValue) as UInt32?)
+    } else {
+        return RefHolder(0)
+    }
+{{/if}}{{#unless isExternal}}
     return moveToCType(swiftEnum?.rawValue)
+{{/unless}}
 }
 
 internal func copyFromCType(_ cValue: UInt32) -> {{name}} {
-    return {{name}}(rawValue: cValue)!
+    return {{name}}(rawValue: {{#if isExternal}}UInt({{/if}}cValue{{#if isExternal}}){{/if}})!
 }
 internal func moveFromCType(_ cValue: UInt32) -> {{name}} {
     return copyFromCType(cValue)
@@ -43,7 +59,7 @@ internal func copyFromCType(_ handle: _baseRef) -> {{name}}? {
     guard handle != 0 else {
         return nil
     }
-    return {{name}}(rawValue: uint32_t_value_get(handle))!
+    return {{name}}(rawValue: {{#if isExternal}}UInt({{/if}}uint32_t_value_get(handle){{#if isExternal}}){{/if}})!
 }
 internal func moveFromCType(_ handle: _baseRef) -> {{name}}? {
     defer {

--- a/gluecodium/src/main/resources/templates/swift/File.mustache
+++ b/gluecodium/src/main/resources/templates/swift/File.mustache
@@ -23,6 +23,9 @@
 //
 
 import Foundation
+{{#imports}}
+import {{this}}
+{{/imports}}
 
 {{#model}}
 {{#classes}}

--- a/gluecodium/src/main/resources/templates/swift/Set.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Set.mustache
@@ -23,6 +23,9 @@
 //
 
 import Foundation
+{{#imports}}
+import {{this}}
+{{/imports}}
 
 {{#sets}}
 internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{publicName}} {

--- a/gluecodium/src/main/resources/templates/swift/Struct.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Struct.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>swift/Comment}}
+{{#unless isExternal}}{{>swift/Comment}}
 {{visibility}} struct {{simpleName}}{{#if isEquatable isCodable logic="or"}}{{!!
 }}:{{#if isEquatable}} Hashable{{/if}}{{#if isEquatable isCodable logic="and"}},{{/if}}{{#if isCodable}} Codable{{/if}}{{!!
 }}{{/if}} {
@@ -113,5 +113,17 @@
 {{prefixPartial 'swift/Method' '    '}}
 {{/methods}}{{/set}}{{/if}}
 }
-{{+initParameter}}{{name}}: {{#isEq type.category.toString "CLOSURE"}}{{#unless type.optional}}@escaping {{/unless}}{{/isEq}}{{!!
+{{/unless}}{{!!
+
+}}{{#if isExternal}}
+extension {{name}} {
+    internal init?(cHandle: _baseRef) {
+        self.init({{#fields}}{{name}}: {{!!
+        }}{{#type}}{{>swift/ConversionPrefixFrom}}{{/type}}moveFromCType({{cPrefix}}_{{name}}_get(cHandle)){{!!
+        }}{{#if iter.hasNext}}, {{/if}}{{/fields}})
+    }
+}
+{{/if}}{{!!
+
+}}{{+initParameter}}{{name}}: {{#isEq type.category.toString "CLOSURE"}}{{#unless type.optional}}@escaping {{/unless}}{{/isEq}}{{!!
 }}{{type.publicName}}{{#type.optional}}?{{/type.optional}}{{#if defaultValue}} = {{defaultValue}}{{/if}}{{/initParameter}}

--- a/gluecodium/src/main/resources/templates/swift/StructConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/StructConversion.mustache
@@ -20,7 +20,7 @@
   !}}
 {{#if fields}}
 internal func copyFromCType(_ handle: _baseRef) -> {{name}} {
-    return {{name}}(cHandle: handle)
+    return {{name}}(cHandle: handle){{#if isExternal}}!{{/if}}
 }
 internal func moveFromCType(_ handle: _baseRef) -> {{name}} {
     defer {
@@ -46,7 +46,7 @@ internal func copyFromCType(_ handle: _baseRef) -> {{name}}? {
         return nil
     }
     let unwrappedHandle = {{cPrefix}}_unwrap_optional_handle(handle)
-    return {{name}}(cHandle: unwrappedHandle) as {{name}}
+    return {{name}}(cHandle: unwrappedHandle){{#if isExternal}}!{{/if}} as {{name}}
 }
 internal func moveFromCType(_ handle: _baseRef) -> {{name}}? {
     defer {

--- a/gluecodium/src/test/resources/smoke/external_types/input/SwiftExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/SwiftExternalTypes.lime
@@ -1,0 +1,47 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct DateInterval {
+    external {
+        swift framework "Foundation"
+    }
+
+    start: Date
+    end: Date
+}
+
+@Swift("URLCredential.Persistence")
+enum Persistence {
+    external {
+        swift framework "Foundation"
+    }
+
+    none,
+    forSession,
+    permanent
+}
+
+class UseSwiftExternalTypes {
+    static fun dateIntervalRoundTrip(input: DateInterval): DateInterval
+    static fun persistenceRoundTrip(input: Persistence): Persistence
+}
+
+typealias ExternalList = List<DateInterval>
+typealias ExternalSet = Set<DateInterval>
+typealias ExternalMap = Map<Persistence, DateInterval>

--- a/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_UseSwiftExternalTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_UseSwiftExternalTypes.cpp
@@ -1,0 +1,40 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_UseSwiftExternalTypes.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
+#include "gluecodium/Optional.h"
+#include "gluecodium/TypeRepository.h"
+#include "smoke/DateInterval.h"
+#include "smoke/Persistence.h"
+#include "smoke/UseSwiftExternalTypes.h"
+#include <memory>
+#include <new>
+void smoke_UseSwiftExternalTypes_release_handle(_baseRef handle) {
+    delete get_pointer<std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle);
+}
+_baseRef smoke_UseSwiftExternalTypes_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle)))
+        : 0;
+}
+const void* smoke_UseSwiftExternalTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle)->get())
+        : nullptr;
+}
+void smoke_UseSwiftExternalTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle)->get(), swift_pointer);
+}
+void smoke_UseSwiftExternalTypes_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle)->get());
+}
+_baseRef smoke_UseSwiftExternalTypes_dateIntervalRoundTrip(_baseRef input) {
+    return Conversion<::smoke::DateInterval>::toBaseRef(::smoke::UseSwiftExternalTypes::date_interval_round_trip(Conversion<::smoke::DateInterval>::toCpp(input)));
+}
+smoke_URLCredential_1Persistence smoke_UseSwiftExternalTypes_persistenceRoundTrip(smoke_URLCredential_1Persistence input) {
+    return static_cast<smoke_URLCredential_1Persistence>(::smoke::UseSwiftExternalTypes::persistence_round_trip(static_cast<::smoke::Persistence>(input)));
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/Collections.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/Collections.swift
@@ -1,0 +1,160 @@
+//
+//
+import Foundation
+import Foundation
+internal func copyFromCType(_ handle: _baseRef) -> [DateInterval] {
+    var result: [DateInterval] = []
+    let count = ArrayOf_smoke_DateInterval_count(handle)
+    for idx in 0..<count {
+        result.append(copyFromCType(ArrayOf_smoke_DateInterval_get(handle, idx)))
+    }
+    return result
+}
+internal func moveFromCType(_ handle: _baseRef) -> [DateInterval] {
+    defer {
+        ArrayOf_smoke_DateInterval_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftArray: [DateInterval]) -> RefHolder {
+    let handle = ArrayOf_smoke_DateInterval_create_handle()
+    for item in swiftArray {
+        let value = moveToCType(item)
+        ArrayOf_smoke_DateInterval_append(handle, value.ref)
+    }
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftArray: [DateInterval]) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftArray).ref, release: ArrayOf_smoke_DateInterval_release_handle)
+}
+internal func copyToCType(_ swiftArray: [DateInterval]?) -> RefHolder {
+    guard let swiftArray = swiftArray else {
+        return RefHolder(0)
+    }
+    let optionalHandle = ArrayOf_smoke_DateInterval_create_optional_handle()
+    let handle = ArrayOf_smoke_DateInterval_unwrap_optional_handle(optionalHandle)
+    for item in swiftArray {
+        ArrayOf_smoke_DateInterval_append(handle, moveToCType(item).ref)
+    }
+    return RefHolder(optionalHandle)
+}
+internal func moveToCType(_ swiftType: [DateInterval]?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: ArrayOf_smoke_DateInterval_release_optional_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> [DateInterval]? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = ArrayOf_smoke_DateInterval_unwrap_optional_handle(handle)
+    return copyFromCType(unwrappedHandle) as [DateInterval]
+}
+internal func moveFromCType(_ handle: _baseRef) -> [DateInterval]? {
+    defer {
+        ArrayOf_smoke_DateInterval_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> [Int8] {
+    var result: [Int8] = []
+    let count = ArrayOf__Byte_count(handle)
+    for idx in 0..<count {
+        result.append(copyFromCType(ArrayOf__Byte_get(handle, idx)))
+    }
+    return result
+}
+internal func moveFromCType(_ handle: _baseRef) -> [Int8] {
+    defer {
+        ArrayOf__Byte_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftArray: [Int8]) -> RefHolder {
+    let handle = ArrayOf__Byte_create_handle()
+    for item in swiftArray {
+        let value = moveToCType(item)
+        ArrayOf__Byte_append(handle, value.ref)
+    }
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftArray: [Int8]) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftArray).ref, release: ArrayOf__Byte_release_handle)
+}
+internal func copyToCType(_ swiftArray: [Int8]?) -> RefHolder {
+    guard let swiftArray = swiftArray else {
+        return RefHolder(0)
+    }
+    let optionalHandle = ArrayOf__Byte_create_optional_handle()
+    let handle = ArrayOf__Byte_unwrap_optional_handle(optionalHandle)
+    for item in swiftArray {
+        ArrayOf__Byte_append(handle, moveToCType(item).ref)
+    }
+    return RefHolder(optionalHandle)
+}
+internal func moveToCType(_ swiftType: [Int8]?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: ArrayOf__Byte_release_optional_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> [Int8]? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = ArrayOf__Byte_unwrap_optional_handle(handle)
+    return copyFromCType(unwrappedHandle) as [Int8]
+}
+internal func moveFromCType(_ handle: _baseRef) -> [Int8]? {
+    defer {
+        ArrayOf__Byte_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> [String] {
+    var result: [String] = []
+    let count = ArrayOf__String_count(handle)
+    for idx in 0..<count {
+        result.append(copyFromCType(ArrayOf__String_get(handle, idx)))
+    }
+    return result
+}
+internal func moveFromCType(_ handle: _baseRef) -> [String] {
+    defer {
+        ArrayOf__String_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftArray: [String]) -> RefHolder {
+    let handle = ArrayOf__String_create_handle()
+    for item in swiftArray {
+        let value = moveToCType(item)
+        ArrayOf__String_append(handle, value.ref)
+    }
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftArray: [String]) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftArray).ref, release: ArrayOf__String_release_handle)
+}
+internal func copyToCType(_ swiftArray: [String]?) -> RefHolder {
+    guard let swiftArray = swiftArray else {
+        return RefHolder(0)
+    }
+    let optionalHandle = ArrayOf__String_create_optional_handle()
+    let handle = ArrayOf__String_unwrap_optional_handle(optionalHandle)
+    for item in swiftArray {
+        ArrayOf__String_append(handle, moveToCType(item).ref)
+    }
+    return RefHolder(optionalHandle)
+}
+internal func moveToCType(_ swiftType: [String]?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: ArrayOf__String_release_optional_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> [String]? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = ArrayOf__String_unwrap_optional_handle(handle)
+    return copyFromCType(unwrappedHandle) as [String]
+}
+internal func moveFromCType(_ handle: _baseRef) -> [String]? {
+    defer {
+        ArrayOf__String_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/Dictionaries.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/Dictionaries.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Foundation
+internal func copyFromCType(_ handle: _baseRef) -> [URLCredential.Persistence: DateInterval] {
+    var swiftDict: [URLCredential.Persistence: DateInterval] = [:]
+    let iterator_handle = MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator(handle)
+    while MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_is_valid(handle, iterator_handle) {
+        swiftDict[moveFromCType(MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_key(iterator_handle))] =
+            moveFromCType(MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_value(iterator_handle)) as DateInterval
+        MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_increment(iterator_handle)
+    }
+    MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_release_handle(iterator_handle)
+    return swiftDict
+}
+internal func moveFromCType(_ handle: _baseRef) -> [URLCredential.Persistence: DateInterval] {
+    defer {
+        MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftDict: [URLCredential.Persistence: DateInterval]) -> RefHolder {
+    let c_handle = MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_create_handle()
+    for (key, value) in swiftDict {
+        let c_key = moveToCType(key)
+        let c_value = moveToCType(value)
+        MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_put(c_handle, c_key.ref, c_value.ref)
+    }
+    return RefHolder(c_handle)
+}
+internal func moveToCType(_ swiftDict: [URLCredential.Persistence: DateInterval]) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftDict).ref, release: MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> [URLCredential.Persistence: DateInterval]? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_unwrap_optional_handle(handle)
+    return copyFromCType(unwrappedHandle) as [URLCredential.Persistence: DateInterval]
+}
+internal func moveFromCType(_ handle: _baseRef) -> [URLCredential.Persistence: DateInterval]? {
+    defer {
+        MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftDict: [URLCredential.Persistence: DateInterval]?) -> RefHolder {
+    guard let swiftDict = swiftDict else {
+        return RefHolder(0)
+    }
+    let optionalHandle = MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_create_optional_handle()
+    let handle = MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_unwrap_optional_handle(optionalHandle)
+    for (key, value) in swiftDict {
+        let c_key = moveToCType(key)
+        let c_value = moveToCType(value)
+        MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_put(handle, c_key.ref, c_value.ref)
+    }
+    return RefHolder(optionalHandle)
+}
+internal func moveToCType(_ swiftType: [URLCredential.Persistence: DateInterval]?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/Sets.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/Sets.swift
@@ -1,0 +1,57 @@
+//
+//
+import Foundation
+import Foundation
+internal func copyFromCType(_ handle: _baseRef) -> Set<DateInterval> {
+    var result: Set<DateInterval> = []
+    let iterator_handle = SetOf_smoke_DateInterval_iterator(handle)
+    while SetOf_smoke_DateInterval_iterator_is_valid(handle, iterator_handle) {
+        result.insert(copyFromCType(SetOf_smoke_DateInterval_iterator_get(iterator_handle)))
+        SetOf_smoke_DateInterval_iterator_increment(iterator_handle)
+    }
+    SetOf_smoke_DateInterval_iterator_release_handle(iterator_handle)
+    return result
+}
+internal func moveFromCType(_ handle: _baseRef) -> Set<DateInterval> {
+    defer {
+        SetOf_smoke_DateInterval_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftSet: Set<DateInterval>) -> RefHolder {
+    let handle = SetOf_smoke_DateInterval_create_handle()
+    for item in swiftSet {
+        SetOf_smoke_DateInterval_insert(handle, moveToCType(item).ref)
+    }
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftSet: Set<DateInterval>) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftSet).ref, release: SetOf_smoke_DateInterval_release_handle)
+}
+internal func copyToCType(_ swiftSet: Set<DateInterval>?) -> RefHolder {
+    guard let swiftSet = swiftSet else {
+        return RefHolder(0)
+    }
+    let optionalHandle = SetOf_smoke_DateInterval_create_optional_handle()
+    let handle = SetOf_smoke_DateInterval_unwrap_optional_handle(optionalHandle)
+    for item in swiftSet {
+        SetOf_smoke_DateInterval_insert(handle, moveToCType(item).ref)
+    }
+    return RefHolder(optionalHandle)
+}
+internal func moveToCType(_ swiftType: Set<DateInterval>?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: SetOf_smoke_DateInterval_release_optional_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> Set<DateInterval>? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = SetOf_smoke_DateInterval_unwrap_optional_handle(handle)
+    return copyFromCType(unwrappedHandle) as Set<DateInterval>
+}
+internal func moveFromCType(_ handle: _baseRef) -> Set<DateInterval>? {
+    defer {
+        SetOf_smoke_DateInterval_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/DateInterval.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/DateInterval.swift
@@ -1,0 +1,50 @@
+//
+//
+import Foundation
+import Foundation
+extension DateInterval {
+    internal init?(cHandle: _baseRef) {
+        self.init(start: moveFromCType(smoke_DateInterval_start_get(cHandle)), end: moveFromCType(smoke_DateInterval_end_get(cHandle)))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> DateInterval {
+    return DateInterval(cHandle: handle)!
+}
+internal func moveFromCType(_ handle: _baseRef) -> DateInterval {
+    defer {
+        smoke_DateInterval_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: DateInterval) -> RefHolder {
+    let c_start = moveToCType(swiftType.start)
+    let c_end = moveToCType(swiftType.end)
+    return RefHolder(smoke_DateInterval_create_handle(c_start.ref, c_end.ref))
+}
+internal func moveToCType(_ swiftType: DateInterval) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DateInterval_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> DateInterval? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_DateInterval_unwrap_optional_handle(handle)
+    return DateInterval(cHandle: unwrappedHandle)! as DateInterval
+}
+internal func moveFromCType(_ handle: _baseRef) -> DateInterval? {
+    defer {
+        smoke_DateInterval_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: DateInterval?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_start = moveToCType(swiftType.start)
+    let c_end = moveToCType(swiftType.end)
+    return RefHolder(smoke_DateInterval_create_optional_handle(c_start.ref, c_end.ref))
+}
+internal func moveToCType(_ swiftType: DateInterval?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DateInterval_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/URLCredential.Persistence.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/URLCredential.Persistence.swift
@@ -1,0 +1,42 @@
+//
+//
+import Foundation
+import Foundation
+internal func copyToCType(_ swiftEnum: URLCredential.Persistence) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(UInt32(swiftEnum.rawValue))
+}
+internal func moveToCType(_ swiftEnum: URLCredential.Persistence) -> PrimitiveHolder<UInt32> {
+    return copyToCType(swiftEnum)
+}
+internal func copyToCType(_ swiftEnum: URLCredential.Persistence?) -> RefHolder {
+    if let rawValue = swiftEnum?.rawValue {
+        return copyToCType(UInt32(rawValue) as UInt32?)
+    } else {
+        return RefHolder(0)
+    }
+}
+internal func moveToCType(_ swiftEnum: URLCredential.Persistence?) -> RefHolder {
+    if let rawValue = swiftEnum?.rawValue {
+        return moveToCType(UInt32(rawValue) as UInt32?)
+    } else {
+        return RefHolder(0)
+    }
+}
+internal func copyFromCType(_ cValue: UInt32) -> URLCredential.Persistence {
+    return URLCredential.Persistence(rawValue: UInt(cValue))!
+}
+internal func moveFromCType(_ cValue: UInt32) -> URLCredential.Persistence {
+    return copyFromCType(cValue)
+}
+internal func copyFromCType(_ handle: _baseRef) -> URLCredential.Persistence? {
+    guard handle != 0 else {
+        return nil
+    }
+    return URLCredential.Persistence(rawValue: UInt(uint32_t_value_get(handle)))!
+}
+internal func moveFromCType(_ handle: _baseRef) -> URLCredential.Persistence? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UseSwiftExternalTypes.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UseSwiftExternalTypes.swift
@@ -1,0 +1,79 @@
+//
+//
+import Foundation
+import Foundation
+public class UseSwiftExternalTypes {
+    let c_instance : _baseRef
+    init(cUseSwiftExternalTypes: _baseRef) {
+        guard cUseSwiftExternalTypes != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cUseSwiftExternalTypes
+    }
+    deinit {
+        smoke_UseSwiftExternalTypes_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_UseSwiftExternalTypes_release_handle(c_instance)
+    }
+    public static func dateIntervalRoundTrip(input: DateInterval) -> DateInterval {
+        let c_input = moveToCType(input)
+        return moveFromCType(smoke_UseSwiftExternalTypes_dateIntervalRoundTrip(c_input.ref))
+    }
+    public static func persistenceRoundTrip(input: URLCredential.Persistence) -> URLCredential.Persistence {
+        let c_input = moveToCType(input)
+        return moveFromCType(smoke_UseSwiftExternalTypes_persistenceRoundTrip(c_input.ref))
+    }
+}
+internal func getRef(_ ref: UseSwiftExternalTypes?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_UseSwiftExternalTypes_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_UseSwiftExternalTypes_release_handle)
+        : RefHolder(handle_copy)
+}
+extension UseSwiftExternalTypes: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func UseSwiftExternalTypes_copyFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes {
+    if let swift_pointer = smoke_UseSwiftExternalTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UseSwiftExternalTypes {
+        return re_constructed
+    }
+    let result = UseSwiftExternalTypes(cUseSwiftExternalTypes: smoke_UseSwiftExternalTypes_copy_handle(handle))
+    smoke_UseSwiftExternalTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func UseSwiftExternalTypes_moveFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes {
+    if let swift_pointer = smoke_UseSwiftExternalTypes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UseSwiftExternalTypes {
+        return re_constructed
+    }
+    let result = UseSwiftExternalTypes(cUseSwiftExternalTypes: handle)
+    smoke_UseSwiftExternalTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func UseSwiftExternalTypes_copyFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes? {
+    guard handle != 0 else {
+        return nil
+    }
+    return UseSwiftExternalTypes_moveFromCType(handle) as UseSwiftExternalTypes
+}
+internal func UseSwiftExternalTypes_moveFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes? {
+    guard handle != 0 else {
+        return nil
+    }
+    return UseSwiftExternalTypes_moveFromCType(handle) as UseSwiftExternalTypes
+}
+internal func copyToCType(_ swiftClass: UseSwiftExternalTypes) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: UseSwiftExternalTypes) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: UseSwiftExternalTypes?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: UseSwiftExternalTypes?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
@@ -28,6 +28,8 @@ class LimeExternalDescriptor private constructor(
         get() = descriptors[CPP_TAG]
     val java
         get() = descriptors[JAVA_TAG]
+    val swift
+        get() = descriptors[SWIFT_TAG]
 
     operator fun plus(other: LimeExternalDescriptor) =
         LimeExternalDescriptor(descriptors + other.descriptors)
@@ -51,8 +53,10 @@ class LimeExternalDescriptor private constructor(
     companion object {
         const val CPP_TAG = "cpp"
         const val JAVA_TAG = "java"
+        const val SWIFT_TAG = "swift"
 
         const val INCLUDE_NAME = "include"
+        const val FRAMEWORK_NAME = "framework"
         const val NAME_NAME = "name"
         const val GETTER_NAME_NAME = "getterName"
         const val SETTER_NAME_NAME = "setterName"


### PR DESCRIPTION
Updated Swift model to support "external" structs and enums. Swift type
definitions are not generated for "external" types, the given
pre-existing type is used instead. Swift and CBridge conversion
functions are still generated.

Updated Swift templates to support additional `import` directives.
Updated templates for Swift conversion functions to support "external"
types.

Added functional tests. Added/updated smoke tests.

See: #408
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>