### PR TITLE
Add support for Dart "external" types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Features:
   * Introduced "external descriptors", new IDL syntax for declaring "external" types. This syntax
     replaces `@Cpp(External*)` group of IDL attributes.
-  * Added support for "external" structs and enums in Java and Swift.
+  * Added support for "external" structs and enums in Java, Swift, and Dart.
 
 ## 7.1.6
 Release date: 2020-07-09

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -322,8 +322,13 @@ names are case-insensitive. Supported platform tags:
   * **swift**: describes "external" behavior for Swift. Currently only supported for structs and
   enums. Supported value names:
     * **framework**: *mandatory value*. Specifies a name of a Swift framework that needs to be
-    imported for the pre-existing type. The value can be an empty string **""** if the type resides
+    imported for the pre-existing type. The value can be an empty string `""` if the type resides
     in the current framework or in the "Foundation" framework.
+  * **dart**: describes "external" behavior for Dart. Currently only supported for structs and
+  enums. Supported value names:
+    * **importPath**: *mandatory value*. Specifies a full import path for a Dart `import` directive
+    needed for the pre-existing type (i.e. either `"dart:<library_name>"` or
+    `"package:<path>/<file_name>.dart"`).
 
 ### Type references
 

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -318,6 +318,12 @@ feature(SwiftExternalTypes swift SOURCES
     lime/test/SwiftExternalTypes.lime
 )
 
+feature(DartExternalTypes dart SOURCES
+    src/test/DartExternalTypes.cpp
+
+    lime/test/DartExternalTypes.lime
+)
+
 feature(UnderscorePackage cpp android swift dart SOURCES
     src/test/UseUnderscorePackage.cpp
 

--- a/examples/libhello/lime/test/DartExternalTypes.lime
+++ b/examples/libhello/lime/test/DartExternalTypes.lime
@@ -1,0 +1,46 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+@Dart("Rectangle<int>")
+struct Rectangle {
+    external {
+        dart importPath "dart:math"
+    }
+
+    left: Int
+    top: Int
+    width: Int
+    height: Int
+}
+
+@Dart("HttpClientResponseCompressionState")
+enum CompressionState {
+    external {
+        dart importPath "dart:io"
+    }
+
+    compressed,
+    decompressed,
+    notCompressed
+}
+
+class UseDartExternalTypes {
+    static fun rectangleRoundTrip(input: Rectangle): Rectangle
+    static fun compressionStateRoundTrip(input: CompressionState): CompressionState
+}

--- a/examples/libhello/src/test/DartExternalTypes.cpp
+++ b/examples/libhello/src/test/DartExternalTypes.cpp
@@ -1,0 +1,34 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/UseDartExternalTypes.h"
+
+namespace test
+{
+Rectangle
+UseDartExternalTypes::rectangle_round_trip(const Rectangle& input) {
+    return input;
+}
+
+CompressionState
+UseDartExternalTypes::compression_state_round_trip(const CompressionState input) {
+    return input;
+}
+}

--- a/examples/platforms/dart/test/ExternalTypes_test.dart
+++ b/examples/platforms/dart/test/ExternalTypes_test.dart
@@ -18,6 +18,8 @@
 //
 // -------------------------------------------------------------------------------------------------
 
+import "dart:io";
+import "dart:math";
 import "package:test/test.dart";
 import "package:hello/external.dart";
 import "package:hello/test.dart";
@@ -48,5 +50,19 @@ void main() {
     final result = UseExternalTypes.extractExternalEnum(input);
 
     expect(result, equals(ExternalEnum.bar));
+  });
+  _testSuite.test("Use Dart external struct", () {
+    final rectangle = Rectangle<int>(0, 1, 2, 3);
+
+    final result = UseDartExternalTypes.rectangleRoundTrip(rectangle);
+
+    expect(result, rectangle);
+  });
+  _testSuite.test("Use Dart external enum", () {
+    final state = HttpClientResponseCompressionState.decompressed;
+
+    final result = UseDartExternalTypes.compressionStateRoundTrip(state);
+
+    expect(result, state);
   });
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -26,7 +26,6 @@ import com.here.gluecodium.common.LimeTypeRefsVisitor
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.GeneratedFile.SourceSet.COMMON
 import com.here.gluecodium.generator.common.LimeModelFilter
-import com.here.gluecodium.generator.common.NameHelper
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.NameRules
 import com.here.gluecodium.generator.common.nameRuleSetFromConfig
@@ -152,13 +151,14 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
         val contentTemplateName = selectTemplate(rootElement) ?: return null
 
         val packagePath = rootElement.path.head.joinToString(separator = "/")
-        val fileName = NameHelper.toLowerSnakeCase(dartNameResolver.resolveName(rootElement))
+        val fileName = importResolver.resolveFileName(rootElement)
         val filePath = "$packagePath/$fileName"
         val relativePath = "$SRC_DIR_SUFFIX/$filePath.dart"
 
         val allTypes = LimeTypeHelper.getAllTypes(rootElement).filterNot { it is LimeTypeAlias }
         val freeConstants = (rootElement as? LimeTypesCollection)?.constants ?: emptyList()
-        val allSymbols = (allTypes + freeConstants)
+        val nonExternalTypes = allTypes.filter { it.external?.dart == null }
+        val allSymbols = (nonExternalTypes + freeConstants)
             .filterNot { it.visibility.isInternal }
             .map { dartNameResolver.resolveName(it) }
         if (allSymbols.isNotEmpty()) {

--- a/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
@@ -18,12 +18,14 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{#unless external.dart}}
 {{>dart/DartDocumentation}}
 enum {{resolveName}} {
 {{#enumerators}}
 {{prefixPartial "dart/DartEnumerator" "    "}}
 {{/enumerators}}
 }
+{{/unless}}
 
 // {{resolveName}} "private" section, not exported.
 

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -18,6 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{#unless external.dart}}
 {{#functions}}
 {{>dart/DartFunctionException}}
 
@@ -71,6 +72,7 @@ class {{resolveName}} {
   }
 {{/if}}
 }
+{{/unless}}
 
 // {{resolveName}} "private" section, not exported.
 

--- a/gluecodium/src/test/resources/smoke/external_types/input/DartExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/DartExternalTypes.lime
@@ -1,0 +1,51 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Dart("Rectangle<int>")
+struct Rectangle {
+    external {
+        dart importPath "dart:math"
+    }
+
+    left: Int
+    top: Int
+    width: Int
+    height: Int
+}
+
+@Dart("HttpClientResponseCompressionState")
+enum CompressionState {
+    external {
+        dart importPath "package:foo/bar.dart"
+    }
+
+    compressed,
+    decompressed,
+    notCompressed
+}
+
+class UseDartExternalTypes {
+    static fun rectangleRoundTrip(input: Rectangle): Rectangle
+    static fun compressionStateRoundTrip(input: CompressionState): CompressionState
+}
+
+@Swift(Skip)
+class UseDartExternalGenerics {
+    fun useGenerics(list: List<Rectangle>, `set`: Set<Rectangle>): Map<CompressionState, Rectangle>
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/ffi/ffi_smoke_UseDartExternalTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/ffi/ffi_smoke_UseDartExternalTypes.cpp
@@ -1,0 +1,51 @@
+#include "ffi_smoke_UseDartExternalTypes.h"
+#include "ConversionBase.h"
+#include "IsolateContext.h"
+#include "smoke/CompressionState.h"
+#include "smoke/Rectangle.h"
+#include "smoke/UseDartExternalTypes.h"
+#include <memory>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+library_smoke_UseDartExternalTypes_rectangleRoundTrip__Rectangle(int32_t _isolate_id, FfiOpaqueHandle input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<::smoke::Rectangle>::toFfi(
+        ::smoke::UseDartExternalTypes::rectangle_round_trip(
+            gluecodium::ffi::Conversion<::smoke::Rectangle>::toCpp(input)
+        )
+    );
+}
+uint32_t
+library_smoke_UseDartExternalTypes_compressionStateRoundTrip__CompressionState(int32_t _isolate_id, uint32_t input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<::smoke::CompressionState>::toFfi(
+        ::smoke::UseDartExternalTypes::compression_state_round_trip(
+            gluecodium::ffi::Conversion<::smoke::CompressionState>::toCpp(input)
+        )
+    );
+}
+FfiOpaqueHandle
+library_smoke_UseDartExternalTypes_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<::smoke::UseDartExternalTypes>(
+            *reinterpret_cast<std::shared_ptr<::smoke::UseDartExternalTypes>*>(handle)
+        )
+    );
+}
+void
+library_smoke_UseDartExternalTypes_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<::smoke::UseDartExternalTypes>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_UseDartExternalTypes_get_raw_pointer(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        reinterpret_cast<std::shared_ptr<::smoke::UseDartExternalTypes>*>(handle)->get()
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
@@ -1,0 +1,709 @@
+import 'dart:math';
+import 'package:foo/bar.dart';
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
+import 'package:library/src/smoke/date_interval.dart';
+import 'package:library/src/smoke/http_client_response_compression_state.dart';
+import 'package:library/src/smoke/persistence.dart';
+import 'package:library/src/smoke/rectangle_int_.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+final _ListOf_Byte_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_ListOf_Byte_create_handle');
+final _ListOf_Byte_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_ListOf_Byte_release_handle');
+final _ListOf_Byte_insert = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int8),
+    void Function(Pointer<Void>, int)
+  >('library_ListOf_Byte_insert');
+final _ListOf_Byte_iterator = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_ListOf_Byte_iterator');
+final _ListOf_Byte_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_ListOf_Byte_iterator_release_handle');
+final _ListOf_Byte_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_ListOf_Byte_iterator_is_valid');
+final _ListOf_Byte_iterator_increment = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_ListOf_Byte_iterator_increment');
+final _ListOf_Byte_iterator_get = __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+>('library_ListOf_Byte_iterator_get');
+Pointer<Void> ListOf_Byte_toFfi(List<int> value) {
+  final _result = _ListOf_Byte_create_handle();
+  for (final element in value) {
+    final _element_handle = (element);
+    _ListOf_Byte_insert(_result, _element_handle);
+    (_element_handle);
+  }
+  return _result;
+}
+List<int> ListOf_Byte_fromFfi(Pointer<Void> handle) {
+  final result = List<int>();
+  final _iterator_handle = _ListOf_Byte_iterator(handle);
+  while (_ListOf_Byte_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _element_handle = _ListOf_Byte_iterator_get(_iterator_handle);
+    try {
+      result.add((_element_handle));
+    } finally {
+      (_element_handle);
+    }
+    _ListOf_Byte_iterator_increment(_iterator_handle);
+  }
+  _ListOf_Byte_iterator_release_handle(_iterator_handle);
+  return result;
+}
+void ListOf_Byte_releaseFfiHandle(Pointer<Void> handle) => _ListOf_Byte_release_handle(handle);
+final _ListOf_Byte_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_ListOf_Byte_create_handle_nullable');
+final _ListOf_Byte_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_ListOf_Byte_release_handle_nullable');
+final _ListOf_Byte_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_ListOf_Byte_get_value_nullable');
+Pointer<Void> ListOf_Byte_toFfi_nullable(List<int> value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = ListOf_Byte_toFfi(value);
+  final result = _ListOf_Byte_create_handle_nullable(_handle);
+  ListOf_Byte_releaseFfiHandle(_handle);
+  return result;
+}
+List<int> ListOf_Byte_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _ListOf_Byte_get_value_nullable(handle);
+  final result = ListOf_Byte_fromFfi(_handle);
+  ListOf_Byte_releaseFfiHandle(_handle);
+  return result;
+}
+void ListOf_Byte_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _ListOf_Byte_release_handle_nullable(handle);
+final _ListOf_String_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_ListOf_String_create_handle');
+final _ListOf_String_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_ListOf_String_release_handle');
+final _ListOf_String_insert = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Pointer<Void>),
+    void Function(Pointer<Void>, Pointer<Void>)
+  >('library_ListOf_String_insert');
+final _ListOf_String_iterator = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_ListOf_String_iterator');
+final _ListOf_String_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_ListOf_String_iterator_release_handle');
+final _ListOf_String_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_ListOf_String_iterator_is_valid');
+final _ListOf_String_iterator_increment = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_ListOf_String_iterator_increment');
+final _ListOf_String_iterator_get = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_ListOf_String_iterator_get');
+Pointer<Void> ListOf_String_toFfi(List<String> value) {
+  final _result = _ListOf_String_create_handle();
+  for (final element in value) {
+    final _element_handle = String_toFfi(element);
+    _ListOf_String_insert(_result, _element_handle);
+    String_releaseFfiHandle(_element_handle);
+  }
+  return _result;
+}
+List<String> ListOf_String_fromFfi(Pointer<Void> handle) {
+  final result = List<String>();
+  final _iterator_handle = _ListOf_String_iterator(handle);
+  while (_ListOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _element_handle = _ListOf_String_iterator_get(_iterator_handle);
+    try {
+      result.add(String_fromFfi(_element_handle));
+    } finally {
+      String_releaseFfiHandle(_element_handle);
+    }
+    _ListOf_String_iterator_increment(_iterator_handle);
+  }
+  _ListOf_String_iterator_release_handle(_iterator_handle);
+  return result;
+}
+void ListOf_String_releaseFfiHandle(Pointer<Void> handle) => _ListOf_String_release_handle(handle);
+final _ListOf_String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_ListOf_String_create_handle_nullable');
+final _ListOf_String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_ListOf_String_release_handle_nullable');
+final _ListOf_String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_ListOf_String_get_value_nullable');
+Pointer<Void> ListOf_String_toFfi_nullable(List<String> value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = ListOf_String_toFfi(value);
+  final result = _ListOf_String_create_handle_nullable(_handle);
+  ListOf_String_releaseFfiHandle(_handle);
+  return result;
+}
+List<String> ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _ListOf_String_get_value_nullable(handle);
+  final result = ListOf_String_fromFfi(_handle);
+  ListOf_String_releaseFfiHandle(_handle);
+  return result;
+}
+void ListOf_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _ListOf_String_release_handle_nullable(handle);
+final _ListOf_smoke_DateInterval_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_ListOf_smoke_DateInterval_create_handle');
+final _ListOf_smoke_DateInterval_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_ListOf_smoke_DateInterval_release_handle');
+final _ListOf_smoke_DateInterval_insert = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Pointer<Void>),
+    void Function(Pointer<Void>, Pointer<Void>)
+  >('library_ListOf_smoke_DateInterval_insert');
+final _ListOf_smoke_DateInterval_iterator = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_ListOf_smoke_DateInterval_iterator');
+final _ListOf_smoke_DateInterval_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_ListOf_smoke_DateInterval_iterator_release_handle');
+final _ListOf_smoke_DateInterval_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_ListOf_smoke_DateInterval_iterator_is_valid');
+final _ListOf_smoke_DateInterval_iterator_increment = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_ListOf_smoke_DateInterval_iterator_increment');
+final _ListOf_smoke_DateInterval_iterator_get = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_ListOf_smoke_DateInterval_iterator_get');
+Pointer<Void> ListOf_smoke_DateInterval_toFfi(List<DateInterval> value) {
+  final _result = _ListOf_smoke_DateInterval_create_handle();
+  for (final element in value) {
+    final _element_handle = smoke_DateInterval_toFfi(element);
+    _ListOf_smoke_DateInterval_insert(_result, _element_handle);
+    smoke_DateInterval_releaseFfiHandle(_element_handle);
+  }
+  return _result;
+}
+List<DateInterval> ListOf_smoke_DateInterval_fromFfi(Pointer<Void> handle) {
+  final result = List<DateInterval>();
+  final _iterator_handle = _ListOf_smoke_DateInterval_iterator(handle);
+  while (_ListOf_smoke_DateInterval_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _element_handle = _ListOf_smoke_DateInterval_iterator_get(_iterator_handle);
+    try {
+      result.add(smoke_DateInterval_fromFfi(_element_handle));
+    } finally {
+      smoke_DateInterval_releaseFfiHandle(_element_handle);
+    }
+    _ListOf_smoke_DateInterval_iterator_increment(_iterator_handle);
+  }
+  _ListOf_smoke_DateInterval_iterator_release_handle(_iterator_handle);
+  return result;
+}
+void ListOf_smoke_DateInterval_releaseFfiHandle(Pointer<Void> handle) => _ListOf_smoke_DateInterval_release_handle(handle);
+final _ListOf_smoke_DateInterval_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_ListOf_smoke_DateInterval_create_handle_nullable');
+final _ListOf_smoke_DateInterval_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_ListOf_smoke_DateInterval_release_handle_nullable');
+final _ListOf_smoke_DateInterval_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_ListOf_smoke_DateInterval_get_value_nullable');
+Pointer<Void> ListOf_smoke_DateInterval_toFfi_nullable(List<DateInterval> value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = ListOf_smoke_DateInterval_toFfi(value);
+  final result = _ListOf_smoke_DateInterval_create_handle_nullable(_handle);
+  ListOf_smoke_DateInterval_releaseFfiHandle(_handle);
+  return result;
+}
+List<DateInterval> ListOf_smoke_DateInterval_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _ListOf_smoke_DateInterval_get_value_nullable(handle);
+  final result = ListOf_smoke_DateInterval_fromFfi(_handle);
+  ListOf_smoke_DateInterval_releaseFfiHandle(_handle);
+  return result;
+}
+void ListOf_smoke_DateInterval_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _ListOf_smoke_DateInterval_release_handle_nullable(handle);
+final _ListOf_smoke_Rectangle_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_ListOf_smoke_Rectangle_create_handle');
+final _ListOf_smoke_Rectangle_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_ListOf_smoke_Rectangle_release_handle');
+final _ListOf_smoke_Rectangle_insert = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Pointer<Void>),
+    void Function(Pointer<Void>, Pointer<Void>)
+  >('library_ListOf_smoke_Rectangle_insert');
+final _ListOf_smoke_Rectangle_iterator = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_ListOf_smoke_Rectangle_iterator');
+final _ListOf_smoke_Rectangle_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_ListOf_smoke_Rectangle_iterator_release_handle');
+final _ListOf_smoke_Rectangle_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_ListOf_smoke_Rectangle_iterator_is_valid');
+final _ListOf_smoke_Rectangle_iterator_increment = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_ListOf_smoke_Rectangle_iterator_increment');
+final _ListOf_smoke_Rectangle_iterator_get = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_ListOf_smoke_Rectangle_iterator_get');
+Pointer<Void> ListOf_smoke_Rectangle_toFfi(List<Rectangle<int>> value) {
+  final _result = _ListOf_smoke_Rectangle_create_handle();
+  for (final element in value) {
+    final _element_handle = smoke_Rectangle_toFfi(element);
+    _ListOf_smoke_Rectangle_insert(_result, _element_handle);
+    smoke_Rectangle_releaseFfiHandle(_element_handle);
+  }
+  return _result;
+}
+List<Rectangle<int>> ListOf_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
+  final result = List<Rectangle<int>>();
+  final _iterator_handle = _ListOf_smoke_Rectangle_iterator(handle);
+  while (_ListOf_smoke_Rectangle_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _element_handle = _ListOf_smoke_Rectangle_iterator_get(_iterator_handle);
+    try {
+      result.add(smoke_Rectangle_fromFfi(_element_handle));
+    } finally {
+      smoke_Rectangle_releaseFfiHandle(_element_handle);
+    }
+    _ListOf_smoke_Rectangle_iterator_increment(_iterator_handle);
+  }
+  _ListOf_smoke_Rectangle_iterator_release_handle(_iterator_handle);
+  return result;
+}
+void ListOf_smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _ListOf_smoke_Rectangle_release_handle(handle);
+final _ListOf_smoke_Rectangle_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_ListOf_smoke_Rectangle_create_handle_nullable');
+final _ListOf_smoke_Rectangle_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_ListOf_smoke_Rectangle_release_handle_nullable');
+final _ListOf_smoke_Rectangle_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_ListOf_smoke_Rectangle_get_value_nullable');
+Pointer<Void> ListOf_smoke_Rectangle_toFfi_nullable(List<Rectangle<int>> value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = ListOf_smoke_Rectangle_toFfi(value);
+  final result = _ListOf_smoke_Rectangle_create_handle_nullable(_handle);
+  ListOf_smoke_Rectangle_releaseFfiHandle(_handle);
+  return result;
+}
+List<Rectangle<int>> ListOf_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _ListOf_smoke_Rectangle_get_value_nullable(handle);
+  final result = ListOf_smoke_Rectangle_fromFfi(_handle);
+  ListOf_smoke_Rectangle_releaseFfiHandle(_handle);
+  return result;
+}
+void ListOf_smoke_Rectangle_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _ListOf_smoke_Rectangle_release_handle_nullable(handle);
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle');
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle');
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_put = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Uint32, Pointer<Void>),
+    void Function(Pointer<Void>, int, Pointer<Void>)
+  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_put');
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator');
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_release_handle');
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_is_valid');
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_increment = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_increment');
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+>('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_key');
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_value');
+Pointer<Void> MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi(Map<HttpClientResponseCompressionState, Rectangle<int>> value) {
+  final _result = _MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle();
+  for (final entry in value.entries) {
+    final _key_handle = smoke_CompressionState_toFfi(entry.key);
+    final _value_handle = smoke_Rectangle_toFfi(entry.value);
+    _MapOf_smoke_CompressionState_to_smoke_Rectangle_put(_result, _key_handle, _value_handle);
+    smoke_CompressionState_releaseFfiHandle(_key_handle);
+    smoke_Rectangle_releaseFfiHandle(_value_handle);
+  }
+  return _result;
+}
+Map<HttpClientResponseCompressionState, Rectangle<int>> MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
+  final result = Map<HttpClientResponseCompressionState, Rectangle<int>>();
+  final _iterator_handle = _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator(handle);
+  while (_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _key_handle = _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_key(_iterator_handle);
+    final _value_handle = _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_value(_iterator_handle);
+    try {
+      result[smoke_CompressionState_fromFfi(_key_handle)] =
+        smoke_Rectangle_fromFfi(_value_handle);
+    } finally {
+      smoke_CompressionState_releaseFfiHandle(_key_handle);
+      smoke_Rectangle_releaseFfiHandle(_value_handle);
+    }
+    _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_increment(_iterator_handle);
+  }
+  _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_release_handle(_iterator_handle);
+  return result;
+}
+void MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle(handle);
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle_nullable');
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle_nullable');
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable');
+Pointer<Void> MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi_nullable(Map<HttpClientResponseCompressionState, Rectangle<int>> value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi(value);
+  final result = _MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle_nullable(_handle);
+  MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle(_handle);
+  return result;
+}
+Map<HttpClientResponseCompressionState, Rectangle<int>> MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable(handle);
+  final result = MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi(_handle);
+  MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle(_handle);
+  return result;
+}
+void MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle_nullable(handle);
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle');
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle');
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_put = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Uint32, Pointer<Void>),
+    void Function(Pointer<Void>, int, Pointer<Void>)
+  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_put');
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator');
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_release_handle');
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_is_valid');
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_increment = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_increment');
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+>('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_key');
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_value');
+Pointer<Void> MapOf_smoke_Persistence_to_smoke_DateInterval_toFfi(Map<Persistence, DateInterval> value) {
+  final _result = _MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle();
+  for (final entry in value.entries) {
+    final _key_handle = smoke_Persistence_toFfi(entry.key);
+    final _value_handle = smoke_DateInterval_toFfi(entry.value);
+    _MapOf_smoke_Persistence_to_smoke_DateInterval_put(_result, _key_handle, _value_handle);
+    smoke_Persistence_releaseFfiHandle(_key_handle);
+    smoke_DateInterval_releaseFfiHandle(_value_handle);
+  }
+  return _result;
+}
+Map<Persistence, DateInterval> MapOf_smoke_Persistence_to_smoke_DateInterval_fromFfi(Pointer<Void> handle) {
+  final result = Map<Persistence, DateInterval>();
+  final _iterator_handle = _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator(handle);
+  while (_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _key_handle = _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_key(_iterator_handle);
+    final _value_handle = _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_value(_iterator_handle);
+    try {
+      result[smoke_Persistence_fromFfi(_key_handle)] =
+        smoke_DateInterval_fromFfi(_value_handle);
+    } finally {
+      smoke_Persistence_releaseFfiHandle(_key_handle);
+      smoke_DateInterval_releaseFfiHandle(_value_handle);
+    }
+    _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_increment(_iterator_handle);
+  }
+  _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_release_handle(_iterator_handle);
+  return result;
+}
+void MapOf_smoke_Persistence_to_smoke_DateInterval_releaseFfiHandle(Pointer<Void> handle) => _MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle(handle);
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle_nullable');
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle_nullable');
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_get_value_nullable');
+Pointer<Void> MapOf_smoke_Persistence_to_smoke_DateInterval_toFfi_nullable(Map<Persistence, DateInterval> value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = MapOf_smoke_Persistence_to_smoke_DateInterval_toFfi(value);
+  final result = _MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle_nullable(_handle);
+  MapOf_smoke_Persistence_to_smoke_DateInterval_releaseFfiHandle(_handle);
+  return result;
+}
+Map<Persistence, DateInterval> MapOf_smoke_Persistence_to_smoke_DateInterval_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _MapOf_smoke_Persistence_to_smoke_DateInterval_get_value_nullable(handle);
+  final result = MapOf_smoke_Persistence_to_smoke_DateInterval_fromFfi(_handle);
+  MapOf_smoke_Persistence_to_smoke_DateInterval_releaseFfiHandle(_handle);
+  return result;
+}
+void MapOf_smoke_Persistence_to_smoke_DateInterval_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle_nullable(handle);
+final _SetOf_smoke_DateInterval_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_SetOf_smoke_DateInterval_create_handle');
+final _SetOf_smoke_DateInterval_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_SetOf_smoke_DateInterval_release_handle');
+final _SetOf_smoke_DateInterval_insert = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Pointer<Void>),
+    void Function(Pointer<Void>, Pointer<Void>)
+  >('library_SetOf_smoke_DateInterval_insert');
+final _SetOf_smoke_DateInterval_iterator = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_SetOf_smoke_DateInterval_iterator');
+final _SetOf_smoke_DateInterval_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_SetOf_smoke_DateInterval_iterator_release_handle');
+final _SetOf_smoke_DateInterval_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_SetOf_smoke_DateInterval_iterator_is_valid');
+final _SetOf_smoke_DateInterval_iterator_increment = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_SetOf_smoke_DateInterval_iterator_increment');
+final _SetOf_smoke_DateInterval_iterator_get = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_SetOf_smoke_DateInterval_iterator_get');
+Pointer<Void> SetOf_smoke_DateInterval_toFfi(Set<DateInterval> value) {
+  final _result = _SetOf_smoke_DateInterval_create_handle();
+  for (final element in value) {
+    final _element_handle = smoke_DateInterval_toFfi(element);
+    _SetOf_smoke_DateInterval_insert(_result, _element_handle);
+    smoke_DateInterval_releaseFfiHandle(_element_handle);
+  }
+  return _result;
+}
+Set<DateInterval> SetOf_smoke_DateInterval_fromFfi(Pointer<Void> handle) {
+  final result = Set<DateInterval>();
+  final _iterator_handle = _SetOf_smoke_DateInterval_iterator(handle);
+  while (_SetOf_smoke_DateInterval_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _element_handle = _SetOf_smoke_DateInterval_iterator_get(_iterator_handle);
+    try {
+      result.add(smoke_DateInterval_fromFfi(_element_handle));
+    } finally {
+      smoke_DateInterval_releaseFfiHandle(_element_handle);
+    }
+    _SetOf_smoke_DateInterval_iterator_increment(_iterator_handle);
+  }
+  _SetOf_smoke_DateInterval_iterator_release_handle(_iterator_handle);
+  return result;
+}
+void SetOf_smoke_DateInterval_releaseFfiHandle(Pointer<Void> handle) => _SetOf_smoke_DateInterval_release_handle(handle);
+final _SetOf_smoke_DateInterval_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_SetOf_smoke_DateInterval_create_handle_nullable');
+final _SetOf_smoke_DateInterval_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_SetOf_smoke_DateInterval_release_handle_nullable');
+final _SetOf_smoke_DateInterval_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_SetOf_smoke_DateInterval_get_value_nullable');
+Pointer<Void> SetOf_smoke_DateInterval_toFfi_nullable(Set<DateInterval> value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = SetOf_smoke_DateInterval_toFfi(value);
+  final result = _SetOf_smoke_DateInterval_create_handle_nullable(_handle);
+  SetOf_smoke_DateInterval_releaseFfiHandle(_handle);
+  return result;
+}
+Set<DateInterval> SetOf_smoke_DateInterval_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _SetOf_smoke_DateInterval_get_value_nullable(handle);
+  final result = SetOf_smoke_DateInterval_fromFfi(_handle);
+  SetOf_smoke_DateInterval_releaseFfiHandle(_handle);
+  return result;
+}
+void SetOf_smoke_DateInterval_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _SetOf_smoke_DateInterval_release_handle_nullable(handle);
+final _SetOf_smoke_Rectangle_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_SetOf_smoke_Rectangle_create_handle');
+final _SetOf_smoke_Rectangle_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_SetOf_smoke_Rectangle_release_handle');
+final _SetOf_smoke_Rectangle_insert = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Pointer<Void>),
+    void Function(Pointer<Void>, Pointer<Void>)
+  >('library_SetOf_smoke_Rectangle_insert');
+final _SetOf_smoke_Rectangle_iterator = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_SetOf_smoke_Rectangle_iterator');
+final _SetOf_smoke_Rectangle_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_SetOf_smoke_Rectangle_iterator_release_handle');
+final _SetOf_smoke_Rectangle_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_SetOf_smoke_Rectangle_iterator_is_valid');
+final _SetOf_smoke_Rectangle_iterator_increment = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_SetOf_smoke_Rectangle_iterator_increment');
+final _SetOf_smoke_Rectangle_iterator_get = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_SetOf_smoke_Rectangle_iterator_get');
+Pointer<Void> SetOf_smoke_Rectangle_toFfi(Set<Rectangle<int>> value) {
+  final _result = _SetOf_smoke_Rectangle_create_handle();
+  for (final element in value) {
+    final _element_handle = smoke_Rectangle_toFfi(element);
+    _SetOf_smoke_Rectangle_insert(_result, _element_handle);
+    smoke_Rectangle_releaseFfiHandle(_element_handle);
+  }
+  return _result;
+}
+Set<Rectangle<int>> SetOf_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
+  final result = Set<Rectangle<int>>();
+  final _iterator_handle = _SetOf_smoke_Rectangle_iterator(handle);
+  while (_SetOf_smoke_Rectangle_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _element_handle = _SetOf_smoke_Rectangle_iterator_get(_iterator_handle);
+    try {
+      result.add(smoke_Rectangle_fromFfi(_element_handle));
+    } finally {
+      smoke_Rectangle_releaseFfiHandle(_element_handle);
+    }
+    _SetOf_smoke_Rectangle_iterator_increment(_iterator_handle);
+  }
+  _SetOf_smoke_Rectangle_iterator_release_handle(_iterator_handle);
+  return result;
+}
+void SetOf_smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _SetOf_smoke_Rectangle_release_handle(handle);
+final _SetOf_smoke_Rectangle_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_SetOf_smoke_Rectangle_create_handle_nullable');
+final _SetOf_smoke_Rectangle_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_SetOf_smoke_Rectangle_release_handle_nullable');
+final _SetOf_smoke_Rectangle_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_SetOf_smoke_Rectangle_get_value_nullable');
+Pointer<Void> SetOf_smoke_Rectangle_toFfi_nullable(Set<Rectangle<int>> value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = SetOf_smoke_Rectangle_toFfi(value);
+  final result = _SetOf_smoke_Rectangle_create_handle_nullable(_handle);
+  SetOf_smoke_Rectangle_releaseFfiHandle(_handle);
+  return result;
+}
+Set<Rectangle<int>> SetOf_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _SetOf_smoke_Rectangle_get_value_nullable(handle);
+  final result = SetOf_smoke_Rectangle_fromFfi(_handle);
+  SetOf_smoke_Rectangle_releaseFfiHandle(_handle);
+  return result;
+}
+void SetOf_smoke_Rectangle_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _SetOf_smoke_Rectangle_release_handle_nullable(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
@@ -1,0 +1,66 @@
+import 'package:foo/bar.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+// HttpClientResponseCompressionState "private" section, not exported.
+int smoke_CompressionState_toFfi(HttpClientResponseCompressionState value) {
+  switch (value) {
+  case HttpClientResponseCompressionState.compressed:
+    return 0;
+  break;
+  case HttpClientResponseCompressionState.decompressed:
+    return 1;
+  break;
+  case HttpClientResponseCompressionState.notCompressed:
+    return 2;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for HttpClientResponseCompressionState enum.");
+  }
+}
+HttpClientResponseCompressionState smoke_CompressionState_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return HttpClientResponseCompressionState.compressed;
+  break;
+  case 1:
+    return HttpClientResponseCompressionState.decompressed;
+  break;
+  case 2:
+    return HttpClientResponseCompressionState.notCompressed;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for HttpClientResponseCompressionState enum.");
+  }
+}
+void smoke_CompressionState_releaseFfiHandle(int handle) {}
+final _smoke_CompressionState_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_CompressionState_create_handle_nullable');
+final _smoke_CompressionState_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_CompressionState_release_handle_nullable');
+final _smoke_CompressionState_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_CompressionState_get_value_nullable');
+Pointer<Void> smoke_CompressionState_toFfi_nullable(HttpClientResponseCompressionState value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_CompressionState_toFfi(value);
+  final result = _smoke_CompressionState_create_handle_nullable(_handle);
+  smoke_CompressionState_releaseFfiHandle(_handle);
+  return result;
+}
+HttpClientResponseCompressionState smoke_CompressionState_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_CompressionState_get_value_nullable(handle);
+  final result = smoke_CompressionState_fromFfi(_handle);
+  smoke_CompressionState_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_CompressionState_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_CompressionState_release_handle_nullable(handle);
+// End of HttpClientResponseCompressionState "private" section.

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
@@ -1,0 +1,93 @@
+import 'dart:math';
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+// Rectangle<int> "private" section, not exported.
+final _smoke_Rectangle_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int32, Int32, Int32, Int32),
+    Pointer<Void> Function(int, int, int, int)
+  >('library_smoke_Rectangle_create_handle');
+final _smoke_Rectangle_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Rectangle_release_handle');
+final _smoke_Rectangle_get_field_left = __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Rectangle_get_field_left');
+final _smoke_Rectangle_get_field_top = __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Rectangle_get_field_top');
+final _smoke_Rectangle_get_field_width = __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Rectangle_get_field_width');
+final _smoke_Rectangle_get_field_height = __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Rectangle_get_field_height');
+Pointer<Void> smoke_Rectangle_toFfi(Rectangle<int> value) {
+  final _left_handle = (value.left);
+  final _top_handle = (value.top);
+  final _width_handle = (value.width);
+  final _height_handle = (value.height);
+  final _result = _smoke_Rectangle_create_handle(_left_handle, _top_handle, _width_handle, _height_handle);
+  (_left_handle);
+  (_top_handle);
+  (_width_handle);
+  (_height_handle);
+  return _result;
+}
+Rectangle<int> smoke_Rectangle_fromFfi(Pointer<Void> handle) {
+  final _left_handle = _smoke_Rectangle_get_field_left(handle);
+  final _top_handle = _smoke_Rectangle_get_field_top(handle);
+  final _width_handle = _smoke_Rectangle_get_field_width(handle);
+  final _height_handle = _smoke_Rectangle_get_field_height(handle);
+  try {
+    return Rectangle<int>(
+      (_left_handle),
+      (_top_handle),
+      (_width_handle),
+      (_height_handle)
+    );
+  } finally {
+    (_left_handle);
+    (_top_handle);
+    (_width_handle);
+    (_height_handle);
+  }
+}
+void smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _smoke_Rectangle_release_handle(handle);
+// Nullable Rectangle<int>
+final _smoke_Rectangle_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Rectangle_create_handle_nullable');
+final _smoke_Rectangle_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Rectangle_release_handle_nullable');
+final _smoke_Rectangle_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Rectangle_get_value_nullable');
+Pointer<Void> smoke_Rectangle_toFfi_nullable(Rectangle<int> value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_Rectangle_toFfi(value);
+  final result = _smoke_Rectangle_create_handle_nullable(_handle);
+  smoke_Rectangle_releaseFfiHandle(_handle);
+  return result;
+}
+Rectangle<int> smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_Rectangle_get_value_nullable(handle);
+  final result = smoke_Rectangle_fromFfi(_handle);
+  smoke_Rectangle_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_Rectangle_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_Rectangle_release_handle_nullable(handle);
+// End of Rectangle<int> "private" section.

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -1,0 +1,85 @@
+import 'dart:math';
+import 'package:foo/bar.dart';
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/smoke/http_client_response_compression_state.dart';
+import 'package:library/src/smoke/rectangle_int_.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+abstract class UseDartExternalTypes {
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+  static Rectangle<int> rectangleRoundTrip(Rectangle<int> input) => UseDartExternalTypes$Impl.rectangleRoundTrip(input);
+  static HttpClientResponseCompressionState compressionStateRoundTrip(HttpClientResponseCompressionState input) => UseDartExternalTypes$Impl.compressionStateRoundTrip(input);
+}
+// UseDartExternalTypes "private" section, not exported.
+final _smoke_UseDartExternalTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_UseDartExternalTypes_copy_handle');
+final _smoke_UseDartExternalTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_UseDartExternalTypes_release_handle');
+final _smoke_UseDartExternalTypes_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_UseDartExternalTypes_get_raw_pointer');
+class UseDartExternalTypes$Impl implements UseDartExternalTypes {
+  @protected
+  Pointer<Void> handle;
+  UseDartExternalTypes$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.reverseCache.remove(_smoke_UseDartExternalTypes_get_raw_pointer(handle));
+    _smoke_UseDartExternalTypes_release_handle(handle);
+    handle = null;
+  }
+  static Rectangle<int> rectangleRoundTrip(Rectangle<int> input) {
+    final _rectangleRoundTrip_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_rectangleRoundTrip__Rectangle');
+    final _input_handle = smoke_Rectangle_toFfi(input);
+    final __result_handle = _rectangleRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
+    smoke_Rectangle_releaseFfiHandle(_input_handle);
+    try {
+      return smoke_Rectangle_fromFfi(__result_handle);
+    } finally {
+      smoke_Rectangle_releaseFfiHandle(__result_handle);
+    }
+  }
+  static HttpClientResponseCompressionState compressionStateRoundTrip(HttpClientResponseCompressionState input) {
+    final _compressionStateRoundTrip_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_compressionStateRoundTrip__CompressionState');
+    final _input_handle = smoke_CompressionState_toFfi(input);
+    final __result_handle = _compressionStateRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
+    smoke_CompressionState_releaseFfiHandle(_input_handle);
+    try {
+      return smoke_CompressionState_fromFfi(__result_handle);
+    } finally {
+      smoke_CompressionState_releaseFfiHandle(__result_handle);
+    }
+  }
+}
+Pointer<Void> smoke_UseDartExternalTypes_toFfi(UseDartExternalTypes value) =>
+  _smoke_UseDartExternalTypes_copy_handle((value as UseDartExternalTypes$Impl).handle);
+UseDartExternalTypes smoke_UseDartExternalTypes_fromFfi(Pointer<Void> handle) {
+  final raw_handle = _smoke_UseDartExternalTypes_get_raw_pointer(handle);
+  final instance = __lib.reverseCache[raw_handle] as UseDartExternalTypes;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_UseDartExternalTypes_copy_handle(handle);
+  final result = UseDartExternalTypes$Impl(_copied_handle);
+  __lib.reverseCache[raw_handle] = result;
+  return result;
+}
+void smoke_UseDartExternalTypes_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_UseDartExternalTypes_release_handle(handle);
+Pointer<Void> smoke_UseDartExternalTypes_toFfi_nullable(UseDartExternalTypes value) =>
+  value != null ? smoke_UseDartExternalTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
+UseDartExternalTypes smoke_UseDartExternalTypes_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_UseDartExternalTypes_fromFfi(handle) : null;
+void smoke_UseDartExternalTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_UseDartExternalTypes_release_handle(handle);
+// End of UseDartExternalTypes "private" section.

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
@@ -30,6 +30,8 @@ class LimeExternalDescriptor private constructor(
         get() = descriptors[JAVA_TAG]
     val swift
         get() = descriptors[SWIFT_TAG]
+    val dart
+        get() = descriptors[DART_TAG]
 
     operator fun plus(other: LimeExternalDescriptor) =
         LimeExternalDescriptor(descriptors + other.descriptors)
@@ -54,9 +56,11 @@ class LimeExternalDescriptor private constructor(
         const val CPP_TAG = "cpp"
         const val JAVA_TAG = "java"
         const val SWIFT_TAG = "swift"
+        const val DART_TAG = "dart"
 
         const val INCLUDE_NAME = "include"
         const val FRAMEWORK_NAME = "framework"
+        const val IMPORT_PATH_NAME = "importPath"
         const val NAME_NAME = "name"
         const val GETTER_NAME_NAME = "getterName"
         const val SETTER_NAME_NAME = "setterName"


### PR DESCRIPTION
Updated Dart templates to support "external" structs and enums. Dart
type definitions are not generated for "external" types, the given
pre-existing type is used instead. Dart and FFI conversion
functions are still generated.

Updated Dart import resolver to support imports for "external" types.

Added functional tests. Added/updated smoke tests.

See: #408
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>