### PR TITLE
Add support for external type converters in Java

### DIFF
--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -319,6 +319,10 @@ names are case-insensitive. Supported platform tags:
     statement).
     * **getterName**, **setterName**: marks a field in a struct type that is already marked as
     external to be accessed through given getter/setter functions instead of directly in Java.
+    * **converter**: specifies a pre-existing converter class (by its full Java name). A converter
+    class should have two static functions named `convertToInternal` and `convertFromInternal`,
+    providing conversion between the "external" type and the generated "internal" type (which has
+    package-private visibility).
   * **swift**: describes "external" behavior for Swift. Currently only supported for structs and
   enums. Supported value names:
     * **framework**: *mandatory value*. Specifies a name of a Swift framework that needs to be

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -502,6 +502,7 @@ elseif(HELLO_APIGEN_GLUECODIUM_GENERATOR STREQUAL android)
         set(ANDROID_PLATFORM "android-${ANDROID_NATIVE_API_LEVEL}")
     endif()
     apigen_java_compile(TARGET hello
+        LOCAL_SOURCES_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/src/android"
         LOCAL_DEPENDENCIES "android"
         LOCAL_DEPENDENCIES_DIRS "$ENV{ANDROID_HOME}/platforms/${ANDROID_PLATFORM}"
         REMOTE_DEPENDENCIES "com.android.support:support-annotations:28.0.0")

--- a/examples/libhello/lime/test/JavaExternalTypes.lime
+++ b/examples/libhello/lime/test/JavaExternalTypes.lime
@@ -38,6 +38,18 @@ struct TimeZone {
     }
 }
 
+struct SystemColor {
+    external {
+        java name "java.lang.Integer"
+        java converter "com.here.android.test.ColorConverter"
+    }
+
+    red: Float
+    green: Float
+    blue: Float
+    alpha: Float
+}
+
 enum Month {
     external {
         java name "java.time.Month"
@@ -48,8 +60,22 @@ enum Month {
     MARCH
 }
 
+enum Season {
+    external {
+        java name "java.lang.String"
+        java converter "com.here.android.test.SeasonConverter"
+    }
+
+    WINTER,
+    SPRING,
+    SUMMER,
+    AUTUMN
+}
+
 class UseJavaExternalTypes {
     static fun currencyRoundTrip(input: Currency): Currency
     static fun timeZoneRoundTrip(input: TimeZone): TimeZone
     static fun monthRoundTrip(input: Month): Month
+    static fun colorRoundTrip(input: SystemColor): SystemColor
+    static fun seasonRoundTrip(input: Season): Season
 }

--- a/examples/libhello/src/android/ColorConverter.java
+++ b/examples/libhello/src/android/ColorConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+class ColorConverter {
+    static Integer convertFromInternal(SystemColor internalColor) {
+        return android.graphics.Color.argb(
+            Math.round(internalColor.alpha * 255),
+            Math.round(internalColor.red * 255),
+            Math.round(internalColor.green * 255),
+            Math.round(internalColor.blue * 255));
+    }
+
+    static SystemColor convertToInternal(Integer systemColor) {
+        return new SystemColor(
+            android.graphics.Color.red(systemColor) / 255.0f,
+            android.graphics.Color.green(systemColor) / 255.0f,
+            android.graphics.Color.blue(systemColor) / 255.0f,
+            android.graphics.Color.alpha(systemColor) / 255.0f);
+    }
+}

--- a/examples/libhello/src/android/SeasonConverter.java
+++ b/examples/libhello/src/android/SeasonConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 HERE Europe B.V.
+ * Copyright (C) 2016-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  * License-Filename: LICENSE
  */
+package com.here.android.test;
 
-package com.here.gluecodium.model.java
+class SeasonConverter {
+    static String convertFromInternal(Season season) {
+        return season.name();
+    }
 
-class JavaEnum(
-    name: String,
-    classNames: List<String> = listOf(name),
-    val items: List<JavaEnumItem> = emptyList(),
-    skipDeclaration: Boolean = false
-) : JavaTopLevelElement(name, classNames, skipDeclaration) {
-
-    override val childElements
-        get() = super.childElements + items
+    static Season convertToInternal(String seasonString) {
+        return Season.valueOf(Season.class, seasonString);
+    }
 }

--- a/examples/libhello/src/test/JavaExternalTypes.cpp
+++ b/examples/libhello/src/test/JavaExternalTypes.cpp
@@ -36,4 +36,14 @@ Month
 UseJavaExternalTypes::month_round_trip(const Month input) {
     return input;
 }
+
+SystemColor
+UseJavaExternalTypes::color_round_trip(const SystemColor& input) {
+    return input;
+}
+
+Season
+UseJavaExternalTypes::season_round_trip(const Season input) {
+    return input;
+}
 }

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/ExternalTypesTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/ExternalTypesTest.java
@@ -103,4 +103,22 @@ public final class ExternalTypesTest {
 
     assertEquals(month, result);
   }
+
+  @Test
+  public void useJavaExternalColor() {
+    Integer color = android.graphics.Color.argb(0, 0, 127, 255);
+
+    Integer result = UseJavaExternalTypes.colorRoundTrip(color);
+
+    assertEquals(color, result);
+  }
+
+  @Test
+  public void useJavaExternalSeason() {
+    String season = "SPRING";
+
+    String result = UseJavaExternalTypes.seasonRoundTrip(season);
+
+    assertEquals(season, result);
+  }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniNameRules.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniNameRules.kt
@@ -19,6 +19,7 @@
 
 package com.here.gluecodium.generator.jni
 
+import com.here.gluecodium.generator.java.JavaNameRules
 import com.here.gluecodium.model.java.JavaCustomTypeRef
 import com.here.gluecodium.model.jni.JniContainer
 import com.here.gluecodium.model.jni.JniTopLevelElement
@@ -55,6 +56,11 @@ class JniNameRules(generatorName: String) {
         fun getFullClassName(javaType: JavaCustomTypeRef) =
             (javaType.packageNames + javaType.classNames.joinToString("$")).joinToString("/")
 
+        fun getFullClassName(importString: String) = (
+            JavaNameRules.getPackageFromImportString(importString) +
+                JavaNameRules.getClassNamesFromImportString(importString).joinToString("$")
+        ).joinToString("/")
+
         fun getJniClassFileName(jniContainer: JniContainer) =
             (jniContainer.javaPackage.packageNames + jniContainer.javaNames).joinToString("_")
 
@@ -62,7 +68,12 @@ class JniNameRules(generatorName: String) {
             (jniElement.javaPackage.packageNames + jniElement.javaName.replace("$", "_")).joinToString("_")
 
         fun getConversionFileName(jniElement: JniTopLevelElement) =
-            getConversionFileName(jniElement.javaPackage.packageNames, jniElement.javaName.split("$"))
+            jniElement.externalConvertedType?.let {
+                it.replace('/', '_').replace('$', '_') + JNI_CONVERSION_SUFFIX
+            } ?: getConversionFileName(
+                jniElement.javaPackage.packageNames,
+                jniElement.javaName.split("$")
+            )
 
         fun getConversionFileName(jniContainer: JniContainer) =
             getConversionFileName(jniContainer.javaPackage.packageNames, jniContainer.javaInterfaceNames)

--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaClass.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaClass.kt
@@ -34,8 +34,8 @@ class JavaClass(
     val isImmutable: Boolean = false,
     val needsBuilder: Boolean = false,
     var generatedConstructorComment: String? = null,
-    isExternal: Boolean = false
-) : JavaTopLevelElement(name, classNames, isExternal) {
+    skipDeclaration: Boolean = false
+) : JavaTopLevelElement(name, classNames, skipDeclaration) {
 
     init {
         this.methods += methods

--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaTopLevelElement.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaTopLevelElement.kt
@@ -22,7 +22,7 @@ package com.here.gluecodium.model.java
 abstract class JavaTopLevelElement(
     name: String,
     val classNames: List<String>,
-    val isExternal: Boolean = false
+    val skipDeclaration: Boolean = false
 ) : JavaElement(name) {
 
     var javaPackage = JavaPackage.DEFAULT

--- a/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniEnum.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniEnum.kt
@@ -26,8 +26,17 @@ class JniEnum(
     cppFullyQualifiedName: String,
     javaPackage: JavaPackage,
     val enumerators: List<JniEnumerator> = emptyList(),
-    val isExternal: Boolean = false
-) : JniTopLevelElement(javaName, cppFullyQualifiedName, javaPackage) {
+    @Suppress("unused")
+    val needsOrdinalConversion: Boolean = false,
+    externalConverter: String? = null,
+    externalConvertedType: String? = null
+) : JniTopLevelElement(
+    javaName,
+    cppFullyQualifiedName,
+    javaPackage,
+    externalConverter,
+    externalConvertedType
+) {
     @Suppress("unused")
     val jniTypeSignature
         get() = (javaPackage.packageNames + javaName)

--- a/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniStruct.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniStruct.kt
@@ -28,8 +28,16 @@ class JniStruct(
     javaPackage: JavaPackage,
     val fields: List<JniField> = emptyList(),
     val methods: List<JniMethod> = emptyList(),
-    val hasImmutableFields: Boolean = false
-) : JniTopLevelElement(javaName, cppFullyQualifiedName, javaPackage) {
+    val hasImmutableFields: Boolean = false,
+    externalConverter: String? = null,
+    externalConvertedType: String? = null
+) : JniTopLevelElement(
+    javaName,
+    cppFullyQualifiedName,
+    javaPackage,
+    externalConverter,
+    externalConvertedType
+) {
     @Suppress("unused")
     override val mangledName
         get() = JniNameRules.getMangledName((javaPackage.packageNames + javaName).joinToString("/"))

--- a/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniTopLevelElement.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniTopLevelElement.kt
@@ -25,8 +25,13 @@ import com.here.gluecodium.model.java.JavaPackage
 abstract class JniTopLevelElement(
     val javaName: String,
     val cppFullyQualifiedName: String,
-    val javaPackage: JavaPackage
+    val javaPackage: JavaPackage,
+    @Suppress("unused")
+    val externalConverter: String? = null,
+    @Suppress("unused")
+    val externalConvertedType: String? = null
 ) : JniElement {
+    @Suppress("MemberVisibilityCanBePrivate")
     val fullJavaName = (javaPackage.packageNames + javaName).joinToString("/")
     open val mangledName = JniNameRules.getMangledName(fullJavaName)
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
@@ -112,7 +112,7 @@ open class JavaGeneratorSuite protected constructor(
 
         val javaTemplates = JavaTemplates(generatorName)
         val nonExternalElements = combinedModel.javaElements.filter {
-            it !is JavaTopLevelElement || !it.isExternal
+            it !is JavaTopLevelElement || !it.skipDeclaration
         }
         val javaFiles = javaTemplates.generateFiles(nonExternalElements).toMutableList()
 

--- a/gluecodium/src/main/resources/templates/jni/EnumConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/EnumConversionImplementation.mustache
@@ -35,9 +35,12 @@ namespace jni
 {
 {{#enum}}
 {{cppFullyQualifiedName}}
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, {{cppFullyQualifiedName}}*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{#if externalConverter}}_ext{{/if}}, {{cppFullyQualifiedName}}*)
 {
-{{#if isExternal}}
+{{#if externalConverter}}
+{{prefixPartial "jni/ExternalConversionFromJni" "    "}}
+{{/if}}
+{{#if needsOrdinalConversion}}
     auto ordinal = call_java_method<jint>(_jenv, _jinput, "ordinal", "()I");
     switch(ordinal) {
 {{#enumerators}}
@@ -48,7 +51,7 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, {{cppFully
             return {};
     }
 {{/if}}{{!!
-}}{{#unless isExternal}}
+}}{{#unless needsOrdinalConversion}}
     return {{cppFullyQualifiedName}}(
         {{>common/InternalNamespace}}jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
 {{/unless}}
@@ -77,7 +80,13 @@ convert_to_jni(JNIEnv* _jenv, const {{cppFullyQualifiedName}} _ninput)
 {{/enumerators}}
     }
     jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "L{{javaPackage.toJniString}}/{{javaName}};");
+{{#unless externalConverter}}
     return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
+{{/unless}}{{#if externalConverter}}
+    auto _jresult = make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
+{{prefixPartial "jni/ExternalConversionToJni" "    "}}
+    return _jresult;
+{{/if}}
 }
 
 JniReference<jobject>

--- a/gluecodium/src/main/resources/templates/jni/ExternalConversionFromJni.mustache
+++ b/gluecodium/src/main/resources/templates/jni/ExternalConversionFromJni.mustache
@@ -1,0 +1,35 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+auto converterClass = find_class(_jenv, "{{externalConverter}}");
+if (converterClass.get() == NULL) {
+    throw_runtime_exception(_jenv, "Converter class '{{externalConverter}}' not found.");
+    return {};
+}
+
+auto convertMethodId = _jenv->GetStaticMethodID(
+    converterClass.get(), "convertToInternal", "(L{{externalConvertedType}};)L{{fullJavaName}};");
+if (convertMethodId == NULL) {
+    throw_runtime_exception(_jenv, "Static method 'convertToInternal(L{{externalConvertedType}};)L{{fullJavaName}};' not found.");
+    return {};
+}
+
+auto _jinput = make_local_ref(
+    _jenv, _jenv->CallStaticObjectMethod(converterClass.get(), convertMethodId, _jinput_ext.get()));

--- a/gluecodium/src/main/resources/templates/jni/ExternalConversionToJni.mustache
+++ b/gluecodium/src/main/resources/templates/jni/ExternalConversionToJni.mustache
@@ -1,0 +1,34 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+auto converterClass = find_class(_jenv, "{{externalConverter}}");
+if (converterClass.get() == NULL) {
+    throw_runtime_exception(_jenv, "Converter class '{{externalConverter}}' not found.");
+    return {};
+}
+
+auto convertMethodId = _jenv->GetStaticMethodID(
+    converterClass.get(), "convertFromInternal", "(L{{fullJavaName}};)L{{externalConvertedType}};");
+if (convertMethodId == NULL) {
+    throw_runtime_exception(_jenv, "Static method 'convertFromInternal(L{{fullJavaName}};)L{{externalConvertedType}};' not found.");
+    return {};
+}
+
+_jresult = make_local_ref(_jenv, _jenv->CallStaticObjectMethod(converterClass.get(), convertMethodId, _jresult.get()));

--- a/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
@@ -36,8 +36,11 @@ namespace jni
 {
 {{#struct}}
 {{cppFullyQualifiedName}}
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, {{cppFullyQualifiedName}}*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{#if externalConverter}}_ext{{/if}}, {{cppFullyQualifiedName}}*)
 {
+{{#if externalConverter}}
+{{prefixPartial "jni/ExternalConversionFromJni" "    "}}
+{{/if}}
     {{#unless hasImmutableFields}}{{cppFullyQualifiedName}} _nout{};{{/unless}}
 {{#fields}}{{#if javaGetterName}}{{#if type.isComplex}}
     auto j_{{cppField.name}} = call_java_method<{{type.name}}>(_jenv, _jinput, "{{javaGetterName}}", "(){{type.jniTypeSignature}}");
@@ -90,6 +93,9 @@ convert_to_jni(JNIEnv* _jenv, const {{cppFullyQualifiedName}}& _ninput)
 {{/if}}{{#unless javaCustomType}}
     {{>common/InternalNamespace}}jni::set_field_value(_jenv, _jresult, "{{javaName}}", {{>getCppFieldValue}});
 {{/unless}}{{/unless}}{{/fields}}
+{{#if externalConverter}}
+{{prefixPartial "jni/ExternalConversionToJni" "    "}}
+{{/if}}
     return _jresult;
 }
 

--- a/gluecodium/src/main/resources/templates/jni/utils/CppProxyBaseHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/CppProxyBaseHeader.mustache
@@ -71,8 +71,7 @@ public:
         auto newProxyInstance = new (::std::nothrow ) ImplType( jenv, std::move(globalRef), jHashCode );
         if ( newProxyInstance == nullptr )
         {
-            auto exceptionClass = find_class(jenv, "java/lang/RuntimeException" );
-            jenv->ThrowNew( exceptionClass.get(), "Cannot allocate native memory." );
+            throw_runtime_exception( jenv, "Cannot allocate native memory." );
             return;
         }
         auto newProxy = ::std::shared_ptr< ImplType >( newProxyInstance );

--- a/gluecodium/src/main/resources/templates/jni/utils/JniCallJavaMethodHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniCallJavaMethodHeader.mustache
@@ -119,6 +119,8 @@ call_java_method( JNIEnv* jni_env,
     return call_java_method<ResultType>(jni_env, java_object, method_id, args...);
 }
 
+void throw_runtime_exception(JNIEnv* jni_env, const char* message);
+
 }
 {{#internalNamespace}}
 }

--- a/gluecodium/src/main/resources/templates/jni/utils/JniCallJavaMethodImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniCallJavaMethodImplementation.mustache
@@ -21,3 +21,21 @@
 {{>java/CopyrightHeader}}
 
 #include "JniCallJavaMethod.h"
+
+{{#internalNamespace}}
+namespace {{.}}
+{
+{{/internalNamespace}}
+namespace jni
+{
+
+void
+throw_runtime_exception(JNIEnv* jni_env, const char* message) {
+    auto exceptionClass = find_class(jni_env, "java/lang/RuntimeException");
+    jni_env->ThrowNew(exceptionClass.get(), message);
+}
+
+}
+{{#internalNamespace}}
+}
+{{/internalNamespace}}

--- a/gluecodium/src/test/resources/smoke/external_types/input/JavaExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/JavaExternalTypes.lime
@@ -48,8 +48,34 @@ enum Month {
     MARCH
 }
 
+struct SystemColor {
+    external {
+        java name "java.lang.Integer"
+        java converter "com.here.android.test.ColorConverter"
+    }
+
+    red: Float
+    green: Float
+    blue: Float
+    alpha: Float
+}
+
+enum Season {
+    external {
+        java name "java.lang.String"
+        java converter "com.here.android.test.SeasonConverter"
+    }
+
+    WINTER,
+    SPRING,
+    SUMMER,
+    AUTUMN
+}
+
 class UseJavaExternalTypes {
     static fun currencyRoundTrip(input: Currency): Currency
     static fun timeZoneRoundTrip(input: TimeZone): TimeZone
     static fun monthRoundTrip(input: Month): Month
+    static fun colorRoundTrip(input: SystemColor): SystemColor
+    static fun seasonRoundTrip(input: Season): Season
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/SystemColor.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/SystemColor.java
@@ -1,0 +1,16 @@
+/*
+ *
+ */
+package com.example.smoke;
+final class SystemColor {
+    public float red;
+    public float green;
+    public float blue;
+    public float alpha;
+    SystemColor(final float red, final float green, final float blue, final float alpha) {
+        this.red = red;
+        this.green = green;
+        this.blue = blue;
+        this.alpha = alpha;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/UseJavaExternalTypes.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/UseJavaExternalTypes.java
@@ -4,6 +4,8 @@
 package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
+import java.lang.Integer;
+import java.lang.String;
 import java.time.Month;
 import java.util.Currency;
 import java.util.SimpleTimeZone;
@@ -27,4 +29,8 @@ public final class UseJavaExternalTypes extends NativeBase {
     public static native SimpleTimeZone timeZoneRoundTrip(@NonNull final SimpleTimeZone input);
     @NonNull
     public static native Month monthRoundTrip(@NonNull final Month input);
+    @NonNull
+    public static native Integer colorRoundTrip(@NonNull final Integer input);
+    @NonNull
+    public static native String seasonRoundTrip(@NonNull final String input);
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_lang_Integer__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_lang_Integer__Conversion.cpp
@@ -1,0 +1,93 @@
+/*
+ *
+ */
+#include "java_lang_Integer__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+namespace gluecodium
+{
+namespace jni
+{
+::smoke::SystemColor
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput_ext, ::smoke::SystemColor*)
+{
+    auto converterClass = find_class(_jenv, "com/here/android/test/ColorConverter");
+    if (converterClass.get() == NULL) {
+        throw_runtime_exception(_jenv, "Converter class 'com/here/android/test/ColorConverter' not found.");
+        return {};
+    }
+    auto convertMethodId = _jenv->GetStaticMethodID(
+        converterClass.get(), "convertToInternal", "(Ljava/lang/Integer;)Lcom/example/smoke/SystemColor;");
+    if (convertMethodId == NULL) {
+        throw_runtime_exception(_jenv, "Static method 'convertToInternal(Ljava/lang/Integer;)Lcom/example/smoke/SystemColor;' not found.");
+        return {};
+    }
+    auto _jinput = make_local_ref(
+        _jenv, _jenv->CallStaticObjectMethod(converterClass.get(), convertMethodId, _jinput_ext.get()));
+    ::smoke::SystemColor _nout{};
+    float n_red = ::gluecodium::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "red",
+        (float*)nullptr );
+    _nout.red = n_red;
+    float n_green = ::gluecodium::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "green",
+        (float*)nullptr );
+    _nout.green = n_green;
+    float n_blue = ::gluecodium::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "blue",
+        (float*)nullptr );
+    _nout.blue = n_blue;
+    float n_alpha = ::gluecodium::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "alpha",
+        (float*)nullptr );
+    _nout.alpha = n_alpha;
+    return _nout;
+}
+::gluecodium::optional<::smoke::SystemColor>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<::smoke::SystemColor>*)
+{
+    return _jinput
+        ? ::gluecodium::optional<::smoke::SystemColor>(convert_from_jni(_jenv, _jinput, (::smoke::SystemColor*)nullptr))
+        : ::gluecodium::optional<::smoke::SystemColor>{};
+}
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/SystemColor", com_example_smoke_SystemColor, ::smoke::SystemColor)
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::SystemColor& _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::SystemColor>::java_class;
+    auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "red", _ninput.red);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "green", _ninput.green);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "blue", _ninput.blue);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "alpha", _ninput.alpha);
+    auto converterClass = find_class(_jenv, "com/here/android/test/ColorConverter");
+    if (converterClass.get() == NULL) {
+        throw_runtime_exception(_jenv, "Converter class 'com/here/android/test/ColorConverter' not found.");
+        return {};
+    }
+    auto convertMethodId = _jenv->GetStaticMethodID(
+        converterClass.get(), "convertFromInternal", "(Lcom/example/smoke/SystemColor;)Ljava/lang/Integer;");
+    if (convertMethodId == NULL) {
+        throw_runtime_exception(_jenv, "Static method 'convertFromInternal(Lcom/example/smoke/SystemColor;)Ljava/lang/Integer;' not found.");
+        return {};
+    }
+    _jresult = make_local_ref(_jenv, _jenv->CallStaticObjectMethod(converterClass.get(), convertMethodId, _jresult.get()));
+    return _jresult;
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<::smoke::SystemColor> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_lang_String__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_lang_String__Conversion.cpp
@@ -1,0 +1,80 @@
+/*
+ *
+ */
+#include "java_lang_String__Conversion.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+namespace gluecodium
+{
+namespace jni
+{
+::smoke::Season
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput_ext, ::smoke::Season*)
+{
+    auto converterClass = find_class(_jenv, "com/here/android/test/SeasonConverter");
+    if (converterClass.get() == NULL) {
+        throw_runtime_exception(_jenv, "Converter class 'com/here/android/test/SeasonConverter' not found.");
+        return {};
+    }
+    auto convertMethodId = _jenv->GetStaticMethodID(
+        converterClass.get(), "convertToInternal", "(Ljava/lang/String;)Lcom/example/smoke/Season;");
+    if (convertMethodId == NULL) {
+        throw_runtime_exception(_jenv, "Static method 'convertToInternal(Ljava/lang/String;)Lcom/example/smoke/Season;' not found.");
+        return {};
+    }
+    auto _jinput = make_local_ref(
+        _jenv, _jenv->CallStaticObjectMethod(converterClass.get(), convertMethodId, _jinput_ext.get()));
+    return ::smoke::Season(
+        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+}
+::gluecodium::optional<::smoke::Season>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<::smoke::Season>*)
+{
+    return _jinput
+        ? ::gluecodium::optional<::smoke::Season>(convert_from_jni(_jenv, _jinput, (::smoke::Season*)nullptr))
+        : ::gluecodium::optional<::smoke::Season>{};
+}
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/Season", com_example_smoke_Season, ::smoke::Season)
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::Season _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::Season>::java_class;
+    const char* enumeratorName = nullptr;
+    switch(_ninput) {
+        case(::smoke::Season::WINTER):
+            enumeratorName = "WINTER";
+            break;
+        case(::smoke::Season::SPRING):
+            enumeratorName = "SPRING";
+            break;
+        case(::smoke::Season::SUMMER):
+            enumeratorName = "SUMMER";
+            break;
+        case(::smoke::Season::AUTUMN):
+            enumeratorName = "AUTUMN";
+            break;
+    }
+    jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Lcom/example/smoke/Season;");
+    auto _jresult = make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
+    auto converterClass = find_class(_jenv, "com/here/android/test/SeasonConverter");
+    if (converterClass.get() == NULL) {
+        throw_runtime_exception(_jenv, "Converter class 'com/here/android/test/SeasonConverter' not found.");
+        return {};
+    }
+    auto convertMethodId = _jenv->GetStaticMethodID(
+        converterClass.get(), "convertFromInternal", "(Lcom/example/smoke/Season;)Ljava/lang/String;");
+    if (convertMethodId == NULL) {
+        throw_runtime_exception(_jenv, "Static method 'convertFromInternal(Lcom/example/smoke/Season;)Ljava/lang/String;' not found.");
+        return {};
+    }
+    _jresult = make_local_ref(_jenv, _jenv->CallStaticObjectMethod(converterClass.get(), convertMethodId, _jresult.get()));
+    return _jresult;
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<::smoke::Season> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+}
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
@@ -58,6 +58,7 @@ class LimeExternalDescriptor private constructor(
         const val SWIFT_TAG = "swift"
         const val DART_TAG = "dart"
 
+        const val CONVERTER_NAME = "converter"
         const val INCLUDE_NAME = "include"
         const val FRAMEWORK_NAME = "framework"
         const val IMPORT_PATH_NAME = "importPath"


### PR DESCRIPTION
Added support for specifying "converter" classes for "external" types in
Java. Converter class is expected to contain static functions
"convertToInternal" and "convertFromInternal", converting the "external"
type to/from internal (package-private) generated intermediate
representation.

Added functional and smoke tests.

See: #408
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>