### PR TITLE
Add support for external type converters in Swift

### DIFF
--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -328,6 +328,10 @@ names are case-insensitive. Supported platform tags:
     * **framework**: *mandatory value*. Specifies a name of a Swift framework that needs to be
     imported for the pre-existing type. The value can be an empty string `""` if the type resides
     in the current framework or in the "Foundation" framework.
+    * **converter**: specifies a pre-existing converter class. A converter class should have two
+    static functions named `convertToInternal` and `convertFromInternal`, providing conversion
+    between the "external" type and the generated "internal" type. The argument of each conversion
+    function has to be anonymous (i.e. with `_` argument label).
   * **dart**: describes "external" behavior for Dart. Currently only supported for structs and
   enums. Supported value names:
     * **importPath**: *mandatory value*. Specifies a full import path for a Dart `import` directive

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -512,6 +512,12 @@ elseif(HELLO_APIGEN_GLUECODIUM_GENERATOR STREQUAL swift)
     # Swift users want a module...
     include(gluecodium/Swift)
 
+    list(APPEND ADDITIONAL_SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/ios/ColorConverter.swift"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/ios/PseudoColor.swift"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/ios/Season.swift"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/ios/SeasonConverter.swift")
+
     apigen_swift_build(hello)
     apigen_swift_framework_info_plist(hello)
     if(HELLO_SWIFT_TESTS)

--- a/examples/libhello/lime/test/SwiftExternalTypes.lime
+++ b/examples/libhello/lime/test/SwiftExternalTypes.lime
@@ -26,6 +26,19 @@ struct DateInterval {
     end: Date
 }
 
+@Swift("PseudoColor")
+struct SystemColor {
+    external {
+        swift framework ""
+        swift converter "ColorConverter"
+    }
+
+    red: Float
+    green: Float
+    blue: Float
+    alpha: Float
+}
+
 @Swift("URLCredential.Persistence")
 enum Persistence {
     external {
@@ -37,7 +50,21 @@ enum Persistence {
     permanent
 }
 
+enum Season {
+    external {
+        swift framework ""
+        swift converter "SeasonConverter"
+    }
+
+    WINTER,
+    SPRING,
+    SUMMER,
+    AUTUMN
+}
+
 class UseSwiftExternalTypes {
     static fun dateIntervalRoundTrip(input: DateInterval): DateInterval
     static fun persistenceRoundTrip(input: Persistence): Persistence
+    static fun colorRoundTrip(input: SystemColor): SystemColor
+    static fun seasonRoundTrip(input: Season): Season
 }

--- a/examples/libhello/src/ios/ColorConverter.swift
+++ b/examples/libhello/src/ios/ColorConverter.swift
@@ -18,27 +18,21 @@
 //
 // -------------------------------------------------------------------------------------------------
 
-#include "test/UseSwiftExternalTypes.h"
+internal class ColorConverter {
+    static func convertFromInternal(_ internalColor: PseudoColor_internal) -> PseudoColor {
+        let alpha = UInt64((internalColor.alpha * 255).rounded()) << 24
+        let red = UInt64((internalColor.red * 255).rounded()) << 16
+        let green = UInt64((internalColor.green * 255).rounded()) << 8
+        let blue = UInt64((internalColor.blue * 255).rounded())
+        return PseudoColor(alpha + red + green + blue)
+    }
 
-namespace test
-{
-DateInterval
-UseSwiftExternalTypes::date_interval_round_trip(const DateInterval& input) {
-    return input;
-}
-
-Persistence
-UseSwiftExternalTypes::persistence_round_trip(const Persistence input) {
-    return input;
-}
-
-SystemColor
-UseSwiftExternalTypes::color_round_trip(const SystemColor& input) {
-    return input;
-}
-
-Season
-UseSwiftExternalTypes::season_round_trip(const Season input) {
-    return input;
-}
+    static func convertToInternal(_ systemColor: PseudoColor) -> PseudoColor_internal {
+        return PseudoColor_internal(
+            red: Float((systemColor.value >> 16) & 0xFF) / 255.0,
+            green: Float((systemColor.value >> 8) & 0xFF) / 255.0,
+            blue: Float(systemColor.value & 0xFF) / 255.0,
+            alpha: Float((systemColor.value >> 24) & 0xFF) / 255.0
+        )
+    }
 }

--- a/examples/libhello/src/ios/PseudoColor.swift
+++ b/examples/libhello/src/ios/PseudoColor.swift
@@ -18,27 +18,9 @@
 //
 // -------------------------------------------------------------------------------------------------
 
-#include "test/UseSwiftExternalTypes.h"
-
-namespace test
-{
-DateInterval
-UseSwiftExternalTypes::date_interval_round_trip(const DateInterval& input) {
-    return input;
-}
-
-Persistence
-UseSwiftExternalTypes::persistence_round_trip(const Persistence input) {
-    return input;
-}
-
-SystemColor
-UseSwiftExternalTypes::color_round_trip(const SystemColor& input) {
-    return input;
-}
-
-Season
-UseSwiftExternalTypes::season_round_trip(const Season input) {
-    return input;
-}
+public class PseudoColor {
+    public let value: UInt64
+    public init(_ value: UInt64) {
+        self.value = value
+    }
 }

--- a/examples/libhello/src/ios/Season.swift
+++ b/examples/libhello/src/ios/Season.swift
@@ -18,27 +18,9 @@
 //
 // -------------------------------------------------------------------------------------------------
 
-#include "test/UseSwiftExternalTypes.h"
-
-namespace test
-{
-DateInterval
-UseSwiftExternalTypes::date_interval_round_trip(const DateInterval& input) {
-    return input;
-}
-
-Persistence
-UseSwiftExternalTypes::persistence_round_trip(const Persistence input) {
-    return input;
-}
-
-SystemColor
-UseSwiftExternalTypes::color_round_trip(const SystemColor& input) {
-    return input;
-}
-
-Season
-UseSwiftExternalTypes::season_round_trip(const Season input) {
-    return input;
-}
+public class Season {
+    public let value: String
+    public init(_ value: String) {
+        self.value = value
+    }
 }

--- a/examples/libhello/src/ios/SeasonConverter.swift
+++ b/examples/libhello/src/ios/SeasonConverter.swift
@@ -18,27 +18,23 @@
 //
 // -------------------------------------------------------------------------------------------------
 
-#include "test/UseSwiftExternalTypes.h"
+internal class SeasonConverter {
+    static func convertFromInternal(_ internalSeason: Season_internal) -> Season {
+        switch (internalSeason) {
+        case .winter: return Season("winter")
+        case .spring: return Season("spring")
+        case .summer: return Season("summer")
+        case .autumn: return Season("autumn")
+        }
+    }
 
-namespace test
-{
-DateInterval
-UseSwiftExternalTypes::date_interval_round_trip(const DateInterval& input) {
-    return input;
-}
-
-Persistence
-UseSwiftExternalTypes::persistence_round_trip(const Persistence input) {
-    return input;
-}
-
-SystemColor
-UseSwiftExternalTypes::color_round_trip(const SystemColor& input) {
-    return input;
-}
-
-Season
-UseSwiftExternalTypes::season_round_trip(const Season input) {
-    return input;
-}
+    static func convertToInternal(_ systemSeason: Season) -> Season_internal {
+        switch (systemSeason.value) {
+        case "winter": return Season_internal.winter
+        case "spring": return Season_internal.spring
+        case "summer": return Season_internal.summer
+        case "autumn": return Season_internal.autumn
+        default: fatalError("Oops! '\(systemSeason.value)'")
+        }
+    }
 }

--- a/examples/platforms/ios/Tests/testTests/ExternalTypesTests.swift
+++ b/examples/platforms/ios/Tests/testTests/ExternalTypesTests.swift
@@ -73,10 +73,28 @@ class ExternalTypesTests: XCTestCase {
         XCTAssertEqual(persistence, result)
     }
 
+    func testSwiftExternalTypeColor() {
+        let color = PseudoColor(0x007FFF)
+
+        let result = UseSwiftExternalTypes.colorRoundTrip(input: color)
+
+        XCTAssertEqual(color.value, result.value)
+    }
+
+    func testSwiftExternalTypeSeason() {
+        let season = Season("spring")
+
+        let result = UseSwiftExternalTypes.seasonRoundTrip(input: season)
+
+        XCTAssertEqual(season.value, result.value)
+    }
+
     static var allTests = [
         ("testUseExternalTypesExternalStruct", testUseExternalTypesExternalStruct),
         ("testUseExternalTypesExternalEnum", testUseExternalTypesExternalEnum),
         ("testSwiftExternalTypeDateInterval", testSwiftExternalTypeDateInterval),
-        ("testSwiftExternalTypePersistence", testSwiftExternalTypePersistence)
+        ("testSwiftExternalTypePersistence", testSwiftExternalTypePersistence),
+        ("testSwiftExternalTypeColor", testSwiftExternalTypeColor),
+        ("testSwiftExternalTypeSeason", testSwiftExternalTypeSeason)
     ]
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
@@ -36,6 +36,7 @@ import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeEnumerator
 import com.here.gluecodium.model.lime.LimeException
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.CONVERTER_NAME
 import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.FRAMEWORK_NAME
 import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeFunction
@@ -264,7 +265,8 @@ class SwiftModelBuilder(
             constants = getPreviousResults(SwiftConstant::class.java),
             methods = getPreviousResults(SwiftMethod::class.java),
             generatedConstructorComment = limeStruct.constructorComment.getFor(PLATFORM_TAG),
-            externalFramework = limeStruct.external?.swift?.get(FRAMEWORK_NAME)
+            externalFramework = limeStruct.external?.swift?.get(FRAMEWORK_NAME),
+            externalConverter = limeStruct.external?.swift?.get(CONVERTER_NAME)
         )
         swiftStruct.comment = createComments(limeStruct)
 
@@ -299,7 +301,8 @@ class SwiftModelBuilder(
             name = nameResolver.getFullName(limeEnumeration),
             visibility = getVisibility(limeEnumeration),
             items = getPreviousResults(SwiftEnumItem::class.java),
-            externalFramework = limeEnumeration.external?.swift?.get(FRAMEWORK_NAME)
+            externalFramework = limeEnumeration.external?.swift?.get(FRAMEWORK_NAME),
+            externalConverter = limeEnumeration.external?.swift?.get(CONVERTER_NAME)
         )
         swiftEnum.comment = createComments(limeEnumeration)
 
@@ -476,6 +479,7 @@ class SwiftModelBuilder(
     private fun getVisibility(limeElement: LimeNamedElement) =
         when {
             limeElement.visibility.isInternal -> SwiftVisibility.INTERNAL
+            limeElement.external?.swift?.get(CONVERTER_NAME) != null -> SwiftVisibility.INTERNAL
             else -> SwiftVisibility.PUBLIC
         }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftEnum.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftEnum.kt
@@ -23,13 +23,15 @@ class SwiftEnum(
     name: String,
     visibility: SwiftVisibility? = null,
     val items: List<SwiftEnumItem> = emptyList(),
-    externalFramework: String? = null
+    externalFramework: String? = null,
+    externalConverter: String? = null
 ) : SwiftType(
     name = name,
     visibility = visibility,
     category = TypeCategory.ENUM,
     publicName = name,
-    externalFramework = externalFramework
+    externalFramework = externalFramework,
+    externalConverter = externalConverter
 ) {
     override val childElements
         get() = items

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftStruct.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftStruct.kt
@@ -34,8 +34,18 @@ class SwiftStruct(
     val constants: List<SwiftConstant> = emptyList(),
     val methods: List<SwiftMethod> = emptyList(),
     var generatedConstructorComment: String? = null,
-    externalFramework: String? = null
-) : SwiftType(name, cPrefix, visibility, category, publicName ?: name, optional, externalFramework) {
+    externalFramework: String? = null,
+    externalConverter: String? = null
+) : SwiftType(
+    name,
+    cPrefix,
+    visibility,
+    category,
+    publicName ?: name,
+    optional,
+    externalFramework,
+    externalConverter
+) {
 
     @Suppress("unused")
     val constructors

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftType.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftType.kt
@@ -26,7 +26,9 @@ open class SwiftType protected constructor(
     val category: TypeCategory,
     val publicName: String = name,
     val optional: Boolean = false,
-    val externalFramework: String? = null
+    val externalFramework: String? = null,
+    @Suppress("unused")
+    val externalConverter: String? = null
 ) : SwiftModelElement(name, visibility) {
     val className
         get() = if (category == TypeCategory.CLASS) mangledName else ""
@@ -59,8 +61,8 @@ open class SwiftType protected constructor(
     fun getcPrefix() = cPrefix
 
     @Suppress("unused")
-    val isExternal
-        get() = externalFramework != null
+    val skipDeclaration
+        get() = externalFramework != null && externalConverter == null
 
     open fun withAlias(aliasName: String) =
         SwiftType(name, cPrefix, visibility, category, aliasName, optional, externalFramework)

--- a/gluecodium/src/main/resources/templates/swift/Enum.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Enum.mustache
@@ -18,8 +18,8 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless isExternal}}{{>swift/Comment}}
-{{visibility}} enum {{simpleName}} : UInt32, CaseIterable, Codable {
+{{#unless skipDeclaration}}{{>swift/Comment}}
+{{visibility}} enum {{simpleName}}{{#if externalConverter}}_internal{{/if}} : UInt32, CaseIterable, Codable {
 {{#items}}{{prefixPartial "enumItem" "    "}}
 {{/items}}
 }

--- a/gluecodium/src/main/resources/templates/swift/EnumConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/EnumConversion.mustache
@@ -18,38 +18,57 @@
   ! License-Filename: LICENSE
   !
   !}}
-internal func copyToCType(_ swiftEnum: {{name}}) -> PrimitiveHolder<UInt32> {
-    return PrimitiveHolder({{#if isExternal}}UInt32({{/if}}swiftEnum.rawValue{{#if isExternal}}){{/if}})
+internal func copyToCType(_ swiftEnum{{#if externalConverter}}_ext{{/if}}: {{name}}) -> PrimitiveHolder<UInt32> {
+{{#if externalConverter}}
+    let swiftEnum = {{externalConverter}}.convertToInternal(swiftEnum_ext)
+{{/if}}
+    return PrimitiveHolder({{#if skipDeclaration}}UInt32({{/if}}swiftEnum.rawValue{{#if skipDeclaration}}){{/if}})
 }
 internal func moveToCType(_ swiftEnum: {{name}}) -> PrimitiveHolder<UInt32> {
     return copyToCType(swiftEnum)
 }
 
-internal func copyToCType(_ swiftEnum: {{name}}?) -> RefHolder {
-{{#if isExternal}}
+internal func copyToCType(_ swiftEnum{{#if externalConverter}}_ext{{/if}}: {{name}}?) -> RefHolder {
+{{#if skipDeclaration}}
     if let rawValue = swiftEnum?.rawValue {
         return copyToCType(UInt32(rawValue) as UInt32?)
     } else {
         return RefHolder(0)
     }
-{{/if}}{{#unless isExternal}}
+{{/if}}{{#unless skipDeclaration}}
+{{#if externalConverter}}
+    guard let swiftEnum_ext = swiftEnum_ext else {
+        return RefHolder(0)
+    }
+    let swiftEnum = {{externalConverter}}.convertToInternal(swiftEnum_ext) as {{name}}_internal?
+{{/if}}
     return copyToCType(swiftEnum?.rawValue)
 {{/unless}}
 }
-internal func moveToCType(_ swiftEnum: {{name}}?) -> RefHolder {
-{{#if isExternal}}
+internal func moveToCType(_ swiftEnum{{#if externalConverter}}_ext{{/if}}: {{name}}?) -> RefHolder {
+{{#if skipDeclaration}}
     if let rawValue = swiftEnum?.rawValue {
         return moveToCType(UInt32(rawValue) as UInt32?)
     } else {
         return RefHolder(0)
     }
-{{/if}}{{#unless isExternal}}
+{{/if}}{{#unless skipDeclaration}}
+{{#if externalConverter}}
+    guard let swiftEnum_ext = swiftEnum_ext else {
+        return RefHolder(0)
+    }
+    let swiftEnum = {{externalConverter}}.convertToInternal(swiftEnum_ext) as {{name}}_internal?
+{{/if}}
     return moveToCType(swiftEnum?.rawValue)
 {{/unless}}
 }
 
 internal func copyFromCType(_ cValue: UInt32) -> {{name}} {
-    return {{name}}(rawValue: {{#if isExternal}}UInt({{/if}}cValue{{#if isExternal}}){{/if}})!
+{{#if externalConverter}}
+    return {{externalConverter}}.convertFromInternal({{name}}_internal(rawValue: cValue)!)
+{{/if}}{{#unless externalConverter}}
+    return {{name}}(rawValue: {{#if skipDeclaration}}UInt({{/if}}cValue{{#if skipDeclaration}}){{/if}})!
+{{/unless}}
 }
 internal func moveFromCType(_ cValue: UInt32) -> {{name}} {
     return copyFromCType(cValue)
@@ -59,7 +78,11 @@ internal func copyFromCType(_ handle: _baseRef) -> {{name}}? {
     guard handle != 0 else {
         return nil
     }
-    return {{name}}(rawValue: {{#if isExternal}}UInt({{/if}}uint32_t_value_get(handle){{#if isExternal}}){{/if}})!
+{{#if externalConverter}}
+    return {{externalConverter}}.convertFromInternal({{name}}_internal(rawValue: uint32_t_value_get(handle))!)
+{{/if}}{{#unless externalConverter}}
+    return {{name}}(rawValue: {{#if skipDeclaration}}UInt({{/if}}uint32_t_value_get(handle){{#if skipDeclaration}}){{/if}})!
+{{/unless}}
 }
 internal func moveFromCType(_ handle: _baseRef) -> {{name}}? {
     defer {

--- a/gluecodium/src/main/resources/templates/swift/Struct.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Struct.mustache
@@ -18,8 +18,8 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless isExternal}}{{>swift/Comment}}
-{{visibility}} struct {{simpleName}}{{#if isEquatable isCodable logic="or"}}{{!!
+{{#unless skipDeclaration}}{{>swift/Comment}}
+{{visibility}} struct {{simpleName}}{{#if externalConverter}}_internal{{/if}}{{#if isEquatable isCodable logic="or"}}{{!!
 }}:{{#if isEquatable}} Hashable{{/if}}{{#if isEquatable isCodable logic="and"}},{{/if}}{{#if isCodable}} Codable{{/if}}{{!!
 }}{{/if}} {
 {{#constants}}
@@ -115,7 +115,7 @@
 }
 {{/unless}}{{!!
 
-}}{{#if isExternal}}
+}}{{#if skipDeclaration}}
 extension {{name}} {
     internal init?(cHandle: _baseRef) {
         self.init({{#fields}}{{name}}: {{!!

--- a/gluecodium/src/main/resources/templates/swift/StructConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/StructConversion.mustache
@@ -20,7 +20,11 @@
   !}}
 {{#if fields}}
 internal func copyFromCType(_ handle: _baseRef) -> {{name}} {
-    return {{name}}(cHandle: handle){{#if isExternal}}!{{/if}}
+{{#if externalConverter}}
+    return {{externalConverter}}.convertFromInternal({{name}}_internal(cHandle: handle))
+{{/if}}{{#unless externalConverter}}
+    return {{name}}(cHandle: handle){{#if skipDeclaration}}!{{/if}}
+{{/unless}}
 }
 internal func moveFromCType(_ handle: _baseRef) -> {{name}} {
     defer {
@@ -29,7 +33,10 @@ internal func moveFromCType(_ handle: _baseRef) -> {{name}} {
     return copyFromCType(handle)
 }
 
-internal func copyToCType(_ swiftType: {{name}}) -> RefHolder {
+internal func copyToCType(_ swiftType{{#if externalConverter}}_ext{{/if}}: {{name}}) -> RefHolder {
+{{#if externalConverter}}
+    let swiftType = {{externalConverter}}.convertToInternal(swiftType_ext)
+{{/if}}
 {{#fields}}
     let c_{{name}} = {{#type}}{{>swift/ConversionPrefixTo}}{{/type}}moveToCType(swiftType.{{name}})
 {{/fields}}
@@ -46,7 +53,11 @@ internal func copyFromCType(_ handle: _baseRef) -> {{name}}? {
         return nil
     }
     let unwrappedHandle = {{cPrefix}}_unwrap_optional_handle(handle)
-    return {{name}}(cHandle: unwrappedHandle){{#if isExternal}}!{{/if}} as {{name}}
+{{#if externalConverter}}
+    return {{externalConverter}}.convertFromInternal({{name}}_internal(cHandle: unwrappedHandle))
+{{/if}}{{#unless externalConverter}}
+    return {{name}}(cHandle: unwrappedHandle){{#if skipDeclaration}}!{{/if}} as {{name}}
+{{/unless}}
 }
 internal func moveFromCType(_ handle: _baseRef) -> {{name}}? {
     defer {
@@ -55,10 +66,13 @@ internal func moveFromCType(_ handle: _baseRef) -> {{name}}? {
     return copyFromCType(handle)
 }
 
-internal func copyToCType(_ swiftType: {{name}}?) -> RefHolder {
-    guard let swiftType = swiftType else {
+internal func copyToCType(_ swiftType{{#if externalConverter}}_ext{{/if}}: {{name}}?) -> RefHolder {
+    guard let swiftType{{#if externalConverter}}_ext{{/if}} = swiftType{{#if externalConverter}}_ext{{/if}} else {
         return RefHolder(0)
     }
+{{#if externalConverter}}
+    let swiftType = {{externalConverter}}.convertToInternal(swiftType_ext)
+{{/if}}
 {{#fields}}
     let c_{{name}} = {{#type}}{{>swift/ConversionPrefixTo}}{{/type}}moveToCType(swiftType.{{name}})
 {{/fields}}

--- a/gluecodium/src/test/resources/smoke/external_types/input/SwiftExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/SwiftExternalTypes.lime
@@ -37,9 +37,35 @@ enum Persistence {
     permanent
 }
 
+struct PseudoColor {
+    external {
+        swift framework ""
+        swift converter "ColorConverter"
+    }
+
+    red: Float
+    green: Float
+    blue: Float
+    alpha: Float
+}
+
+enum SwiftSeason {
+    external {
+        swift framework ""
+        swift converter "SeasonConverter"
+    }
+
+    WINTER,
+    SPRING,
+    SUMMER,
+    AUTUMN
+}
+
 class UseSwiftExternalTypes {
     static fun dateIntervalRoundTrip(input: DateInterval): DateInterval
     static fun persistenceRoundTrip(input: Persistence): Persistence
+    static fun colorRoundTrip(input: PseudoColor): PseudoColor
+    static fun seasonRoundTrip(input: SwiftSeason): SwiftSeason
 }
 
 typealias ExternalList = List<DateInterval>

--- a/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_UseSwiftExternalTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_UseSwiftExternalTypes.cpp
@@ -8,6 +8,8 @@
 #include "gluecodium/TypeRepository.h"
 #include "smoke/DateInterval.h"
 #include "smoke/Persistence.h"
+#include "smoke/PseudoColor.h"
+#include "smoke/SwiftSeason.h"
 #include "smoke/UseSwiftExternalTypes.h"
 #include <memory>
 #include <new>
@@ -37,4 +39,10 @@ _baseRef smoke_UseSwiftExternalTypes_dateIntervalRoundTrip(_baseRef input) {
 }
 smoke_URLCredential_1Persistence smoke_UseSwiftExternalTypes_persistenceRoundTrip(smoke_URLCredential_1Persistence input) {
     return static_cast<smoke_URLCredential_1Persistence>(::smoke::UseSwiftExternalTypes::persistence_round_trip(static_cast<::smoke::Persistence>(input)));
+}
+_baseRef smoke_UseSwiftExternalTypes_colorRoundTrip(_baseRef input) {
+    return Conversion<::smoke::PseudoColor>::toBaseRef(::smoke::UseSwiftExternalTypes::color_round_trip(Conversion<::smoke::PseudoColor>::toCpp(input)));
+}
+smoke_SwiftSeason smoke_UseSwiftExternalTypes_seasonRoundTrip(smoke_SwiftSeason input) {
+    return static_cast<smoke_SwiftSeason>(::smoke::UseSwiftExternalTypes::season_round_trip(static_cast<::smoke::SwiftSeason>(input)));
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/PseudoColor.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/PseudoColor.swift
@@ -1,0 +1,68 @@
+//
+//
+import Foundation
+internal struct PseudoColor_internal {
+    public var red: Float
+    public var green: Float
+    public var blue: Float
+    public var alpha: Float
+    internal init(red: Float, green: Float, blue: Float, alpha: Float) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+        self.alpha = alpha
+    }
+    internal init(cHandle: _baseRef) {
+        red = moveFromCType(smoke_PseudoColor_red_get(cHandle))
+        green = moveFromCType(smoke_PseudoColor_green_get(cHandle))
+        blue = moveFromCType(smoke_PseudoColor_blue_get(cHandle))
+        alpha = moveFromCType(smoke_PseudoColor_alpha_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> PseudoColor {
+    return ColorConverter.convertFromInternal(PseudoColor_internal(cHandle: handle))
+}
+internal func moveFromCType(_ handle: _baseRef) -> PseudoColor {
+    defer {
+        smoke_PseudoColor_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType_ext: PseudoColor) -> RefHolder {
+    let swiftType = ColorConverter.convertToInternal(swiftType_ext)
+    let c_red = moveToCType(swiftType.red)
+    let c_green = moveToCType(swiftType.green)
+    let c_blue = moveToCType(swiftType.blue)
+    let c_alpha = moveToCType(swiftType.alpha)
+    return RefHolder(smoke_PseudoColor_create_handle(c_red.ref, c_green.ref, c_blue.ref, c_alpha.ref))
+}
+internal func moveToCType(_ swiftType: PseudoColor) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PseudoColor_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> PseudoColor? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_PseudoColor_unwrap_optional_handle(handle)
+    return ColorConverter.convertFromInternal(PseudoColor_internal(cHandle: unwrappedHandle))
+}
+internal func moveFromCType(_ handle: _baseRef) -> PseudoColor? {
+    defer {
+        smoke_PseudoColor_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType_ext: PseudoColor?) -> RefHolder {
+    guard let swiftType_ext = swiftType_ext else {
+        return RefHolder(0)
+    }
+    let swiftType = ColorConverter.convertToInternal(swiftType_ext)
+    let c_red = moveToCType(swiftType.red)
+    let c_green = moveToCType(swiftType.green)
+    let c_blue = moveToCType(swiftType.blue)
+    let c_alpha = moveToCType(swiftType.alpha)
+    return RefHolder(smoke_PseudoColor_create_optional_handle(c_red.ref, c_green.ref, c_blue.ref, c_alpha.ref))
+}
+internal func moveToCType(_ swiftType: PseudoColor?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PseudoColor_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Season.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Season.swift
@@ -1,0 +1,39 @@
+//
+//
+import Foundation
+public enum Season : UInt32, CaseIterable, Codable {
+    case winter
+    case spring
+    case summer
+    case autumn
+}
+internal func copyToCType(_ swiftEnum: Season) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func moveToCType(_ swiftEnum: Season) -> PrimitiveHolder<UInt32> {
+    return copyToCType(swiftEnum)
+}
+internal func copyToCType(_ swiftEnum: Season?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func moveToCType(_ swiftEnum: Season?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func copyFromCType(_ cValue: UInt32) -> Season {
+    return Season(rawValue: cValue)!
+}
+internal func moveFromCType(_ cValue: UInt32) -> Season {
+    return copyFromCType(cValue)
+}
+internal func copyFromCType(_ handle: _baseRef) -> Season? {
+    guard handle != 0 else {
+        return nil
+    }
+    return Season(rawValue: uint32_t_value_get(handle))!
+}
+internal func moveFromCType(_ handle: _baseRef) -> Season? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UseSwiftExternalTypes.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UseSwiftExternalTypes.swift
@@ -22,6 +22,14 @@ public class UseSwiftExternalTypes {
         let c_input = moveToCType(input)
         return moveFromCType(smoke_UseSwiftExternalTypes_persistenceRoundTrip(c_input.ref))
     }
+    public static func colorRoundTrip(input: PseudoColor) -> PseudoColor {
+        let c_input = moveToCType(input)
+        return moveFromCType(smoke_UseSwiftExternalTypes_colorRoundTrip(c_input.ref))
+    }
+    public static func seasonRoundTrip(input: SwiftSeason) -> SwiftSeason {
+        let c_input = moveToCType(input)
+        return moveFromCType(smoke_UseSwiftExternalTypes_seasonRoundTrip(c_input.ref))
+    }
 }
 internal func getRef(_ ref: UseSwiftExternalTypes?, owning: Bool = true) -> RefHolder {
     guard let c_handle = ref?.c_instance else {


### PR DESCRIPTION
Added support for specifying "converter" classes for "external" structs
and enums in Swift. Converter class is expected to contain static
functions "convertToInternal" and "convertFromInternal", converting the
"external" type to/from internal generated intermediate representation.

Added functional and smoke tests.

See: #408
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>