### PR TITLE
Add support for external type converters in Dart

### DIFF
--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -337,6 +337,13 @@ names are case-insensitive. Supported platform tags:
     * **importPath**: *mandatory value*. Specifies a full import path for a Dart `import` directive
     needed for the pre-existing type (i.e. either `"dart:<library_name>"` or
     `"package:<path>/<file_name>.dart"`).
+    * **converter**: specifies a pre-existing converter class. A converter class should have two
+    static functions named `convertToInternal` and `convertFromInternal`, providing conversion
+    between the "external" type and the generated "internal" type.
+    * **converterImport**: specifies a relative import path for a Dart `import` directive
+    needed for the pre-existing converter class (i.e. `"<path>/<file_name>.dart"`).
+* **Note:** the following features of struct types cannot be combined with "external" behavior:
+custom constructors, field default values, `@Equatable`.
 
 ### Type references
 

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -525,6 +525,15 @@ elseif(HELLO_APIGEN_GLUECODIUM_GENERATOR STREQUAL swift)
         apigen_swift_test(hello SOURCES ${SWIFT_TEST_SOURCES})
     endif()
 elseif(HELLO_APIGEN_GLUECODIUM_GENERATOR STREQUAL dart)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/dart/color_converter.dart"
+        "${CMAKE_CURRENT_BINARY_DIR}/hello/dart/dart/lib/src/color_converter.dart"
+        COPYONLY)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/dart/season_converter.dart"
+        "${CMAKE_CURRENT_BINARY_DIR}/hello/dart/dart/lib/src/season_converter.dart"
+        COPYONLY)
+
     # Install the shared library for Dart
     install(TARGETS hello EXPORT helloTargets
         LIBRARY DESTINATION lib

--- a/examples/libhello/lime/test/DartExternalTypes.lime
+++ b/examples/libhello/lime/test/DartExternalTypes.lime
@@ -29,6 +29,19 @@ struct Rectangle {
     height: Int
 }
 
+@Dart("int")
+struct SystemColor {
+    external {
+       dart converterImport "../color_converter.dart"
+       dart converter "ColorConverter"
+    }
+
+    red: Float
+    green: Float
+    blue: Float
+    alpha: Float
+}
+
 @Dart("HttpClientResponseCompressionState")
 enum CompressionState {
     external {
@@ -40,7 +53,22 @@ enum CompressionState {
     notCompressed
 }
 
+@Dart("String")
+enum Season {
+    external {
+       dart converterImport "../season_converter.dart"
+       dart converter "SeasonConverter"
+    }
+
+    WINTER,
+    SPRING,
+    SUMMER,
+    AUTUMN
+}
+
 class UseDartExternalTypes {
     static fun rectangleRoundTrip(input: Rectangle): Rectangle
     static fun compressionStateRoundTrip(input: CompressionState): CompressionState
+    static fun colorRoundTrip(input: SystemColor): SystemColor
+    static fun seasonRoundTrip(input: Season): Season
 }

--- a/examples/libhello/src/dart/color_converter.dart
+++ b/examples/libhello/src/dart/color_converter.dart
@@ -18,27 +18,22 @@
 //
 // -------------------------------------------------------------------------------------------------
 
-#include "test/UseDartExternalTypes.h"
+import "test/int.dart";
 
-namespace test
-{
-Rectangle
-UseDartExternalTypes::rectangle_round_trip(const Rectangle& input) {
-    return input;
-}
+class ColorConverter {
+  static int convertFromInternal(int_internal internalColor) {
+    final alpha = (internalColor.alpha * 255).round() << 24;
+    final red = (internalColor.red * 255).round() << 16;
+    final green = (internalColor.green * 255).round() << 8;
+    final blue = (internalColor.blue * 255).round();
+    return alpha + red + green + blue;
+  }
 
-CompressionState
-UseDartExternalTypes::compression_state_round_trip(const CompressionState input) {
-    return input;
-}
-
-SystemColor
-UseDartExternalTypes::color_round_trip(const SystemColor& input) {
-    return input;
-}
-
-Season
-UseDartExternalTypes::season_round_trip(const Season input) {
-    return input;
-}
+  static int_internal convertToInternal(int systemColor) =>
+    int_internal(
+        ((systemColor >> 16) & 0xFF) / 255.0,
+        ((systemColor >> 8) & 0xFF) / 255.0,
+        (systemColor & 0xFF) / 255.0,
+        ((systemColor >> 24) & 0xFF) / 255.0
+    );
 }

--- a/examples/libhello/src/dart/season_converter.dart
+++ b/examples/libhello/src/dart/season_converter.dart
@@ -18,27 +18,32 @@
 //
 // -------------------------------------------------------------------------------------------------
 
-#include "test/UseDartExternalTypes.h"
+import "test/string.dart";
 
-namespace test
-{
-Rectangle
-UseDartExternalTypes::rectangle_round_trip(const Rectangle& input) {
-    return input;
-}
+class SeasonConverter {
+  static String convertFromInternal(String_internal internalSeason) {
+    switch (internalSeason) {
+      case String_internal.winter:
+        return "winter";
+      case String_internal.spring:
+        return "spring";
+      case String_internal.summer:
+        return "summer";
+      case String_internal.autumn:
+        return "autumn";
+    }
+  }
 
-CompressionState
-UseDartExternalTypes::compression_state_round_trip(const CompressionState input) {
-    return input;
-}
-
-SystemColor
-UseDartExternalTypes::color_round_trip(const SystemColor& input) {
-    return input;
-}
-
-Season
-UseDartExternalTypes::season_round_trip(const Season input) {
-    return input;
-}
+  static String_internal convertToInternal(String systemSeason) {
+    switch (systemSeason) {
+      case "winter":
+        return String_internal.winter;
+      case "spring":
+        return String_internal.spring;
+      case "summer":
+        return String_internal.summer;
+      case "autumn":
+        return String_internal.autumn;
+    }
+  }
 }

--- a/examples/platforms/dart/test/ExternalTypes_test.dart
+++ b/examples/platforms/dart/test/ExternalTypes_test.dart
@@ -65,4 +65,18 @@ void main() {
 
     expect(result, state);
   });
+  _testSuite.test("Use Dart external Color", () {
+    final color = 0x007FFF;
+
+    final result = UseDartExternalTypes.colorRoundTrip(color);
+
+    expect(result, color);
+  });
+  _testSuite.test("Use Dart external Season", () {
+    final season = "spring";
+
+    final result = UseDartExternalTypes.seasonRoundTrip(season);
+
+    expect(result, season);
+  });
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -46,6 +46,7 @@ import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeException
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.CONVERTER_NAME
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeGenericType
 import com.here.gluecodium.model.lime.LimeInterface
@@ -180,7 +181,8 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
                 "contentTemplate" to contentTemplateName,
                 "libraryName" to libraryName
             ),
-            nameResolvers
+            nameResolvers,
+            predicates
         )
 
         return GeneratedFile(content, "$LIB_DIR/$relativePath")
@@ -476,5 +478,14 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
         private const val SRC_DIR_SUFFIX = "src"
         private const val FFI_DIR = "$ROOT_DIR/ffi"
         private const val OPAQUE_HANDLE_TYPE = "void*"
+
+        private val predicates = mapOf(
+            "skipDeclaration" to { limeType: Any ->
+                limeType is LimeType && skipDeclaration(limeType)
+            }
+        )
+
+        private fun skipDeclaration(limeType: LimeType) = limeType.external?.dart != null &&
+            limeType.external?.dart?.get(CONVERTER_NAME) == null
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImport.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImport.kt
@@ -22,12 +22,19 @@ package com.here.gluecodium.generator.dart
 data class DartImport(
     val filePath: String,
     val asAlias: String? = null,
-    val isSystem: Boolean = false
+    val importType: ImportType = ImportType.PACKAGE
 ) : Comparable<DartImport> {
+
+    // According to Dart style guide, system imports should precede package imports.
+    enum class ImportType {
+        SYSTEM,
+        PACKAGE,
+        RELATIVE,
+    }
+
     override fun compareTo(other: DartImport) =
-        when (val systemComparison = isSystem.compareTo(other.isSystem)) {
+        when (val typeComparison = importType.compareTo(other.importType)) {
             0 -> filePath.compareTo(other.filePath)
-            // According to Dart style guide, system imports should precede package imports.
-            else -> -systemComparison
+            else -> typeComparison
         }
 }

--- a/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
@@ -18,21 +18,24 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless external.dart}}
+{{#unlessPredicate "skipDeclaration"}}
 {{>dart/DartDocumentation}}
-enum {{resolveName}} {
+enum {{resolveName}}{{#if external.dart.converter}}_internal{{/if}} {
 {{#enumerators}}
 {{prefixPartial "dart/DartEnumerator" "    "}}
 {{/enumerators}}
 }
-{{/unless}}
+{{/unlessPredicate}}
 
 // {{resolveName}} "private" section, not exported.
 
-int {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
+int {{resolveName "Ffi"}}_toFfi({{resolveName}} value{{#if external.dart.converter}}_ext{{/if}}) {
+{{#if external.dart.converter}}
+  final value = {{external.dart.converter}}.convertToInternal(value_ext);
+{{/if}}
   switch (value) {
 {{#set parent=this}}{{#enumerators}}
-  case {{resolveName parent}}.{{resolveName}}:
+  case {{resolveName parent}}{{#if external.dart.converter}}_internal{{/if}}.{{resolveName}}:
     return {{value}};
   break;
 {{/enumerators}}{{/set}}
@@ -45,7 +48,11 @@ int {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
   switch (handle) {
 {{#set parent=this}}{{#enumerators}}
   case {{value}}:
+{{#if external.dart.converter}}
+    return {{external.dart.converter}}.convertFromInternal({{resolveName parent}}_internal.{{resolveName}});
+{{/if}}{{#unless external.dart.converter}}
     return {{resolveName parent}}.{{resolveName}};
+{{/unless}}
   break;
 {{/enumerators}}{{/set}}
   default:

--- a/gluecodium/src/main/resources/templates/dart/DartImport.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartImport.mustache
@@ -18,6 +18,8 @@
   ! License-Filename: LICENSE
   !
   !}}
-import '{{#if isSystem}}dart:{{filePath}}{{/if}}{{!!
-}}{{#unless isSystem}}package:{{filePath}}.dart{{/unless}}'{{!!
-}}{{#asAlias}} as {{.}}{{/asAlias}};
+import '{{#switch importType.toString}}{{!!
+    }}{{#case "SYSTEM"}}dart:{{filePath}}{{/case}}{{!!
+    }}{{#case "PACKAGE"}}package:{{filePath}}.dart{{/case}}{{!!
+    }}{{#case "RELATIVE"}}{{filePath}}.dart{{/case}}{{!!
+}}{{/switch}}'{{#if asAlias}} as {{asAlias}}{{/if}};

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -18,13 +18,13 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless external.dart}}
+{{#unlessPredicate "skipDeclaration"}}
 {{#functions}}
 {{>dart/DartFunctionException}}
 
 {{/functions}}{{!!
 }}{{>dart/DartDocumentation}}
-class {{resolveName}} {
+class {{resolveName}}{{#if external.dart.converter}}_internal{{/if}} {
 {{#set parent=this}}{{#fields}}{{prefixPartial "dart/DartField" "  "}}
 {{/fields}}{{/set}}
 {{#if fields}}{{#unless constructors}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
@@ -34,7 +34,7 @@ class {{resolveName}} {
   }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
 {{/fields}}
 {{/unless}}{{/resolveName}}{{/unless}}{{!!
-}}  {{resolveName}}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
+}}  {{resolveName}}{{#if external.dart.converter}}_internal{{/if}}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{#if constructors}}  {{resolveName}}{{#if constructors}}._copy{{/if}}({{resolveName}} _other) : {{!!
 }}this._({{#fields}}_other.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{/if}}{{#unless constructors}}{{#if initializedFields}}
@@ -72,7 +72,7 @@ class {{resolveName}} {
   }
 {{/if}}
 }
-{{/unless}}
+{{/unlessPredicate}}
 
 // {{resolveName}} "private" section, not exported.
 
@@ -91,7 +91,10 @@ final _{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}} = __lib.nati
   >('{{libraryName}}_{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}}');
 {{/fields}}{{/set}}
 
-Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
+Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value{{#if external.dart.converter}}_ext{{/if}}) {
+{{#if external.dart.converter}}
+  final value = {{external.dart.converter}}.convertToInternal(value_ext);
+{{/if}}
 {{#fields}}
   final _{{resolveName}}_handle = {{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(value.{{resolveName visibility}}{{resolveName}});
 {{/fields}}
@@ -107,9 +110,16 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
   final _{{resolveName}}_handle = _{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}}(handle);
 {{/fields}}{{/set}}
   try {
+{{#if external.dart.converter}}
+    final result_internal = {{resolveName}}_internal{{#if constructors}}._{{/if}}(
+{{#fields}}      {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle){{#if iter.hasNext}}, {{/if}}
+{{/fields}}    );
+    return {{external.dart.converter}}.convertFromInternal(result_internal);
+{{/if}}{{#unless external.dart.converter}}
     return {{resolveName}}{{#if constructors}}._{{/if}}({{#fields}}
       {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle){{#if iter.hasNext}}, {{/if}}
     {{/fields}});
+{{/unless}}
   } finally {
 {{#fields}}
     {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/input/DartExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/DartExternalTypes.lime
@@ -40,9 +40,37 @@ enum CompressionState {
     notCompressed
 }
 
+@Dart("int")
+struct DartColor {
+    external {
+       dart converterImport "../color_converter.dart"
+       dart converter "ColorConverter"
+    }
+
+    red: Float
+    green: Float
+    blue: Float
+    alpha: Float
+}
+
+@Dart("String")
+enum DartSeason {
+    external {
+       dart converterImport "../season_converter.dart"
+       dart converter "SeasonConverter"
+    }
+
+    WINTER,
+    SPRING,
+    SUMMER,
+    AUTUMN
+}
+
 class UseDartExternalTypes {
     static fun rectangleRoundTrip(input: Rectangle): Rectangle
     static fun compressionStateRoundTrip(input: CompressionState): CompressionState
+    static fun colorRoundTrip(input: DartColor): DartColor
+    static fun seasonRoundTrip(input: DartSeason): DartSeason
 }
 
 @Swift(Skip)

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/ffi/ffi_smoke_UseDartExternalTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/ffi/ffi_smoke_UseDartExternalTypes.cpp
@@ -2,6 +2,8 @@
 #include "ConversionBase.h"
 #include "IsolateContext.h"
 #include "smoke/CompressionState.h"
+#include "smoke/DartColor.h"
+#include "smoke/DartSeason.h"
 #include "smoke/Rectangle.h"
 #include "smoke/UseDartExternalTypes.h"
 #include <memory>
@@ -25,6 +27,24 @@ library_smoke_UseDartExternalTypes_compressionStateRoundTrip__CompressionState(i
     return gluecodium::ffi::Conversion<::smoke::CompressionState>::toFfi(
         ::smoke::UseDartExternalTypes::compression_state_round_trip(
             gluecodium::ffi::Conversion<::smoke::CompressionState>::toCpp(input)
+        )
+    );
+}
+FfiOpaqueHandle
+library_smoke_UseDartExternalTypes_colorRoundTrip__DartColor(int32_t _isolate_id, FfiOpaqueHandle input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<::smoke::DartColor>::toFfi(
+        ::smoke::UseDartExternalTypes::color_round_trip(
+            gluecodium::ffi::Conversion<::smoke::DartColor>::toCpp(input)
+        )
+    );
+}
+uint32_t
+library_smoke_UseDartExternalTypes_seasonRoundTrip__DartSeason(int32_t _isolate_id, uint32_t input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<::smoke::DartSeason>::toFfi(
+        ::smoke::UseDartExternalTypes::season_round_trip(
+            gluecodium::ffi::Conversion<::smoke::DartSeason>::toCpp(input)
         )
     );
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
@@ -1,0 +1,102 @@
+import 'package:library/src/builtin_types__conversion.dart';
+import '../color_converter.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+class int_internal {
+  double red;
+  double green;
+  double blue;
+  double alpha;
+  int_internal(this.red, this.green, this.blue, this.alpha);
+}
+// int "private" section, not exported.
+final _smoke_DartColor_create_handle = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Float, Float, Float, Float),
+    Pointer<Void> Function(double, double, double, double)
+  >('library_smoke_DartColor_create_handle');
+final _smoke_DartColor_release_handle = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DartColor_release_handle');
+final _smoke_DartColor_get_field_red = __lib.nativeLibrary.lookupFunction<
+    Float Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('library_smoke_DartColor_get_field_red');
+final _smoke_DartColor_get_field_green = __lib.nativeLibrary.lookupFunction<
+    Float Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('library_smoke_DartColor_get_field_green');
+final _smoke_DartColor_get_field_blue = __lib.nativeLibrary.lookupFunction<
+    Float Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('library_smoke_DartColor_get_field_blue');
+final _smoke_DartColor_get_field_alpha = __lib.nativeLibrary.lookupFunction<
+    Float Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('library_smoke_DartColor_get_field_alpha');
+Pointer<Void> smoke_DartColor_toFfi(int value_ext) {
+  final value = ColorConverter.convertToInternal(value_ext);
+  final _red_handle = (value.red);
+  final _green_handle = (value.green);
+  final _blue_handle = (value.blue);
+  final _alpha_handle = (value.alpha);
+  final _result = _smoke_DartColor_create_handle(_red_handle, _green_handle, _blue_handle, _alpha_handle);
+  (_red_handle);
+  (_green_handle);
+  (_blue_handle);
+  (_alpha_handle);
+  return _result;
+}
+int smoke_DartColor_fromFfi(Pointer<Void> handle) {
+  final _red_handle = _smoke_DartColor_get_field_red(handle);
+  final _green_handle = _smoke_DartColor_get_field_green(handle);
+  final _blue_handle = _smoke_DartColor_get_field_blue(handle);
+  final _alpha_handle = _smoke_DartColor_get_field_alpha(handle);
+  try {
+    final result_internal = int_internal(
+      (_red_handle),
+      (_green_handle),
+      (_blue_handle),
+      (_alpha_handle)
+    );
+    return ColorConverter.convertFromInternal(result_internal);
+  } finally {
+    (_red_handle);
+    (_green_handle);
+    (_blue_handle);
+    (_alpha_handle);
+  }
+}
+void smoke_DartColor_releaseFfiHandle(Pointer<Void> handle) => _smoke_DartColor_release_handle(handle);
+// Nullable int
+final _smoke_DartColor_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DartColor_create_handle_nullable');
+final _smoke_DartColor_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DartColor_release_handle_nullable');
+final _smoke_DartColor_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DartColor_get_value_nullable');
+Pointer<Void> smoke_DartColor_toFfi_nullable(int value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_DartColor_toFfi(value);
+  final result = _smoke_DartColor_create_handle_nullable(_handle);
+  smoke_DartColor_releaseFfiHandle(_handle);
+  return result;
+}
+int smoke_DartColor_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_DartColor_get_value_nullable(handle);
+  final result = smoke_DartColor_fromFfi(_handle);
+  smoke_DartColor_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_DartColor_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_DartColor_release_handle_nullable(handle);
+// End of int "private" section.

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
@@ -1,0 +1,79 @@
+import '../season_converter.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+enum String_internal {
+    winter,
+    spring,
+    summer,
+    autumn
+}
+// String "private" section, not exported.
+int smoke_DartSeason_toFfi(String value_ext) {
+  final value = SeasonConverter.convertToInternal(value_ext);
+  switch (value) {
+  case String_internal.winter:
+    return 0;
+  break;
+  case String_internal.spring:
+    return 1;
+  break;
+  case String_internal.summer:
+    return 2;
+  break;
+  case String_internal.autumn:
+    return 3;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for String enum.");
+  }
+}
+String smoke_DartSeason_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return SeasonConverter.convertFromInternal(String_internal.winter);
+  break;
+  case 1:
+    return SeasonConverter.convertFromInternal(String_internal.spring);
+  break;
+  case 2:
+    return SeasonConverter.convertFromInternal(String_internal.summer);
+  break;
+  case 3:
+    return SeasonConverter.convertFromInternal(String_internal.autumn);
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for String enum.");
+  }
+}
+void smoke_DartSeason_releaseFfiHandle(int handle) {}
+final _smoke_DartSeason_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_DartSeason_create_handle_nullable');
+final _smoke_DartSeason_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DartSeason_release_handle_nullable');
+final _smoke_DartSeason_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DartSeason_get_value_nullable');
+Pointer<Void> smoke_DartSeason_toFfi_nullable(String value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_DartSeason_toFfi(value);
+  final result = _smoke_DartSeason_create_handle_nullable(_handle);
+  smoke_DartSeason_releaseFfiHandle(_handle);
+  return result;
+}
+String smoke_DartSeason_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_DartSeason_get_value_nullable(handle);
+  final result = smoke_DartSeason_fromFfi(_handle);
+  smoke_DartSeason_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_DartSeason_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_DartSeason_release_handle_nullable(handle);
+// End of String "private" section.

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -2,7 +2,9 @@ import 'dart:math';
 import 'package:foo/bar.dart';
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/smoke/http_client_response_compression_state.dart';
+import 'package:library/src/smoke/int.dart';
 import 'package:library/src/smoke/rectangle_int_.dart';
+import 'package:library/src/smoke/string.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
@@ -15,6 +17,8 @@ abstract class UseDartExternalTypes {
   void release();
   static Rectangle<int> rectangleRoundTrip(Rectangle<int> input) => UseDartExternalTypes$Impl.rectangleRoundTrip(input);
   static HttpClientResponseCompressionState compressionStateRoundTrip(HttpClientResponseCompressionState input) => UseDartExternalTypes$Impl.compressionStateRoundTrip(input);
+  static int colorRoundTrip(int input) => UseDartExternalTypes$Impl.colorRoundTrip(input);
+  static String seasonRoundTrip(String input) => UseDartExternalTypes$Impl.seasonRoundTrip(input);
 }
 // UseDartExternalTypes "private" section, not exported.
 final _smoke_UseDartExternalTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
@@ -60,6 +64,28 @@ class UseDartExternalTypes$Impl implements UseDartExternalTypes {
       return smoke_CompressionState_fromFfi(__result_handle);
     } finally {
       smoke_CompressionState_releaseFfiHandle(__result_handle);
+    }
+  }
+  static int colorRoundTrip(int input) {
+    final _colorRoundTrip_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_colorRoundTrip__DartColor');
+    final _input_handle = smoke_DartColor_toFfi(input);
+    final __result_handle = _colorRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
+    smoke_DartColor_releaseFfiHandle(_input_handle);
+    try {
+      return smoke_DartColor_fromFfi(__result_handle);
+    } finally {
+      smoke_DartColor_releaseFfiHandle(__result_handle);
+    }
+  }
+  static String seasonRoundTrip(String input) {
+    final _seasonRoundTrip_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_seasonRoundTrip__DartSeason');
+    final _input_handle = smoke_DartSeason_toFfi(input);
+    final __result_handle = _seasonRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
+    smoke_DartSeason_releaseFfiHandle(_input_handle);
+    try {
+      return smoke_DartSeason_fromFfi(__result_handle);
+    } finally {
+      smoke_DartSeason_releaseFfiHandle(__result_handle);
     }
   }
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
@@ -62,6 +62,7 @@ class LimeExternalDescriptor private constructor(
         const val INCLUDE_NAME = "include"
         const val FRAMEWORK_NAME = "framework"
         const val IMPORT_PATH_NAME = "importPath"
+        const val CONVERTER_IMPORT_NAME = "converterImport"
         const val NAME_NAME = "name"
         const val GETTER_NAME_NAME = "getterName"
         const val SETTER_NAME_NAME = "setterName"


### PR DESCRIPTION
Added support for specifying "converter" classes for "external" structs
and enums in Dart. Converter class is expected to contain static
functions "convertToInternal" and "convertFromInternal", converting the
"external" type to/from internal generated intermediate representation.

Added functional and smoke tests.

See: #408
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>