### PR TITLE
Add @immutable attribute in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Introduced "external descriptors", new IDL syntax for declaring "external" types. This syntax
     replaces `@Cpp(External*)` group of IDL attributes.
   * Added support for "external" structs and enums in Java, Swift, and Dart.
+  * Structs marked as `@Immutable` in IDL are now marked as `@immutable` in Dart generated code as
+    well.
 ### Deprecated:
   * `@Java(Builder)` IDL attribute is now deprecated. It still works the same way as before but
     its use is discouraged.

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -23,7 +23,8 @@
 {{>dart/DartFunctionException}}
 
 {{/functions}}{{!!
-}}{{>dart/DartDocumentation}}
+}}{{>dart/DartDocumentation}}{{#if attributes.immutable}}
+@immutable{{/if}}
 class {{resolveName}}{{#if external.dart.converter}}_internal{{/if}} {
 {{#set parent=this}}{{#fields}}{{prefixPartial "dart/DartField" "  "}}
 {{/fields}}{{/set}}
@@ -34,11 +35,12 @@ class {{resolveName}}{{#if external.dart.converter}}_internal{{/if}} {
   }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
 {{/fields}}
 {{/unless}}{{/resolveName}}{{/unless}}{{!!
-}}  {{resolveName}}{{#if external.dart.converter}}_internal{{/if}}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
+}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}_internal{{/if}}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{#if constructors}}  {{resolveName}}{{#if constructors}}._copy{{/if}}({{resolveName}} _other) : {{!!
 }}this._({{#fields}}_other.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{/if}}{{#unless constructors}}{{#if initializedFields}}
-  {{resolveName}}.withDefaults({{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}})
+  {{#if attributes.immutable}}const {{/if}}{{resolveName}}.withDefaults({{!!
+  }}{{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}})
     : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{#if defaultValue}}{{resolveName defaultValue}}{{/if}}{{!!
     }}{{#unless defaultValue}}{{resolveName}}{{/unless}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
 {{/if}}{{/unless}}{{/if}}
@@ -135,7 +137,7 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveN
 
 // End of {{resolveName}} "private" section.{{!!
 
-}}{{+dartConstructor}}{{resolveName parent}}{{#unless attributes.dart.default}}{{!!
+}}{{+dartConstructor}}{{#if attributes.immutable}}const {{/if}}{{resolveName parent}}{{#unless attributes.dart.default}}{{!!
 }}{{#isNotEq constructors.size 1}}.{{resolveName visibility}}{{resolveName}}{{/isNotEq}}{{!!
 }}{{/unless}}({{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) : {{!!

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -190,6 +190,7 @@ StructWithDefaults smoke_TypesWithDefaults_StructWithDefaults_fromFfi_nullable(P
 void smoke_TypesWithDefaults_StructWithDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_TypesWithDefaults_StructWithDefaults_release_handle_nullable(handle);
 // End of StructWithDefaults "private" section.
+@immutable
 class ImmutableStructWithDefaults {
   final int intField;
   final int uintField;
@@ -199,8 +200,8 @@ class ImmutableStructWithDefaults {
   final String stringField;
   final SomeEnum enumField;
   final DefaultValues_ExternalEnum externalEnumField;
-  ImmutableStructWithDefaults(this.intField, this.uintField, this.floatField, this.doubleField, this.boolField, this.stringField, this.enumField, this.externalEnumField);
-  ImmutableStructWithDefaults.withDefaults(int uintField, bool boolField)
+  const ImmutableStructWithDefaults(this.intField, this.uintField, this.floatField, this.doubleField, this.boolField, this.stringField, this.enumField, this.externalEnumField);
+  const ImmutableStructWithDefaults.withDefaults(int uintField, bool boolField)
     : intField = 42, uintField = uintField, floatField = 3.14, doubleField = -1.4142, boolField = boolField, stringField = "\\Jonny \"Magic\" Smith\n", enumField = SomeEnum.barValue, externalEnumField = DefaultValues_ExternalEnum.anotherValue;
 }
 // ImmutableStructWithDefaults "private" section, not exported.

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -225,6 +225,7 @@ Structs_Line smoke_Structs_Line_fromFfi_nullable(Pointer<Void> handle) {
 void smoke_Structs_Line_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Structs_Line_release_handle_nullable(handle);
 // End of Structs_Line "private" section.
+@immutable
 class Structs_AllTypesStruct {
   final int int8Field;
   final int uint8Field;
@@ -240,7 +241,7 @@ class Structs_AllTypesStruct {
   final bool booleanField;
   final Uint8List bytesField;
   final Structs_Point pointField;
-  Structs_AllTypesStruct(this.int8Field, this.uint8Field, this.int16Field, this.uint16Field, this.int32Field, this.uint32Field, this.int64Field, this.uint64Field, this.floatField, this.doubleField, this.stringField, this.booleanField, this.bytesField, this.pointField);
+  const Structs_AllTypesStruct(this.int8Field, this.uint8Field, this.int16Field, this.uint16Field, this.int32Field, this.uint32Field, this.int64Field, this.uint64Field, this.floatField, this.doubleField, this.stringField, this.booleanField, this.bytesField, this.pointField);
 }
 // Structs_AllTypesStruct "private" section, not exported.
 final _smoke_Structs_AllTypesStruct_create_handle = __lib.nativeLibrary.lookupFunction<
@@ -611,9 +612,10 @@ Structs_StructWithArrayOfImmutable smoke_Structs_StructWithArrayOfImmutable_from
 void smoke_Structs_StructWithArrayOfImmutable_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Structs_StructWithArrayOfImmutable_release_handle_nullable(handle);
 // End of Structs_StructWithArrayOfImmutable "private" section.
+@immutable
 class Structs_ImmutableStructWithCppAccessors {
   final String stringField;
-  Structs_ImmutableStructWithCppAccessors(this.stringField);
+  const Structs_ImmutableStructWithCppAccessors(this.stringField);
 }
 // Structs_ImmutableStructWithCppAccessors "private" section, not exported.
 final _smoke_Structs_ImmutableStructWithCppAccessors_create_handle = __lib.nativeLibrary.lookupFunction<


### PR DESCRIPTION
Updated Dart template for structs to add `@immutable` attribute to
structs that are marked as `@Immutable` in IDL. Also added `const`
modifier to constructors of such structs in Dart.

Updated smoke tests. No new functional tests are needed as this change
is aimed for Dart static analysis tools and so are expected to have no
impact to Dart compilation and run-time behavior.

Resolves: #433
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>