### PR TITLE
Refactor method qualifiers in Java model

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaClass.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaClass.kt
@@ -22,6 +22,8 @@ package com.here.gluecodium.model.java
 class JavaClass(
     name: String,
     classNames: List<String> = listOf(name),
+    isFinal: Boolean = false,
+    skipDeclaration: Boolean = false,
     val extendedClass: JavaTypeRef? = null,
     val fields: List<JavaField> = emptyList(),
     methods: List<JavaMethod> = emptyList(),
@@ -33,9 +35,13 @@ class JavaClass(
     val hasNativeEquatable: Boolean = false,
     val isImmutable: Boolean = false,
     val needsBuilder: Boolean = false,
-    var generatedConstructorComment: String? = null,
-    skipDeclaration: Boolean = false
-) : JavaTopLevelElement(name, classNames, skipDeclaration) {
+    var generatedConstructorComment: String? = null
+) : JavaTopLevelElement(
+    name = name,
+    classNames = classNames,
+    isFinal = isFinal,
+    skipDeclaration = skipDeclaration
+) {
 
     init {
         this.methods += methods

--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaExceptionClass.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaExceptionClass.kt
@@ -21,5 +21,10 @@ package com.here.gluecodium.model.java
 
 class JavaExceptionClass(
     exceptionName: String,
+    isFinal: Boolean = false,
     val errorTypeRef: JavaTypeRef
-) : JavaTopLevelElement(exceptionName, listOf(exceptionName))
+) : JavaTopLevelElement(
+    name = exceptionName,
+    classNames = listOf(exceptionName),
+    isFinal = isFinal
+)

--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaMethod.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaMethod.kt
@@ -20,7 +20,6 @@
 package com.here.gluecodium.model.java
 
 import com.here.gluecodium.model.common.Comments
-import java.util.EnumSet
 
 class JavaMethod(
     name: String,
@@ -32,13 +31,12 @@ class JavaMethod(
     var throwsComment: String? = null,
     val parameters: List<JavaParameter> = emptyList(),
     val isConstructor: Boolean = false,
+    val isStatic: Boolean = false,
+    var isNative: Boolean = false,
     val isGetter: Boolean = false,
     val isCached: Boolean = false,
-    qualifiers: Set<MethodQualifier> = EnumSet.noneOf(MethodQualifier::class.java),
     annotations: Set<JavaTypeRef> = emptySet()
 ) : JavaElement(name) {
-
-    val qualifiers: MutableSet<MethodQualifier> = LinkedHashSet(qualifiers)
 
     init {
         this.comment = comment
@@ -57,18 +55,8 @@ class JavaMethod(
     val hasComment: Boolean
         get() = !comment.isEmpty || !returnComment.isNullOrBlank() || parameters.any { !it.comment.isEmpty }
 
-    enum class MethodQualifier constructor(private val value: String) {
-        STATIC("static"),
-        NATIVE("native");
-
-        override fun toString() = value
-    }
-
     override val childElements
         get() = listOfNotNull(returnType, exception) + parameters + super.childElements
-
-    val isStatic
-        get() = qualifiers.contains(MethodQualifier.STATIC)
 
     fun shallowCopy() = JavaMethod(
         name = name,
@@ -79,9 +67,10 @@ class JavaMethod(
         exception = exception,
         parameters = parameters,
         isConstructor = isConstructor,
+        isStatic = isStatic,
+        isNative = isNative,
         isGetter = isGetter,
         isCached = isCached,
-        qualifiers = qualifiers,
         annotations = annotations
     )
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaTopLevelElement.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaTopLevelElement.kt
@@ -22,6 +22,8 @@ package com.here.gluecodium.model.java
 abstract class JavaTopLevelElement(
     name: String,
     val classNames: List<String>,
+    var isStatic: Boolean = false,
+    val isFinal: Boolean = false,
     val skipDeclaration: Boolean = false
 ) : JavaElement(name) {
 
@@ -35,7 +37,6 @@ abstract class JavaTopLevelElement(
 
     val innerClasses: MutableSet<JavaClass> = mutableSetOf()
     val innerInterfaces: MutableSet<JavaInterface> = mutableSetOf()
-    val qualifiers: MutableSet<Qualifier> = mutableSetOf()
 
     open val imports: Set<JavaImport>
         get() {
@@ -53,13 +54,6 @@ abstract class JavaTopLevelElement(
 
             return imports.toSortedSet()
         }
-
-    enum class Qualifier(private val value: String) {
-        STATIC("static"),
-        FINAL("final");
-
-        override fun toString() = value
-    }
 
     override val childElements
         get() = super.childElements + methods + constants + parentInterfaces + enums +

--- a/gluecodium/src/main/resources/templates/java/Class.mustache
+++ b/gluecodium/src/main/resources/templates/java/Class.mustache
@@ -22,7 +22,8 @@
 {{#annotations}}
 @{{name}}
 {{/annotations}}
-{{#if visibility.toString}}{{visibility}} {{/if}}{{#qualifiers}}{{.}} {{/qualifiers}}class {{name}} {{#if this.extendedClass}}extends {{extendedClass.name}} {{/if}}{{#if parentInterfaces}}implements {{join parentInterfaces delimiter=", " }} {{/if}}{
+{{#if visibility.toString}}{{visibility}} {{/if}}{{#if isFinal}}final {{/if}}{{#if isStatic}}static {{/if}}{{!!
+}}class {{name}} {{#if this.extendedClass}}extends {{extendedClass.name}} {{/if}}{{#if parentInterfaces}}implements {{join parentInterfaces delimiter=", " }} {{/if}}{
 {{#if isParcelable}}{{prefixPartial "java/ParcelableCreator" "    "}}
 
 {{/if}}

--- a/gluecodium/src/main/resources/templates/java/ExceptionDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/java/ExceptionDefinition.mustache
@@ -19,8 +19,8 @@
   !
   !}}
 {{>java/DocComment}}
-{{#if visibility.toString}}{{visibility}} {{/if}}{{#qualifiers}}{{.}} {{/qualifiers}}{{!!
-}}{{#if static}}static {{/if}}class {{name}} extends Exception {
+{{#if visibility.toString}}{{visibility}} {{/if}}{{#if isFinal}}final {{/if}}{{!!
+}}{{#if isStatic static logic="or"}}static {{/if}}class {{name}} extends Exception {
     {{#if visibility.toString}}{{visibility}} {{/if}}{{name}}(final {{errorTypeRef.name}} error) {
         super(error.toString());
         this.error = error;

--- a/gluecodium/src/main/resources/templates/java/MethodSignature.mustache
+++ b/gluecodium/src/main/resources/templates/java/MethodSignature.mustache
@@ -22,5 +22,7 @@
 {{#allAnnotations}}
 @{{name}}
 {{/allAnnotations}}
-{{^isInterface}}{{#if isConstructor}}private {{/if}}{{#unless isConstructor}}{{#if visibility.toString}}{{visibility}} {{/if}}{{/unless}}{{/isInterface}}{{!!
-}}{{#qualifiers}}{{.}} {{/qualifiers}}{{returnType.name}} {{name}}({{joinPartial parameters "java/Parameter" ", "}}){{#exception}} throws {{name}}{{/exception}};
+{{^isInterface}}{{#if isConstructor}}private {{/if}}{{!!
+}}{{#unless isConstructor}}{{#if visibility.toString}}{{visibility}} {{/if}}{{/unless}}{{/isInterface}}{{!!
+}}{{#if isStatic}}static {{/if}}{{#if isNative}}native {{/if}}{{returnType.name}} {{name}}({{!!
+}}{{joinPartial parameters "java/Parameter" ", "}}){{#exception}} throws {{name}}{{/exception}};

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/java/JavaModelBuilderContainersTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/java/JavaModelBuilderContainersTest.kt
@@ -69,7 +69,7 @@ class JavaModelBuilderContainersTest {
     private val javaEnum = JavaEnum("")
     private val javaEnumTypeRef =
         JavaEnumTypeRef("", emptyList(), emptyList(), JavaImport("", JavaPackage.DEFAULT))
-    private val javaException = JavaExceptionClass("", javaEnumTypeRef)
+    private val javaException = JavaExceptionClass("", errorTypeRef = javaEnumTypeRef)
     private val javaMethod = JavaMethod("")
 
     private val limeInterface = LimeInterface(LimePath(emptyList(), listOf("foo")))
@@ -130,7 +130,7 @@ class JavaModelBuilderContainersTest {
         val result = modelBuilder.getFinalResult(JavaClass::class.java)
         assertEquals("Foo", result.name)
         assertEquals(rootPackage, result.javaPackage)
-        assertContains(JavaTopLevelElement.Qualifier.FINAL, result.qualifiers)
+        assertTrue(result.isFinal)
         assertEquals("some comment", result.comment.documentation)
         assertEquals("Bar", result.comment.deprecated)
         assertContains(JavaModelBuilder.deprecatedAnnotation, result.annotations)
@@ -207,7 +207,7 @@ class JavaModelBuilderContainersTest {
 
         val result = modelBuilder.getFinalResult(JavaInterface::class.java)
         assertContains(javaClass, result.innerClasses)
-        assertContains(JavaTopLevelElement.Qualifier.STATIC, javaClass.qualifiers)
+        assertTrue(javaClass.isStatic)
         assertContains(javaInterface, result.innerInterfaces)
     }
 
@@ -233,7 +233,7 @@ class JavaModelBuilderContainersTest {
 
         val result = modelBuilder.getFinalResult(JavaClass::class.java)
         assertEquals(1, result.methods.size)
-        assertContains(JavaMethod.MethodQualifier.NATIVE, result.methods.first().qualifiers)
+        assertTrue(result.methods.first().isNative)
     }
 
     @Test
@@ -244,7 +244,7 @@ class JavaModelBuilderContainersTest {
 
         val result = modelBuilder.getFinalResult(JavaClass::class.java)
         assertEquals(1, result.methods.size)
-        assertContains(JavaMethod.MethodQualifier.NATIVE, result.methods.first().qualifiers)
+        assertTrue(result.methods.first().isNative)
     }
 
     @Test
@@ -282,7 +282,7 @@ class JavaModelBuilderContainersTest {
         assertEquals("Bar", result.comment.deprecated)
         assertContains(JavaModelBuilder.deprecatedAnnotation, result.annotations)
         assertTrue(result.needsDisposer)
-        assertContains(JavaTopLevelElement.Qualifier.FINAL, result.qualifiers)
+        assertTrue(result.isFinal)
     }
 
     @Test
@@ -306,7 +306,7 @@ class JavaModelBuilderContainersTest {
         modelBuilder.finishBuilding(limeElement)
 
         val result = modelBuilder.getFinalResult(JavaClass::class.java)
-        assertTrue(result.qualifiers.isEmpty())
+        assertFalse(result.isFinal)
     }
 
     @Test
@@ -361,7 +361,7 @@ class JavaModelBuilderContainersTest {
 
         val result = modelBuilder.getFinalResult(JavaClass::class.java)
         assertContains(javaClass, result.innerClasses)
-        assertContains(JavaTopLevelElement.Qualifier.STATIC, javaClass.qualifiers)
+        assertTrue(javaClass.isStatic)
     }
 
     @Test
@@ -372,7 +372,7 @@ class JavaModelBuilderContainersTest {
 
         val result = modelBuilder.getFinalResult(JavaClass::class.java)
         assertEquals(1, result.methods.size)
-        assertContains(JavaMethod.MethodQualifier.NATIVE, result.methods.first().qualifiers)
+        assertTrue(result.methods.first().isNative)
     }
 
     @Test

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/java/JavaModelBuilderTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/java/JavaModelBuilderTest.kt
@@ -36,7 +36,6 @@ import com.here.gluecodium.model.java.JavaMethod
 import com.here.gluecodium.model.java.JavaPackage
 import com.here.gluecodium.model.java.JavaParameter
 import com.here.gluecodium.model.java.JavaPrimitiveTypeRef
-import com.here.gluecodium.model.java.JavaTopLevelElement
 import com.here.gluecodium.model.java.JavaTypeRef
 import com.here.gluecodium.model.java.JavaValue
 import com.here.gluecodium.model.java.JavaVisibility
@@ -213,7 +212,7 @@ class JavaModelBuilderTest {
 
         val result = modelBuilder.getFinalResult(JavaMethod::class.java)
         assertTrue(result.isConstructor)
-        assertContains(JavaMethod.MethodQualifier.STATIC, result.qualifiers)
+        assertTrue(result.isStatic)
         assertEquals(JavaPrimitiveTypeRef.LONG, result.returnType)
     }
 
@@ -236,7 +235,7 @@ class JavaModelBuilderTest {
         modelBuilder.finishBuilding(limeElement)
 
         val result = modelBuilder.getFinalResult(JavaMethod::class.java)
-        assertContains(JavaMethod.MethodQualifier.STATIC, result.qualifiers)
+        assertTrue(result.isStatic)
     }
 
     @Test
@@ -333,7 +332,7 @@ class JavaModelBuilderTest {
         assertContains(JavaModelBuilder.deprecatedAnnotation, result.annotations)
         assertEquals(rootPackage, result.javaPackage)
         assertEquals("other comment", result.generatedConstructorComment)
-        assertContains(JavaTopLevelElement.Qualifier.FINAL, result.qualifiers)
+        assertTrue(result.isFinal)
     }
 
     @Test
@@ -369,7 +368,7 @@ class JavaModelBuilderTest {
         val result = modelBuilder.getFinalResult(JavaClass::class.java)
         val resultMethod = result.methods.first()
         assertEquals("bar", resultMethod.name)
-        assertContains(JavaMethod.MethodQualifier.NATIVE, resultMethod.qualifiers)
+        assertTrue(resultMethod.isNative)
     }
 
     @Test
@@ -573,7 +572,7 @@ class JavaModelBuilderTest {
         val result = modelBuilder.getFinalResult(JavaExceptionClass::class.java)
         assertEquals("FooException", result.name)
         assertEquals(javaEnumTypeRef, result.errorTypeRef)
-        assertContains(JavaTopLevelElement.Qualifier.FINAL, result.qualifiers)
+        assertTrue(result.isFinal)
     }
 
     @Test
@@ -693,8 +692,8 @@ class JavaModelBuilderTest {
 
         val results = modelBuilder.finalResults.filterIsInstance<JavaMethod>()
         assertEquals(2, results.size)
-        assertContains(JavaMethod.MethodQualifier.STATIC, results.first().qualifiers)
-        assertContains(JavaMethod.MethodQualifier.STATIC, results.last().qualifiers)
+        assertTrue(results.first().isStatic)
+        assertTrue(results.last().isStatic)
     }
 
     @Test


### PR DESCRIPTION
Updated Java language model to represent "static" and "native"
qualifiers for methods as Boolean flags instead of a set of enum values.
Updated Java templates for this change.

This allows for more fine-grained control over these qualifiers on
template level. In particular, it will be necessary to suppress "native"
qualifier if the "stubs" mode is enabled in the future "stubs" mode
implementation.

See: #436
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>