### PR TITLE
Fix qualifier order in Java

### DIFF
--- a/gluecodium/src/main/resources/templates/java/Class.mustache
+++ b/gluecodium/src/main/resources/templates/java/Class.mustache
@@ -22,7 +22,7 @@
 {{#annotations}}
 @{{name}}
 {{/annotations}}
-{{#if visibility.toString}}{{visibility}} {{/if}}{{#if isFinal}}final {{/if}}{{#if isStatic}}static {{/if}}{{!!
+{{#if visibility.toString}}{{visibility}} {{/if}}{{#if isStatic}}static {{/if}}{{#if isFinal}}final {{/if}}{{!!
 }}class {{name}} {{#if this.extendedClass}}extends {{extendedClass.name}} {{/if}}{{#if parentInterfaces}}implements {{join parentInterfaces delimiter=", " }} {{/if}}{
 {{#if isParcelable}}{{prefixPartial "java/ParcelableCreator" "    "}}
 

--- a/gluecodium/src/main/resources/templates/java/ExceptionDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/java/ExceptionDefinition.mustache
@@ -19,8 +19,8 @@
   !
   !}}
 {{>java/DocComment}}
-{{#if visibility.toString}}{{visibility}} {{/if}}{{#if isFinal}}final {{/if}}{{!!
-}}{{#if isStatic static logic="or"}}static {{/if}}class {{name}} extends Exception {
+{{#if visibility.toString}}{{visibility}} {{/if}}{{#if isStatic static logic="or"}}static {{/if}}{{!!
+}}{{#if isFinal}}final {{/if}}class {{name}} extends Exception {
     {{#if visibility.toString}}{{visibility}} {{/if}}{{name}}(final {{errorTypeRef.name}} error) {
         super(error.toString());
         this.error = error;

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
@@ -33,7 +33,7 @@ public final class Comments extends NativeBase {
     /**
      * <p>This is some very useful exception.</p>
      */
-    public final static class SomethingWrongException extends Exception {
+    public static final class SomethingWrongException extends Exception {
         public SomethingWrongException(final Comments.SomeEnum error) {
             super(error.toString());
             this.error = error;
@@ -64,7 +64,7 @@ public final class Comments extends NativeBase {
     /**
      * <p>This is some very useful struct.</p>
      */
-    public final static class SomeStruct {
+    public static final class SomeStruct {
         /**
          * <p>How useful this struct is
          * remains to be seen</p>

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsInterface.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsInterface.java
@@ -32,7 +32,7 @@ public interface CommentsInterface {
     /**
      * <p>This is some very useful struct.</p>
      */
-    public final static class SomeStruct {
+    public static final class SomeStruct {
         /**
          * <p>How useful this struct is</p>
          */

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
@@ -14,7 +14,7 @@ public final class CommentsLinks extends NativeBase {
     /**
      * <p>Links also work in:</p>
      */
-    public final static class RandomStruct {
+    public static final class RandomStruct {
         /**
          * <p>Some random field {@link com.example.smoke.Comments.SomeStruct}</p>
          */

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/DeprecationComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/DeprecationComments.java
@@ -36,7 +36,7 @@ public interface DeprecationComments {
     /**
      * @deprecated <p>Unfortunately, this exception is deprecated, please use {@link com.example.smoke.Comments.SomethingWrongException} instead.</p>
      */
-    public final static class SomethingWrongException extends Exception {
+    public static final class SomethingWrongException extends Exception {
         public SomethingWrongException(final DeprecationComments.SomeEnum error) {
             super(error.toString());
             this.error = error;
@@ -48,7 +48,7 @@ public interface DeprecationComments {
      * @deprecated <p>Unfortunately, this struct is deprecated. Use {@link com.example.smoke.Comments.SomeStruct} instead.</p>
      */
     @Deprecated
-    public final static class SomeStruct {
+    public static final class SomeStruct {
         /**
          * <p>How useful this struct is.</p>
          * @deprecated <p>Unfortunately, this field is deprecated.

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/DeprecationCommentsOnly.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/DeprecationCommentsOnly.java
@@ -33,7 +33,7 @@ public interface DeprecationCommentsOnly {
      * @deprecated <p>Unfortunately, this struct is deprecated.</p>
      */
     @Deprecated
-    public final static class SomeStruct {
+    public static final class SomeStruct {
         /**
          * @deprecated <p>Unfortunately, this field is deprecated.</p>
          */

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/PlatformComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/PlatformComments.java
@@ -16,7 +16,7 @@ public final class PlatformComments extends NativeBase {
     /**
      * <p>An exception when something goes wrong.</p>
      */
-    public final static class SomethingWrongException extends Exception {
+    public static final class SomethingWrongException extends Exception {
         public SomethingWrongException(final PlatformComments.SomeEnum error) {
             super(error.toString());
             this.error = error;
@@ -26,7 +26,7 @@ public final class PlatformComments extends NativeBase {
     /**
      * <p>This is a very super struct.</p>
      */
-    public final static class Something {
+    public static final class Something {
         @NonNull
         public String nothing;
         public Something(@NonNull final String nothing) {

--- a/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/StructConstants.java
+++ b/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/StructConstants.java
@@ -8,7 +8,7 @@ import com.example.NativeBase;
 public final class StructConstants extends NativeBase {
     public static final StructConstants.SomeStruct STRUCT_CONSTANT = new StructConstants.SomeStruct("bar Buzz", 1.41f);
     public static final StructConstants.NestingStruct NESTING_STRUCT_CONSTANT = new StructConstants.NestingStruct(new StructConstants.SomeStruct("nonsense", -2.82f));
-    public final static class SomeStruct {
+    public static final class SomeStruct {
         @NonNull
         public String stringField;
         public float floatField;
@@ -17,7 +17,7 @@ public final class StructConstants extends NativeBase {
             this.floatField = floatField;
         }
     }
-    public final static class NestingStruct {
+    public static final class NestingStruct {
         @NonNull
         public StructConstants.SomeStruct structField;
         public NestingStruct(@NonNull final StructConstants.SomeStruct structField) {

--- a/gluecodium/src/test/resources/smoke/constructors/output/android/com/example/smoke/Constructors.java
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android/com/example/smoke/Constructors.java
@@ -14,7 +14,7 @@ public class Constructors extends NativeBase {
             this.value = value;
         }
     }
-    public final static class ConstructorExplodedException extends Exception {
+    public static final class ConstructorExplodedException extends Exception {
         public ConstructorExplodedException(final Constructors.ErrorEnum error) {
             super(error.toString());
             this.error = error;

--- a/gluecodium/src/test/resources/smoke/dates/output/android/com/example/smoke/Dates.java
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/com/example/smoke/Dates.java
@@ -7,7 +7,7 @@ import android.support.annotation.NonNull;
 import com.example.NativeBase;
 import java.util.Date;
 public final class Dates extends NativeBase {
-    public final static class DateStruct {
+    public static final class DateStruct {
         @NonNull
         public Date dateField;
         public DateStruct(@NonNull final Date dateField) {

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/DefaultValues.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/DefaultValues.java
@@ -29,7 +29,7 @@ public final class DefaultValues extends NativeBase {
             this.value = value;
         }
     }
-    public final static class StructWithDefaults {
+    public static final class StructWithDefaults {
         public int intField;
         public long uintField;
         public float floatField;
@@ -62,7 +62,7 @@ public final class DefaultValues extends NativeBase {
             this.externalEnumField = externalEnumField;
         }
     }
-    public final static class NullableStructWithDefaults {
+    public static final class NullableStructWithDefaults {
         @Nullable
         public Integer intField;
         @Nullable
@@ -92,7 +92,7 @@ public final class DefaultValues extends NativeBase {
             this.enumField = enumField;
         }
     }
-    public final static class StructWithSpecialDefaults {
+    public static final class StructWithSpecialDefaults {
         public float floatNanField;
         public float floatInfinityField;
         public float floatNegativeInfinityField;
@@ -116,7 +116,7 @@ public final class DefaultValues extends NativeBase {
             this.doubleNegativeInfinityField = doubleNegativeInfinityField;
         }
     }
-    public final static class StructWithEmptyDefaults {
+    public static final class StructWithEmptyDefaults {
         @NonNull
         public List<Integer> intsField;
         @NonNull
@@ -142,7 +142,7 @@ public final class DefaultValues extends NativeBase {
             this.setTypeField = setTypeField;
         }
     }
-    public final static class StructWithTypedefDefaults {
+    public static final class StructWithTypedefDefaults {
         public long longField;
         public boolean boolField;
         @NonNull

--- a/gluecodium/src/test/resources/smoke/enums/output/android/com/example/smoke/Enums.java
+++ b/gluecodium/src/test/resources/smoke/enums/output/android/com/example/smoke/Enums.java
@@ -21,7 +21,7 @@ public final class Enums extends NativeBase {
             this.value = value;
         }
     }
-    public final static class ErrorStruct {
+    public static final class ErrorStruct {
         @NonNull
         public Enums.InternalErrorCode type;
         @NonNull

--- a/gluecodium/src/test/resources/smoke/equatable/output/android/com/example/smoke/EquatableClass.java
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android/com/example/smoke/EquatableClass.java
@@ -6,7 +6,7 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
 public final class EquatableClass extends NativeBase {
-    public final static class EquatableStruct {
+    public static final class EquatableStruct {
         public int intField;
         @NonNull
         public String stringField;

--- a/gluecodium/src/test/resources/smoke/errors/output/android/com/example/smoke/Errors.java
+++ b/gluecodium/src/test/resources/smoke/errors/output/android/com/example/smoke/Errors.java
@@ -22,14 +22,14 @@ public final class Errors extends NativeBase {
             this.value = value;
         }
     }
-    public final static class InternalException extends Exception {
+    public static final class InternalException extends Exception {
         public InternalException(final Errors.InternalErrorCode error) {
             super(error.toString());
             this.error = error;
         }
         public final Errors.InternalErrorCode error;
     }
-    public final static class ExternalException extends Exception {
+    public static final class ExternalException extends Exception {
         public ExternalException(final Errors.ExternalErrors error) {
             super(error.toString());
             this.error = error;

--- a/gluecodium/src/test/resources/smoke/errors/output/android/com/example/smoke/ErrorsInterface.java
+++ b/gluecodium/src/test/resources/smoke/errors/output/android/com/example/smoke/ErrorsInterface.java
@@ -21,14 +21,14 @@ public interface ErrorsInterface {
             this.value = value;
         }
     }
-    public final static class InternalException extends Exception {
+    public static final class InternalException extends Exception {
         public InternalException(final ErrorsInterface.InternalError error) {
             super(error.toString());
             this.error = error;
         }
         public final ErrorsInterface.InternalError error;
     }
-    public final static class ExternalException extends Exception {
+    public static final class ExternalException extends Exception {
         public ExternalException(final ErrorsInterface.ExternalErrors error) {
             super(error.toString());
             this.error = error;

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/ExternalClass.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/ExternalClass.java
@@ -13,7 +13,7 @@ public final class ExternalClass extends NativeBase {
             this.value = value;
         }
     }
-    public final static class SomeStruct {
+    public static final class SomeStruct {
         @NonNull
         public String someField;
         public SomeStruct(@NonNull final String someField) {

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/ExternalInterface.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/ExternalInterface.java
@@ -12,7 +12,7 @@ public interface ExternalInterface {
             this.value = value;
         }
     }
-    public final static class SomeStruct {
+    public static final class SomeStruct {
         @NonNull
         public String someField;
         public SomeStruct(@NonNull final String someField) {

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/Structs.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/Structs.java
@@ -6,7 +6,7 @@ import android.support.annotation.NonNull;
 import com.example.NativeBase;
 import java.util.List;
 public final class Structs extends NativeBase {
-    public final static class ExternalStruct {
+    public static final class ExternalStruct {
         @NonNull
         public String stringField;
         @NonNull
@@ -22,7 +22,7 @@ public final class Structs extends NativeBase {
             this.externalStructField = externalStructField;
         }
     }
-    public final static class AnotherExternalStruct {
+    public static final class AnotherExternalStruct {
         public byte intField;
         public AnotherExternalStruct(final byte intField) {
             this.intField = intField;

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/GenericTypesWithBasicTypes.java
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/GenericTypesWithBasicTypes.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 public final class GenericTypesWithBasicTypes extends NativeBase {
-    public final static class StructWithGenerics {
+    public static final class StructWithGenerics {
         @NonNull
         public List<Short> numbersList;
         @NonNull

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/GenericTypesWithCompoundTypes.java
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/GenericTypesWithCompoundTypes.java
@@ -25,13 +25,13 @@ public final class GenericTypesWithCompoundTypes extends NativeBase {
             this.value = value;
         }
     }
-    public final static class BasicStruct {
+    public static final class BasicStruct {
         public double value;
         public BasicStruct(final double value) {
             this.value = value;
         }
     }
-    public final static class ExternalStruct {
+    public static final class ExternalStruct {
         @NonNull
         public String string;
         public ExternalStruct(@NonNull final String string) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/CalculatorListener.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/CalculatorListener.java
@@ -7,7 +7,7 @@ import android.support.annotation.NonNull;
 import java.util.List;
 import java.util.Map;
 public interface CalculatorListener {
-    public final static class ResultStruct {
+    public static final class ResultStruct {
         public double result;
         public ResultStruct(final double result) {
             this.result = result;

--- a/gluecodium/src/test/resources/smoke/locales/output/android/com/example/smoke/Locales.java
+++ b/gluecodium/src/test/resources/smoke/locales/output/android/com/example/smoke/Locales.java
@@ -6,7 +6,7 @@ import android.support.annotation.NonNull;
 import com.example.NativeBase;
 import java.util.Locale;
 public final class Locales extends NativeBase {
-    public final static class LocaleStruct {
+    public static final class LocaleStruct {
         @NonNull
         public Locale localeField;
         public LocaleStruct(@NonNull final Locale localeField) {

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/com/example/smoke/MethodOverloads.java
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/com/example/smoke/MethodOverloads.java
@@ -7,7 +7,7 @@ import android.support.annotation.NonNull;
 import com.example.NativeBase;
 import java.util.List;
 public final class MethodOverloads extends NativeBase {
-    public final static class Point {
+    public static final class Point {
         public double x;
         public double y;
         public Point(final double x, final double y) {

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android/com/example/namerules/NAME_RULES_DROID.java
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android/com/example/namerules/NAME_RULES_DROID.java
@@ -13,14 +13,14 @@ public final class NAME_RULES_DROID extends NativeBase {
             this.value = value;
         }
     }
-    public final static class example_x extends Exception {
+    public static final class example_x extends Exception {
         public example_x(final NAME_RULES_DROID.EXAMPLE_ERROR_CODE_DROID error) {
             super(error.toString());
             this.error = error;
         }
         public final NAME_RULES_DROID.EXAMPLE_ERROR_CODE_DROID error;
     }
-    public final static class EXAMPLE_STRUCT_DROID {
+    public static final class EXAMPLE_STRUCT_DROID {
         public double j_value;
         public List<Long> j_int_value;
         public EXAMPLE_STRUCT_DROID(final double j_value, final List<Long> j_int_value) {

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/LevelOne.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/LevelOne.java
@@ -5,8 +5,8 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
 public final class LevelOne extends NativeBase {
-    public final static class LevelTwo extends NativeBase {
-        public final static class LevelThree extends NativeBase {
+    public static final class LevelTwo extends NativeBase {
+        public static final class LevelThree extends NativeBase {
             public enum LevelFourEnum {
                 NONE(0);
                 public final int value;
@@ -14,7 +14,7 @@ public final class LevelOne extends NativeBase {
                     this.value = value;
                 }
             }
-            public final static class LevelFour {
+            public static final class LevelFour {
                 public static final boolean FOO = false;
                 @NonNull
                 public String stringField;

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/NestedReferences.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/NestedReferences.java
@@ -5,7 +5,7 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
 public final class NestedReferences extends NativeBase {
-    public final static class NestedReferences {
+    public static final class NestedReferences {
         @NonNull
         public String stringField;
         public NestedReferences(@NonNull final String stringField) {

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/OuterClass.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/OuterClass.java
@@ -5,7 +5,7 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
 public final class OuterClass extends NativeBase {
-    public final static class InnerClass extends NativeBase {
+    public static final class InnerClass extends NativeBase {
         /**
          * For internal use only.
          * @exclude

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/OuterInterface.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/OuterInterface.java
@@ -5,7 +5,7 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
 public interface OuterInterface {
-    public final static class InnerClass extends NativeBase {
+    public static final class InnerClass extends NativeBase {
         /**
          * For internal use only.
          * @exclude

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/com/example/smoke/Nullable.java
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/com/example/smoke/Nullable.java
@@ -17,14 +17,14 @@ public final class Nullable extends NativeBase {
             this.value = value;
         }
     }
-    public final static class SomeStruct {
+    public static final class SomeStruct {
         @NonNull
         public String stringField;
         public SomeStruct(@NonNull final String stringField) {
             this.stringField = stringField;
         }
     }
-    public final static class NullableStruct {
+    public static final class NullableStruct {
         @Nullable
         public String stringField;
         @Nullable
@@ -55,7 +55,7 @@ public final class Nullable extends NativeBase {
             this.instanceField = instanceField;
         }
     }
-    public final static class NullableIntsStruct {
+    public static final class NullableIntsStruct {
         @Nullable
         public Byte int8Field;
         @Nullable

--- a/gluecodium/src/test/resources/smoke/packages/output/android/com/example/smoke/off/NestedPackages.java
+++ b/gluecodium/src/test/resources/smoke/packages/output/android/com/example/smoke/off/NestedPackages.java
@@ -6,7 +6,7 @@ package com.example.smoke.off;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
 public final class NestedPackages extends NativeBase {
-    public final static class SomeStruct {
+    public static final class SomeStruct {
         @NonNull
         public String someField;
         public SomeStruct(@NonNull final String someField) {

--- a/gluecodium/src/test/resources/smoke/properties/output/android/com/example/smoke/Properties.java
+++ b/gluecodium/src/test/resources/smoke/properties/output/android/com/example/smoke/Properties.java
@@ -14,7 +14,7 @@ public final class Properties extends NativeBase {
             this.value = value;
         }
     }
-    public final static class ExampleStruct {
+    public static final class ExampleStruct {
         public double value;
         public ExampleStruct(final double value) {
             this.value = value;

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipTypes.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipTypes.java
@@ -5,14 +5,14 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
 public final class SkipTypes extends NativeBase {
-    public final static class NotInSwift {
+    public static final class NotInSwift {
         @NonNull
         public String fooField;
         public NotInSwift(@NonNull final String fooField) {
             this.fooField = fooField;
         }
     }
-    public final static class NotInDart {
+    public static final class NotInDart {
         @NonNull
         public String fooField;
         public NotInDart(@NonNull final String fooField) {

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Structs.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Structs.java
@@ -14,7 +14,7 @@ public final class Structs extends NativeBase {
             this.value = value;
         }
     }
-    public final static class Point {
+    public static final class Point {
         public double x;
         public double y;
         public Point(final double x, final double y) {
@@ -22,7 +22,7 @@ public final class Structs extends NativeBase {
             this.y = y;
         }
     }
-    public final static class Line {
+    public static final class Line {
         @NonNull
         public Structs.Point a;
         @NonNull
@@ -32,7 +32,7 @@ public final class Structs extends NativeBase {
             this.b = b;
         }
     }
-    public final static class AllTypesStruct {
+    public static final class AllTypesStruct {
         public final byte int8Field;
         public final short uint8Field;
         public final short int16Field;
@@ -365,35 +365,35 @@ public final class Structs extends NativeBase {
             }
         }
     }
-    public final static class NestingImmutableStruct {
+    public static final class NestingImmutableStruct {
         @NonNull
         public Structs.AllTypesStruct structField;
         public NestingImmutableStruct(@NonNull final Structs.AllTypesStruct structField) {
             this.structField = structField;
         }
     }
-    public final static class DoubleNestingImmutableStruct {
+    public static final class DoubleNestingImmutableStruct {
         @NonNull
         public Structs.NestingImmutableStruct nestingStructField;
         public DoubleNestingImmutableStruct(@NonNull final Structs.NestingImmutableStruct nestingStructField) {
             this.nestingStructField = nestingStructField;
         }
     }
-    public final static class StructWithArrayOfImmutable {
+    public static final class StructWithArrayOfImmutable {
         @NonNull
         public List<Structs.AllTypesStruct> arrayField;
         public StructWithArrayOfImmutable(@NonNull final List<Structs.AllTypesStruct> arrayField) {
             this.arrayField = arrayField;
         }
     }
-    public final static class ImmutableStructWithCppAccessors {
+    public static final class ImmutableStructWithCppAccessors {
         @NonNull
         public final String stringField;
         public ImmutableStructWithCppAccessors(@NonNull final String stringField) {
             this.stringField = stringField;
         }
     }
-    public final static class MutableStructWithCppAccessors {
+    public static final class MutableStructWithCppAccessors {
         @NonNull
         public String stringField;
         public MutableStructWithCppAccessors(@NonNull final String stringField) {

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/StructsWithConstantsInterface.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/StructsWithConstantsInterface.java
@@ -7,7 +7,7 @@ import android.support.annotation.NonNull;
 import com.example.NativeBase;
 import java.util.List;
 public final class StructsWithConstantsInterface extends NativeBase {
-    public final static class MultiRoute {
+    public static final class MultiRoute {
         public static final String DEFAULT_DESCRIPTION = "Foo";
         public static final RouteType DEFAULT_TYPE = RouteType.NONE;
         @NonNull
@@ -19,7 +19,7 @@ public final class StructsWithConstantsInterface extends NativeBase {
             this.type = type;
         }
     }
-    public final static class StructWithConstantsOnly {
+    public static final class StructWithConstantsOnly {
         public static final String DEFAULT_DESCRIPTION = "Foo";
     }
     /**

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/StructsWithMethodsInterface.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/StructsWithMethodsInterface.java
@@ -5,7 +5,7 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
 public final class StructsWithMethodsInterface extends NativeBase {
-    public final static class Vector3 {
+    public static final class Vector3 {
         public double x;
         public double y;
         public double z;
@@ -28,7 +28,7 @@ public final class StructsWithMethodsInterface extends NativeBase {
         private static native StructsWithMethodsInterface.Vector3 create(@NonNull final String input);
         private static native StructsWithMethodsInterface.Vector3 create(@NonNull final StructsWithMethodsInterface.Vector3 other) throws ValidationException;
     }
-    public final static class StructWithStaticMethodsOnly {
+    public static final class StructWithStaticMethodsOnly {
         public static native void doStuff();
     }
     /**

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android/com/example/smoke/TypeDefs.java
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android/com/example/smoke/TypeDefs.java
@@ -7,13 +7,13 @@ import android.support.annotation.NonNull;
 import com.example.NativeBase;
 import java.util.List;
 public final class TypeDefs extends NativeBase {
-    public final static class StructHavingAliasFieldDefinedBelow {
+    public static final class StructHavingAliasFieldDefinedBelow {
         public double field;
         public StructHavingAliasFieldDefinedBelow(final double field) {
             this.field = field;
         }
     }
-    public final static class TestStruct {
+    public static final class TestStruct {
         @NonNull
         public String something;
         public TestStruct(@NonNull final String something) {

--- a/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/PublicClass.java
+++ b/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/PublicClass.java
@@ -14,21 +14,21 @@ public final class PublicClass extends NativeBase {
             this.value = value;
         }
     }
-    final static class InternalStruct {
+    static final class InternalStruct {
         @NonNull
         String stringField;
         InternalStruct(@NonNull final String stringField) {
             this.stringField = stringField;
         }
     }
-    public final static class PublicStruct {
+    public static final class PublicStruct {
         @NonNull
         PublicClass.InternalStruct internalField;
         PublicStruct(@NonNull final PublicClass.InternalStruct internalField) {
             this.internalField = internalField;
         }
     }
-    public final static class PublicStructWithInternalDefaults {
+    public static final class PublicStructWithInternalDefaults {
         @NonNull
         String internalField;
         public float publicField;

--- a/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/PublicInterface.java
+++ b/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/PublicInterface.java
@@ -5,7 +5,7 @@
 package com.example.smoke;
 import android.support.annotation.NonNull;
 public interface PublicInterface {
-    final static class InternalStruct {
+    static final class InternalStruct {
         @NonNull
         PublicClass.InternalStruct fieldOfInternalType;
         InternalStruct(@NonNull final PublicClass.InternalStruct fieldOfInternalType) {


### PR DESCRIPTION
Updated Java templates to fix non-canonical qualifier order "final
static" for inner classes and replace it with canonical "static final".

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>