### PR TITLE
Add "stubs" mode for Java generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Introduced "stubs" mode for Java generator (`-stubs` command-line parameter). This mode replaces
+    "native" methods in generated Java code with stubs (i.e. empty implementation) and removes
+    "final" qualifier from classes and fields. This makes code generated for classes and structs
+    fully mockable in unit tests.
+
 ## 8.0.1
 Release date: 2020-07-29
 ### Bug fixes:

--- a/cmake/modules/gluecodium/gluecodium/Generate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/Generate.cmake
@@ -72,7 +72,7 @@ set(APIGEN_GLUECODIUM_DIR ${CMAKE_CURRENT_LIST_DIR})
 include(${APIGEN_GLUECODIUM_DIR}/GeneratedSources.cmake)
 
 function(apigen_generate)
-  set(options VALIDATE_ONLY VERBOSE)
+  set(options VALIDATE_ONLY VERBOSE STUBS)
   set(oneValueArgs TARGET GENERATOR VERSION
       ANDROID_MERGE_MANIFEST
       JAVA_PACKAGE
@@ -122,13 +122,16 @@ function(apigen_generate)
     APIGEN_BUILD_OUTPUT_DIR "${APIGEN_BUILD_OUTPUT_DIR}")
 
   if(NOT apigen_generate_GENERATOR MATCHES cpp)
-    set(apigen_generate_GENERATOR "cpp,${apigen_generate_GENERATOR}")
+    if(NOT apigen_generate_STUBS)
+      set(apigen_generate_GENERATOR "cpp,${apigen_generate_GENERATOR}")
+    endif()
   endif()
 
   set(APIGEN_GLUECODIUM_PROPERTIES "\
 output=${APIGEN_OUTPUT_DIR}\n\
 generators=${apigen_generate_GENERATOR}\n\
 validate=${validateProperty}\n\
+stubs=${apigen_generate_STUBS}\n\
 cache=true\n")
 
   unset (_apigen_input_list)

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -223,6 +223,7 @@ class Gluecodium(
         var internalPrefix: String? = null,
         var libraryName: String = "library",
         var werror: Set<String> = emptySet(),
+        var generateStubs: Boolean = false,
         var cppNameRules: Configuration = ConfigurationProperties.fromResource(
             Gluecodium::class.java,
             "/namerules/cpp.properties"

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -122,6 +122,12 @@ object OptionReader {
                     Gluecodium.Options.WARNING_DART_OVERLOADS
                 ).joinToString()
         )
+        addOption(
+            "stubs",
+            "generate-stubs",
+            false,
+            "Generate methods stubs, suitable for mocking in unit tests. Only supported for Java."
+        )
         addOption("cppnamerules", true, "C++ name rules property file.")
         addOption("javanamerules", true, "Java name rules property file.")
         addOption("swiftnamerules", true, "Swift name rules property file.")
@@ -182,6 +188,7 @@ object OptionReader {
         getStringValue("internalprefix")?.let { options.internalPrefix = it }
         getStringValue("libraryname")?.let { options.libraryName = it }
         getStringListValue("werror")?.let { options.werror = it.toSet() }
+        options.generateStubs = getFlagValue("stubs")
 
         options.cppNameRules = readConfigFile(getStringValue("cppnamerules"), options.cppNameRules)
         options.javaNameRules =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaTemplates.kt
@@ -28,7 +28,7 @@ import com.here.gluecodium.model.java.JavaExceptionClass
 import com.here.gluecodium.model.java.JavaInterface
 import com.here.gluecodium.model.java.JavaTopLevelElement
 
-class JavaTemplates(generatorName: String) {
+class JavaTemplates(generatorName: String, private val generateStubs: Boolean) {
 
     private val javaFileMapper: JavaFileMapper = JavaFileMapper(generatorName)
 
@@ -47,7 +47,7 @@ class JavaTemplates(generatorName: String) {
 
     private fun generateFileForElement(templateName: String, javaElement: JavaTopLevelElement) =
         GeneratedFile(
-            TemplateEngine.render(templateName, javaElement),
+            TemplateEngine.render(templateName, mapOf("model" to javaElement, "stubs" to generateStubs)),
             javaFileMapper.getFileName(javaElement)
         )
 

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
@@ -65,6 +65,7 @@ open class JavaGeneratorSuite protected constructor(
     private val javaNameRules = JavaNameRules(nameRuleSetFromConfig(options.javaNameRules))
     private val nonNullAnnotation = annotationFromOption(options.javaNonNullAnnotation)
     private val nullableAnnotation = annotationFromOption(options.javaNullableAnnotation)
+    private val generateStubs = options.generateStubs
 
     protected open val generatorName = GENERATOR_NAME
 
@@ -110,7 +111,7 @@ open class JavaGeneratorSuite protected constructor(
             throw GluecodiumExecutionException("Validation errors found, see log for details.")
         }
 
-        val javaTemplates = JavaTemplates(generatorName)
+        val javaTemplates = JavaTemplates(generatorName, generateStubs)
         val nonExternalElements = combinedModel.javaElements.filter {
             it !is JavaTopLevelElement || !it.skipDeclaration
         }
@@ -128,6 +129,8 @@ open class JavaGeneratorSuite protected constructor(
             val androidManifestGenerator = AndroidManifestGenerator(javaPackageList)
             headers += androidManifestGenerator.generate()
         }
+
+        if (generateStubs) return headers + javaFiles
 
         val jniTemplates =
             JniTemplates(javaPackageList, internalPackage, internalNamespace, generatorName)

--- a/gluecodium/src/main/resources/templates/java/Class.mustache
+++ b/gluecodium/src/main/resources/templates/java/Class.mustache
@@ -22,7 +22,7 @@
 {{#annotations}}
 @{{name}}
 {{/annotations}}
-{{#if visibility.toString}}{{visibility}} {{/if}}{{#if isStatic}}static {{/if}}{{#if isFinal}}final {{/if}}{{!!
+{{#if visibility.toString}}{{visibility}} {{/if}}{{#if isStatic}}static {{/if}}{{#if isFinal}}{{#unless stubs}}final {{/unless}}{{/if}}{{!!
 }}class {{name}} {{#if this.extendedClass}}extends {{extendedClass.name}} {{/if}}{{#if parentInterfaces}}implements {{join parentInterfaces delimiter=", " }} {{/if}}{
 {{#if isParcelable}}{{prefixPartial "java/ParcelableCreator" "    "}}
 
@@ -42,22 +42,22 @@
 {{#set className=name}}{{#constructors}}
 {{prefixPartial "java/MethodComment" "    "}}
     {{visibility}} {{className}}({{joinPartial parameters "java/Parameter" ", "}}){{#exception}} throws {{name}}{{/exception}} {
-{{#if isImplClass}}
+{{#unless stubs}}{{#if isImplClass}}
         this({{name}}({{join parameters delimiter=", " }}));
         cacheThisInstance();
 {{/if}}{{#unless isImplClass}}
         {{className}} _other = {{name}}({{join parameters delimiter=", " }});
 {{#fields}}        this.{{name}} = _other.{{name}};
 {{/fields}}
-{{/unless}}
+{{/unless}}{{/unless}}
     }
 {{/constructors}}{{/set}}
-{{#if isImplClass}}
+{{#unless stubs}}{{#if isImplClass}}
 {{prefixPartial "java/NativeConstructor" "    "}}
 {{#if constructors}}
     private native void cacheThisInstance();
 {{/if}}
-{{/if}}
+{{/if}}{{/unless}}
 {{#if fields}}{{#unless constructors}}
 
 {{#if generatedConstructorComment}}
@@ -93,18 +93,27 @@
 {{/if}}
 {{#if isEquatable}}{{prefixPartial "java/EqualsAndHashCode" "    "}}
 {{/if}}
-{{#hasNativeEquatable}}
+{{#unless stubs}}{{#hasNativeEquatable}}
     @Override
     public native boolean equals(Object rhs);
 
     @Override
     public native int hashCode();
 
-{{/hasNativeEquatable}}
+{{/hasNativeEquatable}}{{/unless}}
 {{#if needsBuilder}}{{#unless constructors}}{{prefixPartial "java/FieldsBuilder" "    "}}
 
 {{/unless}}{{/if}}
-{{#methods}}{{#if isCached}}
+{{#methods}}{{#if stubs}}{{#unless isConstructor}}
+{{prefixPartial "java/MethodSignature" "    "}} {
+{{#unless isReturningVoid}}
+        return {{#instanceOf returnType "JavaPrimitiveTypeRef"}}{{!!
+        }}{{#isEq returnType.name "boolean"}}false{{/isEq}}{{!!
+        }}{{#isNotEq returnType.name "boolean"}}0{{/isNotEq}}{{/instanceOf}}{{!!
+        }}{{#notInstanceOf returnType "JavaPrimitiveTypeRef"}}null{{/notInstanceOf}};
+{{/unless}}
+    }
+{{/unless}}{{/if}}{{#unless stubs}}{{#if isCached}}
     private {{#if isStatic}}static {{/if}}{{returnType.name}} cache_{{name}};
     private {{#if isStatic}}static {{/if}}boolean is_cached_{{name}} = false;
 
@@ -124,6 +133,6 @@
     private {{#if isStatic}}static {{/if}}native {{returnType.name}} {{name}}_private{{!!
 }}({{joinPartial parameters "java/Parameter" ", "}});
 {{/if}}{{!!
-}}{{#unless isCached}}{{prefixPartial "java/MethodSignature" "    "}}{{/unless}}
+}}{{#unless isCached}}{{prefixPartial "java/MethodSignature" "    "}};{{/unless}}{{/unless}}
 {{/methods}}
 }

--- a/gluecodium/src/main/resources/templates/java/ClassHeader.mustache
+++ b/gluecodium/src/main/resources/templates/java/ClassHeader.mustache
@@ -20,6 +20,7 @@
   !}}
 {{>java/CopyrightHeader}}
 
+{{#model}}
 {{#javaPackage}}
 package {{this}};
 {{/javaPackage}}
@@ -31,3 +32,4 @@ package {{this}};
 
 {{/if}}
 {{>java/Class}}
+{{/model}}

--- a/gluecodium/src/main/resources/templates/java/EnumHeader.mustache
+++ b/gluecodium/src/main/resources/templates/java/EnumHeader.mustache
@@ -20,8 +20,10 @@
   !}}
 {{>java/CopyrightHeader}}
 
+{{#model}}
 {{#javaPackage}}
 package {{this}};
 {{/javaPackage}}
 
 {{>java/Enum}}
+{{/model}}

--- a/gluecodium/src/main/resources/templates/java/ExceptionDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/java/ExceptionDefinition.mustache
@@ -20,11 +20,11 @@
   !}}
 {{>java/DocComment}}
 {{#if visibility.toString}}{{visibility}} {{/if}}{{#if isStatic static logic="or"}}static {{/if}}{{!!
-}}{{#if isFinal}}final {{/if}}class {{name}} extends Exception {
+}}{{#if isFinal}}{{#unless stubs}}final {{/unless}}{{/if}}class {{name}} extends Exception {
     {{#if visibility.toString}}{{visibility}} {{/if}}{{name}}(final {{errorTypeRef.name}} error) {
         super(error.toString());
         this.error = error;
     }
 
-    {{#if visibility.toString}}{{visibility}} {{/if}}final {{errorTypeRef.name}} error;
+    {{#if visibility.toString}}{{visibility}} {{/if}}{{#unless stubs}}final {{/unless}}{{errorTypeRef.name}} error;
 }

--- a/gluecodium/src/main/resources/templates/java/ExceptionFile.mustache
+++ b/gluecodium/src/main/resources/templates/java/ExceptionFile.mustache
@@ -20,8 +20,10 @@
   !}}
 {{>java/CopyrightHeader}}
 
+{{#model}}
 {{#javaPackage}}
 package {{this}};
 {{/javaPackage}}
 
 {{>java/ExceptionDefinition}}
+{{/model}}

--- a/gluecodium/src/main/resources/templates/java/Field.mustache
+++ b/gluecodium/src/main/resources/templates/java/Field.mustache
@@ -27,4 +27,5 @@
 {{#allAnnotations}}
 @{{name}}
 {{/allAnnotations}}
-{{#if visibility.toString}}{{visibility}} {{/if}}{{#if isImmutable}}final {{/if}}{{type.name}} {{name}};
+{{#if visibility.toString}}{{visibility}} {{/if}}{{!!
+}}{{#if isImmutable}}{{#unless stubs}}final {{/unless}}{{/if}}{{type.name}} {{name}};

--- a/gluecodium/src/main/resources/templates/java/Interface.mustache
+++ b/gluecodium/src/main/resources/templates/java/Interface.mustache
@@ -33,6 +33,6 @@
 {{/innerClasses}}
 {{#innerInterfaces}}{{prefixPartial "java/Interface" "    "}}
 {{/innerInterfaces}}
-{{#set isInterface=true}}{{#methods}}{{prefixPartial "java/MethodSignature" "    "}}
+{{#set isInterface=true}}{{#methods}}{{prefixPartial "java/MethodSignature" "    "}};
 {{/methods}}{{/set}}
 }

--- a/gluecodium/src/main/resources/templates/java/InterfaceHeader.mustache
+++ b/gluecodium/src/main/resources/templates/java/InterfaceHeader.mustache
@@ -20,6 +20,7 @@
   !}}
 {{>java/CopyrightHeader}}
 
+{{#model}}
 {{#javaPackage}}
 package {{this}};
 {{/javaPackage}}
@@ -31,3 +32,4 @@ package {{this}};
 
 {{/if}}
 {{>java/Interface}}
+{{/model}}

--- a/gluecodium/src/main/resources/templates/java/MethodSignature.mustache
+++ b/gluecodium/src/main/resources/templates/java/MethodSignature.mustache
@@ -24,5 +24,5 @@
 {{/allAnnotations}}
 {{^isInterface}}{{#if isConstructor}}private {{/if}}{{!!
 }}{{#unless isConstructor}}{{#if visibility.toString}}{{visibility}} {{/if}}{{/unless}}{{/isInterface}}{{!!
-}}{{#if isStatic}}static {{/if}}{{#if isNative}}native {{/if}}{{returnType.name}} {{name}}({{!!
-}}{{joinPartial parameters "java/Parameter" ", "}}){{#exception}} throws {{name}}{{/exception}};
+}}{{#if isStatic}}static {{/if}}{{#if isNative}}{{#unless stubs}}native {{/unless}}{{/if}}{{returnType.name}} {{name}}({{!!
+}}{{joinPartial parameters "java/Parameter" ", "}}){{#exception}} throws {{name}}{{/exception}}

--- a/gluecodium/src/test/java/com/here/gluecodium/StubsSmokeTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/StubsSmokeTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium
+
+import java.io.File
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+
+@RunWith(Parameterized::class)
+class StubsSmokeTest(
+    featureDirectory: File,
+    generatorName: String,
+    @Suppress("UNUSED_PARAMETER") featureName: String
+) : AcceptanceTestBase(featureDirectory, generatorName) {
+
+    override fun getGluecodiumOptions() = Gluecodium.Options(generateStubs = true)
+
+    @Test
+    fun smokeTest() {
+        runTest()
+    }
+
+    companion object {
+        private const val RESOURCE_PREFIX = "stubs_smoke"
+
+        @JvmStatic
+        @Parameters(name = "{2}, {1}")
+        fun data(): Collection<Array<Any>> {
+            return getData(RESOURCE_PREFIX)
+        }
+    }
+}

--- a/gluecodium/src/test/resources/stubs_smoke/classes/input/Classes.lime
+++ b/gluecodium/src/test/resources/stubs_smoke/classes/input/Classes.lime
@@ -1,0 +1,28 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+class SomeClass {
+    constructor fooBar()
+    fun voidFunction()
+    fun boolFunction(): Boolean
+    fun intFunction(): Int
+    fun stringFunction(): String
+    fun classFunction(): SomeClass
+    static fun staticFunction()
+}

--- a/gluecodium/src/test/resources/stubs_smoke/classes/output/android/com/example/smoke/SomeClass.java
+++ b/gluecodium/src/test/resources/stubs_smoke/classes/output/android/com/example/smoke/SomeClass.java
@@ -1,0 +1,25 @@
+/*
+ *
+ */
+package com.example.smoke;
+import com.example.NativeBase;
+public class SomeClass extends NativeBase {
+    public SomeClass() {
+    }
+    public void voidFunction() {
+    }
+    public boolean boolFunction() {
+        return false;
+    }
+    public int intFunction() {
+        return 0;
+    }
+    public String stringFunction() {
+        return null;
+    }
+    public SomeClass classFunction() {
+        return null;
+    }
+    public static void staticFunction() {
+    }
+}

--- a/gluecodium/src/test/resources/stubs_smoke/exceptions/input/Exceptions.lime
+++ b/gluecodium/src/test/resources/stubs_smoke/exceptions/input/Exceptions.lime
@@ -1,0 +1,20 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+exception Some(Boolean)

--- a/gluecodium/src/test/resources/stubs_smoke/exceptions/output/android/com/example/smoke/SomeException.java
+++ b/gluecodium/src/test/resources/stubs_smoke/exceptions/output/android/com/example/smoke/SomeException.java
@@ -1,0 +1,11 @@
+/*
+ *
+ */
+package com.example.smoke;
+public class SomeException extends Exception {
+    public SomeException(final boolean error) {
+        super(error.toString());
+        this.error = error;
+    }
+    public boolean error;
+}

--- a/gluecodium/src/test/resources/stubs_smoke/structs/input/Structs.lime
+++ b/gluecodium/src/test/resources/stubs_smoke/structs/input/Structs.lime
@@ -1,0 +1,39 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct StructWithMethods {
+    field: String
+
+    fun voidFunction()
+    fun boolFunction(): Boolean
+    fun intFunction(): Int
+    fun stringFunction(): String
+    fun structFunction(): StructWithMethods
+    static fun staticFunction()
+}
+
+struct StructWithConstructor {
+    field: String
+    constructor fooBar()
+}
+
+@Immutable
+struct ImmutableStruct {
+    field: String
+}

--- a/gluecodium/src/test/resources/stubs_smoke/structs/output/android/com/example/smoke/ImmutableStruct.java
+++ b/gluecodium/src/test/resources/stubs_smoke/structs/output/android/com/example/smoke/ImmutableStruct.java
@@ -1,0 +1,10 @@
+/*
+ *
+ */
+package com.example.smoke;
+public class ImmutableStruct {
+    public String field;
+    public ImmutableStruct(final String field) {
+        this.field = field;
+    }
+}

--- a/gluecodium/src/test/resources/stubs_smoke/structs/output/android/com/example/smoke/StructWithConstructor.java
+++ b/gluecodium/src/test/resources/stubs_smoke/structs/output/android/com/example/smoke/StructWithConstructor.java
@@ -1,0 +1,9 @@
+/*
+ *
+ */
+package com.example.smoke;
+public class StructWithConstructor {
+    public String field;
+    public StructWithConstructor() {
+    }
+}

--- a/gluecodium/src/test/resources/stubs_smoke/structs/output/android/com/example/smoke/StructWithMethods.java
+++ b/gluecodium/src/test/resources/stubs_smoke/structs/output/android/com/example/smoke/StructWithMethods.java
@@ -1,0 +1,26 @@
+/*
+ *
+ */
+package com.example.smoke;
+public class StructWithMethods {
+    public String field;
+    public StructWithMethods(final String field) {
+        this.field = field;
+    }
+    public void voidFunction() {
+    }
+    public boolean boolFunction() {
+        return false;
+    }
+    public int intFunction() {
+        return 0;
+    }
+    public String stringFunction() {
+        return null;
+    }
+    public StructWithMethods structFunction() {
+        return null;
+    }
+    public static void staticFunction() {
+    }
+}


### PR DESCRIPTION
Added "stubs" mode for Java generator, enabled by "-stubs" command-line
parameter. This mode replaces "native" methods in generated Java code
with stubs (i.e. empty implementation) and removes "final" qualifier
from classes and fields. This makes code generated for classes and
structs fully mockable in unit tests.

"Stubs" mode also skips generation of JNI code.

Added new smoke test group StubsSmokeTest that runs its use cases with
"stubs" mode enabled. Added smoke tests for classes, exceptions, and
structs with methods there.

Added "STUBS" Boolean parameter to apigen_generate() CMake function. Apart from
enabling "stubs" mode for Gluecodium, this flag also skip generation of
C++ code.

Resolves: #436
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>