### PR TITLE
Add more functional tests for external types

### DIFF
--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -344,6 +344,14 @@ names are case-insensitive. Supported platform tags:
     needed for the pre-existing converter class (i.e. `"<path>/<file_name>.dart"`).
 * **Note:** the following features of struct types cannot be combined with "external" behavior:
 custom constructors, field default values, `@Equatable`.
+* **Note:** the way of specifying the name of the external type to use varies slightly between
+output languages. For C++ and Java it needs to be a fully-qualified name and it is specified through
+`cpp name "..."` and `java name "..."` values of the external descriptor. For Swift and Dart a
+regular short name is enough so it can be specified through `@Swift("...")` and `@Dart("...")`
+attributes (or omitted if the name is the name of the type in IDL declaration).
+* **Note:** due to specifics of external type naming mentioned just above, the intermediate internal
+type which is generated when a converter is specified has an additional `_internal` suffix to its
+name in Swift and Dart.
 
 ### Type references
 

--- a/examples/libhello/lime/test/DartExternalTypes.lime
+++ b/examples/libhello/lime/test/DartExternalTypes.lime
@@ -71,4 +71,13 @@ class UseDartExternalTypes {
     static fun compressionStateRoundTrip(input: CompressionState): CompressionState
     static fun colorRoundTrip(input: SystemColor): SystemColor
     static fun seasonRoundTrip(input: Season): Season
+
+    static fun structRoundTrip(input: DartExternalTypesStruct): DartExternalTypesStruct
+}
+
+struct DartExternalTypesStruct {
+    rectangle: Rectangle
+    compressionState: CompressionState
+    color: SystemColor
+    season: Season
 }

--- a/examples/libhello/lime/test/JavaExternalTypes.lime
+++ b/examples/libhello/lime/test/JavaExternalTypes.lime
@@ -78,4 +78,14 @@ class UseJavaExternalTypes {
     static fun monthRoundTrip(input: Month): Month
     static fun colorRoundTrip(input: SystemColor): SystemColor
     static fun seasonRoundTrip(input: Season): Season
+
+    static fun structRoundTrip(input: JavaExternalTypesStruct): JavaExternalTypesStruct
+}
+
+struct JavaExternalTypesStruct {
+    currency: Currency
+    timeZone: TimeZone
+    month: Month
+    color: SystemColor
+    season: Season
 }

--- a/examples/libhello/lime/test/SwiftExternalTypes.lime
+++ b/examples/libhello/lime/test/SwiftExternalTypes.lime
@@ -67,4 +67,13 @@ class UseSwiftExternalTypes {
     static fun persistenceRoundTrip(input: Persistence): Persistence
     static fun colorRoundTrip(input: SystemColor): SystemColor
     static fun seasonRoundTrip(input: Season): Season
+
+    static fun structRoundTrip(input: SwiftExternalTypesStruct): SwiftExternalTypesStruct
+}
+
+struct SwiftExternalTypesStruct {
+    dateInterval: DateInterval
+    persistence: Persistence
+    color: SystemColor
+    season: Season
 }

--- a/examples/libhello/src/test/DartExternalTypes.cpp
+++ b/examples/libhello/src/test/DartExternalTypes.cpp
@@ -41,4 +41,9 @@ Season
 UseDartExternalTypes::season_round_trip(const Season input) {
     return input;
 }
+
+DartExternalTypesStruct
+UseDartExternalTypes::struct_round_trip(const DartExternalTypesStruct& input) {
+    return input;
+}
 }

--- a/examples/libhello/src/test/JavaExternalTypes.cpp
+++ b/examples/libhello/src/test/JavaExternalTypes.cpp
@@ -18,6 +18,7 @@
 //
 // -------------------------------------------------------------------------------------------------
 
+#include "test/JavaExternalTypesStruct.h"
 #include "test/UseJavaExternalTypes.h"
 
 namespace test
@@ -44,6 +45,11 @@ UseJavaExternalTypes::color_round_trip(const SystemColor& input) {
 
 Season
 UseJavaExternalTypes::season_round_trip(const Season input) {
+    return input;
+}
+
+JavaExternalTypesStruct
+UseJavaExternalTypes::struct_round_trip(const JavaExternalTypesStruct& input) {
     return input;
 }
 }

--- a/examples/libhello/src/test/SwiftExternalTypes.cpp
+++ b/examples/libhello/src/test/SwiftExternalTypes.cpp
@@ -18,6 +18,7 @@
 //
 // -------------------------------------------------------------------------------------------------
 
+#include "test/SwiftExternalTypesStruct.h"
 #include "test/UseSwiftExternalTypes.h"
 
 namespace test
@@ -39,6 +40,11 @@ UseSwiftExternalTypes::color_round_trip(const SystemColor& input) {
 
 Season
 UseSwiftExternalTypes::season_round_trip(const Season input) {
+    return input;
+}
+
+SwiftExternalTypesStruct
+UseSwiftExternalTypes::struct_round_trip(const SwiftExternalTypesStruct& input) {
     return input;
 }
 }

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/ExternalTypesTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/ExternalTypesTest.java
@@ -121,4 +121,25 @@ public final class ExternalTypesTest {
 
     assertEquals(season, result);
   }
+
+  @Test
+  public void useJavaExternalTypesInStruct() {
+    SimpleTimeZone timeZone = new SimpleTimeZone(2, "foobar");
+    timeZone.setRawOffset(42);
+    JavaExternalTypesStruct struct =
+        new JavaExternalTypesStruct(
+            Currency.getInstance("EUR"),
+            timeZone,
+            Month.of(2),
+            android.graphics.Color.argb(0, 0, 127, 255),
+            "SPRING");
+
+    JavaExternalTypesStruct result = UseJavaExternalTypes.structRoundTrip(struct);
+
+    assertEquals(struct.currency.getCurrencyCode(), result.currency.getCurrencyCode());
+    assertEquals(struct.timeZone.getRawOffset(), result.timeZone.getRawOffset());
+    assertEquals(struct.month, result.month);
+    assertEquals(struct.color, result.color);
+    assertEquals(struct.season, result.season);
+  }
 }

--- a/examples/platforms/dart/test/ExternalTypes_test.dart
+++ b/examples/platforms/dart/test/ExternalTypes_test.dart
@@ -79,4 +79,19 @@ void main() {
 
     expect(result, season);
   });
+  _testSuite.test("Use Dart struct with external types", () {
+    final struct = DartExternalTypesStruct(
+      Rectangle<int>(0, 1, 2, 3),
+      HttpClientResponseCompressionState.decompressed,
+      0x007FFF,
+      "spring"
+    );
+
+    final result = UseDartExternalTypes.structRoundTrip(struct);
+
+    expect(result.rectangle, struct.rectangle);
+    expect(result.compressionState, struct.compressionState);
+    expect(result.color, struct.color);
+    expect(result.season, struct.season);
+  });
 }

--- a/examples/platforms/ios/Tests/testTests/ExternalTypesTests.swift
+++ b/examples/platforms/ios/Tests/testTests/ExternalTypesTests.swift
@@ -89,12 +89,31 @@ class ExternalTypesTests: XCTestCase {
         XCTAssertEqual(season.value, result.value)
     }
 
+    func testSwiftExternalTypesInStruct() {
+        let typesStruct = SwiftExternalTypesStruct(
+            dateInterval: DateInterval(start: Date(), duration: 60),
+            persistence: URLCredential.Persistence.forSession,
+            color: PseudoColor(0x007FFF),
+            season: Season("spring"))
+
+        let result = UseSwiftExternalTypes.structRoundTrip(input: typesStruct)
+
+        XCTAssertEqual(typesStruct.dateInterval.start.timeIntervalSinceReferenceDate,
+            result.dateInterval.start.timeIntervalSinceReferenceDate, accuracy: 1e-6)
+        XCTAssertEqual(typesStruct.dateInterval.end.timeIntervalSinceReferenceDate,
+            result.dateInterval.end.timeIntervalSinceReferenceDate, accuracy: 1e-6)
+        XCTAssertEqual(typesStruct.persistence, result.persistence)
+        XCTAssertEqual(typesStruct.color.value, result.color.value)
+        XCTAssertEqual(typesStruct.season.value, result.season.value)
+    }
+
     static var allTests = [
         ("testUseExternalTypesExternalStruct", testUseExternalTypesExternalStruct),
         ("testUseExternalTypesExternalEnum", testUseExternalTypesExternalEnum),
         ("testSwiftExternalTypeDateInterval", testSwiftExternalTypeDateInterval),
         ("testSwiftExternalTypePersistence", testSwiftExternalTypePersistence),
         ("testSwiftExternalTypeColor", testSwiftExternalTypeColor),
-        ("testSwiftExternalTypeSeason", testSwiftExternalTypeSeason)
+        ("testSwiftExternalTypeSeason", testSwiftExternalTypeSeason),
+        ("testSwiftExternalTypesInStruct", testSwiftExternalTypesInStruct)
     ]
 }


### PR DESCRIPTION
Added functional tests for usage to external types in struct fields.

Also updated the documentation for "external types" feature to clarify
naming conventions.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>