### PR TITLE
Use fully-qualified name for Java external types

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaEnumTypeRef.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaEnumTypeRef.kt
@@ -23,5 +23,5 @@ class JavaEnumTypeRef(
     fullName: String,
     classNames: List<String>,
     packageNames: List<String>,
-    anImport: JavaImport
-) : JavaCustomTypeRef(fullName, setOf(anImport), classNames, packageNames)
+    anImport: JavaImport?
+) : JavaCustomTypeRef(fullName, listOfNotNull(anImport).toSet(), classNames, packageNames)

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/UseJavaExternalTypes.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/UseJavaExternalTypes.java
@@ -4,11 +4,6 @@
 package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
-import java.lang.Integer;
-import java.lang.String;
-import java.time.Month;
-import java.util.Currency;
-import java.util.SimpleTimeZone;
 public final class UseJavaExternalTypes extends NativeBase {
     /**
      * For internal use only.
@@ -24,13 +19,13 @@ public final class UseJavaExternalTypes extends NativeBase {
     }
     private static native void disposeNativeHandle(long nativeHandle);
     @NonNull
-    public static native Currency currencyRoundTrip(@NonNull final Currency input);
+    public static native java.util.Currency currencyRoundTrip(@NonNull final java.util.Currency input);
     @NonNull
-    public static native SimpleTimeZone timeZoneRoundTrip(@NonNull final SimpleTimeZone input);
+    public static native java.util.SimpleTimeZone timeZoneRoundTrip(@NonNull final java.util.SimpleTimeZone input);
     @NonNull
-    public static native Month monthRoundTrip(@NonNull final Month input);
+    public static native java.time.Month monthRoundTrip(@NonNull final java.time.Month input);
     @NonNull
-    public static native Integer colorRoundTrip(@NonNull final Integer input);
+    public static native java.lang.Integer colorRoundTrip(@NonNull final java.lang.Integer input);
     @NonNull
-    public static native String seasonRoundTrip(@NonNull final String input);
+    public static native java.lang.String seasonRoundTrip(@NonNull final java.lang.String input);
 }


### PR DESCRIPTION
Updated JavaTypeMapper to use fully-qualified names for references to
external types.

Resolves: #445
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>