### PR TITLE
Use import aliases for Dart external types

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/NameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/NameResolver.kt
@@ -23,4 +23,5 @@ interface NameResolver {
     fun resolveName(element: Any): String
     fun resolveGetterName(element: Any): String? { throw IllegalArgumentException() }
     fun resolveSetterName(element: Any): String? { throw IllegalArgumentException() }
+    fun resolveReferenceName(element: Any): String? { throw IllegalArgumentException() }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/NameResolverHelper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/NameResolverHelper.kt
@@ -72,6 +72,7 @@ internal class NameResolverHelper : BasicHelper() {
         val name = when (subKey?.toLowerCase()) {
             "getter" -> resolver.resolveGetterName(element)
             "setter" -> resolver.resolveSetterName(element)
+            "ref" -> resolver.resolveReferenceName(element)
             else -> resolver.resolveName(element)
         } ?: return
 

--- a/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
@@ -29,13 +29,13 @@ enum {{resolveName}}{{#if external.dart.converter}}_internal{{/if}} {
 
 // {{resolveName}} "private" section, not exported.
 
-int {{resolveName "Ffi"}}_toFfi({{resolveName}} value{{#if external.dart.converter}}_ext{{/if}}) {
+int {{resolveName "Ffi"}}_toFfi({{resolveName this "" "ref"}} value{{#if external.dart.converter}}_ext{{/if}}) {
 {{#if external.dart.converter}}
   final value = {{external.dart.converter}}.convertToInternal(value_ext);
 {{/if}}
   switch (value) {
 {{#set parent=this}}{{#enumerators}}
-  case {{resolveName parent}}{{#if external.dart.converter}}_internal{{/if}}.{{resolveName}}:
+  case {{resolveName parent "" "ref"}}{{#if external.dart.converter}}_internal{{/if}}.{{resolveName}}:
     return {{value}};
   break;
 {{/enumerators}}{{/set}}
@@ -44,14 +44,14 @@ int {{resolveName "Ffi"}}_toFfi({{resolveName}} value{{#if external.dart.convert
   }
 }
 
-{{resolveName}} {{resolveName "Ffi"}}_fromFfi(int handle) {
+{{resolveName this "" "ref"}} {{resolveName "Ffi"}}_fromFfi(int handle) {
   switch (handle) {
 {{#set parent=this}}{{#enumerators}}
   case {{value}}:
 {{#if external.dart.converter}}
     return {{external.dart.converter}}.convertFromInternal({{resolveName parent}}_internal.{{resolveName}});
 {{/if}}{{#unless external.dart.converter}}
-    return {{resolveName parent}}.{{resolveName}};
+    return {{resolveName parent "" "ref"}}.{{resolveName}};
 {{/unless}}
   break;
 {{/enumerators}}{{/set}}

--- a/gluecodium/src/main/resources/templates/dart/DartNullableTypeConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartNullableTypeConversion.mustache
@@ -31,7 +31,7 @@ final _{{resolveName "Ffi"}}_get_value_nullable = __lib.nativeLibrary.lookupFunc
     {{resolveName "FfiDartTypes"}} Function(Pointer<Void>)
   >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_get_value_nullable');
 
-Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}} value) {
+Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName this "" "ref"}} value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = {{resolveName "Ffi"}}_toFfi(value);
   final result = _{{resolveName "Ffi"}}_create_handle_nullable(_handle);
@@ -39,7 +39,7 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}} value) {
   return result;
 }
 
-{{resolveName}} {{resolveName "Ffi"}}_fromFfi_nullable(Pointer<Void> handle) {
+{{resolveName this "" "ref"}} {{resolveName "Ffi"}}_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _{{resolveName "Ffi"}}_get_value_nullable(handle);
   final result = {{resolveName "Ffi"}}_fromFfi(_handle);

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -39,7 +39,7 @@ class {{resolveName}}{{#if external.dart.converter}}_internal{{/if}} {
 {{#if constructors}}  {{resolveName}}{{#if constructors}}._copy{{/if}}({{resolveName}} _other) : {{!!
 }}this._({{#fields}}_other.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{/if}}{{#unless constructors}}{{#if initializedFields}}
-  {{#if attributes.immutable}}const {{/if}}{{resolveName}}.withDefaults({{!!
+  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}_internal{{/if}}.withDefaults({{!!
   }}{{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}})
     : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{#if defaultValue}}{{resolveName defaultValue}}{{/if}}{{!!
     }}{{#unless defaultValue}}{{resolveName}}{{/unless}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
@@ -93,7 +93,7 @@ final _{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}} = __lib.nati
   >('{{libraryName}}_{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}}');
 {{/fields}}{{/set}}
 
-Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value{{#if external.dart.converter}}_ext{{/if}}) {
+Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName this "" "ref"}} value{{#if external.dart.converter}}_ext{{/if}}) {
 {{#if external.dart.converter}}
   final value = {{external.dart.converter}}.convertToInternal(value_ext);
 {{/if}}
@@ -107,7 +107,7 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value{{#if external.da
   return _result;
 }
 
-{{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
+{{resolveName this "" "ref"}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
 {{#set parent=this}}{{#fields}}
   final _{{resolveName}}_handle = _{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}}(handle);
 {{/fields}}{{/set}}
@@ -118,7 +118,7 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value{{#if external.da
 {{/fields}}    );
     return {{external.dart.converter}}.convertFromInternal(result_internal);
 {{/if}}{{#unless external.dart.converter}}
-    return {{resolveName}}{{#if constructors}}._{{/if}}({{#fields}}
+    return {{resolveName this "" "ref"}}{{#if constructors}}._{{/if}}({{#fields}}
       {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle){{#if iter.hasNext}}, {{/if}}
     {{/fields}});
 {{/unless}}

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/NameResolverHelperTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/NameResolverHelperTest.kt
@@ -200,4 +200,35 @@ class NameResolverHelperTest {
 
         verify(exactly = 0) { options.append(any()) }
     }
+
+    @Test
+    fun executeThreeParametersRefSubKey() {
+        parameters.add(genericElement)
+        parameters.add("nonsense")
+        parameters.add("ref")
+        helper.nameResolvers["nonsense"] = object : NameResolver {
+            override fun resolveName(element: Any) = throw IllegalArgumentException()
+            override fun resolveReferenceName(element: Any) =
+                if (element === genericElement) "baz" else "fizz"
+        }
+
+        helper.execute(options)
+
+        verify(exactly = 1) { options.append("baz") }
+    }
+
+    @Test
+    fun executeThreeParametersRefSubKeyReturnsNull() {
+        parameters.add(genericElement)
+        parameters.add("nonsense")
+        parameters.add("ref")
+        helper.nameResolvers["nonsense"] = object : NameResolver {
+            override fun resolveName(element: Any) = throw IllegalArgumentException()
+            override fun resolveReferenceName(element: Any): String? = null
+        }
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.append(any()) }
+    }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/input/DartExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/DartExternalTypes.lime
@@ -50,7 +50,7 @@ struct DartColor {
     red: Float
     green: Float
     blue: Float
-    alpha: Float
+    alpha: Float = 0
 }
 
 @Dart("String")

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
@@ -1,5 +1,5 @@
-import 'dart:math';
-import 'package:foo/bar.dart';
+import 'dart:math' as math;
+import 'package:foo/bar.dart' as bar;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/date_interval.dart';
@@ -296,7 +296,7 @@ final _ListOf_smoke_Rectangle_iterator_get = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_ListOf_smoke_Rectangle_iterator_get');
-Pointer<Void> ListOf_smoke_Rectangle_toFfi(List<Rectangle<int>> value) {
+Pointer<Void> ListOf_smoke_Rectangle_toFfi(List<math.Rectangle<int>> value) {
   final _result = _ListOf_smoke_Rectangle_create_handle();
   for (final element in value) {
     final _element_handle = smoke_Rectangle_toFfi(element);
@@ -305,8 +305,8 @@ Pointer<Void> ListOf_smoke_Rectangle_toFfi(List<Rectangle<int>> value) {
   }
   return _result;
 }
-List<Rectangle<int>> ListOf_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
-  final result = List<Rectangle<int>>();
+List<math.Rectangle<int>> ListOf_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
+  final result = List<math.Rectangle<int>>();
   final _iterator_handle = _ListOf_smoke_Rectangle_iterator(handle);
   while (_ListOf_smoke_Rectangle_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _ListOf_smoke_Rectangle_iterator_get(_iterator_handle);
@@ -333,14 +333,14 @@ final _ListOf_smoke_Rectangle_get_value_nullable = __lib.nativeLibrary.lookupFun
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_ListOf_smoke_Rectangle_get_value_nullable');
-Pointer<Void> ListOf_smoke_Rectangle_toFfi_nullable(List<Rectangle<int>> value) {
+Pointer<Void> ListOf_smoke_Rectangle_toFfi_nullable(List<math.Rectangle<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = ListOf_smoke_Rectangle_toFfi(value);
   final result = _ListOf_smoke_Rectangle_create_handle_nullable(_handle);
   ListOf_smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
-List<Rectangle<int>> ListOf_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
+List<math.Rectangle<int>> ListOf_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _ListOf_smoke_Rectangle_get_value_nullable(handle);
   final result = ListOf_smoke_Rectangle_fromFfi(_handle);
@@ -385,7 +385,7 @@ final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_value = __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_value');
-Pointer<Void> MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi(Map<HttpClientResponseCompressionState, Rectangle<int>> value) {
+Pointer<Void> MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi(Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> value) {
   final _result = _MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle();
   for (final entry in value.entries) {
     final _key_handle = smoke_CompressionState_toFfi(entry.key);
@@ -396,8 +396,8 @@ Pointer<Void> MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi(Map<HttpClie
   }
   return _result;
 }
-Map<HttpClientResponseCompressionState, Rectangle<int>> MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
-  final result = Map<HttpClientResponseCompressionState, Rectangle<int>>();
+Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
+  final result = Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>>();
   final _iterator_handle = _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator(handle);
   while (_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_key(_iterator_handle);
@@ -427,14 +427,14 @@ final _MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable = __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable');
-Pointer<Void> MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi_nullable(Map<HttpClientResponseCompressionState, Rectangle<int>> value) {
+Pointer<Void> MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi_nullable(Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi(value);
   final result = _MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle_nullable(_handle);
   MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
-Map<HttpClientResponseCompressionState, Rectangle<int>> MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
+Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable(handle);
   final result = MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi(_handle);
@@ -654,7 +654,7 @@ final _SetOf_smoke_Rectangle_iterator_get = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_SetOf_smoke_Rectangle_iterator_get');
-Pointer<Void> SetOf_smoke_Rectangle_toFfi(Set<Rectangle<int>> value) {
+Pointer<Void> SetOf_smoke_Rectangle_toFfi(Set<math.Rectangle<int>> value) {
   final _result = _SetOf_smoke_Rectangle_create_handle();
   for (final element in value) {
     final _element_handle = smoke_Rectangle_toFfi(element);
@@ -663,8 +663,8 @@ Pointer<Void> SetOf_smoke_Rectangle_toFfi(Set<Rectangle<int>> value) {
   }
   return _result;
 }
-Set<Rectangle<int>> SetOf_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
-  final result = Set<Rectangle<int>>();
+Set<math.Rectangle<int>> SetOf_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
+  final result = Set<math.Rectangle<int>>();
   final _iterator_handle = _SetOf_smoke_Rectangle_iterator(handle);
   while (_SetOf_smoke_Rectangle_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _SetOf_smoke_Rectangle_iterator_get(_iterator_handle);
@@ -691,14 +691,14 @@ final _SetOf_smoke_Rectangle_get_value_nullable = __lib.nativeLibrary.lookupFunc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_SetOf_smoke_Rectangle_get_value_nullable');
-Pointer<Void> SetOf_smoke_Rectangle_toFfi_nullable(Set<Rectangle<int>> value) {
+Pointer<Void> SetOf_smoke_Rectangle_toFfi_nullable(Set<math.Rectangle<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = SetOf_smoke_Rectangle_toFfi(value);
   final result = _SetOf_smoke_Rectangle_create_handle_nullable(_handle);
   SetOf_smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
-Set<Rectangle<int>> SetOf_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
+Set<math.Rectangle<int>> SetOf_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _SetOf_smoke_Rectangle_get_value_nullable(handle);
   final result = SetOf_smoke_Rectangle_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
@@ -1,34 +1,34 @@
-import 'package:foo/bar.dart';
+import 'package:foo/bar.dart' as bar;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 // HttpClientResponseCompressionState "private" section, not exported.
-int smoke_CompressionState_toFfi(HttpClientResponseCompressionState value) {
+int smoke_CompressionState_toFfi(bar.HttpClientResponseCompressionState value) {
   switch (value) {
-  case HttpClientResponseCompressionState.compressed:
+  case bar.HttpClientResponseCompressionState.compressed:
     return 0;
   break;
-  case HttpClientResponseCompressionState.decompressed:
+  case bar.HttpClientResponseCompressionState.decompressed:
     return 1;
   break;
-  case HttpClientResponseCompressionState.notCompressed:
+  case bar.HttpClientResponseCompressionState.notCompressed:
     return 2;
   break;
   default:
     throw StateError("Invalid enum value $value for HttpClientResponseCompressionState enum.");
   }
 }
-HttpClientResponseCompressionState smoke_CompressionState_fromFfi(int handle) {
+bar.HttpClientResponseCompressionState smoke_CompressionState_fromFfi(int handle) {
   switch (handle) {
   case 0:
-    return HttpClientResponseCompressionState.compressed;
+    return bar.HttpClientResponseCompressionState.compressed;
   break;
   case 1:
-    return HttpClientResponseCompressionState.decompressed;
+    return bar.HttpClientResponseCompressionState.decompressed;
   break;
   case 2:
-    return HttpClientResponseCompressionState.notCompressed;
+    return bar.HttpClientResponseCompressionState.notCompressed;
   break;
   default:
     throw StateError("Invalid numeric value $handle for HttpClientResponseCompressionState enum.");
@@ -47,14 +47,14 @@ final _smoke_CompressionState_get_value_nullable = __lib.nativeLibrary.lookupFun
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CompressionState_get_value_nullable');
-Pointer<Void> smoke_CompressionState_toFfi_nullable(HttpClientResponseCompressionState value) {
+Pointer<Void> smoke_CompressionState_toFfi_nullable(bar.HttpClientResponseCompressionState value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CompressionState_toFfi(value);
   final result = _smoke_CompressionState_create_handle_nullable(_handle);
   smoke_CompressionState_releaseFfiHandle(_handle);
   return result;
 }
-HttpClientResponseCompressionState smoke_CompressionState_fromFfi_nullable(Pointer<Void> handle) {
+bar.HttpClientResponseCompressionState smoke_CompressionState_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_CompressionState_get_value_nullable(handle);
   final result = smoke_CompressionState_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
@@ -10,6 +10,8 @@ class int_internal {
   double blue;
   double alpha;
   int_internal(this.red, this.green, this.blue, this.alpha);
+  int_internal.withDefaults(double red, double green, double blue)
+    : red = red, green = green, blue = blue, alpha = 0;
 }
 // int "private" section, not exported.
 final _smoke_DartColor_create_handle = __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
@@ -1,4 +1,4 @@
-import 'dart:math';
+import 'dart:math' as math;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -29,7 +29,7 @@ final _smoke_Rectangle_get_field_height = __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Rectangle_get_field_height');
-Pointer<Void> smoke_Rectangle_toFfi(Rectangle<int> value) {
+Pointer<Void> smoke_Rectangle_toFfi(math.Rectangle<int> value) {
   final _left_handle = (value.left);
   final _top_handle = (value.top);
   final _width_handle = (value.width);
@@ -41,13 +41,13 @@ Pointer<Void> smoke_Rectangle_toFfi(Rectangle<int> value) {
   (_height_handle);
   return _result;
 }
-Rectangle<int> smoke_Rectangle_fromFfi(Pointer<Void> handle) {
+math.Rectangle<int> smoke_Rectangle_fromFfi(Pointer<Void> handle) {
   final _left_handle = _smoke_Rectangle_get_field_left(handle);
   final _top_handle = _smoke_Rectangle_get_field_top(handle);
   final _width_handle = _smoke_Rectangle_get_field_width(handle);
   final _height_handle = _smoke_Rectangle_get_field_height(handle);
   try {
-    return Rectangle<int>(
+    return math.Rectangle<int>(
       (_left_handle),
       (_top_handle),
       (_width_handle),
@@ -74,14 +74,14 @@ final _smoke_Rectangle_get_value_nullable = __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Rectangle_get_value_nullable');
-Pointer<Void> smoke_Rectangle_toFfi_nullable(Rectangle<int> value) {
+Pointer<Void> smoke_Rectangle_toFfi_nullable(math.Rectangle<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Rectangle_toFfi(value);
   final result = _smoke_Rectangle_create_handle_nullable(_handle);
   smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
-Rectangle<int> smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
+math.Rectangle<int> smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Rectangle_get_value_nullable(handle);
   final result = smoke_Rectangle_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -1,5 +1,5 @@
-import 'dart:math';
-import 'package:foo/bar.dart';
+import 'dart:math' as math;
+import 'package:foo/bar.dart' as bar;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/smoke/http_client_response_compression_state.dart';
 import 'package:library/src/smoke/int.dart';
@@ -15,8 +15,8 @@ abstract class UseDartExternalTypes {
   /// Call this to free memory when you no longer need this instance.
   /// Note that setting the instance to null will not destroy the underlying native object.
   void release();
-  static Rectangle<int> rectangleRoundTrip(Rectangle<int> input) => UseDartExternalTypes$Impl.rectangleRoundTrip(input);
-  static HttpClientResponseCompressionState compressionStateRoundTrip(HttpClientResponseCompressionState input) => UseDartExternalTypes$Impl.compressionStateRoundTrip(input);
+  static math.Rectangle<int> rectangleRoundTrip(math.Rectangle<int> input) => UseDartExternalTypes$Impl.rectangleRoundTrip(input);
+  static bar.HttpClientResponseCompressionState compressionStateRoundTrip(bar.HttpClientResponseCompressionState input) => UseDartExternalTypes$Impl.compressionStateRoundTrip(input);
   static int colorRoundTrip(int input) => UseDartExternalTypes$Impl.colorRoundTrip(input);
   static String seasonRoundTrip(String input) => UseDartExternalTypes$Impl.seasonRoundTrip(input);
 }
@@ -44,7 +44,7 @@ class UseDartExternalTypes$Impl implements UseDartExternalTypes {
     _smoke_UseDartExternalTypes_release_handle(handle);
     handle = null;
   }
-  static Rectangle<int> rectangleRoundTrip(Rectangle<int> input) {
+  static math.Rectangle<int> rectangleRoundTrip(math.Rectangle<int> input) {
     final _rectangleRoundTrip_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_rectangleRoundTrip__Rectangle');
     final _input_handle = smoke_Rectangle_toFfi(input);
     final __result_handle = _rectangleRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
@@ -55,7 +55,7 @@ class UseDartExternalTypes$Impl implements UseDartExternalTypes {
       smoke_Rectangle_releaseFfiHandle(__result_handle);
     }
   }
-  static HttpClientResponseCompressionState compressionStateRoundTrip(HttpClientResponseCompressionState input) {
+  static bar.HttpClientResponseCompressionState compressionStateRoundTrip(bar.HttpClientResponseCompressionState input) {
     final _compressionStateRoundTrip_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_compressionStateRoundTrip__CompressionState');
     final _input_handle = smoke_CompressionState_toFfi(input);
     final __result_handle = _compressionStateRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);


### PR DESCRIPTION
Updated DartImportResolver to add import aliases to imports for external
types. Updated DartNameResolver to use these import aliases for type
references to external types.

Added new "ref" subkey to NameResolverHelper template helper to allow
resolving type names as if they were type references.

Updated Dart templates to use "ref" subkey to resolve type names for
conversion functions.

Resolves: #446
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>