### PR TITLE
Fix resolution of Java fully-qualified names

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaTypeMapper.kt
@@ -154,21 +154,21 @@ class JavaTypeMapper(
 
     fun mapCustomType(limeType: LimeType): JavaTypeRef {
         val externalImport = limeType.external?.java?.get(NAME_NAME)
-        val javaPackage = externalImport?.let { JavaPackage(emptyList()) }
-            ?: basePackage.createChildPackage(limeType.path.head)
-        val classNames = externalImport?.let {
-            JavaNameRules.getPackageFromImportString(it) +
-                    JavaNameRules.getClassNamesFromImportString(it)
-        } ?: nameResolver.getClassNames(limeType)
+        val javaPackage = externalImport?.let {
+            JavaPackage(JavaNameRules.getPackageFromImportString(it))
+        } ?: basePackage.createChildPackage(limeType.path.head)
+        val classNames = externalImport?.let { JavaNameRules.getClassNamesFromImportString(it) }
+            ?: nameResolver.getClassNames(limeType)
 
         val javaImport =
             if (externalImport == null) JavaImport(classNames.first(), javaPackage) else null
-        val typeName = classNames.joinToString(".")
+        val packagePrefix = if (externalImport != null) javaPackage.packageNames else emptyList()
+        val fullName = (packagePrefix + classNames).joinToString(".")
         return when (limeType) {
             is LimeEnumeration ->
-                JavaEnumTypeRef(typeName, classNames, javaPackage.packageNames, javaImport)
+                JavaEnumTypeRef(fullName, classNames, javaPackage.packageNames, javaImport)
             else -> JavaCustomTypeRef(
-                typeName,
+                fullName,
                 listOfNotNull(javaImport).toSet(),
                 classNames,
                 javaPackage.packageNames

--- a/gluecodium/src/test/resources/smoke/external_types/input/JavaExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/JavaExternalTypes.lime
@@ -78,4 +78,14 @@ class UseJavaExternalTypes {
     static fun monthRoundTrip(input: Month): Month
     static fun colorRoundTrip(input: SystemColor): SystemColor
     static fun seasonRoundTrip(input: Season): Season
+
+    static fun structRoundTrip(input: JavaExternalTypesStruct): JavaExternalTypesStruct
+}
+
+struct JavaExternalTypesStruct {
+    currency: Currency
+    timeZone: TimeZone
+    month: Month
+    color: SystemColor
+    season: Season
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/UseJavaExternalTypes.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/UseJavaExternalTypes.java
@@ -28,4 +28,6 @@ public final class UseJavaExternalTypes extends NativeBase {
     public static native java.lang.Integer colorRoundTrip(@NonNull final java.lang.Integer input);
     @NonNull
     public static native java.lang.String seasonRoundTrip(@NonNull final java.lang.String input);
+    @NonNull
+    public static native JavaExternalTypesStruct structRoundTrip(@NonNull final JavaExternalTypesStruct input);
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_JavaExternalTypesStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_JavaExternalTypesStruct__Conversion.cpp
@@ -1,0 +1,74 @@
+/*
+ *
+ */
+#include "java_util_Currency__Conversion.h"
+#include "java_util_SimpleTimeZone__Conversion.h"
+#include "java_time_Month__Conversion.h"
+#include "java_lang_Integer__Conversion.h"
+#include "java_lang_String__Conversion.h"
+#include "com_example_smoke_JavaExternalTypesStruct__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+namespace gluecodium
+{
+namespace jni
+{
+::smoke::JavaExternalTypesStruct
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::JavaExternalTypesStruct*)
+{
+    ::smoke::Currency n_currency = convert_from_jni(
+        _jenv,
+        ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "currency", "Ljava/util/Currency;"),
+        (::smoke::Currency*)nullptr );
+    ::smoke::TimeZone n_time_zone = convert_from_jni(
+        _jenv,
+        ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "timeZone", "Ljava/util/SimpleTimeZone;"),
+        (::smoke::TimeZone*)nullptr );
+    ::smoke::Month n_month = convert_from_jni(
+        _jenv,
+        ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "month", "Ljava/time/Month;"),
+        (::smoke::Month*)nullptr );
+    ::smoke::SystemColor n_color = convert_from_jni(
+        _jenv,
+        ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "color", "Ljava/lang/Integer;"),
+        (::smoke::SystemColor*)nullptr );
+    ::smoke::Season n_season = convert_from_jni(
+        _jenv,
+        ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "season", "Ljava/lang/String;"),
+        (::smoke::Season*)nullptr );
+    return ::smoke::JavaExternalTypesStruct(std::move(n_currency), std::move(n_time_zone), std::move(n_month), std::move(n_color), std::move(n_season));
+}
+::gluecodium::optional<::smoke::JavaExternalTypesStruct>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<::smoke::JavaExternalTypesStruct>*)
+{
+    return _jinput
+        ? ::gluecodium::optional<::smoke::JavaExternalTypesStruct>(convert_from_jni(_jenv, _jinput, (::smoke::JavaExternalTypesStruct*)nullptr))
+        : ::gluecodium::optional<::smoke::JavaExternalTypesStruct>{};
+}
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/JavaExternalTypesStruct", com_example_smoke_JavaExternalTypesStruct, ::smoke::JavaExternalTypesStruct)
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::JavaExternalTypesStruct& _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::JavaExternalTypesStruct>::java_class;
+    auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+    auto jcurrency = convert_to_jni(_jenv, _ninput.currency);
+    ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "currency", "Ljava/util/Currency;", jcurrency);
+    auto jtime_zone = convert_to_jni(_jenv, _ninput.time_zone);
+    ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "timeZone", "Ljava/util/SimpleTimeZone;", jtime_zone);
+    auto jmonth = convert_to_jni(_jenv, _ninput.month);
+    ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "month", "Ljava/time/Month;", jmonth);
+    auto jcolor = convert_to_jni(_jenv, _ninput.color);
+    ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "color", "Ljava/lang/Integer;", jcolor);
+    auto jseason = convert_to_jni(_jenv, _ninput.season);
+    ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "season", "Ljava/lang/String;", jseason);
+    return _jresult;
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<::smoke::JavaExternalTypesStruct> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+}
+}


### PR DESCRIPTION
Updated JavaTypeMapper to fill in fully-qualified names for type
references to external types only into "fullName" field, but not in
"classNames" fields. Previous implementation of placing FQNs into
"classNames" was incorrect and led to JNI bugs.

Added "struct with external type fields" use case to smoke tests to
close the testing gap that should have revealed this issue earlier.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>