### PR TITLE
Add support for platform-specific deprecation messages

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -209,6 +209,9 @@
         <option name="TAB_SIZE" value="2" />
       </indentOptions>
     </codeStyleSettings>
+    <codeStyleSettings language="Markdown">
+      <option name="RIGHT_MARGIN" value="120" />
+    </codeStyleSettings>
     <codeStyleSettings language="ObjectiveC">
       <option name="RIGHT_MARGIN" value="80" />
       <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
@@ -588,6 +591,7 @@
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+      <option name="RIGHT_MARGIN" value="120" />
     </codeStyleSettings>
     <codeStyleSettings language="protobuf">
       <option name="RIGHT_MARGIN" value="80" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for platform-specific inline tags in `@Deprecated` deprecation messages.
+
 ## 8.0.1
 Release date: 2020-07-29
 ### Bug fixes:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -480,7 +480,8 @@ was an interim tool for manually ensuring referential equality (which is now ens
 Please note that this attribute is not supported for interfaces.
 * **@Serializable**: marks a struct type as serializable.
 * **@Deprecated(**\[**Message** **=**\] **"**_DeprecationMessage_**"**__)__: marks an element as
-deprecated, takes a string literal value as a deprecation message.
+deprecated, takes a string literal value as a deprecation message. Platform-specific inline tags are supported for
+deprecation messages (see `Platform-specific comments` below for syntax).
 * **@Cached**: marks a property to be cached on platform side (i.e. read from C++ only once on first
 access and cached in Java/Swift/Dart afterwards). Currently only supported for read-only properties.
 * **@Java**: marks an element with Java-specific behaviors:

--- a/gluecodium/src/main/resources/templates/cpp/CppDocComment.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppDocComment.mustache
@@ -22,7 +22,7 @@
 /**{{#unless comment.isEmpty}}{{#resolveName comment}}
 {{prefix this " * "}}{{/resolveName}}{{/unless}}{{!!
 }}{{#if attributes.deprecated}}
- * \deprecated {{#attributes.deprecated.message}}{{#resolveName this}}{{!!
-}}{{prefix this " * " skipFirstLine=true}}{{/resolveName}}{{/attributes.deprecated.message}}{{/if}}
+ * \deprecated {{#resolveName attributes.deprecated.message}}{{!!
+}}{{prefix this " * " skipFirstLine=true}}{{/resolveName}}{{/if}}
  */
 {{/ifPredicate}}

--- a/gluecodium/src/main/resources/templates/cpp/CppFieldDoc.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppFieldDoc.mustache
@@ -22,8 +22,8 @@
 /**{{#unless comment.isEmpty}}{{#resolveName comment}}
 {{prefix this " * "}}{{/resolveName}}{{/unless}}{{!!
 }}{{#if attributes.deprecated}}
- * \deprecated {{#attributes.deprecated.message}}{{#resolveName this}}{{!!
-}}{{prefix this " * " skipFirstLine=true}}{{/resolveName}}{{/attributes.deprecated.message}}{{/if}}
+ * \deprecated {{#resolveName attributes.deprecated.message}}{{!!
+}}{{prefix this " * " skipFirstLine=true}}{{/resolveName}}{{/if}}
 {{#ifPredicate typeRef "needsNotNullComment"}}
  * \warning @NotNull
 {{/ifPredicate}}

--- a/gluecodium/src/main/resources/templates/cpp/CppFunctionDoc.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppFunctionDoc.mustache
@@ -25,7 +25,7 @@
 {{/ifPredicate}}{{!!
 
 }}{{+combinedComment}}{{resolveName comment}}{{#if attributes.deprecated}}
-\deprecated {{#attributes.deprecated.message}}{{resolveName this}}{{/attributes.deprecated.message}}{{/if}}{{!!
+\deprecated {{resolveName attributes.deprecated.message}}{{/if}}{{!!
 }}{{#parameters}}
 \param[in] {{resolveName}} {{#ifPredicate typeRef "needsNotNullComment"}}@NotNull {{/ifPredicate}}{{!!
 }}{{#resolveName comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{/parameters}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartDocumentation.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartDocumentation.mustache
@@ -24,5 +24,5 @@
 /// @nodoc
 {{/if}}{{!!
 }}{{#if attributes.deprecated}}
-@Deprecated("{{#attributes.deprecated.message}}{{#resolveName this}}{{escape this}}{{/resolveName}}{{/attributes.deprecated.message}}")
+@Deprecated("{{#resolveName attributes.deprecated.message}}{{escape this}}{{/resolveName}}")
 {{/if}}

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
@@ -28,5 +28,5 @@
 }}{{#if visibility.isInternal}}
 /// @nodoc{{/if}}{{!!
 }}{{#if attributes.deprecated}}
-@Deprecated("{{#attributes.deprecated.message}}{{#resolveName this}}{{escape this}}{{/resolveName}}{{/attributes.deprecated.message}}")
+@Deprecated("{{#resolveName attributes.deprecated.message}}{{escape this}}{{/resolveName}}")
 {{/if}}

--- a/gluecodium/src/test/resources/smoke/comments/input/PlatformComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/PlatformComments.lime
@@ -39,6 +39,9 @@ class PlatformComments {
     // @throws Sometimes it happens{@Swift  but not on iOS [SomethingWrong] \\esc\@pe\{s\} }.
     fun someMethodWithAllComments(input: String): Boolean throws SomethingWrong
 
+    @Deprecated("A very {@Cpp useful}{@Java @Dart useless}{@Swift awesome} method that is deprecated.")
+    fun someDeprecatedMethod()
+
     // This is a{@Cpp @Java  very}{@Java @Swift  super}{@Swift @Cpp  useful}{@Cpp @Java @Swift  struct}.
     struct something {
         nothing: String

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/PlatformComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/PlatformComments.java
@@ -61,4 +61,10 @@ public final class PlatformComments extends NativeBase {
      * @throws PlatformComments.SomethingWrongException <p>Sometimes it happens.</p>
      */
     public native boolean someMethodWithAllComments(@NonNull final String input) throws PlatformComments.SomethingWrongException;
+    /**
+     *
+     * @deprecated <p>A very useless method that is deprecated.</p>
+     */
+    @Deprecated
+    public native void someDeprecatedMethod();
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/PlatformComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/PlatformComments.h
@@ -45,6 +45,11 @@ public:
      * \retval ::smoke::PlatformComments::SomeEnum Sometimes it happens.
      */
     virtual ::gluecodium::Return< bool, ::std::error_code > some_method_with_all_comments( const ::std::string& input ) = 0;
+    /**
+     *
+     * \deprecated A very useful method that is deprecated.
+     */
+    virtual void some_deprecated_method(  ) = 0;
 };
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::PlatformComments::SomeEnum value ) noexcept;
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -19,6 +19,8 @@ abstract class PlatformComments {
   /// Returns [bool]. Uselessness [PlatformComments_SomeEnum] of the input
   /// Throws [PlatformComments_SomethingWrongException]. Sometimes it happens.
   bool someMethodWithAllComments(String input);
+  @Deprecated("A very useless method that is deprecated.")
+  someDeprecatedMethod();
 }
 enum PlatformComments_SomeEnum {
     useless,
@@ -233,6 +235,17 @@ class PlatformComments$Impl implements PlatformComments {
       return Boolean_fromFfi(__result_handle);
     } finally {
       Boolean_releaseFfiHandle(__result_handle);
+    }
+  }
+  @override
+  someDeprecatedMethod() {
+    final _someDeprecatedMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_someDeprecatedMethod');
+    final _handle = this.handle;
+    final __result_handle = _someDeprecatedMethod_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/PlatformComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/PlatformComments.lime
@@ -22,4 +22,6 @@ class PlatformComments {
     fun someMethodWithAllComments(
         input: String
     ): Boolean throws SomethingWrong
+    @Deprecated("A very {@Cpp useful}{@Java useless}{@Dart useless}{@Swift awesome} method that is deprecated.")
+    fun someDeprecatedMethod()
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
@@ -50,6 +50,11 @@ public class PlatformComments {
             return moveFromCType(RESULT.returned_value)
         }
     }
+    ///
+    @available(*, deprecated, message: "A very awesome method that is deprecated.")
+    public func someDeprecatedMethod() -> Void {
+        return moveFromCType(smoke_PlatformComments_someDeprecatedMethod(self.c_instance))
+    }
 }
 internal func getRef(_ ref: PlatformComments?, owning: Bool = true) -> RefHolder {
     guard let c_handle = ref?.c_instance else {

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -20,8 +20,6 @@
 package com.here.gluecodium.loader
 
 import com.here.gluecodium.antlr.LimeParser
-import com.here.gluecodium.antlr.LimedocLexer
-import com.here.gluecodium.antlr.LimedocParser
 import com.here.gluecodium.common.ModelBuilderContextStack
 import com.here.gluecodium.model.lime.LimeAmbiguousEnumeratorRef
 import com.here.gluecodium.model.lime.LimeAmbiguousTypeRef
@@ -55,11 +53,8 @@ import com.here.gluecodium.model.lime.LimeValue
 import com.here.gluecodium.model.lime.LimeValue.Special.ValueId
 import com.here.gluecodium.model.lime.LimeVisibility
 import java.util.LinkedList
-import org.antlr.v4.runtime.CharStreams
-import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.ParserRuleContext
 import org.antlr.v4.runtime.misc.ParseCancellationException
-import org.antlr.v4.runtime.tree.ParseTreeWalker
 
 internal class AntlrLimeModelBuilder(
     private val referenceResolver: LimeReferenceResolver,
@@ -679,7 +674,7 @@ internal class AntlrLimeModelBuilder(
         commentContexts: List<LimeParser.DocCommentContext>,
         ctx: ParserRuleContext
     ): LimeStructuredComment {
-        val commentString = commentContexts.joinToString(separator = "\n") { it ->
+        val commentString = commentContexts.joinToString(separator = "\n") {
             when {
                 it.DelimitedCommentOpen() != null ->
                     it.DelimitedCommentText()?.text?.dropLast(2) ?: ""
@@ -689,15 +684,7 @@ internal class AntlrLimeModelBuilder(
             }
         }.trimIndent().split('\n').joinToString("\n") { line -> line.trimEnd() }
 
-        val lexer = LimedocLexer(CharStreams.fromString(commentString))
-        val parser = LimedocParser(CommonTokenStream(lexer))
-        parser.removeErrorListeners()
-        parser.addErrorListener(ThrowingErrorListener(ctx.getStart().line - 1))
-
-        val builder = AntlrLimedocBuilder(currentPath)
-        ParseTreeWalker.DEFAULT.walk(builder, parser.documentation())
-
-        return builder.result
+        return AntlrLimeConverter.parseStructuredComment(commentString, ctx.getStart().line, currentPath)
     }
 
     private fun parseExternalDescriptor(


### PR DESCRIPTION
Updated AntlrLimeModelBuilder to parse `@Deprecated` messages with LimeDoc
parser, similar to regular comments, thus adding support for platform-specific
inline tags (e.g. `{@Java }`).

Updated C++ and Dart templates that render the deprecation message to be less
verbose (this is a refactoring with no change in functionality).

Added a new use case to "comments" smoke test to test for platform-specific
inline tags in deprecation messages.

Resolves: #447
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>