### PR TITLE
Don't generate @Equatable support for external types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Features:
   * Added support for platform-specific inline tags in `@Deprecated` deprecation messages.
+### Bug fixes:
+  * Equality support code is no longer generated for "external" types in Java, Swift, and Dart.
 
 ## 8.0.1
 Release date: 2020-07-29

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -343,7 +343,7 @@ names are case-insensitive. Supported platform tags:
     * **converterImport**: specifies a relative import path for a Dart `import` directive
     needed for the pre-existing converter class (i.e. `"<path>/<file_name>.dart"`).
 * **Note:** the following features of struct types cannot be combined with "external" behavior:
-custom constructors, field default values, `@Equatable`.
+custom constructors, field default values.
 * **Note:** the way of specifying the name of the external type to use varies slightly between
 output languages. For C++ and Java it needs to be a fully-qualified name and it is specified through
 `cpp name "..."` and `java name "..."` values of the external descriptor. For Swift and Dart a

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
@@ -50,7 +50,8 @@ internal class DartImportResolver(
     fun resolveDeclarationImports(limeElement: LimeElement): List<DartImport> =
         when {
             limeElement is LimeLambda -> listOf(tokenCacheImport)
-            limeElement is LimeStruct && limeElement.attributes.have(LimeAttributeType.EQUATABLE) ->
+            limeElement is LimeStruct && limeElement.external?.dart == null &&
+                    limeElement.attributes.have(LimeAttributeType.EQUATABLE) ->
                 listOf(collectionSystemImport, collectionPackageImport)
             limeElement is LimeInterface ->
                 listOf(builtInTypesConversionImport, typeRepositoryImport, tokenCacheImport)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaModelBuilder.kt
@@ -192,7 +192,7 @@ class JavaModelBuilder(
             methods = methods,
             constants = getPreviousResults(JavaConstant::class.java),
             isParcelable = isSerializable,
-            isEquatable = limeStruct.attributes.have(LimeAttributeType.EQUATABLE),
+            isEquatable = !hasConverter && limeStruct.attributes.have(LimeAttributeType.EQUATABLE),
             isImmutable = limeStruct.attributes.have(LimeAttributeType.IMMUTABLE),
             needsBuilder = limeStruct.attributes.have(JAVA, BUILDER),
             generatedConstructorComment = limeStruct.constructorComment.getFor(PLATFORM_TAG),

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -54,7 +54,7 @@ class {{resolveName}}{{#if external.dart.converter}}_internal{{/if}} {
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
 {{prefixPartial "dart/DartFunction" "  "}}
 {{/functions}}{{/set}}
-{{#if attributes.equatable}}
+{{#if attributes.equatable}}{{#unless external.dart.converter}}
   @override
   bool operator ==(dynamic other) {
     if (identical(this, other)) return true;
@@ -72,7 +72,7 @@ class {{resolveName}}{{#if external.dart.converter}}_internal{{/if}} {
 {{/fields}}
     return result;
   }
-{{/if}}
+{{/unless}}{{/if}}
 }
 {{/unlessPredicate}}
 

--- a/gluecodium/src/main/resources/templates/swift/Struct.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Struct.mustache
@@ -19,9 +19,10 @@
   !
   !}}
 {{#unless skipDeclaration}}{{>swift/Comment}}
-{{visibility}} struct {{simpleName}}{{#if externalConverter}}_internal{{/if}}{{#if isEquatable isCodable logic="or"}}{{!!
+{{visibility}} struct {{simpleName}}{{#if externalConverter}}_internal{{/if}}{{#unless externalConverter}}{{!!
+}}{{#if isEquatable isCodable logic="or"}}{{!!
 }}:{{#if isEquatable}} Hashable{{/if}}{{#if isEquatable isCodable logic="and"}},{{/if}}{{#if isCodable}} Codable{{/if}}{{!!
-}}{{/if}} {
+}}{{/if}}{{/unless}} {
 {{#constants}}
 {{prefixPartial "swift/Constant" "    "}}
 {{/constants}}{{!!

--- a/gluecodium/src/test/resources/smoke/external_types/input/DartExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/DartExternalTypes.lime
@@ -41,6 +41,7 @@ enum CompressionState {
 }
 
 @Dart("int")
+@Equatable
 struct DartColor {
     external {
        dart converterImport "../color_converter.dart"

--- a/gluecodium/src/test/resources/smoke/external_types/input/JavaExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/JavaExternalTypes.lime
@@ -48,6 +48,7 @@ enum Month {
     MARCH
 }
 
+@Equatable
 struct SystemColor {
     external {
         java name "java.lang.Integer"

--- a/gluecodium/src/test/resources/smoke/external_types/input/SwiftExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/SwiftExternalTypes.lime
@@ -37,6 +37,7 @@ enum Persistence {
     permanent
 }
 
+@Equatable
 struct PseudoColor {
     external {
         swift framework ""


### PR DESCRIPTION
Updated Java model as well as Swift and Dart templates to avoid generating code
supporting `@Equatable` for structs that are declared "external" for that
language. If the pre-existing type being used is "equatable" on its own, it will
work without any additional generated code.

Added `@Equatable` to existing use cases of "external types" smoke tests to make
sure no additional code is generated.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>