### PR TITLE
Fix Swift memory leaks

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,14 +86,14 @@ jobs:
       addons:
         apt:
           packages:
-            - libcurl3
+            - libcurl4
             - ninja-build
             - valgrind
       install:
         - source ./scripts/install-cmake.sh
-        - SWIFT_BRANCH=swift-5.1.3-release
-        - SWIFT_VERSION=swift-5.1.3-RELEASE
-        - SWIFT_PLATFORM=ubuntu16.04
+        - SWIFT_BRANCH=swift-5.2.5-release
+        - SWIFT_VERSION=swift-5.2.5-RELEASE
+        - SWIFT_PLATFORM=ubuntu18.04
         - SWIFT_ARCHIVE_NAME=${SWIFT_VERSION}-${SWIFT_PLATFORM}
         - SWIFT_URL=https://swift.org/builds/${SWIFT_BRANCH}/$(echo "${SWIFT_PLATFORM}" | tr -d .)/${SWIFT_VERSION}/${SWIFT_ARCHIVE_NAME}.tar.gz
         - CMAKE_VERSION=3.15.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Features
   * Updated method stubs generated "stubs" mode of Java generator to uncondionally throw `RuntimeException`.
+### Bug fixes:
+  * Fixed several memory leaks in Swift.
 
 ## 8.1.0
 Release date: 2020-08-11

--- a/cmake/modules/gluecodium/swift/Test.cmake
+++ b/cmake/modules/gluecodium/swift/Test.cmake
@@ -79,6 +79,7 @@ function(apigen_swift_test target)
       -L$<TARGET_FILE_DIR:${target}>
       -I$<TARGET_FILE_DIR:${target}>
       -l${target}
+      -lstdc++
       "${swift_link_libraries}"
       -enable-testing
       -Xlinker -rpath -Xlinker "'$$ORIGIN'")

--- a/examples/scripts/valgrind_suppressions
+++ b/examples/scripts/valgrind_suppressions
@@ -33,6 +33,16 @@
    fun:*
 }
 {
+   getGenericMetadata2
+
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znam
+   fun:swift_allocateGenericClassMetadata
+   fun:swift_getGenericMetadata
+   fun:*
+}
+{
    getTupleTypeMetadata
 
    Memcheck:Leak
@@ -94,9 +104,8 @@
 
    Memcheck:Cond
    fun:swift_initStructMetadata
+   fun:$s*
    ...
-   fun:_ZN5swift22MetadataCacheEntryBaseIN12_GLOBAL__N_117GenericCacheEntryEJPKvEE16doInitializationERNS_18ConcurrencyControlEPNS_28MetadataCompletionQueueEntryENS_15MetadataRequestE
-   fun:*
 }
 {
    relocateClassMetadata
@@ -157,5 +166,57 @@
    fun:_Znam
    fun:_ZN5swift17MetadataAllocator8AllocateEmm
    fun:swift_getWitnessTable
+   fun:*
+}
+{
+   invalid read in std::shared_ptr
+
+   Memcheck:Addr8
+   ...
+   fun:_ZNSt12__shared_ptr*
+   fun:*
+}
+{
+   invalid read 1 in std::string
+
+   Memcheck:Addr1
+   ...
+   fun:_ZNSt7__cxx1112basic_string*
+   fun:*
+}
+{
+   invalid read 2 in std::string
+
+   Memcheck:Addr2
+   ...
+   fun:_ZNSt7__cxx1112basic_string*
+   fun:*
+}
+{
+   invalid read 8 in std::string
+
+   Memcheck:Addr8
+   fun:_ZN*St7__cxx1112basic_string*
+   fun:*
+}
+{
+   invalid read 16 in std::string
+
+   Memcheck:Addr16
+   fun:_ZNSt7__cxx1112basic_string*
+   fun:*
+}
+{
+   invalid read 1 in std::hash
+
+   Memcheck:Addr1
+   fun:_ZSt11_Hash_bytesPKvmm
+   fun:*
+}
+{
+   invalid read 1 in OptionalBase
+
+   Memcheck:Addr1
+   fun:_ZN11lorem_ipsum4test12OptionalBase*
    fun:*
 }

--- a/gluecodium/src/main/resources/swift/BuiltinConversions.swift
+++ b/gluecodium/src/main/resources/swift/BuiltinConversions.swift
@@ -255,7 +255,11 @@ internal func copyToCType(_ swiftType: Locale?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    return RefHolder(locale_create_optional_handle(copyToCType(swiftType).ref))
+    let handle = copyToCType(swiftType).ref
+    defer {
+        locale_release_handle(handle)
+    }
+    return RefHolder(locale_create_optional_handle(handle))
 }
 
 internal func moveToCType(_ swiftType: Locale?) -> RefHolder {

--- a/gluecodium/src/main/resources/templates/cbridge/LocaleHandle.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/LocaleHandle.mustache
@@ -120,8 +120,6 @@ _baseRef
 locale_unwrap_optional_handle(_baseRef handle)
 {
     return reinterpret_cast<_baseRef>(
-        new (std::nothrow) {{>common/InternalNamespace}}Locale(
-            **reinterpret_cast<{{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>*>(handle)
-        )
+        &**reinterpret_cast<{{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>*>(handle)
     );
 }

--- a/gluecodium/src/main/resources/templates/swift/ClassConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ClassConversion.mustache
@@ -99,6 +99,7 @@ internal func {{mangledName}}moveFromCType(_ handle: _baseRef) -> {{name}} {
 {{/if}}
     if let swift_pointer = {{cInstance}}_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? {{name}} {
+        {{cInstance}}_release_handle(handle)
         return re_constructed
     }
 {{#if hasTypeRepository}}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/swift/smoke/BasicTypes.swift
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/swift/smoke/BasicTypes.swift
@@ -86,6 +86,7 @@ internal func BasicTypes_copyFromCType(_ handle: _baseRef) -> BasicTypes {
 internal func BasicTypes_moveFromCType(_ handle: _baseRef) -> BasicTypes {
     if let swift_pointer = smoke_BasicTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? BasicTypes {
+        smoke_BasicTypes_release_handle(handle)
         return re_constructed
     }
     let result = BasicTypes(cBasicTypes: handle)

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -165,6 +165,7 @@ internal func Comments_copyFromCType(_ handle: _baseRef) -> Comments {
 internal func Comments_moveFromCType(_ handle: _baseRef) -> Comments {
     if let swift_pointer = smoke_Comments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Comments {
+        smoke_Comments_release_handle(handle)
         return re_constructed
     }
     let result = Comments(cComments: handle)

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsInterface.swift
@@ -221,6 +221,7 @@ internal func CommentsInterface_moveFromCType(_ handle: _baseRef) -> CommentsInt
     }
     if let swift_pointer = smoke_CommentsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CommentsInterface {
+        smoke_CommentsInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_CommentsInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
@@ -114,6 +114,7 @@ internal func CommentsLinks_copyFromCType(_ handle: _baseRef) -> CommentsLinks {
 internal func CommentsLinks_moveFromCType(_ handle: _baseRef) -> CommentsLinks {
     if let swift_pointer = smoke_CommentsLinks_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CommentsLinks {
+        smoke_CommentsLinks_release_handle(handle)
         return re_constructed
     }
     let result = CommentsLinks(cCommentsLinks: handle)

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationComments.swift
@@ -121,6 +121,7 @@ internal func DeprecationComments_moveFromCType(_ handle: _baseRef) -> Deprecati
     }
     if let swift_pointer = smoke_DeprecationComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DeprecationComments {
+        smoke_DeprecationComments_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_DeprecationComments_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationCommentsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationCommentsOnly.swift
@@ -110,6 +110,7 @@ internal func DeprecationCommentsOnly_moveFromCType(_ handle: _baseRef) -> Depre
     }
     if let swift_pointer = smoke_DeprecationCommentsOnly_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DeprecationCommentsOnly {
+        smoke_DeprecationCommentsOnly_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_DeprecationCommentsOnly_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/LongComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/LongComments.swift
@@ -49,6 +49,7 @@ internal func LongComments_copyFromCType(_ handle: _baseRef) -> LongComments {
 internal func LongComments_moveFromCType(_ handle: _baseRef) -> LongComments {
     if let swift_pointer = smoke_LongComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LongComments {
+        smoke_LongComments_release_handle(handle)
         return re_constructed
     }
     let result = LongComments(cLongComments: handle)

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MultiLineComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MultiLineComments.swift
@@ -70,6 +70,7 @@ internal func MultiLineComments_copyFromCType(_ handle: _baseRef) -> MultiLineCo
 internal func MultiLineComments_moveFromCType(_ handle: _baseRef) -> MultiLineComments {
     if let swift_pointer = smoke_MultiLineComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MultiLineComments {
+        smoke_MultiLineComments_release_handle(handle)
         return re_constructed
     }
     let result = MultiLineComments(cMultiLineComments: handle)

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
@@ -80,6 +80,7 @@ internal func PlatformComments_copyFromCType(_ handle: _baseRef) -> PlatformComm
 internal func PlatformComments_moveFromCType(_ handle: _baseRef) -> PlatformComments {
     if let swift_pointer = smoke_PlatformComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PlatformComments {
+        smoke_PlatformComments_release_handle(handle)
         return re_constructed
     }
     let result = PlatformComments(cPlatformComments: handle)

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/UnicodeComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/UnicodeComments.swift
@@ -51,6 +51,7 @@ internal func UnicodeComments_copyFromCType(_ handle: _baseRef) -> UnicodeCommen
 internal func UnicodeComments_moveFromCType(_ handle: _baseRef) -> UnicodeComments {
     if let swift_pointer = smoke_UnicodeComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UnicodeComments {
+        smoke_UnicodeComments_release_handle(handle)
         return re_constructed
     }
     let result = UnicodeComments(cUnicodeComments: handle)

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/CollectionConstants.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/CollectionConstants.swift
@@ -42,6 +42,7 @@ internal func CollectionConstants_copyFromCType(_ handle: _baseRef) -> Collectio
 internal func CollectionConstants_moveFromCType(_ handle: _baseRef) -> CollectionConstants {
     if let swift_pointer = smoke_CollectionConstants_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CollectionConstants {
+        smoke_CollectionConstants_release_handle(handle)
         return re_constructed
     }
     let result = CollectionConstants(cCollectionConstants: handle)

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/ConstantsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/ConstantsInterface.swift
@@ -49,6 +49,7 @@ internal func ConstantsInterface_copyFromCType(_ handle: _baseRef) -> ConstantsI
 internal func ConstantsInterface_moveFromCType(_ handle: _baseRef) -> ConstantsInterface {
     if let swift_pointer = smoke_ConstantsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ConstantsInterface {
+        smoke_ConstantsInterface_release_handle(handle)
         return re_constructed
     }
     let result = ConstantsInterface(cConstantsInterface: handle)

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/StructConstants.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/StructConstants.swift
@@ -61,6 +61,7 @@ internal func StructConstants_copyFromCType(_ handle: _baseRef) -> StructConstan
 internal func StructConstants_moveFromCType(_ handle: _baseRef) -> StructConstants {
     if let swift_pointer = smoke_StructConstants_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructConstants {
+        smoke_StructConstants_release_handle(handle)
         return re_constructed
     }
     let result = StructConstants(cStructConstants: handle)

--- a/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/ChildConstructors.swift
+++ b/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/ChildConstructors.swift
@@ -52,6 +52,7 @@ internal func ChildConstructors_copyFromCType(_ handle: _baseRef) -> ChildConstr
 internal func ChildConstructors_moveFromCType(_ handle: _baseRef) -> ChildConstructors {
     if let swift_pointer = smoke_ChildConstructors_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildConstructors {
+        smoke_ChildConstructors_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ChildConstructors_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/Constructors.swift
+++ b/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/Constructors.swift
@@ -116,6 +116,7 @@ internal func Constructors_copyFromCType(_ handle: _baseRef) -> Constructors {
 internal func Constructors_moveFromCType(_ handle: _baseRef) -> Constructors {
     if let swift_pointer = smoke_Constructors_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Constructors {
+        smoke_Constructors_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_Constructors_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/Dates.swift
+++ b/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/Dates.swift
@@ -63,6 +63,7 @@ internal func Dates_copyFromCType(_ handle: _baseRef) -> Dates {
 internal func Dates_moveFromCType(_ handle: _baseRef) -> Dates {
     if let swift_pointer = smoke_Dates_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Dates {
+        smoke_Dates_release_handle(handle)
         return re_constructed
     }
     let result = Dates(cDates: handle)

--- a/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/DefaultValues.swift
+++ b/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/DefaultValues.swift
@@ -174,6 +174,7 @@ internal func DefaultValues_copyFromCType(_ handle: _baseRef) -> DefaultValues {
 internal func DefaultValues_moveFromCType(_ handle: _baseRef) -> DefaultValues {
     if let swift_pointer = smoke_DefaultValues_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DefaultValues {
+        smoke_DefaultValues_release_handle(handle)
         return re_constructed
     }
     let result = DefaultValues(cDefaultValues: handle)

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/Enums.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/Enums.swift
@@ -76,6 +76,7 @@ internal func Enums_copyFromCType(_ handle: _baseRef) -> Enums {
 internal func Enums_moveFromCType(_ handle: _baseRef) -> Enums {
     if let swift_pointer = smoke_Enums_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Enums {
+        smoke_Enums_release_handle(handle)
         return re_constructed
     }
     let result = Enums(cEnums: handle)

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumsInTypeCollectionInterface.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumsInTypeCollectionInterface.swift
@@ -42,6 +42,7 @@ internal func EnumsInTypeCollectionInterface_copyFromCType(_ handle: _baseRef) -
 internal func EnumsInTypeCollectionInterface_moveFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface {
     if let swift_pointer = smoke_EnumsInTypeCollectionInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EnumsInTypeCollectionInterface {
+        smoke_EnumsInTypeCollectionInterface_release_handle(handle)
         return re_constructed
     }
     let result = EnumsInTypeCollectionInterface(cEnumsInTypeCollectionInterface: handle)

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableClass.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableClass.swift
@@ -64,6 +64,7 @@ internal func EquatableClass_copyFromCType(_ handle: _baseRef) -> EquatableClass
 internal func EquatableClass_moveFromCType(_ handle: _baseRef) -> EquatableClass {
     if let swift_pointer = smoke_EquatableClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableClass {
+        smoke_EquatableClass_release_handle(handle)
         return re_constructed
     }
     let result = EquatableClass(cEquatableClass: handle)

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableInterface.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableInterface.swift
@@ -81,6 +81,7 @@ internal func EquatableInterface_moveFromCType(_ handle: _baseRef) -> EquatableI
     }
     if let swift_pointer = smoke_EquatableInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableInterface {
+        smoke_EquatableInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_EquatableInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/PointerEquatableClass.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/PointerEquatableClass.swift
@@ -46,6 +46,7 @@ internal func PointerEquatableClass_copyFromCType(_ handle: _baseRef) -> Pointer
 internal func PointerEquatableClass_moveFromCType(_ handle: _baseRef) -> PointerEquatableClass {
     if let swift_pointer = smoke_PointerEquatableClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PointerEquatableClass {
+        smoke_PointerEquatableClass_release_handle(handle)
         return re_constructed
     }
     let result = PointerEquatableClass(cPointerEquatableClass: handle)

--- a/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/Errors.swift
+++ b/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/Errors.swift
@@ -83,6 +83,7 @@ internal func Errors_copyFromCType(_ handle: _baseRef) -> Errors {
 internal func Errors_moveFromCType(_ handle: _baseRef) -> Errors {
     if let swift_pointer = smoke_Errors_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Errors {
+        smoke_Errors_release_handle(handle)
         return re_constructed
     }
     let result = Errors(cErrors: handle)

--- a/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/ErrorsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/ErrorsInterface.swift
@@ -165,6 +165,7 @@ internal func ErrorsInterface_moveFromCType(_ handle: _baseRef) -> ErrorsInterfa
     }
     if let swift_pointer = smoke_ErrorsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ErrorsInterface {
+        smoke_ErrorsInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ErrorsInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Class.swift
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Class.swift
@@ -75,6 +75,7 @@ internal func Class_copyFromCType(_ handle: _baseRef) -> Class {
 internal func Class_moveFromCType(_ handle: _baseRef) -> Class {
     if let swift_pointer = package_Class_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Class {
+        package_Class_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = package_Class_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Interface.swift
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Interface.swift
@@ -68,6 +68,7 @@ internal func Interface_moveFromCType(_ handle: _baseRef) -> Interface {
     }
     if let swift_pointer = package_Interface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Interface {
+        package_Interface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = package_Interface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Enums.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Enums.swift
@@ -50,6 +50,7 @@ internal func Enums_copyFromCType(_ handle: _baseRef) -> Enums {
 internal func Enums_moveFromCType(_ handle: _baseRef) -> Enums {
     if let swift_pointer = smoke_Enums_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Enums {
+        smoke_Enums_release_handle(handle)
         return re_constructed
     }
     let result = Enums(cEnums: handle)

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalClass.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalClass.swift
@@ -59,6 +59,7 @@ internal func ExternalClass_copyFromCType(_ handle: _baseRef) -> ExternalClass {
 internal func ExternalClass_moveFromCType(_ handle: _baseRef) -> ExternalClass {
     if let swift_pointer = smoke_ExternalClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExternalClass {
+        smoke_ExternalClass_release_handle(handle)
         return re_constructed
     }
     let result = ExternalClass(cExternalClass: handle)

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalInterface.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalInterface.swift
@@ -87,6 +87,7 @@ internal func ExternalInterface_moveFromCType(_ handle: _baseRef) -> ExternalInt
     }
     if let swift_pointer = smoke_ExternalInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExternalInterface {
+        smoke_ExternalInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ExternalInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Structs.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Structs.swift
@@ -71,6 +71,7 @@ internal func Structs_copyFromCType(_ handle: _baseRef) -> Structs {
 internal func Structs_moveFromCType(_ handle: _baseRef) -> Structs {
     if let swift_pointer = smoke_Structs_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Structs {
+        smoke_Structs_release_handle(handle)
         return re_constructed
     }
     let result = Structs(cStructs: handle)

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UseSwiftExternalTypes.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UseSwiftExternalTypes.swift
@@ -55,6 +55,7 @@ internal func UseSwiftExternalTypes_copyFromCType(_ handle: _baseRef) -> UseSwif
 internal func UseSwiftExternalTypes_moveFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes {
     if let swift_pointer = smoke_UseSwiftExternalTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UseSwiftExternalTypes {
+        smoke_UseSwiftExternalTypes_release_handle(handle)
         return re_constructed
     }
     let result = UseSwiftExternalTypes(cUseSwiftExternalTypes: handle)

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithBasicTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithBasicTypes.swift
@@ -107,6 +107,7 @@ internal func GenericTypesWithBasicTypes_copyFromCType(_ handle: _baseRef) -> Ge
 internal func GenericTypesWithBasicTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes {
     if let swift_pointer = smoke_GenericTypesWithBasicTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithBasicTypes {
+        smoke_GenericTypesWithBasicTypes_release_handle(handle)
         return re_constructed
     }
     let result = GenericTypesWithBasicTypes(cGenericTypesWithBasicTypes: handle)

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithCompoundTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithCompoundTypes.swift
@@ -96,6 +96,7 @@ internal func GenericTypesWithCompoundTypes_copyFromCType(_ handle: _baseRef) ->
 internal func GenericTypesWithCompoundTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes {
     if let swift_pointer = smoke_GenericTypesWithCompoundTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithCompoundTypes {
+        smoke_GenericTypesWithCompoundTypes_release_handle(handle)
         return re_constructed
     }
     let result = GenericTypesWithCompoundTypes(cGenericTypesWithCompoundTypes: handle)

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithGenericTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithGenericTypes.swift
@@ -66,6 +66,7 @@ internal func GenericTypesWithGenericTypes_copyFromCType(_ handle: _baseRef) -> 
 internal func GenericTypesWithGenericTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes {
     if let swift_pointer = smoke_GenericTypesWithGenericTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithGenericTypes {
+        smoke_GenericTypesWithGenericTypes_release_handle(handle)
         return re_constructed
     }
     let result = GenericTypesWithGenericTypes(cGenericTypesWithGenericTypes: handle)

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromClass.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromClass.swift
@@ -38,6 +38,7 @@ internal func ChildClassFromClass_copyFromCType(_ handle: _baseRef) -> ChildClas
 internal func ChildClassFromClass_moveFromCType(_ handle: _baseRef) -> ChildClassFromClass {
     if let swift_pointer = smoke_ChildClassFromClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromClass {
+        smoke_ChildClassFromClass_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ChildClassFromClass_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromInterface.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromInterface.swift
@@ -61,6 +61,7 @@ internal func ChildClassFromInterface_copyFromCType(_ handle: _baseRef) -> Child
 internal func ChildClassFromInterface_moveFromCType(_ handle: _baseRef) -> ChildClassFromInterface {
     if let swift_pointer = smoke_ChildClassFromInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromInterface {
+        smoke_ChildClassFromInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ChildClassFromInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildInterface.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildInterface.swift
@@ -102,6 +102,7 @@ internal func ChildInterface_moveFromCType(_ handle: _baseRef) -> ChildInterface
     }
     if let swift_pointer = smoke_ChildInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildInterface {
+        smoke_ChildInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ChildInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalChild.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalChild.swift
@@ -35,6 +35,7 @@ internal func InternalChild_copyFromCType(_ handle: _baseRef) -> InternalChild {
 internal func InternalChild_moveFromCType(_ handle: _baseRef) -> InternalChild {
     if let swift_pointer = smoke_InternalChild_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalChild {
+        smoke_InternalChild_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_InternalChild_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalParent.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalParent.swift
@@ -46,6 +46,7 @@ internal func InternalParent_copyFromCType(_ handle: _baseRef) -> InternalParent
 internal func InternalParent_moveFromCType(_ handle: _baseRef) -> InternalParent {
     if let swift_pointer = smoke_InternalParent_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalParent {
+        smoke_InternalParent_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_InternalParent_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleClass.swift
+++ b/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleClass.swift
@@ -45,6 +45,7 @@ internal func SimpleClass_copyFromCType(_ handle: _baseRef) -> SimpleClass {
 internal func SimpleClass_moveFromCType(_ handle: _baseRef) -> SimpleClass {
     if let swift_pointer = smoke_SimpleClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SimpleClass {
+        smoke_SimpleClass_release_handle(handle)
         return re_constructed
     }
     let result = SimpleClass(cSimpleClass: handle)

--- a/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleInterface.swift
+++ b/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleInterface.swift
@@ -85,6 +85,7 @@ internal func SimpleInterface_moveFromCType(_ handle: _baseRef) -> SimpleInterfa
     }
     if let swift_pointer = smoke_SimpleInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SimpleInterface {
+        smoke_SimpleInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_SimpleInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
@@ -54,6 +54,7 @@ internal func Lambdas_copyFromCType(_ handle: _baseRef) -> Lambdas {
 internal func Lambdas_moveFromCType(_ handle: _baseRef) -> Lambdas {
     if let swift_pointer = smoke_Lambdas_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Lambdas {
+        smoke_Lambdas_release_handle(handle)
         return re_constructed
     }
     let result = Lambdas(cLambdas: handle)

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasInterface.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasInterface.swift
@@ -78,6 +78,7 @@ internal func LambdasInterface_moveFromCType(_ handle: _baseRef) -> LambdasInter
     }
     if let swift_pointer = smoke_LambdasInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LambdasInterface {
+        smoke_LambdasInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_LambdasInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
@@ -48,6 +48,7 @@ internal func LambdasWithStructuredTypes_copyFromCType(_ handle: _baseRef) -> La
 internal func LambdasWithStructuredTypes_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes {
     if let swift_pointer = smoke_LambdasWithStructuredTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LambdasWithStructuredTypes {
+        smoke_LambdasWithStructuredTypes_release_handle(handle)
         return re_constructed
     }
     let result = LambdasWithStructuredTypes(cLambdasWithStructuredTypes: handle)

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Calculator.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Calculator.swift
@@ -46,6 +46,7 @@ internal func Calculator_copyFromCType(_ handle: _baseRef) -> Calculator {
 internal func Calculator_moveFromCType(_ handle: _baseRef) -> Calculator {
     if let swift_pointer = smoke_Calculator_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Calculator {
+        smoke_Calculator_release_handle(handle)
         return re_constructed
     }
     let result = Calculator(cCalculator: handle)

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/CalculatorListener.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/CalculatorListener.swift
@@ -123,6 +123,7 @@ internal func CalculatorListener_moveFromCType(_ handle: _baseRef) -> Calculator
     }
     if let swift_pointer = smoke_CalculatorListener_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CalculatorListener {
+        smoke_CalculatorListener_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_CalculatorListener_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenerWithProperties.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenerWithProperties.swift
@@ -195,6 +195,7 @@ internal func ListenerWithProperties_moveFromCType(_ handle: _baseRef) -> Listen
     }
     if let swift_pointer = smoke_ListenerWithProperties_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerWithProperties {
+        smoke_ListenerWithProperties_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ListenerWithProperties_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenersWithReturnValues.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenersWithReturnValues.swift
@@ -125,6 +125,7 @@ internal func ListenersWithReturnValues_moveFromCType(_ handle: _baseRef) -> Lis
     }
     if let swift_pointer = smoke_ListenersWithReturnValues_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenersWithReturnValues {
+        smoke_ListenersWithReturnValues_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ListenersWithReturnValues_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/Locales.swift
+++ b/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/Locales.swift
@@ -63,6 +63,7 @@ internal func Locales_copyFromCType(_ handle: _baseRef) -> Locales {
 internal func Locales_moveFromCType(_ handle: _baseRef) -> Locales {
     if let swift_pointer = smoke_Locales_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Locales {
+        smoke_Locales_release_handle(handle)
         return re_constructed
     }
     let result = Locales(cLocales: handle)

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/MethodOverloads.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/MethodOverloads.swift
@@ -94,6 +94,7 @@ internal func MethodOverloads_copyFromCType(_ handle: _baseRef) -> MethodOverloa
 internal func MethodOverloads_moveFromCType(_ handle: _baseRef) -> MethodOverloads {
     if let swift_pointer = smoke_MethodOverloads_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MethodOverloads {
+        smoke_MethodOverloads_release_handle(handle)
         return re_constructed
     }
     let result = MethodOverloads(cMethodOverloads: handle)

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SpecialNames.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SpecialNames.swift
@@ -50,6 +50,7 @@ internal func SpecialNames_copyFromCType(_ handle: _baseRef) -> SpecialNames {
 internal func SpecialNames_moveFromCType(_ handle: _baseRef) -> SpecialNames {
     if let swift_pointer = smoke_SpecialNames_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SpecialNames {
+        smoke_SpecialNames_release_handle(handle)
         return re_constructed
     }
     let result = SpecialNames(cSpecialNames: handle)

--- a/gluecodium/src/test/resources/smoke/name_rules/output/swift/namerules/INameRules.swift
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/swift/namerules/INameRules.swift
@@ -103,6 +103,7 @@ internal func INameRules_copyFromCType(_ handle: _baseRef) -> INameRules {
 internal func INameRules_moveFromCType(_ handle: _baseRef) -> INameRules {
     if let swift_pointer = namerules_NameRules_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? INameRules {
+        namerules_NameRules_release_handle(handle)
         return re_constructed
     }
     let result = INameRules(cINameRules: handle)

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/LevelOne.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/LevelOne.swift
@@ -84,6 +84,7 @@ internal func LevelOne_copyFromCType(_ handle: _baseRef) -> LevelOne {
 internal func LevelOne_moveFromCType(_ handle: _baseRef) -> LevelOne {
     if let swift_pointer = smoke_LevelOne_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne {
+        smoke_LevelOne_release_handle(handle)
         return re_constructed
     }
     let result = LevelOne(cLevelOne: handle)
@@ -138,6 +139,7 @@ internal func LevelOne_LevelTwo_copyFromCType(_ handle: _baseRef) -> LevelOne.Le
 internal func LevelOne_LevelTwo_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo {
     if let swift_pointer = smoke_LevelOne_LevelTwo_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne.LevelTwo {
+        smoke_LevelOne_LevelTwo_release_handle(handle)
         return re_constructed
     }
     let result = LevelOne.LevelTwo(cLevelTwo: handle)
@@ -192,6 +194,7 @@ internal func LevelOne_LevelTwo_LevelThree_copyFromCType(_ handle: _baseRef) -> 
 internal func LevelOne_LevelTwo_LevelThree_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree {
     if let swift_pointer = smoke_LevelOne_LevelTwo_LevelThree_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne.LevelTwo.LevelThree {
+        smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle)
         return re_constructed
     }
     let result = LevelOne.LevelTwo.LevelThree(cLevelThree: handle)

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/NestedReferences.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/NestedReferences.swift
@@ -52,6 +52,7 @@ internal func NestedReferences_copyFromCType(_ handle: _baseRef) -> NestedRefere
 internal func NestedReferences_moveFromCType(_ handle: _baseRef) -> NestedReferences {
     if let swift_pointer = smoke_NestedReferences_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? NestedReferences {
+        smoke_NestedReferences_release_handle(handle)
         return re_constructed
     }
     let result = NestedReferences(cNestedReferences: handle)

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClass.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClass.swift
@@ -79,6 +79,7 @@ internal func OuterClass_copyFromCType(_ handle: _baseRef) -> OuterClass {
 internal func OuterClass_moveFromCType(_ handle: _baseRef) -> OuterClass {
     if let swift_pointer = smoke_OuterClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass {
+        smoke_OuterClass_release_handle(handle)
         return re_constructed
     }
     let result = OuterClass(cOuterClass: handle)
@@ -133,6 +134,7 @@ internal func OuterClass_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterCl
 internal func OuterClass_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterClass.InnerClass {
     if let swift_pointer = smoke_OuterClass_InnerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerClass {
+        smoke_OuterClass_InnerClass_release_handle(handle)
         return re_constructed
     }
     let result = OuterClass.InnerClass(cInnerClass: handle)
@@ -219,6 +221,7 @@ internal func OuterClass_InnerInterface_moveFromCType(_ handle: _baseRef) -> Out
     }
     if let swift_pointer = smoke_OuterClass_InnerInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerInterface {
+        smoke_OuterClass_InnerInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_OuterClass_InnerInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterInterface.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterInterface.swift
@@ -77,6 +77,7 @@ internal func OuterInterface_moveFromCType(_ handle: _baseRef) -> OuterInterface
     }
     if let swift_pointer = smoke_OuterInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterInterface {
+        smoke_OuterInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_OuterInterface_get_typed(handle),
@@ -151,6 +152,7 @@ internal func InnerClass_copyFromCType(_ handle: _baseRef) -> InnerClass {
 internal func InnerClass_moveFromCType(_ handle: _baseRef) -> InnerClass {
     if let swift_pointer = smoke_OuterInterface_InnerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerClass {
+        smoke_OuterInterface_InnerClass_release_handle(handle)
         return re_constructed
     }
     let result = InnerClass(cInnerClass: handle)
@@ -257,6 +259,7 @@ internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface
     }
     if let swift_pointer = smoke_OuterInterface_InnerInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
+        smoke_OuterInterface_InnerInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_OuterInterface_InnerInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/UseFreeTypes.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/UseFreeTypes.swift
@@ -48,6 +48,7 @@ internal func UseFreeTypes_copyFromCType(_ handle: _baseRef) -> UseFreeTypes {
 internal func UseFreeTypes_moveFromCType(_ handle: _baseRef) -> UseFreeTypes {
     if let swift_pointer = smoke_UseFreeTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UseFreeTypes {
+        smoke_UseFreeTypes_release_handle(handle)
         return re_constructed
     }
     let result = UseFreeTypes(cUseFreeTypes: handle)

--- a/gluecodium/src/test/resources/smoke/nullable/output/swift/smoke/Nullable.swift
+++ b/gluecodium/src/test/resources/smoke/nullable/output/swift/smoke/Nullable.swift
@@ -246,6 +246,7 @@ internal func Nullable_copyFromCType(_ handle: _baseRef) -> Nullable {
 internal func Nullable_moveFromCType(_ handle: _baseRef) -> Nullable {
     if let swift_pointer = smoke_Nullable_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Nullable {
+        smoke_Nullable_release_handle(handle)
         return re_constructed
     }
     let result = Nullable(cNullable: handle)

--- a/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcChildClass.swift
+++ b/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcChildClass.swift
@@ -36,6 +36,7 @@ internal func ObjcChildClass_copyFromCType(_ handle: _baseRef) -> ObjcChildClass
 internal func ObjcChildClass_moveFromCType(_ handle: _baseRef) -> ObjcChildClass {
     if let swift_pointer = smoke_ObjcChildClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcChildClass {
+        smoke_ObjcChildClass_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ObjcChildClass_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcChildInterface.swift
+++ b/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcChildInterface.swift
@@ -69,6 +69,7 @@ internal func ObjcChildInterface_moveFromCType(_ handle: _baseRef) -> ObjcChildI
     }
     if let swift_pointer = smoke_ObjcChildInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcChildInterface {
+        smoke_ObjcChildInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ObjcChildInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcClass.swift
+++ b/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcClass.swift
@@ -47,6 +47,7 @@ internal func ObjcClass_copyFromCType(_ handle: _baseRef) -> ObjcClass {
 internal func ObjcClass_moveFromCType(_ handle: _baseRef) -> ObjcClass {
     if let swift_pointer = smoke_ObjcClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcClass {
+        smoke_ObjcClass_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ObjcClass_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcImplementerClass.swift
+++ b/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcImplementerClass.swift
@@ -47,6 +47,7 @@ internal func ObjcImplementerClass_copyFromCType(_ handle: _baseRef) -> ObjcImpl
 internal func ObjcImplementerClass_moveFromCType(_ handle: _baseRef) -> ObjcImplementerClass {
     if let swift_pointer = smoke_ObjcImplementerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcImplementerClass {
+        smoke_ObjcImplementerClass_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ObjcImplementerClass_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcInterface.swift
+++ b/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcInterface.swift
@@ -69,6 +69,7 @@ internal func ObjcInterface_moveFromCType(_ handle: _baseRef) -> ObjcInterface {
     }
     if let swift_pointer = smoke_ObjcInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcInterface {
+        smoke_ObjcInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_ObjcInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazInterface.swift
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazInterface.swift
@@ -63,6 +63,7 @@ internal func bazInterface_copyFromCType(_ handle: _baseRef) -> bazInterface {
 internal func bazInterface_moveFromCType(_ handle: _baseRef) -> bazInterface {
     if let swift_pointer = smoke_PlatformNamesInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? bazInterface {
+        smoke_PlatformNamesInterface_release_handle(handle)
         return re_constructed
     }
     let result = bazInterface(cbazInterface: handle)

--- a/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazListener.swift
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazListener.swift
@@ -77,6 +77,7 @@ internal func bazListener_moveFromCType(_ handle: _baseRef) -> bazListener {
     }
     if let swift_pointer = smoke_PlatformNamesListener_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? bazListener {
+        smoke_PlatformNamesListener_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_PlatformNamesListener_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/CachedProperties.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/CachedProperties.swift
@@ -44,6 +44,7 @@ internal func CachedProperties_copyFromCType(_ handle: _baseRef) -> CachedProper
 internal func CachedProperties_moveFromCType(_ handle: _baseRef) -> CachedProperties {
     if let swift_pointer = smoke_CachedProperties_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CachedProperties {
+        smoke_CachedProperties_release_handle(handle)
         return re_constructed
     }
     let result = CachedProperties(cCachedProperties: handle)

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/Properties.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/Properties.swift
@@ -133,6 +133,7 @@ internal func Properties_copyFromCType(_ handle: _baseRef) -> Properties {
 internal func Properties_moveFromCType(_ handle: _baseRef) -> Properties {
     if let swift_pointer = smoke_Properties_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Properties {
+        smoke_Properties_release_handle(handle)
         return re_constructed
     }
     let result = Properties(cProperties: handle)

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/PropertiesInterface.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/PropertiesInterface.swift
@@ -86,6 +86,7 @@ internal func PropertiesInterface_moveFromCType(_ handle: _baseRef) -> Propertie
     }
     if let swift_pointer = smoke_PropertiesInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PropertiesInterface {
+        smoke_PropertiesInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_PropertiesInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipFunctions.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipFunctions.swift
@@ -46,6 +46,7 @@ internal func SkipFunctions_copyFromCType(_ handle: _baseRef) -> SkipFunctions {
 internal func SkipFunctions_moveFromCType(_ handle: _baseRef) -> SkipFunctions {
     if let swift_pointer = smoke_SkipFunctions_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipFunctions {
+        smoke_SkipFunctions_release_handle(handle)
         return re_constructed
     }
     let result = SkipFunctions(cSkipFunctions: handle)

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTypes.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTypes.swift
@@ -56,6 +56,7 @@ internal func SkipTypes_copyFromCType(_ handle: _baseRef) -> SkipTypes {
 internal func SkipTypes_moveFromCType(_ handle: _baseRef) -> SkipTypes {
     if let swift_pointer = smoke_SkipTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipTypes {
+        smoke_SkipTypes_release_handle(handle)
         return re_constructed
     }
     let result = SkipTypes(cSkipTypes: handle)

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/Structs.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/Structs.swift
@@ -177,6 +177,7 @@ internal func Structs_copyFromCType(_ handle: _baseRef) -> Structs {
 internal func Structs_moveFromCType(_ handle: _baseRef) -> Structs {
     if let swift_pointer = smoke_Structs_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Structs {
+        smoke_Structs_release_handle(handle)
         return re_constructed
     }
     let result = Structs(cStructs: handle)

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithConstantsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithConstantsInterface.swift
@@ -55,6 +55,7 @@ internal func StructsWithConstantsInterface_copyFromCType(_ handle: _baseRef) ->
 internal func StructsWithConstantsInterface_moveFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface {
     if let swift_pointer = smoke_StructsWithConstantsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructsWithConstantsInterface {
+        smoke_StructsWithConstantsInterface_release_handle(handle)
         return re_constructed
     }
     let result = StructsWithConstantsInterface(cStructsWithConstantsInterface: handle)

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithMethodsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithMethodsInterface.swift
@@ -102,6 +102,7 @@ internal func StructsWithMethodsInterface_copyFromCType(_ handle: _baseRef) -> S
 internal func StructsWithMethodsInterface_moveFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface {
     if let swift_pointer = smoke_StructsWithMethodsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructsWithMethodsInterface {
+        smoke_StructsWithMethodsInterface_release_handle(handle)
         return re_constructed
     }
     let result = StructsWithMethodsInterface(cStructsWithMethodsInterface: handle)

--- a/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/TypeDefs.swift
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/TypeDefs.swift
@@ -95,6 +95,7 @@ internal func TypeDefs_copyFromCType(_ handle: _baseRef) -> TypeDefs {
 internal func TypeDefs_moveFromCType(_ handle: _baseRef) -> TypeDefs {
     if let swift_pointer = smoke_TypeDefs_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? TypeDefs {
+        smoke_TypeDefs_release_handle(handle)
         return re_constructed
     }
     let result = TypeDefs(cTypeDefs: handle)

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalClass.swift
@@ -38,6 +38,7 @@ internal func InternalClass_copyFromCType(_ handle: _baseRef) -> InternalClass {
 internal func InternalClass_moveFromCType(_ handle: _baseRef) -> InternalClass {
     if let swift_pointer = smoke_InternalClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalClass {
+        smoke_InternalClass_release_handle(handle)
         return re_constructed
     }
     let result = InternalClass(cInternalClass: handle)

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalInterface.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalInterface.swift
@@ -68,6 +68,7 @@ internal func InternalInterface_moveFromCType(_ handle: _baseRef) -> InternalInt
     }
     if let swift_pointer = smoke_InternalInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalInterface {
+        smoke_InternalInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_InternalInterface_get_typed(handle),

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicClass.swift
@@ -101,6 +101,7 @@ internal func PublicClass_copyFromCType(_ handle: _baseRef) -> PublicClass {
 internal func PublicClass_moveFromCType(_ handle: _baseRef) -> PublicClass {
     if let swift_pointer = smoke_PublicClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PublicClass {
+        smoke_PublicClass_release_handle(handle)
         return re_constructed
     }
     let result = PublicClass(cPublicClass: handle)

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicInterface.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicInterface.swift
@@ -68,6 +68,7 @@ internal func PublicInterface_moveFromCType(_ handle: _baseRef) -> PublicInterfa
     }
     if let swift_pointer = smoke_PublicInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PublicInterface {
+        smoke_PublicInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_PublicInterface_get_typed(handle),


### PR DESCRIPTION
Updated Swift version in travis.yaml to 5.2.5 (the latest). Also fixed a
typo in OS version of Swift distribution (was Ubuntu 16.04 instead of
Ubuntu 18.04).

OS version fix in Travis restored valgrind functionality on CI. This
revealed existing real leaks that accumulated while valgrind was
silently broken. Updated Swift templates to fix these leaks. Updated
smoke tests accordingly.

Updated Test.cmake to link Swift executable with stdc++ library, as
required by Swift 5.2.

Added/updated valgrind suppressions. There were new false positives,
caused both by Swift 5.2 on its own and by linking to stdc++.

Resolves: #464
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>