### PR TITLE
Add support for @Swift(Weak) attribute on properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Bug fixes:
   * Fixed Java compilation issue for class constructors with a single `Long` or `ULong` parameter.
   * Fixed compilation issue in Dart caused by `@Dart(Default)` constructors.
+### Features
+  * Added `@Swift(Weak)` attributes for marking properties as `weak` in Swift.
 
 ## 8.1.1
 Release date: 2020-08-13

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -503,6 +503,9 @@ access and cached in Java/Swift/Dart afterwards). Currently only supported for r
   Extending a generated type is also possible, but requires usage of `Name` attribute to avoid name
   clashes on other platforms.
   * **Skip**: marks an element to be skipped (not generated) in Swift.
+  * **Weak**: marks a property in an interface as `weak` in Swift. Property should have a nullable type. Please note
+  that `weak` properties are still represented with "strong" pointers on C++ side. Due to this limitation, if an
+  interface type is used for such property, that interface can only have methods that return nullable values or `void`.
 * **@Dart**: marks an element with Dart-specific behaviors:
   * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in Dart.
   This is the default specification for this attribute.

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -234,6 +234,13 @@ feature(ListenersWithReturnValues cpp android swift dart SOURCES
     lime/test/ListenerInternal.lime
 )
 
+# This is a Swift-only feature
+feature(WeakListeners swift SOURCES
+    src/test/WeakListeners.cpp
+
+    lime/test/WeakListeners.lime
+)
+
 feature(GenericTypes cpp android swift dart SOURCES
     src/hello/HelloWorldArrays.cpp
     src/hello/HelloWorldMaps.cpp

--- a/examples/libhello/lime/test/WeakListeners.lime
+++ b/examples/libhello/lime/test/WeakListeners.lime
@@ -1,0 +1,35 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+interface ListenerInterface {
+    fun notify()
+    fun notifyMaybe(): Boolean?
+}
+
+interface Weakling {
+    @Swift(Weak)
+    property weakListener: ListenerInterface?
+    property strongListener: ListenerInterface?
+}
+
+class WeaklingNotifier {
+    static fun createWeakling(): Weakling
+    static fun pushNotifications(whom: Weakling)
+    static fun pushNotificationMaybe(whom: Weakling): Boolean?
+}

--- a/examples/libhello/src/test/WeakListeners.cpp
+++ b/examples/libhello/src/test/WeakListeners.cpp
@@ -1,0 +1,72 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/ListenerInterface.h"
+#include "test/Weakling.h"
+#include "test/WeaklingNotifier.h"
+
+namespace test
+{
+class WeaklingImpl : public Weakling {
+public:
+    std::shared_ptr<ListenerInterface> get_weak_listener() const override {
+        return m_weak_listener;
+    }
+
+    void set_weak_listener(const std::shared_ptr<ListenerInterface>& value) override {
+        m_weak_listener = value;
+    }
+
+    std::shared_ptr<ListenerInterface> get_strong_listener() const override {
+        return m_strong_listener;
+    }
+
+    void set_strong_listener(const std::shared_ptr<ListenerInterface>& value) override {
+        m_strong_listener = value;
+    }
+
+private:
+    std::shared_ptr<ListenerInterface> m_weak_listener;
+    std::shared_ptr<ListenerInterface> m_strong_listener;
+};
+
+std::shared_ptr<Weakling>
+WeaklingNotifier::create_weakling() {
+    return std::make_shared<WeaklingImpl>();
+}
+
+void
+WeaklingNotifier::push_notifications(const std::shared_ptr<test::Weakling>& whom) {
+    auto weak_listener = whom->get_weak_listener();
+    if (weak_listener) {
+        weak_listener->notify();
+    }
+
+    auto strong_listener = whom->get_strong_listener();
+    if (strong_listener) {
+        strong_listener->notify();
+    }
+}
+
+lorem_ipsum::test::optional<bool>
+WeaklingNotifier::push_notification_maybe(const std::shared_ptr<test::Weakling>& whom) {
+    return whom->get_weak_listener()->notify_maybe();
+}
+}

--- a/examples/platforms/ios/Tests/main.swift
+++ b/examples/platforms/ios/Tests/main.swift
@@ -70,7 +70,8 @@ let allTests = [
     testCase(StructWithConstantsTests.allTests),
     testCase(StructsWithMethodsTests.allTests),
     testCase(StructWithInstanceTests.allTests),
-    testCase(TypeDefTests.allTests)
+    testCase(TypeDefTests.allTests),
+    testCase(WeakListenersTests.allTests)
 ]
 
 XCTMain(allTests)

--- a/examples/platforms/ios/Tests/testTests/WeakListenersTests.swift
+++ b/examples/platforms/ios/Tests/testTests/WeakListenersTests.swift
@@ -1,0 +1,108 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import hello
+
+class WeakListenersTests: XCTestCase {
+
+    static var itHappened = false
+
+    class ListenerImpl: ListenerInterface {
+        func notify() { WeakListenersTests.itHappened = true }
+        func notifyMaybe() -> Bool? { return true }
+    }
+
+    override func setUp() {
+        WeakListenersTests.itHappened = false
+    }
+
+    func testWeaklingIsPushed() {
+        let listener = ListenerImpl()
+        let weakling = WeaklingNotifier.createWeakling()
+        weakling.weakListener = listener
+
+        WeaklingNotifier.pushNotifications(whom: weakling)
+
+        XCTAssertTrue(WeakListenersTests.itHappened)
+    }
+
+    func testWeaklingIsIgnored() {
+        var listener: ListenerInterface? = ListenerImpl()
+        let weakling = WeaklingNotifier.createWeakling()
+        weakling.weakListener = listener
+        listener = nil
+
+        WeaklingNotifier.pushNotifications(whom: weakling)
+
+        XCTAssertFalse(WeakListenersTests.itHappened)
+    }
+
+    func testWeaklingIsPushedStrongly() {
+        let listener = ListenerImpl()
+        let weakling = WeaklingNotifier.createWeakling()
+        weakling.strongListener = listener
+
+        WeaklingNotifier.pushNotifications(whom: weakling)
+
+        XCTAssertTrue(WeakListenersTests.itHappened)
+    }
+
+    func testWeaklingIsNotIgnored() {
+        var listener: ListenerInterface? = ListenerImpl()
+        let weakling = WeaklingNotifier.createWeakling()
+        weakling.strongListener = listener
+        listener = nil
+
+        WeaklingNotifier.pushNotifications(whom: weakling)
+
+        XCTAssertTrue(WeakListenersTests.itHappened)
+    }
+
+    func testWeaklingIsPushedMaybe() {
+        let listener = ListenerImpl()
+        let weakling = WeaklingNotifier.createWeakling()
+        weakling.weakListener = listener
+
+        let result = WeaklingNotifier.pushNotificationMaybe(whom: weakling)
+
+        XCTAssertTrue(result!)
+    }
+
+    func testWeaklingIsIgnoredMaybe() {
+        var listener: ListenerInterface? = ListenerImpl()
+        let weakling = WeaklingNotifier.createWeakling()
+        weakling.weakListener = listener
+        listener = nil
+
+        let result = WeaklingNotifier.pushNotificationMaybe(whom: weakling)
+
+        XCTAssertNil(result)
+    }
+
+    static var allTests = [
+        ("testWeaklingIsPushed", testWeaklingIsPushed),
+        ("testWeaklingIsIgnored", testWeaklingIsIgnored),
+        ("testWeaklingIsPushedStrongly", testWeaklingIsPushedStrongly),
+        ("testWeaklingIsNotIgnored", testWeaklingIsNotIgnored),
+        ("testWeaklingIsPushedMaybe", testWeaklingIsPushedMaybe),
+        ("testWeaklingIsIgnoredMaybe", testWeaklingIsIgnoredMaybe)
+    ]
+}

--- a/examples/scripts/valgrind_suppressions
+++ b/examples/scripts/valgrind_suppressions
@@ -26,19 +26,7 @@
 
    Memcheck:Leak
    match-leak-kinds: possible
-   fun:_Znam
-   fun:_ZN5swift17MetadataAllocator8AllocateEmm
    ...
-   fun:swift_getGenericMetadata
-   fun:*
-}
-{
-   getGenericMetadata2
-
-   Memcheck:Leak
-   match-leak-kinds: possible
-   fun:_Znam
-   fun:swift_allocateGenericClassMetadata
    fun:swift_getGenericMetadata
    fun:*
 }
@@ -163,8 +151,7 @@
 
    Memcheck:Leak
    match-leak-kinds: possible
-   fun:_Znam
-   fun:_ZN5swift17MetadataAllocator8AllocateEmm
+   ...
    fun:swift_getWitnessTable
    fun:*
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
@@ -28,6 +28,7 @@ import com.here.gluecodium.model.lime.LimeAttributeType.EQUATABLE
 import com.here.gluecodium.model.lime.LimeAttributeType.POINTER_EQUATABLE
 import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
 import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeAttributeValueType.WEAK
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeConstant
@@ -159,6 +160,9 @@ class SwiftModelBuilder(
     private fun finishBuildingInterface(limeContainer: LimeInterface) {
         val parentClass =
             limeContainer.parent?.type?.let { buildTransientModel(it).first().classes.first() }
+        val hasWeakSupport = limeReferenceMap.values.filterIsInstance<LimeProperty>()
+            .filter { it.attributes.have(SWIFT, WEAK) }
+            .any { it.typeRef.type.actualType.path.toString() == limeContainer.path.toString() }
         val swiftClass = SwiftClass(
             nestedNames = nameResolver.getNestedNames(limeContainer),
             visibility = getVisibility(limeContainer),
@@ -169,7 +173,8 @@ class SwiftModelBuilder(
             functionTableName = CBridgeNameRules.getFunctionTableName(limeContainer),
             hasEquatableType = limeContainer.attributes.have(EQUATABLE),
             isObjcInterface = limeContainer.attributes.have(SWIFT, LimeAttributeValueType.OBJC),
-            hasTypeRepository = true
+            hasTypeRepository = true,
+            hasWeakSupport = hasWeakSupport
         )
         swiftClass.comment = createComments(limeContainer)
 
@@ -392,7 +397,8 @@ class SwiftModelBuilder(
             getter = getterMethod,
             setter = swiftSetter,
             isStatic = limeProperty.isStatic,
-            isCached = limeProperty.attributes.have(CACHED)
+            isCached = limeProperty.attributes.have(CACHED),
+            isWeak = limeProperty.attributes.have(SWIFT, WEAK)
         )
         property.comment = createComments(limeProperty)
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftWeakPropertiesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftWeakPropertiesValidator.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.swift
+
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
+import com.here.gluecodium.model.lime.LimeAttributeValueType.WEAK
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeProperty
+import com.here.gluecodium.model.lime.LimeType
+
+/**
+ * Validate properties marked as "weak" in Swift. Swift only supports weak properties of nullable type. Also, due to the
+ * nature of C++ representation of such properties, there are additional restrictions on the types used.
+ */
+internal class SwiftWeakPropertiesValidator(private val logger: LimeLogger) {
+
+    fun validate(limeElements: List<LimeNamedElement>): Boolean {
+        val validationResults = limeElements
+            .filterIsInstance<LimeProperty>()
+            .map { validateProperty(it) }
+
+        return !validationResults.contains(false)
+    }
+
+    private fun validateProperty(limeProperty: LimeProperty) =
+        when {
+            !limeProperty.attributes.have(SWIFT, WEAK) -> true
+            !limeProperty.typeRef.isNullable -> {
+                logger.error(limeProperty, "@Swift(Weak) can only apply to a property with a nullable type.")
+                false
+            }
+            isRestrictedType(limeProperty.typeRef.type.actualType) -> {
+                logger.error(limeProperty, "An interface type held by @Swift(Weak) property can only have methods " +
+                        "that return nullable values (or `void`).")
+                false
+            }
+            else -> true
+        }
+
+    private fun isRestrictedType(limeType: LimeType) =
+        limeType is LimeInterface &&
+                limeType.functions.any { !it.returnType.isVoid && !it.returnType.typeRef.isNullable }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftClass.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftClass.kt
@@ -30,7 +30,8 @@ class SwiftClass(
     val useParentCInstance: Boolean = false,
     val hasEquatableType: Boolean = false,
     @Suppress("unused") val isObjcInterface: Boolean = false,
-    @Suppress("unused") val hasTypeRepository: Boolean = false
+    @Suppress("unused") val hasTypeRepository: Boolean = false,
+    @Suppress("unused") val hasWeakSupport: Boolean = false
 ) : SwiftType(
     name = nestedNames.joinToString("."),
     visibility = visibility,

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftProperty.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftProperty.kt
@@ -26,7 +26,8 @@ class SwiftProperty(
     val getter: SwiftMethod,
     val setter: SwiftMethod?,
     val isStatic: Boolean,
-    val isCached: Boolean = false
+    val isCached: Boolean = false,
+    val isWeak: Boolean = false
 ) : SwiftTypedModelElement(propertyName, visibility, type) {
 
     override val childElements

--- a/gluecodium/src/main/resources/templates/swift/GetReference.mustache
+++ b/gluecodium/src/main/resources/templates/swift/GetReference.mustache
@@ -18,7 +18,17 @@
   ! License-Filename: LICENSE
   !
   !}}
-internal func getRef(_ ref: {{name}}?, owning: Bool = true) -> RefHolder {
+{{#if hasWeakSupport}}
+internal class {{name}}_WeakHolder {
+    weak var value: {{name}}?
+
+    init(_ value: {{name}}) {
+        self.value = value
+    }
+}
+
+{{/if}}
+internal func getRef(_ ref: {{name}}?, owning: Bool = true{{#if hasWeakSupport}}, isWeak: Bool = false{{/if}}) -> RefHolder {
 
     guard let reference = ref else {
         return RefHolder(0)
@@ -32,7 +42,12 @@ internal func getRef(_ ref: {{name}}?, owning: Bool = true) -> RefHolder {
     }
 
     var functions = {{functionTableName}}()
+{{#if hasWeakSupport}}
+    let strongRef: AnyObject = isWeak ? {{name}}_WeakHolder(reference) : reference
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(strongRef).toOpaque()
+{{/if}}{{#unless hasWeakSupport}}
     functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+{{/unless}}
     functions.release = {swift_class_pointer in
         if let swift_class = swift_class_pointer {
             Unmanaged<AnyObject>.fromOpaque(swift_class).release()
@@ -50,10 +65,39 @@ internal func getRef(_ ref: {{name}}?, owning: Bool = true) -> RefHolder {
     let proxy = {{cInstance}}_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: {{cInstance}}_release_handle) : RefHolder(proxy)
 }
-{{/set}}{{!!
+{{/set}}
+{{#if hasWeakSupport}}
+
+internal func weakToCType(_ swiftClass: {{name}}?) -> RefHolder {
+    return getRef(swiftClass, owning: true, isWeak: true)
+}
+{{/if}}{{!!
+
 }}{{+functionTableEntry}}
     functions.{{cBaseName}} = {(swift_class_pointer{{#if parameters}}, {{/if}}{{joinPartial parameters "swiftParameter" ", "}}) in
+{{#if hasWeakSupport}}
+        let unretained_value = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue()
+        let swift_class: {{className}}
+        if (unretained_value is {{className}}_WeakHolder) {
+            if let weak_value = (unretained_value as! {{className}}_WeakHolder).value {
+                swift_class = weak_value
+            } else {
+{{#if error}}{{#if isReturningVoid}}
+                return {{cBaseName}}_result(has_value: true, error_value: 0)
+{{/if}}{{#unless isReturningVoid}}
+                return {{cBaseName}}_result(has_value: true, .init(returned_value: 0))
+{{/unless}}{{/if}}{{#unless error}}{{#if isReturningVoid}}
+                return
+{{/if}}{{#unless isReturningVoid}}
+                return 0
+{{/unless}}{{/unless}}
+            }
+        } else {
+            swift_class = unretained_value as! {{className}}
+        }
+{{/if}}{{#unless hasWeakSupport}}
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! {{className}}
+{{/unless}}
         {{#if error}}do { {{#if isReturningVoid}}
             try {{include delegateToCall}}
             return {{cBaseName}}_result(has_value: true, error_value: 0)

--- a/gluecodium/src/main/resources/templates/swift/ParametersConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ParametersConversion.mustache
@@ -20,7 +20,8 @@
   !}}
 {{#selfIsStruct}}{{^isStatic}}let c_self_handle = moveToCType(self){{/isStatic}}{{/selfIsStruct}}
 {{#parameters}}
-let c_{{name}} = {{#type}}{{>swift/ConversionPrefixTo}}{{/type}}moveToCType({{name}})
+let c_{{name}} = {{#type}}{{>swift/ConversionPrefixTo}}{{/type}}{{!!
+}}{{#if isWeak}}weak{{/if}}{{#unless isWeak}}move{{/unless}}ToCType({{name}})
 {{/parameters}}
 {{#if error}}
 let RESULT = {{>swift/DelegateCall}}

--- a/gluecodium/src/main/resources/templates/swift/Property.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Property.mustache
@@ -24,7 +24,7 @@
     {{#getter}}{{>swift/ParametersConversion}}{{/getter}}
 }(){{!!
 }}{{/if}}{{#unless isCached}}{{!!
-}}{{^isInterface}}{{visibility}} {{/isInterface}}{{>setterVisibility}}{{#if isStatic}}static {{/if}}{{!!
+}}{{^isInterface}}{{visibility}} {{/isInterface}}{{>setterVisibility}}{{#if isStatic}}static {{/if}}{{#if isWeak}}weak {{/if}}{{!!
 }}var {{name}}: {{type.publicName}}{{#if type.optional}}?{{/if}} {
 {{#getter}}
     get {

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/swift/SwiftWeakPropertiesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/swift/SwiftWeakPropertiesValidatorTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.swift
+
+import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
+import com.here.gluecodium.model.lime.LimeAttributeValueType.WEAK
+import com.here.gluecodium.model.lime.LimeAttributes
+import com.here.gluecodium.model.lime.LimeBasicType
+import com.here.gluecodium.model.lime.LimeBasicTypeRef
+import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeDirectTypeRef
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimePath
+import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
+import com.here.gluecodium.model.lime.LimeProperty
+import com.here.gluecodium.model.lime.LimeReturnType
+import io.mockk.MockKAnnotations
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class SwiftWeakPropertiesValidatorTest {
+
+    private val barPath = LimePath(emptyList(), listOf("Bar"))
+    private val fooPath = barPath.child("foo")
+    private val nullableBool = LimeBasicTypeRef(LimeBasicType.TypeId.BOOLEAN, isNullable = true)
+    private val dummyFunction = LimeFunction(EMPTY_PATH)
+    private val weakAttributes = LimeAttributes.Builder().addAttribute(SWIFT, WEAK).build()
+
+    private val limeReferenceMap = mutableMapOf<String, LimeElement>()
+
+    private lateinit var validator: SwiftWeakPropertiesValidator
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+        validator = SwiftWeakPropertiesValidator(mockk(relaxed = true))
+    }
+
+    @Test
+    fun validatePropertyWithNoAttribute() {
+        val limeProperty = LimeProperty(EMPTY_PATH, typeRef = LimeBasicTypeRef.DOUBLE, getter = dummyFunction)
+
+        assertTrue(validator.validate(listOf(limeProperty)))
+    }
+
+    @Test
+    fun validatePropertyInClass() {
+        val limeProperty = LimeProperty(
+            fooPath,
+            typeRef = nullableBool,
+            getter = dummyFunction,
+            attributes = weakAttributes
+        )
+        limeReferenceMap[barPath.toString()] = LimeClass(barPath)
+
+        assertTrue(validator.validate(listOf(limeProperty)))
+    }
+
+    @Test
+    fun validatePropertyNonNullable() {
+        val limeProperty = LimeProperty(
+            fooPath,
+            typeRef = LimeBasicTypeRef.DOUBLE,
+            getter = dummyFunction,
+            attributes = weakAttributes
+        )
+        limeReferenceMap[barPath.toString()] = LimeInterface(barPath)
+
+        assertFalse(validator.validate(listOf(limeProperty)))
+    }
+
+    @Test
+    fun validatePropertyValidNonInterface() {
+        val limeProperty = LimeProperty(
+            fooPath,
+            typeRef = nullableBool,
+            getter = dummyFunction,
+            attributes = weakAttributes
+        )
+        limeReferenceMap[barPath.toString()] = LimeInterface(barPath)
+
+        assertTrue(validator.validate(listOf(limeProperty)))
+    }
+
+    @Test
+    fun validatePropertyValidInterfaceVoid() {
+        val limeInterface = LimeInterface(EMPTY_PATH, functions = listOf(LimeFunction(EMPTY_PATH)))
+        val limeProperty = LimeProperty(
+            fooPath,
+            typeRef = LimeDirectTypeRef(limeInterface, isNullable = true),
+            getter = dummyFunction,
+            attributes = weakAttributes
+        )
+        limeReferenceMap[barPath.toString()] = LimeInterface(barPath)
+
+        assertTrue(validator.validate(listOf(limeProperty)))
+    }
+
+    @Test
+    fun validatePropertyValidInterfaceNullable() {
+        val limeFunction = LimeFunction(EMPTY_PATH, returnType = LimeReturnType(nullableBool))
+        val limeInterface = LimeInterface(EMPTY_PATH, functions = listOf(limeFunction))
+        val limeProperty = LimeProperty(
+            fooPath,
+            typeRef = LimeDirectTypeRef(limeInterface, isNullable = true),
+            getter = dummyFunction,
+            attributes = weakAttributes
+        )
+        limeReferenceMap[barPath.toString()] = LimeInterface(barPath)
+
+        assertTrue(validator.validate(listOf(limeProperty)))
+    }
+
+    @Test
+    fun validatePropertyInvalidInterface() {
+        val limeFunction =
+            LimeFunction(EMPTY_PATH, returnType = LimeReturnType(LimeBasicTypeRef(LimeBasicType.TypeId.BOOLEAN)))
+        val limeInterface = LimeInterface(EMPTY_PATH, functions = listOf(limeFunction))
+        val limeProperty = LimeProperty(
+            fooPath,
+            typeRef = LimeDirectTypeRef(limeInterface, isNullable = true),
+            getter = dummyFunction,
+            attributes = weakAttributes
+        )
+        limeReferenceMap[barPath.toString()] = LimeInterface(barPath)
+
+        assertFalse(validator.validate(listOf(limeProperty)))
+    }
+}

--- a/gluecodium/src/test/resources/smoke/listeners/input/WeakListeners.lime
+++ b/gluecodium/src/test/resources/smoke/listeners/input/WeakListeners.lime
@@ -1,0 +1,27 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+interface ListenerInterface {
+    fun notify()
+}
+
+interface Weakling {
+    @Swift(Weak)
+    property listener: ListenerInterface?
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/include/smoke/cbridge_Weakling.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/include/smoke/cbridge_Weakling.h
@@ -1,0 +1,27 @@
+//
+//
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "cbridge\include\BaseHandle.h"
+#include "cbridge\include\Export.h"
+_GLUECODIUM_C_EXPORT void smoke_Weakling_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_Weakling_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_Weakling_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_Weakling_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
+_GLUECODIUM_C_EXPORT void smoke_Weakling_remove_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void* smoke_Weakling_get_typed(_baseRef handle);
+typedef struct {
+    void* swift_pointer;
+    void(*release)(void* swift_pointer);
+    _baseRef(*smoke_Weakling_listener_get)(void* swift_pointer);
+    void(*smoke_Weakling_listener_set)(void* swift_pointer, _baseRef newValue);
+} smoke_Weakling_FunctionTable;
+_GLUECODIUM_C_EXPORT _baseRef smoke_Weakling_create_proxy(smoke_Weakling_FunctionTable functionTable);
+_GLUECODIUM_C_EXPORT const void* smoke_Weakling_get_swift_object_from_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_Weakling_listener_get(_baseRef _instance);
+_GLUECODIUM_C_EXPORT void smoke_Weakling_listener_set(_baseRef _instance, _baseRef newValue);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_Weakling.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_Weakling.cpp
@@ -1,0 +1,84 @@
+//
+//
+#include "cbridge\include\smoke\cbridge_ListenerInterface.h"
+#include "cbridge\include\smoke\cbridge_Weakling.h"
+#include "cbridge_internal\include\BaseHandleImpl.h"
+#include "cbridge_internal\include\CachedProxyBase.h"
+#include "cbridge_internal\include\TypeInitRepository.h"
+#include "cbridge_internal\include\WrapperCache.h"
+#include "gluecodium\Optional.h"
+#include "gluecodium\TypeRepository.h"
+#include "smoke\ListenerInterface.h"
+#include "smoke\Weakling.h"
+#include <memory>
+#include <new>
+void smoke_Weakling_release_handle(_baseRef handle) {
+    delete get_pointer<std::shared_ptr<::smoke::Weakling>>(handle);
+}
+_baseRef smoke_Weakling_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Weakling>>(handle)))
+        : 0;
+}
+const void* smoke_Weakling_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Weakling>>(handle)->get())
+        : nullptr;
+}
+void smoke_Weakling_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Weakling>>(handle)->get(), swift_pointer);
+}
+void smoke_Weakling_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Weakling>>(handle)->get());
+}
+extern "C" {
+extern void* _CBridgeInitsmoke_Weakling(_baseRef handle);
+}
+namespace {
+struct smoke_WeaklingRegisterInit {
+    smoke_WeaklingRegisterInit() {
+        get_init_repository().add_init("smoke_Weakling", &_CBridgeInitsmoke_Weakling);
+    }
+} s_smoke_Weakling_register_init;
+}
+void* smoke_Weakling_get_typed(_baseRef handle) {
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::Weakling>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::Weakling>>(handle)->get());
+    auto init_function = get_init_repository().get_init(real_type_id);
+    return init_function ? init_function(handle) : _CBridgeInitsmoke_Weakling(handle);
+}
+_baseRef smoke_Weakling_listener_get(_baseRef _instance) {
+    return Conversion<::std::shared_ptr< ::smoke::ListenerInterface >>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Weakling>>(_instance)->get()->get_listener());
+}
+void smoke_Weakling_listener_set(_baseRef _instance, _baseRef newValue) {
+    return get_pointer<std::shared_ptr<::smoke::Weakling>>(_instance)->get()->set_listener(Conversion<::std::shared_ptr< ::smoke::ListenerInterface >>::toCpp(newValue));
+}
+class smoke_WeaklingProxy : public std::shared_ptr<::smoke::Weakling>::element_type, public CachedProxyBase<smoke_WeaklingProxy> {
+public:
+    smoke_WeaklingProxy(smoke_Weakling_FunctionTable&& functions)
+     : mFunctions(std::move(functions))
+    {
+    }
+    virtual ~smoke_WeaklingProxy() {
+        mFunctions.release(mFunctions.swift_pointer);
+    }
+    smoke_WeaklingProxy(const smoke_WeaklingProxy&) = delete;
+    smoke_WeaklingProxy& operator=(const smoke_WeaklingProxy&) = delete;
+    ::std::shared_ptr< ::smoke::ListenerInterface > get_listener() const override {
+        auto _call_result = mFunctions.smoke_Weakling_listener_get(mFunctions.swift_pointer);
+        return Conversion<::std::shared_ptr< ::smoke::ListenerInterface >>::toCppReturn(_call_result);
+    }
+    void set_listener(const ::std::shared_ptr< ::smoke::ListenerInterface >& newValue) override {
+        mFunctions.smoke_Weakling_listener_set(mFunctions.swift_pointer, Conversion<::std::shared_ptr< ::smoke::ListenerInterface >>::toBaseRef(newValue));
+    }
+private:
+    smoke_Weakling_FunctionTable mFunctions;
+};
+_baseRef smoke_Weakling_create_proxy(smoke_Weakling_FunctionTable functionTable) {
+    auto proxy = smoke_WeaklingProxy::get_proxy(std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::Weakling>(proxy)) : 0;
+}
+const void* smoke_Weakling_get_swift_object_from_cache(_baseRef handle) {
+    return handle ? smoke_WeaklingProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::Weakling>>(handle)->get()) : nullptr;
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenerInterface.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenerInterface.swift
@@ -1,0 +1,132 @@
+//
+//
+import Foundation
+public protocol ListenerInterface : AnyObject {
+    func notify() -> Void
+}
+internal class _ListenerInterface: ListenerInterface {
+    let c_instance : _baseRef
+    init(cListenerInterface: _baseRef) {
+        guard cListenerInterface != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cListenerInterface
+    }
+    deinit {
+        smoke_ListenerInterface_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_ListenerInterface_release_handle(c_instance)
+    }
+    public func notify() -> Void {
+        return moveFromCType(smoke_ListenerInterface_notify(self.c_instance))
+    }
+}
+@_cdecl("_CBridgeInitsmoke_ListenerInterface")
+internal func _CBridgeInitsmoke_ListenerInterface(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _ListenerInterface(cListenerInterface: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal class ListenerInterface_WeakHolder {
+    weak var value: ListenerInterface?
+    init(_ value: ListenerInterface) {
+        self.value = value
+    }
+}
+internal func getRef(_ ref: ListenerInterface?, owning: Bool = true, isWeak: Bool = false) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_ListenerInterface_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_ListenerInterface_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_ListenerInterface_FunctionTable()
+    let strongRef: AnyObject = isWeak ? ListenerInterface_WeakHolder(reference) : reference
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(strongRef).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    functions.smoke_ListenerInterface_notify = {(swift_class_pointer) in
+        let unretained_value = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue()
+        let swift_class: ListenerInterface
+        if (unretained_value is ListenerInterface_WeakHolder) {
+            if let weak_value = (unretained_value as! ListenerInterface_WeakHolder).value {
+                swift_class = weak_value
+            } else {
+                return
+            }
+        } else {
+            swift_class = unretained_value as! ListenerInterface
+        }
+        swift_class.notify()
+    }
+    let proxy = smoke_ListenerInterface_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_ListenerInterface_release_handle) : RefHolder(proxy)
+}
+internal func weakToCType(_ swiftClass: ListenerInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: true, isWeak: true)
+}
+extension _ListenerInterface: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func ListenerInterface_copyFromCType(_ handle: _baseRef) -> ListenerInterface {
+    if let swift_pointer = smoke_ListenerInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ListenerInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ListenerInterface_get_typed(smoke_ListenerInterface_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ListenerInterface {
+        smoke_ListenerInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func ListenerInterface_moveFromCType(_ handle: _baseRef) -> ListenerInterface {
+    if let swift_pointer = smoke_ListenerInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerInterface {
+        smoke_ListenerInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ListenerInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerInterface {
+        smoke_ListenerInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ListenerInterface_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ListenerInterface {
+        smoke_ListenerInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func ListenerInterface_copyFromCType(_ handle: _baseRef) -> ListenerInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ListenerInterface_moveFromCType(handle) as ListenerInterface
+}
+internal func ListenerInterface_moveFromCType(_ handle: _baseRef) -> ListenerInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ListenerInterface_moveFromCType(handle) as ListenerInterface
+}
+internal func copyToCType(_ swiftClass: ListenerInterface) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ListenerInterface) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: ListenerInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ListenerInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Weakling.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Weakling.swift
@@ -1,0 +1,122 @@
+//
+//
+import Foundation
+public protocol Weakling : AnyObject {
+    var listener: ListenerInterface? { get set }
+}
+internal class _Weakling: Weakling {
+    weak var listener: ListenerInterface? {
+        get {
+            return ListenerInterface_moveFromCType(smoke_Weakling_listener_get(self.c_instance))
+        }
+        set {
+            let c_newValue = weakToCType(newValue)
+            return moveFromCType(smoke_Weakling_listener_set(self.c_instance, c_newValue.ref))
+        }
+    }
+    let c_instance : _baseRef
+    init(cWeakling: _baseRef) {
+        guard cWeakling != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cWeakling
+    }
+    deinit {
+        smoke_Weakling_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_Weakling_release_handle(c_instance)
+    }
+}
+@_cdecl("_CBridgeInitsmoke_Weakling")
+internal func _CBridgeInitsmoke_Weakling(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _Weakling(cWeakling: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: Weakling?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_Weakling_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_Weakling_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_Weakling_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    functions.smoke_Weakling_listener_get = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! Weakling
+        return copyToCType(swift_class.listener).ref
+    }
+    functions.smoke_Weakling_listener_set = {(swift_class_pointer, newValue) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! Weakling
+        swift_class.listener = ListenerInterface_moveFromCType(newValue)
+    }
+    let proxy = smoke_Weakling_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_Weakling_release_handle) : RefHolder(proxy)
+}
+extension _Weakling: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func Weakling_copyFromCType(_ handle: _baseRef) -> Weakling {
+    if let swift_pointer = smoke_Weakling_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Weakling {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_Weakling_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Weakling {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_Weakling_get_typed(smoke_Weakling_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? Weakling {
+        smoke_Weakling_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func Weakling_moveFromCType(_ handle: _baseRef) -> Weakling {
+    if let swift_pointer = smoke_Weakling_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Weakling {
+        smoke_Weakling_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_Weakling_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Weakling {
+        smoke_Weakling_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_Weakling_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? Weakling {
+        smoke_Weakling_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func Weakling_copyFromCType(_ handle: _baseRef) -> Weakling? {
+    guard handle != 0 else {
+        return nil
+    }
+    return Weakling_moveFromCType(handle) as Weakling
+}
+internal func Weakling_moveFromCType(_ handle: _baseRef) -> Weakling? {
+    guard handle != 0 else {
+        return nil
+    }
+    return Weakling_moveFromCType(handle) as Weakling
+}
+internal func copyToCType(_ swiftClass: Weakling) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: Weakling) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: Weakling?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: Weakling?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -140,6 +140,7 @@ internal object AntlrLimeConverter {
             "ObjC" -> LimeAttributeValueType.OBJC
             "Message" -> LimeAttributeValueType.MESSAGE
             "Skip" -> LimeAttributeValueType.SKIP
+            "Weak" -> LimeAttributeValueType.WEAK
             "ExternalType", "ExternalName", "ExternalGetter", "ExternalSetter" -> null
             else -> throw LimeLoadingException("Unsupported attribute value: '$id'")
         }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
@@ -31,7 +31,8 @@ enum class LimeAttributeValueType(private val tag: String) {
     LABEL("Label"),
     OBJC("ObjC"),
     MESSAGE("Message"),
-    SKIP("Skip");
+    SKIP("Skip"),
+    WEAK("Weak");
 
     override fun toString() = tag
 }


### PR DESCRIPTION
Added support for `@Swift(Weak)` attribute on properties of interfaces.
Such properties are generated with `weak` keyword in Swift. Protocols
generated in Swift for iterfaces with such properties can only be
implemented by Swift code. CBridge infrastructure for backing such
interfaces with C++ objects is not generated.

Added SwiftWeakPropertiesValidator to validate the correct usage of the
new attribute. Added unit tests for the validator.

Added smoke and functional tests as appropriate.

Resolves: #465
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>