### PR TITLE
Fix Java signature clash for classes with Long/ULong constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed Java compilation issue for class constructors with a single `Long` or `ULong` parameter.
+
 ## 8.1.1
 Release date: 2020-08-13
 ### Features

--- a/gluecodium/src/main/resources/templates/java/Class.mustache
+++ b/gluecodium/src/main/resources/templates/java/Class.mustache
@@ -43,7 +43,7 @@
 {{prefixPartial "java/MethodComment" "    "}}
     {{visibility}} {{className}}({{joinPartial parameters "java/Parameter" ", "}}){{#exception}} throws {{name}}{{/exception}} {
 {{#unless stubs}}{{#if isImplClass}}
-        this({{name}}({{join parameters delimiter=", " }}));
+        this({{name}}({{join parameters delimiter=", " }}), (Object)null);
         cacheThisInstance();
 {{/if}}{{#unless isImplClass}}
         {{className}} _other = {{name}}({{join parameters delimiter=", " }});

--- a/gluecodium/src/main/resources/templates/java/NativeConstructor.mustache
+++ b/gluecodium/src/main/resources/templates/java/NativeConstructor.mustache
@@ -23,13 +23,13 @@
  * For internal use only.
  * @exclude
  */
-{{/if}}protected {{name}}(final long nativeHandle) {
-    super(nativeHandle{{#if needsDisposer}}, new Disposer() {
+{{/if}}protected {{name}}(final long nativeHandle, final Object dummy) {
+    super(nativeHandle, {{#if needsDisposer}}new Disposer() {
         @Override
         public void disposeNative(long handle) {
             disposeNativeHandle(handle);
         }
-    }{{/if}});
+    }{{/if}}{{#unless needsDisposer}}dummy{{/unless}});
 }{{#if needsDisposer}}
 
 private static native void disposeNativeHandle(long nativeHandle);{{/if}}

--- a/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsImplementation.mustache
@@ -218,7 +218,8 @@ convert_to_jni( JNIEnv* env, const std::chrono::system_clock::time_point& nvalue
     auto time_ms_epoch =
         std::chrono::duration_cast< std::chrono::milliseconds >( nvalue.time_since_epoch( ) ).count( );
 
-    return create_instance_object( env, javaDateClass, time_ms_epoch );
+    auto constructorMethodId = env->GetMethodID(javaDateClass.get(), "<init>", "(J)V");
+    return new_object(env, javaDateClass, constructorMethodId, time_ms_epoch);
 }
 
 JniReference<jobject>

--- a/gluecodium/src/main/resources/templates/jni/utils/JniReferenceHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniReferenceHeader.mustache
@@ -186,10 +186,10 @@ inline JniReference<jobject>
 create_instance_object( JNIEnv* env, const JniReference<jclass>& javaClass, jlong instancePointer )
 {
     const char* name = "<init>";
-    const char* signature = "(J)V";
+    const char* signature = "(JLjava/lang/Object;)V";
     auto theConstructor = env->GetMethodID( javaClass.get(), name, signature );
 
-    return new_object(env, javaClass, theConstructor, instancePointer );
+    return new_object(env, javaClass, theConstructor, instancePointer, NULL );
 }
 
 inline JniReference<jobject>

--- a/gluecodium/src/test/resources/smoke/annotations/output/android/com/example/smoke/Annotations.java
+++ b/gluecodium/src/test/resources/smoke/annotations/output/android/com/example/smoke/Annotations.java
@@ -11,7 +11,7 @@ public final class Annotations extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Annotations(final long nativeHandle) {
+    protected Annotations(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android/com/example/smoke/BasicTypes.java
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android/com/example/smoke/BasicTypes.java
@@ -9,7 +9,7 @@ public final class BasicTypes extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected BasicTypes(final long nativeHandle) {
+    protected BasicTypes(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
@@ -44,7 +44,7 @@ public final class Comments extends NativeBase {
      * @exclude
      */
     static class SomeLambdaImpl extends NativeBase implements SomeLambda {
-        protected SomeLambdaImpl(final long nativeHandle) {
+        protected SomeLambdaImpl(final long nativeHandle, final Object dummy) {
             super(nativeHandle, new Disposer() {
                 @Override
                 public void disposeNative(long handle) {
@@ -103,7 +103,7 @@ public final class Comments extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Comments(final long nativeHandle) {
+    protected Comments(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
@@ -32,7 +32,7 @@ public final class CommentsLinks extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected CommentsLinks(final long nativeHandle) {
+    protected CommentsLinks(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/LongComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/LongComments.java
@@ -13,7 +13,7 @@ public final class LongComments extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected LongComments(final long nativeHandle) {
+    protected LongComments(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/MultiLineComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/MultiLineComments.java
@@ -23,7 +23,7 @@ public final class MultiLineComments extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected MultiLineComments(final long nativeHandle) {
+    protected MultiLineComments(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/PlatformComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/PlatformComments.java
@@ -37,7 +37,7 @@ public final class PlatformComments extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected PlatformComments(final long nativeHandle) {
+    protected PlatformComments(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/UnicodeComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/UnicodeComments.java
@@ -9,7 +9,7 @@ public final class UnicodeComments extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected UnicodeComments(final long nativeHandle) {
+    protected UnicodeComments(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/CollectionConstants.java
+++ b/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/CollectionConstants.java
@@ -22,7 +22,7 @@ public final class CollectionConstants extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected CollectionConstants(final long nativeHandle) {
+    protected CollectionConstants(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/ConstantsInterface.java
+++ b/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/ConstantsInterface.java
@@ -24,7 +24,7 @@ public final class ConstantsInterface extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected ConstantsInterface(final long nativeHandle) {
+    protected ConstantsInterface(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/StructConstants.java
+++ b/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/StructConstants.java
@@ -28,7 +28,7 @@ public final class StructConstants extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected StructConstants(final long nativeHandle) {
+    protected StructConstants(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/constructors/output/android/com/example/smoke/ChildConstructors.java
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android/com/example/smoke/ChildConstructors.java
@@ -5,19 +5,19 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 public final class ChildConstructors extends Constructors {
     public ChildConstructors() {
-        this(createNoArgsChild());
+        this(createNoArgsChild(), (Object)null);
         cacheThisInstance();
     }
     public ChildConstructors(@NonNull final Constructors other) {
-        this(createCopyFromParent(other));
+        this(createCopyFromParent(other), (Object)null);
         cacheThisInstance();
     }
     /**
      * For internal use only.
      * @exclude
      */
-    protected ChildConstructors(final long nativeHandle) {
-        super(nativeHandle);
+    protected ChildConstructors(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, dummy);
     }
     private native void cacheThisInstance();
     private static native long createNoArgsChild();

--- a/gluecodium/src/test/resources/smoke/constructors/output/android/com/example/smoke/Constructors.java
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android/com/example/smoke/Constructors.java
@@ -22,30 +22,30 @@ public class Constructors extends NativeBase {
         public final Constructors.ErrorEnum error;
     }
     public Constructors() {
-        this(create());
+        this(create(), (Object)null);
         cacheThisInstance();
     }
     public Constructors(@NonNull final Constructors other) {
-        this(create(other));
+        this(create(other), (Object)null);
         cacheThisInstance();
     }
     public Constructors(@NonNull final String foo, final long bar) {
-        this(create(foo, bar));
+        this(create(foo, bar), (Object)null);
         cacheThisInstance();
     }
     public Constructors(@NonNull final String input) throws Constructors.ConstructorExplodedException {
-        this(create(input));
+        this(create(input), (Object)null);
         cacheThisInstance();
     }
     public Constructors(@NonNull final List<Double> input) {
-        this(create(input));
+        this(create(input), (Object)null);
         cacheThisInstance();
     }
     /**
      * For internal use only.
      * @exclude
      */
-    protected Constructors(final long nativeHandle) {
+    protected Constructors(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/dates/output/android/com/example/smoke/Dates.java
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/com/example/smoke/Dates.java
@@ -18,7 +18,7 @@ public final class Dates extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Dates(final long nativeHandle) {
+    protected Dates(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/DefaultValues.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/DefaultValues.java
@@ -166,7 +166,7 @@ public final class DefaultValues extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected DefaultValues(final long nativeHandle) {
+    protected DefaultValues(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/enums/output/android/com/example/smoke/Enums.java
+++ b/gluecodium/src/test/resources/smoke/enums/output/android/com/example/smoke/Enums.java
@@ -35,7 +35,7 @@ public final class Enums extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Enums(final long nativeHandle) {
+    protected Enums(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/enums/output/android/com/example/smoke/EnumsInTypeCollectionInterface.java
+++ b/gluecodium/src/test/resources/smoke/enums/output/android/com/example/smoke/EnumsInTypeCollectionInterface.java
@@ -12,7 +12,7 @@ public final class EnumsInTypeCollectionInterface extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected EnumsInTypeCollectionInterface(final long nativeHandle) {
+    protected EnumsInTypeCollectionInterface(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/equatable/output/android/com/example/smoke/EquatableClass.java
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android/com/example/smoke/EquatableClass.java
@@ -44,7 +44,7 @@ public final class EquatableClass extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected EquatableClass(final long nativeHandle) {
+    protected EquatableClass(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/equatable/output/android/com/example/smoke/EquatableInterfaceImpl.java
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android/com/example/smoke/EquatableInterfaceImpl.java
@@ -4,7 +4,7 @@
 package com.example.smoke;
 import com.example.NativeBase;
 class EquatableInterfaceImpl extends NativeBase implements EquatableInterface {
-    protected EquatableInterfaceImpl(final long nativeHandle) {
+    protected EquatableInterfaceImpl(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/errors/output/android/com/example/example/FooBar.java
+++ b/gluecodium/src/test/resources/smoke/errors/output/android/com/example/example/FooBar.java
@@ -10,7 +10,7 @@ public final class FooBar extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected FooBar(final long nativeHandle) {
+    protected FooBar(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/errors/output/android/com/example/smoke/Errors.java
+++ b/gluecodium/src/test/resources/smoke/errors/output/android/com/example/smoke/Errors.java
@@ -40,7 +40,7 @@ public final class Errors extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Errors(final long nativeHandle) {
+    protected Errors(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android/com/example/package/Class.java
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android/com/example/package/Class.java
@@ -7,14 +7,14 @@ import com.example.NativeBase;
 import java.util.List;
 public final class Class extends NativeBase implements Interface {
     public Class() {
-        this(constructor());
+        this(constructor(), (Object)null);
         cacheThisInstance();
     }
     /**
      * For internal use only.
      * @exclude
      */
-    protected Class(final long nativeHandle) {
+    protected Class(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/Enums.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/Enums.java
@@ -25,7 +25,7 @@ public final class Enums extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Enums(final long nativeHandle) {
+    protected Enums(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/ExternalClass.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/ExternalClass.java
@@ -24,7 +24,7 @@ public final class ExternalClass extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected ExternalClass(final long nativeHandle) {
+    protected ExternalClass(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/ExternalInterfaceImpl.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/ExternalInterfaceImpl.java
@@ -6,7 +6,7 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
 class ExternalInterfaceImpl extends NativeBase implements ExternalInterface {
-    protected ExternalInterfaceImpl(final long nativeHandle) {
+    protected ExternalInterfaceImpl(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/Structs.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/Structs.java
@@ -32,7 +32,7 @@ public final class Structs extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Structs(final long nativeHandle) {
+    protected Structs(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/UseJavaExternalTypes.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/UseJavaExternalTypes.java
@@ -9,7 +9,7 @@ public final class UseJavaExternalTypes extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected UseJavaExternalTypes(final long nativeHandle) {
+    protected UseJavaExternalTypes(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/GenericTypesWithBasicTypes.java
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/GenericTypesWithBasicTypes.java
@@ -26,7 +26,7 @@ public final class GenericTypesWithBasicTypes extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected GenericTypesWithBasicTypes(final long nativeHandle) {
+    protected GenericTypesWithBasicTypes(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/GenericTypesWithCompoundTypes.java
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/GenericTypesWithCompoundTypes.java
@@ -42,7 +42,7 @@ public final class GenericTypesWithCompoundTypes extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected GenericTypesWithCompoundTypes(final long nativeHandle) {
+    protected GenericTypesWithCompoundTypes(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/GenericTypesWithGenericTypes.java
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/GenericTypesWithGenericTypes.java
@@ -13,7 +13,7 @@ public final class GenericTypesWithGenericTypes extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected GenericTypesWithGenericTypes(final long nativeHandle) {
+    protected GenericTypesWithGenericTypes(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/com/example/smoke/ChildClassFromClass.java
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/com/example/smoke/ChildClassFromClass.java
@@ -8,8 +8,8 @@ public final class ChildClassFromClass extends ParentClass {
      * For internal use only.
      * @exclude
      */
-    protected ChildClassFromClass(final long nativeHandle) {
-        super(nativeHandle);
+    protected ChildClassFromClass(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, dummy);
     }
     public native void childClassMethod();
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/com/example/smoke/ChildClassFromInterface.java
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/com/example/smoke/ChildClassFromInterface.java
@@ -9,7 +9,7 @@ public final class ChildClassFromInterface extends NativeBase implements ParentI
      * For internal use only.
      * @exclude
      */
-    protected ChildClassFromInterface(final long nativeHandle) {
+    protected ChildClassFromInterface(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/com/example/smoke/ChildInterfaceImpl.java
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/com/example/smoke/ChildInterfaceImpl.java
@@ -1,11 +1,10 @@
 /*
  *
-
  */
 package com.example.smoke;
 class ChildInterfaceImpl extends ParentInterfaceImpl implements ChildInterface {
-    protected ChildInterfaceImpl(final long nativeHandle) {
-        super(nativeHandle);
+    protected ChildInterfaceImpl(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, dummy);
     }
     public native void childMethod();
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/com/example/smoke/InternalChild.java
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/com/example/smoke/InternalChild.java
@@ -4,7 +4,7 @@
  */
 package com.example.smoke;
 class InternalChild extends InternalParent {
-    protected InternalChild(final long nativeHandle) {
-        super(nativeHandle);
+    protected InternalChild(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, dummy);
     }
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/com/example/smoke/InternalParent.java
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/com/example/smoke/InternalParent.java
@@ -5,7 +5,7 @@
 package com.example.smoke;
 import com.example.NativeBase;
 class InternalParent extends NativeBase {
-    protected InternalParent(final long nativeHandle) {
+    protected InternalParent(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/instances/output/android/com/example/smoke/SimpleClass.java
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/com/example/smoke/SimpleClass.java
@@ -9,7 +9,7 @@ public final class SimpleClass extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected SimpleClass(final long nativeHandle) {
+    protected SimpleClass(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/instances/output/android/com/example/smoke/SimpleInterfaceImpl.java
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/com/example/smoke/SimpleInterfaceImpl.java
@@ -5,7 +5,7 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
 class SimpleInterfaceImpl extends NativeBase implements SimpleInterface {
-    protected SimpleInterfaceImpl(final long nativeHandle) {
+    protected SimpleInterfaceImpl(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/com/example/smoke/Lambdas.java
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/com/example/smoke/Lambdas.java
@@ -12,7 +12,7 @@ public final class Lambdas extends NativeBase {
      * @exclude
      */
     static class ProducerImpl extends NativeBase implements Producer {
-        protected ProducerImpl(final long nativeHandle) {
+        protected ProducerImpl(final long nativeHandle, final Object dummy) {
             super(nativeHandle, new Disposer() {
                 @Override
                 public void disposeNative(long handle) {
@@ -28,7 +28,7 @@ public final class Lambdas extends NativeBase {
      * @exclude
      */
     static class ConfounderImpl extends NativeBase implements Confounder {
-        protected ConfounderImpl(final long nativeHandle) {
+        protected ConfounderImpl(final long nativeHandle, final Object dummy) {
             super(nativeHandle, new Disposer() {
                 @Override
                 public void disposeNative(long handle) {
@@ -49,7 +49,7 @@ public final class Lambdas extends NativeBase {
      * @exclude
      */
     static class ConsumerImpl extends NativeBase implements Consumer {
-        protected ConsumerImpl(final long nativeHandle) {
+        protected ConsumerImpl(final long nativeHandle, final Object dummy) {
             super(nativeHandle, new Disposer() {
                 @Override
                 public void disposeNative(long handle) {
@@ -64,7 +64,7 @@ public final class Lambdas extends NativeBase {
      * @exclude
      */
     static class IndexerImpl extends NativeBase implements Indexer {
-        protected IndexerImpl(final long nativeHandle) {
+        protected IndexerImpl(final long nativeHandle, final Object dummy) {
             super(nativeHandle, new Disposer() {
                 @Override
                 public void disposeNative(long handle) {
@@ -79,7 +79,7 @@ public final class Lambdas extends NativeBase {
      * @exclude
      */
     static class NullableConfuserImpl extends NativeBase implements NullableConfuser {
-        protected NullableConfuserImpl(final long nativeHandle) {
+        protected NullableConfuserImpl(final long nativeHandle, final Object dummy) {
             super(nativeHandle, new Disposer() {
                 @Override
                 public void disposeNative(long handle) {
@@ -126,7 +126,7 @@ public final class Lambdas extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Lambdas(final long nativeHandle) {
+    protected Lambdas(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Calculator.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Calculator.java
@@ -10,7 +10,7 @@ public final class Calculator extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Calculator(final long nativeHandle) {
+    protected Calculator(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/InternalListenerImpl.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/InternalListenerImpl.java
@@ -5,7 +5,7 @@
 package com.example.smoke;
 import com.example.NativeBase;
 class InternalListenerImpl extends NativeBase implements InternalListener {
-    protected InternalListenerImpl(final long nativeHandle) {
+    protected InternalListenerImpl(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/locales/output/android/com/example/smoke/Locales.java
+++ b/gluecodium/src/test/resources/smoke/locales/output/android/com/example/smoke/Locales.java
@@ -17,7 +17,7 @@ public final class Locales extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Locales(final long nativeHandle) {
+    protected Locales(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/com/example/smoke/MethodOverloads.java
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/com/example/smoke/MethodOverloads.java
@@ -19,7 +19,7 @@ public final class MethodOverloads extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected MethodOverloads(final long nativeHandle) {
+    protected MethodOverloads(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/com/example/smoke/SpecialNames.java
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/com/example/smoke/SpecialNames.java
@@ -9,7 +9,7 @@ public final class SpecialNames extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected SpecialNames(final long nativeHandle) {
+    protected SpecialNames(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android/com/example/namerules/NAME_RULES_DROID.java
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android/com/example/namerules/NAME_RULES_DROID.java
@@ -29,14 +29,14 @@ public final class NAME_RULES_DROID extends NativeBase {
         }
     }
     public NAME_RULES_DROID() {
-        this(create());
+        this(create(), (Object)null);
         cacheThisInstance();
     }
     /**
      * For internal use only.
      * @exclude
      */
-    protected NAME_RULES_DROID(final long nativeHandle) {
+    protected NAME_RULES_DROID(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/LevelOne.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/LevelOne.java
@@ -28,7 +28,7 @@ public final class LevelOne extends NativeBase {
              * For internal use only.
              * @exclude
              */
-            protected LevelThree(final long nativeHandle) {
+            protected LevelThree(final long nativeHandle, final Object dummy) {
                 super(nativeHandle, new Disposer() {
                     @Override
                     public void disposeNative(long handle) {
@@ -44,7 +44,7 @@ public final class LevelOne extends NativeBase {
          * For internal use only.
          * @exclude
          */
-        protected LevelTwo(final long nativeHandle) {
+        protected LevelTwo(final long nativeHandle, final Object dummy) {
             super(nativeHandle, new Disposer() {
                 @Override
                 public void disposeNative(long handle) {
@@ -58,7 +58,7 @@ public final class LevelOne extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected LevelOne(final long nativeHandle) {
+    protected LevelOne(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/NestedReferences.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/NestedReferences.java
@@ -16,7 +16,7 @@ public final class NestedReferences extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected NestedReferences(final long nativeHandle) {
+    protected NestedReferences(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/OuterClass.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/OuterClass.java
@@ -10,7 +10,7 @@ public final class OuterClass extends NativeBase {
          * For internal use only.
          * @exclude
          */
-        protected InnerClass(final long nativeHandle) {
+        protected InnerClass(final long nativeHandle, final Object dummy) {
             super(nativeHandle, new Disposer() {
                 @Override
                 public void disposeNative(long handle) {
@@ -23,7 +23,7 @@ public final class OuterClass extends NativeBase {
         public native String foo(@NonNull final String input);
     }
     static class InnerInterfaceImpl extends NativeBase implements InnerInterface {
-        protected InnerInterfaceImpl(final long nativeHandle) {
+        protected InnerInterfaceImpl(final long nativeHandle, final Object dummy) {
             super(nativeHandle, new Disposer() {
                 @Override
                 public void disposeNative(long handle) {
@@ -43,7 +43,7 @@ public final class OuterClass extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected OuterClass(final long nativeHandle) {
+    protected OuterClass(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/OuterInterface.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/OuterInterface.java
@@ -10,7 +10,7 @@ public interface OuterInterface {
          * For internal use only.
          * @exclude
          */
-        protected InnerClass(final long nativeHandle) {
+        protected InnerClass(final long nativeHandle, final Object dummy) {
             super(nativeHandle, new Disposer() {
                 @Override
                 public void disposeNative(long handle) {
@@ -23,7 +23,7 @@ public interface OuterInterface {
         public native String foo(@NonNull final String input);
     }
     static class InnerInterfaceImpl extends NativeBase implements InnerInterface {
-        protected InnerInterfaceImpl(final long nativeHandle) {
+        protected InnerInterfaceImpl(final long nativeHandle, final Object dummy) {
             super(nativeHandle, new Disposer() {
                 @Override
                 public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/UseFreeTypes.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/UseFreeTypes.java
@@ -10,7 +10,7 @@ public final class UseFreeTypes extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected UseFreeTypes(final long nativeHandle) {
+    protected UseFreeTypes(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/com/example/smoke/Nullable.java
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/com/example/smoke/Nullable.java
@@ -87,7 +87,7 @@ public final class Nullable extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Nullable(final long nativeHandle) {
+    protected Nullable(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/packages/output/android/com/example/smoke/off/NestedPackages.java
+++ b/gluecodium/src/test/resources/smoke/packages/output/android/com/example/smoke/off/NestedPackages.java
@@ -17,7 +17,7 @@ public final class NestedPackages extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected NestedPackages(final long nativeHandle) {
+    protected NestedPackages(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/packages/output/android/com/example/smokeoff/UnderscorePackage.java
+++ b/gluecodium/src/test/resources/smoke/packages/output/android/com/example/smokeoff/UnderscorePackage.java
@@ -10,7 +10,7 @@ public final class UnderscorePackage extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected UnderscorePackage(final long nativeHandle) {
+    protected UnderscorePackage(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android/com/example/smoke/barInterface.java
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android/com/example/smoke/barInterface.java
@@ -6,14 +6,14 @@ import android.support.annotation.NonNull;
 import com.example.NativeBase;
 public final class barInterface extends NativeBase {
     public barInterface(@NonNull final String makeParameter) {
-        this(make(makeParameter));
+        this(make(makeParameter), (Object)null);
         cacheThisInstance();
     }
     /**
      * For internal use only.
      * @exclude
      */
-    protected barInterface(final long nativeHandle) {
+    protected barInterface(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android/com/example/smoke/barListenerImpl.java
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android/com/example/smoke/barListenerImpl.java
@@ -6,7 +6,7 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
 class barListenerImpl extends NativeBase implements barListener {
-    protected barListenerImpl(final long nativeHandle) {
+    protected barListenerImpl(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/properties/output/android/com/example/smoke/CachedProperties.java
+++ b/gluecodium/src/test/resources/smoke/properties/output/android/com/example/smoke/CachedProperties.java
@@ -10,7 +10,7 @@ public final class CachedProperties extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected CachedProperties(final long nativeHandle) {
+    protected CachedProperties(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/properties/output/android/com/example/smoke/Properties.java
+++ b/gluecodium/src/test/resources/smoke/properties/output/android/com/example/smoke/Properties.java
@@ -24,7 +24,7 @@ public final class Properties extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Properties(final long nativeHandle) {
+    protected Properties(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipFunctions.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipFunctions.java
@@ -8,7 +8,7 @@ public final class SkipFunctions extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected SkipFunctions(final long nativeHandle) {
+    protected SkipFunctions(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipTypes.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipTypes.java
@@ -23,7 +23,7 @@ public final class SkipTypes extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected SkipTypes(final long nativeHandle) {
+    protected SkipTypes(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Structs.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Structs.java
@@ -406,7 +406,7 @@ public final class Structs extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected Structs(final long nativeHandle) {
+    protected Structs(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/StructsWithConstantsInterface.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/StructsWithConstantsInterface.java
@@ -26,7 +26,7 @@ public final class StructsWithConstantsInterface extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected StructsWithConstantsInterface(final long nativeHandle) {
+    protected StructsWithConstantsInterface(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/StructsWithMethodsInterface.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/StructsWithMethodsInterface.java
@@ -35,7 +35,7 @@ public final class StructsWithMethodsInterface extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected StructsWithMethodsInterface(final long nativeHandle) {
+    protected StructsWithMethodsInterface(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android/com/example/smoke/TypeDefs.java
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android/com/example/smoke/TypeDefs.java
@@ -24,7 +24,7 @@ public final class TypeDefs extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected TypeDefs(final long nativeHandle) {
+    protected TypeDefs(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalClass.java
+++ b/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalClass.java
@@ -9,7 +9,7 @@ import com.example.NativeBase;
 
 class InternalClass extends NativeBase {
 
-    protected InternalClass(final long nativeHandle) {
+    protected InternalClass(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {

--- a/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/PublicClass.java
+++ b/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/PublicClass.java
@@ -45,7 +45,7 @@ public final class PublicClass extends NativeBase {
      * For internal use only.
      * @exclude
      */
-    protected PublicClass(final long nativeHandle) {
+    protected PublicClass(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {


### PR DESCRIPTION
Updated Java and JNI templates to add an dummy parameter to the
protected `nativeHandle` constructor. This avoids signature clashes with
custom constructors if the custom constructor has a single parameter of
`Long` or `ULong` type.

Updated smoke tests.

Resolves: #470
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>