### PR TITLE
Improve error message for failed FFI lookups in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features
+  * Added customizable additional error message in Dart for when FFI function lookup fails.
+
 ## 8.2.1
 Release date: 2020-08-26
 ### Bug fixes:

--- a/cmake/modules/gluecodium/gluecodium/Generate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/Generate.cmake
@@ -90,6 +90,7 @@ function(apigen_generate)
       COMMON_OUTPUT_DIR
       BUILD_OUTPUT_DIR
       DART_LIBRARY_NAME
+      DART_FUNCTION_LOOKUP_ERROR_MESSAGE
       DART_NAMERULES)
   set(multiValueArgs LIME_SOURCES FRANCA_SOURCES WERROR)
   cmake_parse_arguments(apigen_generate "${options}" "${oneValueArgs}"
@@ -164,6 +165,7 @@ cache=true\n")
   _apigen_parse_path_option(dartnamerules DART_NAMERULES)
   _apigen_parse_path_option(commonoutput COMMON_OUTPUT_DIR)
   _apigen_parse_option(libraryname DART_LIBRARY_NAME)
+  _apigen_parse_option(dartlookuperrormessage DART_FUNCTION_LOOKUP_ERROR_MESSAGE)
   _apigen_parse_option(internalprefix INTERNAL_PREFIX)
   _apigen_parse_option(cppexport CPP_EXPORT)
 

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -222,6 +222,8 @@ class Gluecodium(
         var cppExport: String = DEFAULT_CPP_EXPORT_MACRO_NAME,
         var internalPrefix: String? = null,
         var libraryName: String = "library",
+        var dartLookupErrorMessage: String =
+            "Failed to resolve an FFI function. Perhaps `LibraryContext.init()` was not called.",
         var werror: Set<String> = emptySet(),
         var generateStubs: Boolean = false,
         var cppNameRules: Configuration = ConfigurationProperties.fromResource(

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -111,6 +111,7 @@ object OptionReader {
         addOption("cppexport", true, "C++ export macro name for explicit symbol exporting.")
         addOption("internalprefix", true, "Name prefix for internal conversion functions in Swift.")
         addOption("libraryname", true, "Name of the generated library for some generators (e.g. Dart).")
+        addOption("dartlookuperrormessage", true, "Custom error message for when Dart FFI function lookup fails.")
         addOption(
             "werror",
             "warning-as-error",
@@ -187,6 +188,7 @@ object OptionReader {
         getStringValue("cppexport")?.let { options.cppExport = it }
         getStringValue("internalprefix")?.let { options.internalPrefix = it }
         getStringValue("libraryname")?.let { options.libraryName = it }
+        getStringValue("dartlookuperrormessage")?.let { options.dartLookupErrorMessage = it }
         getStringListValue("werror")?.let { options.werror = it.toSet() }
         options.generateStubs = getFlagValue("stubs")
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -68,6 +68,7 @@ import java.util.logging.Logger
 class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
 
     private val libraryName = options.libraryName
+    private val lookupErrorMessage = options.dartLookupErrorMessage
     private val nameRules = NameRules(nameRuleSetFromConfig(options.dartNameRules))
     private val cppNameRules =
         CppNameRules(options.cppRootNamespace, nameRuleSetFromConfig(options.cppNameRules))
@@ -306,6 +307,7 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
         }
         val templateData = mapOf(
             "libraryName" to libraryName,
+            "lookupErrorMessage" to lookupErrorMessage,
             "builtInTypes" to
                 LimeBasicType.TypeId.values().filterNot { it == LimeBasicType.TypeId.VOID },
             "typeRepositories" to typeRepositories.sortedBy { it.fullName },

--- a/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
@@ -29,31 +29,31 @@ import 'package:{{libraryName}}/src/_library_context.dart' as __lib;
 
 // Blob
 
-final _Blob_create_handle = __lib.nativeLibrary.lookupFunction<
+final _Blob_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64),
     Pointer<Void> Function(int)
-  >('{{libraryName}}_blob_create_handle');
-final _Blob_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_blob_create_handle'));
+final _Blob_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_blob_release_handle');
-final _Blob_get_length = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_blob_release_handle'));
+final _Blob_get_length = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('{{libraryName}}_blob_get_length');
-final _Blob_get_data_pointer = __lib.nativeLibrary.lookupFunction<
+>('{{libraryName}}_blob_get_length'));
+final _Blob_get_data_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Uint8> Function(Pointer<Void>),
     Pointer<Uint8> Function(Pointer<Void>)
->('{{libraryName}}_blob_get_data_pointer');
+>('{{libraryName}}_blob_get_data_pointer'));
 
 Pointer<Void> Blob_toFfi(Uint8List list) {
   final result = _Blob_create_handle(list.length);
-  _Blob_get_data_pointer(result).asTypedList(list.length).setRange(0, list.length, list);
+  (_Blob_get_data_pointer(result) as Pointer<Uint8>).asTypedList(list.length).setRange(0, list.length, list);
   return result;
 }
 
 Uint8List Blob_fromFfi(Pointer<Void> handle) =>
-  Uint8List.fromList(_Blob_get_data_pointer(handle).asTypedList(_Blob_get_length(handle)));
+  Uint8List.fromList((_Blob_get_data_pointer(handle) as Pointer<Uint8>).asTypedList(_Blob_get_length(handle)));
 
 void Blob_releaseFfiHandle(Pointer<Void> handle) => _Blob_release_handle(handle);
 
@@ -75,18 +75,18 @@ void Date_releaseFfiHandle(int handle) {}
 
 // String
 
-final _String_create_handle = __lib.nativeLibrary.lookupFunction<
+final _String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Utf8>),
     Pointer<Void> Function(Pointer<Utf8>)
-  >('{{libraryName}}_std_string_create_handle');
-final _String_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_std_string_create_handle'));
+final _String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_std_string_release_handle');
-final _String_get_value = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_std_string_release_handle'));
+final _String_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
-  >('{{libraryName}}_std_string_get_value');
+  >('{{libraryName}}_std_string_get_value'));
 
 Pointer<Void> String_toFfi(String value) {
   final cValue = Utf8.toUtf8(value);
@@ -101,30 +101,30 @@ void String_releaseFfiHandle(Pointer<Void> handle) => _String_release_handle(han
 
 // Locale
 
-final _Locale_create_handle = __lib.nativeLibrary.lookupFunction<
+final _Locale_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
     Pointer<Void> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
-  >('{{libraryName}}_locale_create_handle');
-final _Locale_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_locale_create_handle'));
+final _Locale_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_locale_release_handle');
-final _Locale_get_language_code = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_locale_release_handle'));
+final _Locale_get_language_code = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
->('{{libraryName}}_locale_get_language_code');
-final _Locale_get_country_code = __lib.nativeLibrary.lookupFunction<
+>('{{libraryName}}_locale_get_language_code'));
+final _Locale_get_country_code = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
->('{{libraryName}}_locale_get_country_code');
-final _Locale_get_script_code = __lib.nativeLibrary.lookupFunction<
+>('{{libraryName}}_locale_get_country_code'));
+final _Locale_get_script_code = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
->('{{libraryName}}_locale_get_script_code');
-final _Locale_get_language_tag = __lib.nativeLibrary.lookupFunction<
+>('{{libraryName}}_locale_get_script_code'));
+final _Locale_get_language_tag = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
->('{{libraryName}}_locale_get_language_tag');
+>('{{libraryName}}_locale_get_language_tag'));
 
 Pointer<Void> Locale_toFfi(Locale locale) {
   final cLanguageCode = Utf8.toUtf8(locale.languageCode);
@@ -167,18 +167,18 @@ void Locale_releaseFfiHandle(Pointer<Void> handle) => _Locale_release_handle(han
 {{#builtInTypes}}
 // Nullable {{this}}
 
-final _{{this}}_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _{{this}}_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function({{resolveName "FfiApiTypes"}}),
     Pointer<Void> Function({{resolveName "FfiDartTypes"}})
-  >('{{libraryName}}_{{this}}_create_handle_nullable');
-final _{{this}}_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{this}}_create_handle_nullable'));
+final _{{this}}_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_{{this}}_release_handle_nullable');
-final _{{this}}_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{this}}_release_handle_nullable'));
+final _{{this}}_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName "FfiDartTypes"}} Function(Pointer<Void>)
-  >('{{libraryName}}_{{this}}_get_value_nullable');
+  >('{{libraryName}}_{{this}}_get_value_nullable'));
 
 Pointer<Void> {{this}}_toFfi_nullable({{resolveName}} value) {
   if (value == null) return Pointer<Void>.fromAddress(0);

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -64,25 +64,25 @@ abstract class {{resolveName}} {{#if parent}}implements {{resolveName parent}} {
 
 // {{resolveName}} "private" section, not exported.
 
-final _{{resolveName "Ffi"}}_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_copy_handle');
-final _{{resolveName "Ffi"}}_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{resolveName "Ffi"}}_copy_handle'));
+final _{{resolveName "Ffi"}}_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle');
-final _{{resolveName "Ffi"}}_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle'));
+final _{{resolveName "Ffi"}}_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('{{libraryName}}_{{resolveName "Ffi"}}_get_raw_pointer');
+    >('{{libraryName}}_{{resolveName "Ffi"}}_get_raw_pointer'));
 {{#if attributes.equatable}}{{>dart/DartFfiEqualityFunction}}{{/if}}{{!!
 }}{{#if attributes.pointerEquatable}}{{>dart/DartFfiEqualityFunction}}{{/if}}
 {{#if parent visibility.isOpen logic="or"}}
-final _{{resolveName "Ffi"}}_get_type_id = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_get_type_id');
+  >('{{libraryName}}_{{resolveName "Ffi"}}_get_type_id'));
 {{/if}}
 
 {{#functions}}
@@ -201,10 +201,10 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 {{/unless}}
 {{#if isStatic}}static {{/if}}{{resolveName typeRef}} get {{resolveName visibility}}{{resolveName}} {
   if (!_is_cached_{{resolveName}}) {
-    final _{{resolveName getter}}_ffi = __lib.nativeLibrary.lookupFunction<{{!!
+    final _{{resolveName getter}}_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<{{!!
     }}{{resolveName typeRef "FfiApiTypes"}} Function({{#unless isStatic}}Pointer<Void>, {{/unless}}Int32), {{!!
     }}{{resolveName typeRef "FfiDartTypes"}} Function({{#unless isStatic}}Pointer<Void>, {{/unless}}int)>{{!!
-    }}('{{libraryName}}_{{resolveName getter "Ffi"}}');
+    }}('{{libraryName}}_{{resolveName getter "Ffi"}}'));
     final __result_handle = _{{resolveName getter}}_ffi({{!!
     }}{{#unless isStatic}}this.handle, {{/unless}}__lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/main/resources/templates/dart/DartFfiEqualityFunction.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFfiEqualityFunction.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-final __are_equal = __lib.nativeLibrary.lookupFunction<
+final __are_equal = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_are_equal');
+  >('{{libraryName}}_{{resolveName "Ffi"}}_are_equal'));

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
@@ -19,7 +19,7 @@
   !
   !}}
  {
-  final _{{resolveName}}_ffi = __lib.nativeLibrary.lookupFunction<{{>ffiApi}}, {{>ffiDart}}>('{{libraryName}}_{{resolveName "Ffi"}}');
+  final _{{resolveName}}_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<{{>ffiApi}}, {{>ffiDart}}>('{{libraryName}}_{{resolveName "Ffi"}}'));
 {{#parameters}}
   final _{{resolveName}}_handle = {{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
 {{/parameters}}{{#unless isStatic}}

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionException.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionException.mustache
@@ -19,22 +19,22 @@
   !
   !}}
 {{#if thrownType}}
-final _{{resolveName}}_return_release_handle = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName}}_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_return_release_handle');
-final _{{resolveName}}_return_get_result = {{#unless returnType.isVoid}}__lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{resolveName "Ffi"}}_return_release_handle'));
+final _{{resolveName}}_return_get_result = {{#unless returnType.isVoid}}__lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName returnType.typeRef "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName returnType.typeRef "FfiDartTypes"}} Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_return_get_result');{{/unless}}{{!!
+  >('{{libraryName}}_{{resolveName "Ffi"}}_return_get_result'));{{/unless}}{{!!
     }}{{#if returnType.isVoid}}(Pointer) {};{{/if}}
-final _{{resolveName}}_return_get_error = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName}}_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName exception.errorType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName exception.errorType "FfiDartTypes"}} Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_return_get_error');
-final _{{resolveName}}_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{resolveName "Ffi"}}_return_get_error'));
+final _{{resolveName}}_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_return_has_error');
+  >('{{libraryName}}_{{resolveName "Ffi"}}_return_has_error'));
 
 {{/if}}

--- a/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
@@ -30,57 +30,57 @@ import 'package:ffi/ffi.dart';
 import 'package:{{libraryName}}/src/_library_context.dart' as __lib;
 
 {{#genericTypes}}
-final _{{resolveName "Ffi"}}_create_handle = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('{{libraryName}}_{{resolveName "Ffi"}}_create_handle');
-final _{{resolveName "Ffi"}}_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{resolveName "Ffi"}}_create_handle'));
+final _{{resolveName "Ffi"}}_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle');
+  >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle'));
 {{#instanceOf this "LimeMap"}}
-final _{{resolveName "Ffi"}}_put = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, {{resolveName keyType "FfiApiTypes"}}, {{resolveName valueType "FfiApiTypes"}}),
     void Function(Pointer<Void>, {{resolveName keyType "FfiDartTypes"}}, {{resolveName valueType "FfiDartTypes"}})
-  >('{{libraryName}}_{{resolveName "Ffi"}}_put');
+  >('{{libraryName}}_{{resolveName "Ffi"}}_put'));
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
-final _{{resolveName "Ffi"}}_insert = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, {{resolveName elementType "FfiApiTypes"}}),
     void Function(Pointer<Void>, {{resolveName elementType "FfiDartTypes"}})
-  >('{{libraryName}}_{{resolveName "Ffi"}}_insert');
+  >('{{libraryName}}_{{resolveName "Ffi"}}_insert'));
 {{/notInstanceOf}}
-final _{{resolveName "Ffi"}}_iterator = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator');
-final _{{resolveName "Ffi"}}_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('{{libraryName}}_{{resolveName "Ffi"}}_iterator'));
+final _{{resolveName "Ffi"}}_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator_release_handle');
-final _{{resolveName "Ffi"}}_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('{{libraryName}}_{{resolveName "Ffi"}}_iterator_release_handle'));
+final _{{resolveName "Ffi"}}_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator_is_valid');
-final _{{resolveName "Ffi"}}_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('{{libraryName}}_{{resolveName "Ffi"}}_iterator_is_valid'));
+final _{{resolveName "Ffi"}}_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator_increment');
+>('{{libraryName}}_{{resolveName "Ffi"}}_iterator_increment'));
 {{#instanceOf this "LimeMap"}}
-final _{{resolveName "Ffi"}}_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName keyType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName keyType "FfiDartTypes"}} Function(Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator_get_key');
-final _{{resolveName "Ffi"}}_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('{{libraryName}}_{{resolveName "Ffi"}}_iterator_get_key'));
+final _{{resolveName "Ffi"}}_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName valueType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName valueType "FfiDartTypes"}} Function(Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator_get_value');
+>('{{libraryName}}_{{resolveName "Ffi"}}_iterator_get_value'));
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
-final _{{resolveName "Ffi"}}_iterator_get = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName elementType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName elementType "FfiDartTypes"}} Function(Pointer<Void>)
->('{{libraryName}}_{{resolveName "Ffi"}}_iterator_get');
+>('{{libraryName}}_{{resolveName "Ffi"}}_iterator_get'));
 {{/notInstanceOf}}
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -82,27 +82,27 @@ abstract class {{resolveName}} {{#if parent}}implements {{resolveName parent}} {
 
 // {{resolveName}} "private" section, not exported.
 
-final _{{resolveName "Ffi"}}_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_copy_handle');
-final _{{resolveName "Ffi"}}_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{resolveName "Ffi"}}_copy_handle'));
+final _{{resolveName "Ffi"}}_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle');
-final _{{resolveName "Ffi"}}_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle'));
+final _{{resolveName "Ffi"}}_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer{{>ffiFunctionPointers}}),
     Pointer<Void> Function(int, int, Pointer{{>ffiFunctionPointers}})
-  >('{{libraryName}}_{{resolveName "Ffi"}}_create_proxy');
-final _{{resolveName "Ffi"}}_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{resolveName "Ffi"}}_create_proxy'));
+final _{{resolveName "Ffi"}}_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('{{libraryName}}_{{resolveName "Ffi"}}_get_raw_pointer');
+    >('{{libraryName}}_{{resolveName "Ffi"}}_get_raw_pointer'));
 {{#if attributes.equatable}}{{>dart/DartFfiEqualityFunction}}{{/if}}
-final _{{resolveName "Ffi"}}_get_type_id = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_get_type_id');
+  >('{{libraryName}}_{{resolveName "Ffi"}}_get_type_id'));
 
 {{#functions}}
 {{>dart/DartFunctionException}}

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -23,22 +23,22 @@ typedef {{resolveName}} = {{>dart/DartLambdaType}};
 
 // {{resolveName}} "private" section, not exported.
 
-final _{{resolveName "Ffi"}}_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_copy_handle');
-final _{{resolveName "Ffi"}}_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{resolveName "Ffi"}}_copy_handle'));
+final _{{resolveName "Ffi"}}_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle');
-final _{{resolveName "Ffi"}}_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle'));
+final _{{resolveName "Ffi"}}_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_create_proxy');
-final _{{resolveName "Ffi"}}_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{resolveName "Ffi"}}_create_proxy'));
+final _{{resolveName "Ffi"}}_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('{{libraryName}}_{{resolveName "Ffi"}}_get_raw_pointer');
+    >('{{libraryName}}_{{resolveName "Ffi"}}_get_raw_pointer'));
 
 class {{resolveName}}$Impl {
   Pointer<Void> get _handle => handle;

--- a/gluecodium/src/main/resources/templates/dart/DartLibraryContext.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLibraryContext.mustache
@@ -42,22 +42,30 @@ String _getLibraryPath(String nativeLibraryName) {
   return 'lib${nativeLibraryName}.so';
 }
 
-final _library_callbacks_queue_init = nativeLibrary.lookupFunction<
+dynamic catchArgumentError(Function f) {
+  try {
+    return f();
+  } on ArgumentError catch (e) {
+    throw ArgumentError("{{lookupErrorMessage}}\n" + e.message);
+  }
+}
+
+final _library_callbacks_queue_init = catchArgumentError(() => nativeLibrary.lookupFunction<
     Int32 Function(Uint8),
     int Function(int)
-  >('{{libraryName}}_library_callbacks_queue_init');
-final _library_callbacks_queue_release = nativeLibrary.lookupFunction<
+  >('{{libraryName}}_library_callbacks_queue_init'));
+final _library_callbacks_queue_release = catchArgumentError(() => nativeLibrary.lookupFunction<
     Void Function(Int32),
     void Function(int)
-  >('{{libraryName}}_library_callbacks_queue_release');
-final _library_wait_for_callbacks = nativeLibrary.lookupFunction<
+  >('{{libraryName}}_library_callbacks_queue_release'));
+final _library_wait_for_callbacks = catchArgumentError(() => nativeLibrary.lookupFunction<
     Uint8 Function(Int32),
     int Function(int)
-  >('{{libraryName}}_library_wait_for_callbacks');
-final _library_execute_callbacks = nativeLibrary.lookupFunction<
+  >('{{libraryName}}_library_wait_for_callbacks'));
+final _library_execute_callbacks = catchArgumentError(() => nativeLibrary.lookupFunction<
     Void Function(Int32),
     void Function(int)
-  >('{{libraryName}}_library_execute_callbacks');
+  >('{{libraryName}}_library_execute_callbacks'));
 
 class _SentryIsolateMessage {
   _SentryIsolateMessage(this.port, this.isolateId, this.nativeLibraryPath);

--- a/gluecodium/src/main/resources/templates/dart/DartNullableTypeConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartNullableTypeConversion.mustache
@@ -18,18 +18,18 @@
   ! License-Filename: LICENSE
   !
   !}}
-final _{{resolveName "Ffi"}}_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function({{resolveName "FfiApiTypes"}}),
     Pointer<Void> Function({{resolveName "FfiDartTypes"}})
-  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_create_handle_nullable');
-final _{{resolveName "Ffi"}}_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_create_handle_nullable'));
+final _{{resolveName "Ffi"}}_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_release_handle_nullable');
-final _{{resolveName "Ffi"}}_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_release_handle_nullable'));
+final _{{resolveName "Ffi"}}_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName "FfiDartTypes"}} Function(Pointer<Void>)
-  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_get_value_nullable');
+  >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_get_value_nullable'));
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName this "" "ref"}} value) {
   if (value == null) return Pointer<Void>.fromAddress(0);

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -78,19 +78,19 @@ class {{resolveName}}{{#if external.dart.converter}}_internal{{/if}} {
 
 // {{resolveName}} "private" section, not exported.
 
-final _{{resolveName "Ffi"}}_create_handle = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function({{#fields}}{{resolveName typeRef "FfiApiTypes"}}{{#if iter.hasNext}}, {{/if}}{{/fields}}),
     Pointer<Void> Function({{#fields}}{{resolveName typeRef "FfiDartTypes"}}{{#if iter.hasNext}}, {{/if}}{{/fields}})
-  >('{{libraryName}}_{{resolveName "Ffi"}}_create_handle');
-final _{{resolveName "Ffi"}}_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('{{libraryName}}_{{resolveName "Ffi"}}_create_handle'));
+final _{{resolveName "Ffi"}}_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle');
+  >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle'));
 {{#set parent=this}}{{#fields}}
-final _{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}} = __lib.nativeLibrary.lookupFunction<
+final _{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}} = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName typeRef "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName typeRef "FfiDartTypes"}} Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}}');
+  >('{{libraryName}}_{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}}'));
 {{/fields}}{{/set}}
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName this "" "ref"}} value{{#if external.dart.converter}}_ext{{/if}}) {

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/builtin_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/builtin_types__conversion.dart
@@ -4,29 +4,29 @@ import 'package:ffi/ffi.dart';
 import 'package:intl/locale.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 // Blob
-final _Blob_create_handle = __lib.nativeLibrary.lookupFunction<
+final _Blob_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64),
     Pointer<Void> Function(int)
-  >('library_blob_create_handle');
-final _Blob_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_blob_create_handle'));
+final _Blob_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_blob_release_handle');
-final _Blob_get_length = __lib.nativeLibrary.lookupFunction<
+  >('library_blob_release_handle'));
+final _Blob_get_length = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_blob_get_length');
-final _Blob_get_data_pointer = __lib.nativeLibrary.lookupFunction<
+>('library_blob_get_length'));
+final _Blob_get_data_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Uint8> Function(Pointer<Void>),
     Pointer<Uint8> Function(Pointer<Void>)
->('library_blob_get_data_pointer');
+>('library_blob_get_data_pointer'));
 Pointer<Void> Blob_toFfi(Uint8List list) {
   final result = _Blob_create_handle(list.length);
-  _Blob_get_data_pointer(result).asTypedList(list.length).setRange(0, list.length, list);
+  (_Blob_get_data_pointer(result) as Pointer<Uint8>).asTypedList(list.length).setRange(0, list.length, list);
   return result;
 }
 Uint8List Blob_fromFfi(Pointer<Void> handle) =>
-  Uint8List.fromList(_Blob_get_data_pointer(handle).asTypedList(_Blob_get_length(handle)));
+  Uint8List.fromList((_Blob_get_data_pointer(handle) as Pointer<Uint8>).asTypedList(_Blob_get_length(handle)));
 void Blob_releaseFfiHandle(Pointer<Void> handle) => _Blob_release_handle(handle);
 // Boolean
 int Boolean_toFfi(bool value) => value ? 1 : 0;
@@ -37,18 +37,18 @@ int Date_toFfi(DateTime value) => value.microsecondsSinceEpoch;
 DateTime Date_fromFfi(int us) => DateTime.fromMicrosecondsSinceEpoch(us, isUtc: true);
 void Date_releaseFfiHandle(int handle) {}
 // String
-final _String_create_handle = __lib.nativeLibrary.lookupFunction<
+final _String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Utf8>),
     Pointer<Void> Function(Pointer<Utf8>)
-  >('library_std_string_create_handle');
-final _String_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_std_string_create_handle'));
+final _String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_std_string_release_handle');
-final _String_get_value = __lib.nativeLibrary.lookupFunction<
+  >('library_std_string_release_handle'));
+final _String_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
-  >('library_std_string_get_value');
+  >('library_std_string_get_value'));
 Pointer<Void> String_toFfi(String value) {
   final cValue = Utf8.toUtf8(value);
   final result = _String_create_handle(cValue);
@@ -58,30 +58,30 @@ Pointer<Void> String_toFfi(String value) {
 String String_fromFfi(Pointer<Void> handle) => Utf8.fromUtf8(_String_get_value(handle));
 void String_releaseFfiHandle(Pointer<Void> handle) => _String_release_handle(handle);
 // Locale
-final _Locale_create_handle = __lib.nativeLibrary.lookupFunction<
+final _Locale_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
     Pointer<Void> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
-  >('library_locale_create_handle');
-final _Locale_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_locale_create_handle'));
+final _Locale_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_locale_release_handle');
-final _Locale_get_language_code = __lib.nativeLibrary.lookupFunction<
+  >('library_locale_release_handle'));
+final _Locale_get_language_code = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
->('library_locale_get_language_code');
-final _Locale_get_country_code = __lib.nativeLibrary.lookupFunction<
+>('library_locale_get_language_code'));
+final _Locale_get_country_code = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
->('library_locale_get_country_code');
-final _Locale_get_script_code = __lib.nativeLibrary.lookupFunction<
+>('library_locale_get_country_code'));
+final _Locale_get_script_code = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
->('library_locale_get_script_code');
-final _Locale_get_language_tag = __lib.nativeLibrary.lookupFunction<
+>('library_locale_get_script_code'));
+final _Locale_get_language_tag = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
->('library_locale_get_language_tag');
+>('library_locale_get_language_tag'));
 Pointer<Void> Locale_toFfi(Locale locale) {
   final cLanguageCode = Utf8.toUtf8(locale.languageCode);
   final cCountryCode =
@@ -113,18 +113,18 @@ Locale Locale_fromFfi(Pointer<Void> handle) {
 }
 void Locale_releaseFfiHandle(Pointer<Void> handle) => _Locale_release_handle(handle);
 // Nullable Byte
-final _Byte_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _Byte_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int8),
     Pointer<Void> Function(int)
-  >('library_Byte_create_handle_nullable');
-final _Byte_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Byte_create_handle_nullable'));
+final _Byte_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_Byte_release_handle_nullable');
-final _Byte_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Byte_release_handle_nullable'));
+final _Byte_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_Byte_get_value_nullable');
+  >('library_Byte_get_value_nullable'));
 Pointer<Void> Byte_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
@@ -139,18 +139,18 @@ int Byte_fromFfi_nullable(Pointer<Void> handle) {
 }
 void Byte_releaseFfiHandle_nullable(Pointer<Void> handle) => _Byte_release_handle_nullable(handle);
 // Nullable UByte
-final _UByte_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _UByte_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
-  >('library_UByte_create_handle_nullable');
-final _UByte_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_UByte_create_handle_nullable'));
+final _UByte_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_UByte_release_handle_nullable');
-final _UByte_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_UByte_release_handle_nullable'));
+final _UByte_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_UByte_get_value_nullable');
+  >('library_UByte_get_value_nullable'));
 Pointer<Void> UByte_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
@@ -165,18 +165,18 @@ int UByte_fromFfi_nullable(Pointer<Void> handle) {
 }
 void UByte_releaseFfiHandle_nullable(Pointer<Void> handle) => _UByte_release_handle_nullable(handle);
 // Nullable Short
-final _Short_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _Short_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int16),
     Pointer<Void> Function(int)
-  >('library_Short_create_handle_nullable');
-final _Short_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Short_create_handle_nullable'));
+final _Short_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_Short_release_handle_nullable');
-final _Short_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Short_release_handle_nullable'));
+final _Short_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int16 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_Short_get_value_nullable');
+  >('library_Short_get_value_nullable'));
 Pointer<Void> Short_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
@@ -191,18 +191,18 @@ int Short_fromFfi_nullable(Pointer<Void> handle) {
 }
 void Short_releaseFfiHandle_nullable(Pointer<Void> handle) => _Short_release_handle_nullable(handle);
 // Nullable UShort
-final _UShort_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _UShort_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint16),
     Pointer<Void> Function(int)
-  >('library_UShort_create_handle_nullable');
-final _UShort_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_UShort_create_handle_nullable'));
+final _UShort_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_UShort_release_handle_nullable');
-final _UShort_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_UShort_release_handle_nullable'));
+final _UShort_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint16 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_UShort_get_value_nullable');
+  >('library_UShort_get_value_nullable'));
 Pointer<Void> UShort_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
@@ -217,18 +217,18 @@ int UShort_fromFfi_nullable(Pointer<Void> handle) {
 }
 void UShort_releaseFfiHandle_nullable(Pointer<Void> handle) => _UShort_release_handle_nullable(handle);
 // Nullable Int
-final _Int_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32),
     Pointer<Void> Function(int)
-  >('library_Int_create_handle_nullable');
-final _Int_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Int_create_handle_nullable'));
+final _Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_Int_release_handle_nullable');
-final _Int_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Int_release_handle_nullable'));
+final _Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_Int_get_value_nullable');
+  >('library_Int_get_value_nullable'));
 Pointer<Void> Int_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
@@ -243,18 +243,18 @@ int Int_fromFfi_nullable(Pointer<Void> handle) {
 }
 void Int_releaseFfiHandle_nullable(Pointer<Void> handle) => _Int_release_handle_nullable(handle);
 // Nullable UInt
-final _UInt_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _UInt_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_UInt_create_handle_nullable');
-final _UInt_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_UInt_create_handle_nullable'));
+final _UInt_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_UInt_release_handle_nullable');
-final _UInt_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_UInt_release_handle_nullable'));
+final _UInt_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_UInt_get_value_nullable');
+  >('library_UInt_get_value_nullable'));
 Pointer<Void> UInt_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
@@ -269,18 +269,18 @@ int UInt_fromFfi_nullable(Pointer<Void> handle) {
 }
 void UInt_releaseFfiHandle_nullable(Pointer<Void> handle) => _UInt_release_handle_nullable(handle);
 // Nullable Long
-final _Long_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _Long_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int64),
     Pointer<Void> Function(int)
-  >('library_Long_create_handle_nullable');
-final _Long_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Long_create_handle_nullable'));
+final _Long_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_Long_release_handle_nullable');
-final _Long_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Long_release_handle_nullable'));
+final _Long_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_Long_get_value_nullable');
+  >('library_Long_get_value_nullable'));
 Pointer<Void> Long_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
@@ -295,18 +295,18 @@ int Long_fromFfi_nullable(Pointer<Void> handle) {
 }
 void Long_releaseFfiHandle_nullable(Pointer<Void> handle) => _Long_release_handle_nullable(handle);
 // Nullable ULong
-final _ULong_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _ULong_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64),
     Pointer<Void> Function(int)
-  >('library_ULong_create_handle_nullable');
-final _ULong_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ULong_create_handle_nullable'));
+final _ULong_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ULong_release_handle_nullable');
-final _ULong_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ULong_release_handle_nullable'));
+final _ULong_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_ULong_get_value_nullable');
+  >('library_ULong_get_value_nullable'));
 Pointer<Void> ULong_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
@@ -321,18 +321,18 @@ int ULong_fromFfi_nullable(Pointer<Void> handle) {
 }
 void ULong_releaseFfiHandle_nullable(Pointer<Void> handle) => _ULong_release_handle_nullable(handle);
 // Nullable Float
-final _Float_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _Float_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Float),
     Pointer<Void> Function(double)
-  >('library_Float_create_handle_nullable');
-final _Float_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Float_create_handle_nullable'));
+final _Float_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_Float_release_handle_nullable');
-final _Float_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Float_release_handle_nullable'));
+final _Float_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_Float_get_value_nullable');
+  >('library_Float_get_value_nullable'));
 Pointer<Void> Float_toFfi_nullable(double value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
@@ -347,18 +347,18 @@ double Float_fromFfi_nullable(Pointer<Void> handle) {
 }
 void Float_releaseFfiHandle_nullable(Pointer<Void> handle) => _Float_release_handle_nullable(handle);
 // Nullable Double
-final _Double_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _Double_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
-  >('library_Double_create_handle_nullable');
-final _Double_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Double_create_handle_nullable'));
+final _Double_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_Double_release_handle_nullable');
-final _Double_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Double_release_handle_nullable'));
+final _Double_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_Double_get_value_nullable');
+  >('library_Double_get_value_nullable'));
 Pointer<Void> Double_toFfi_nullable(double value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
@@ -373,18 +373,18 @@ double Double_fromFfi_nullable(Pointer<Void> handle) {
 }
 void Double_releaseFfiHandle_nullable(Pointer<Void> handle) => _Double_release_handle_nullable(handle);
 // Nullable Boolean
-final _Boolean_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
-  >('library_Boolean_create_handle_nullable');
-final _Boolean_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Boolean_create_handle_nullable'));
+final _Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_Boolean_release_handle_nullable');
-final _Boolean_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Boolean_release_handle_nullable'));
+final _Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_Boolean_get_value_nullable');
+  >('library_Boolean_get_value_nullable'));
 Pointer<Void> Boolean_toFfi_nullable(bool value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = Boolean_toFfi(value);
@@ -401,18 +401,18 @@ bool Boolean_fromFfi_nullable(Pointer<Void> handle) {
 }
 void Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) => _Boolean_release_handle_nullable(handle);
 // Nullable String
-final _String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_String_create_handle_nullable');
-final _String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_String_create_handle_nullable'));
+final _String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_String_release_handle_nullable');
-final _String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_String_release_handle_nullable'));
+final _String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_String_get_value_nullable');
+  >('library_String_get_value_nullable'));
 Pointer<Void> String_toFfi_nullable(String value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = String_toFfi(value);
@@ -429,18 +429,18 @@ String String_fromFfi_nullable(Pointer<Void> handle) {
 }
 void String_releaseFfiHandle_nullable(Pointer<Void> handle) => _String_release_handle_nullable(handle);
 // Nullable Blob
-final _Blob_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _Blob_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_Blob_create_handle_nullable');
-final _Blob_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Blob_create_handle_nullable'));
+final _Blob_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_Blob_release_handle_nullable');
-final _Blob_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Blob_release_handle_nullable'));
+final _Blob_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_Blob_get_value_nullable');
+  >('library_Blob_get_value_nullable'));
 Pointer<Void> Blob_toFfi_nullable(Uint8List value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = Blob_toFfi(value);
@@ -457,18 +457,18 @@ Uint8List Blob_fromFfi_nullable(Pointer<Void> handle) {
 }
 void Blob_releaseFfiHandle_nullable(Pointer<Void> handle) => _Blob_release_handle_nullable(handle);
 // Nullable Date
-final _Date_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _Date_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64),
     Pointer<Void> Function(int)
-  >('library_Date_create_handle_nullable');
-final _Date_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Date_create_handle_nullable'));
+final _Date_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_Date_release_handle_nullable');
-final _Date_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Date_release_handle_nullable'));
+final _Date_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_Date_get_value_nullable');
+  >('library_Date_get_value_nullable'));
 Pointer<Void> Date_toFfi_nullable(DateTime value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = Date_toFfi(value);
@@ -485,18 +485,18 @@ DateTime Date_fromFfi_nullable(Pointer<Void> handle) {
 }
 void Date_releaseFfiHandle_nullable(Pointer<Void> handle) => _Date_release_handle_nullable(handle);
 // Nullable Locale
-final _Locale_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _Locale_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_Locale_create_handle_nullable');
-final _Locale_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Locale_create_handle_nullable'));
+final _Locale_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_Locale_release_handle_nullable');
-final _Locale_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_Locale_release_handle_nullable'));
+final _Locale_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_Locale_get_value_nullable');
+  >('library_Locale_get_value_nullable'));
 Pointer<Void> Locale_toFfi_nullable(Locale value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = Locale_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -24,18 +24,18 @@ abstract class BasicTypes {
   static int ulongFunction(int input) => BasicTypes$Impl.ulongFunction(input);
 }
 // BasicTypes "private" section, not exported.
-final _smoke_BasicTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_BasicTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_BasicTypes_copy_handle');
-final _smoke_BasicTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_BasicTypes_copy_handle'));
+final _smoke_BasicTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_BasicTypes_release_handle');
-final _smoke_BasicTypes_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_BasicTypes_release_handle'));
+final _smoke_BasicTypes_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_BasicTypes_get_raw_pointer');
+    >('library_smoke_BasicTypes_get_raw_pointer'));
 class BasicTypes$Impl implements BasicTypes {
   @protected
   Pointer<Void> handle;
@@ -48,7 +48,7 @@ class BasicTypes$Impl implements BasicTypes {
     handle = null;
   }
   static String stringFunction(String input) {
-    final _stringFunction_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_BasicTypes_stringFunction__String');
+    final _stringFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_BasicTypes_stringFunction__String'));
     final _input_handle = String_toFfi(input);
     final __result_handle = _stringFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
@@ -59,7 +59,7 @@ class BasicTypes$Impl implements BasicTypes {
     }
   }
   static bool boolFunction(bool input) {
-    final _boolFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_boolFunction__Boolean');
+    final _boolFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_boolFunction__Boolean'));
     final _input_handle = Boolean_toFfi(input);
     final __result_handle = _boolFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     Boolean_releaseFfiHandle(_input_handle);
@@ -70,7 +70,7 @@ class BasicTypes$Impl implements BasicTypes {
     }
   }
   static double floatFunction(double input) {
-    final _floatFunction_ffi = __lib.nativeLibrary.lookupFunction<Float Function(Int32, Float), double Function(int, double)>('library_smoke_BasicTypes_floatFunction__Float');
+    final _floatFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Int32, Float), double Function(int, double)>('library_smoke_BasicTypes_floatFunction__Float'));
     final _input_handle = (input);
     final __result_handle = _floatFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
@@ -81,7 +81,7 @@ class BasicTypes$Impl implements BasicTypes {
     }
   }
   static double doubleFunction(double input) {
-    final _doubleFunction_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_BasicTypes_doubleFunction__Double');
+    final _doubleFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_BasicTypes_doubleFunction__Double'));
     final _input_handle = (input);
     final __result_handle = _doubleFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
@@ -92,7 +92,7 @@ class BasicTypes$Impl implements BasicTypes {
     }
   }
   static int byteFunction(int input) {
-    final _byteFunction_ffi = __lib.nativeLibrary.lookupFunction<Int8 Function(Int32, Int8), int Function(int, int)>('library_smoke_BasicTypes_byteFunction__Byte');
+    final _byteFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int8 Function(Int32, Int8), int Function(int, int)>('library_smoke_BasicTypes_byteFunction__Byte'));
     final _input_handle = (input);
     final __result_handle = _byteFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
@@ -103,7 +103,7 @@ class BasicTypes$Impl implements BasicTypes {
     }
   }
   static int shortFunction(int input) {
-    final _shortFunction_ffi = __lib.nativeLibrary.lookupFunction<Int16 Function(Int32, Int16), int Function(int, int)>('library_smoke_BasicTypes_shortFunction__Short');
+    final _shortFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int16 Function(Int32, Int16), int Function(int, int)>('library_smoke_BasicTypes_shortFunction__Short'));
     final _input_handle = (input);
     final __result_handle = _shortFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
@@ -114,7 +114,7 @@ class BasicTypes$Impl implements BasicTypes {
     }
   }
   static int intFunction(int input) {
-    final _intFunction_ffi = __lib.nativeLibrary.lookupFunction<Int32 Function(Int32, Int32), int Function(int, int)>('library_smoke_BasicTypes_intFunction__Int');
+    final _intFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Int32, Int32), int Function(int, int)>('library_smoke_BasicTypes_intFunction__Int'));
     final _input_handle = (input);
     final __result_handle = _intFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
@@ -125,7 +125,7 @@ class BasicTypes$Impl implements BasicTypes {
     }
   }
   static int longFunction(int input) {
-    final _longFunction_ffi = __lib.nativeLibrary.lookupFunction<Int64 Function(Int32, Int64), int Function(int, int)>('library_smoke_BasicTypes_longFunction__Long');
+    final _longFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int64 Function(Int32, Int64), int Function(int, int)>('library_smoke_BasicTypes_longFunction__Long'));
     final _input_handle = (input);
     final __result_handle = _longFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
@@ -136,7 +136,7 @@ class BasicTypes$Impl implements BasicTypes {
     }
   }
   static int ubyteFunction(int input) {
-    final _ubyteFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_ubyteFunction__UByte');
+    final _ubyteFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_ubyteFunction__UByte'));
     final _input_handle = (input);
     final __result_handle = _ubyteFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
@@ -147,7 +147,7 @@ class BasicTypes$Impl implements BasicTypes {
     }
   }
   static int ushortFunction(int input) {
-    final _ushortFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint16 Function(Int32, Uint16), int Function(int, int)>('library_smoke_BasicTypes_ushortFunction__UShort');
+    final _ushortFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint16 Function(Int32, Uint16), int Function(int, int)>('library_smoke_BasicTypes_ushortFunction__UShort'));
     final _input_handle = (input);
     final __result_handle = _ushortFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
@@ -158,7 +158,7 @@ class BasicTypes$Impl implements BasicTypes {
     }
   }
   static int uintFunction(int input) {
-    final _uintFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_BasicTypes_uintFunction__UInt');
+    final _uintFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_BasicTypes_uintFunction__UInt'));
     final _input_handle = (input);
     final __result_handle = _uintFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
@@ -169,7 +169,7 @@ class BasicTypes$Impl implements BasicTypes {
     }
   }
   static int ulongFunction(int input) {
-    final _ulongFunction_ffi = __lib.nativeLibrary.lookupFunction<Uint64 Function(Int32, Uint64), int Function(int, int)>('library_smoke_BasicTypes_ulongFunction__ULong');
+    final _ulongFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Int32, Uint64), int Function(int, int)>('library_smoke_BasicTypes_ulongFunction__ULong'));
     final _input_handle = (input);
     final __result_handle = _ulongFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -81,18 +81,18 @@ Comments_SomeEnum smoke_Comments_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_Comments_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_Comments_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Comments_SomeEnum_create_handle_nullable');
-final _smoke_Comments_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_SomeEnum_create_handle_nullable'));
+final _smoke_Comments_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeEnum_release_handle_nullable');
-final _smoke_Comments_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_SomeEnum_release_handle_nullable'));
+final _smoke_Comments_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeEnum_get_value_nullable');
+  >('library_smoke_Comments_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_Comments_SomeEnum_toFfi_nullable(Comments_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Comments_SomeEnum_toFfi(value);
@@ -129,22 +129,22 @@ class Comments_SomeStruct {
   Comments_SomeStruct(this.someField, this.nullableField);
 }
 // Comments_SomeStruct "private" section, not exported.
-final _smoke_Comments_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8, Pointer<Void>),
     Pointer<Void> Function(int, Pointer<Void>)
-  >('library_smoke_Comments_SomeStruct_create_handle');
-final _smoke_Comments_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_SomeStruct_create_handle'));
+final _smoke_Comments_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeStruct_release_handle');
-final _smoke_Comments_SomeStruct_get_field_someField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_SomeStruct_release_handle'));
+final _smoke_Comments_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeStruct_get_field_someField');
-final _smoke_Comments_SomeStruct_get_field_nullableField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_SomeStruct_get_field_someField'));
+final _smoke_Comments_SomeStruct_get_field_nullableField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeStruct_get_field_nullableField');
+  >('library_smoke_Comments_SomeStruct_get_field_nullableField'));
 Pointer<Void> smoke_Comments_SomeStruct_toFfi(Comments_SomeStruct value) {
   final _someField_handle = Boolean_toFfi(value.someField);
   final _nullableField_handle = String_toFfi_nullable(value.nullableField);
@@ -168,18 +168,18 @@ Comments_SomeStruct smoke_Comments_SomeStruct_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Comments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Comments_SomeStruct_release_handle(handle);
 // Nullable Comments_SomeStruct
-final _smoke_Comments_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeStruct_create_handle_nullable');
-final _smoke_Comments_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_SomeStruct_create_handle_nullable'));
+final _smoke_Comments_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeStruct_release_handle_nullable');
-final _smoke_Comments_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_SomeStruct_release_handle_nullable'));
+final _smoke_Comments_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeStruct_get_value_nullable');
+  >('library_smoke_Comments_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_Comments_SomeStruct_toFfi_nullable(Comments_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Comments_SomeStruct_toFfi(value);
@@ -200,29 +200,29 @@ void smoke_Comments_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =
 /// This is some very useful lambda that does it.
 typedef Comments_SomeLambda = double Function(String, int);
 // Comments_SomeLambda "private" section, not exported.
-final _smoke_Comments_SomeLambda_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeLambda_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeLambda_copy_handle');
-final _smoke_Comments_SomeLambda_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_SomeLambda_copy_handle'));
+final _smoke_Comments_SomeLambda_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeLambda_release_handle');
-final _smoke_Comments_SomeLambda_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_SomeLambda_release_handle'));
+final _smoke_Comments_SomeLambda_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_Comments_SomeLambda_create_proxy');
-final _smoke_Comments_SomeLambda_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_SomeLambda_create_proxy'));
+final _smoke_Comments_SomeLambda_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Comments_SomeLambda_get_raw_pointer');
+    >('library_smoke_Comments_SomeLambda_get_raw_pointer'));
 class Comments_SomeLambda$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Comments_SomeLambda$Impl(this.handle);
   void release() => _smoke_Comments_SomeLambda_release_handle(handle);
   double call(String p0, int p1) {
-    final _call_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>, Int32), double Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_Comments_SomeLambda_call__String_Int');
+    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>, Int32), double Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_Comments_SomeLambda_call__String_Int'));
     final _p0_handle = String_toFfi(p0);
     final _p1_handle = (p1);
     final _handle = this.handle;
@@ -270,18 +270,18 @@ Comments_SomeLambda smoke_Comments_SomeLambda_fromFfi(Pointer<Void> handle) {
 void smoke_Comments_SomeLambda_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Comments_SomeLambda_release_handle(handle);
 // Nullable Comments_SomeLambda
-final _smoke_Comments_SomeLambda_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeLambda_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeLambda_create_handle_nullable');
-final _smoke_Comments_SomeLambda_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_SomeLambda_create_handle_nullable'));
+final _smoke_Comments_SomeLambda_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeLambda_release_handle_nullable');
-final _smoke_Comments_SomeLambda_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_SomeLambda_release_handle_nullable'));
+final _smoke_Comments_SomeLambda_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Comments_SomeLambda_get_value_nullable');
+  >('library_smoke_Comments_SomeLambda_get_value_nullable'));
 Pointer<Void> smoke_Comments_SomeLambda_toFfi_nullable(Comments_SomeLambda value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Comments_SomeLambda_toFfi(value);
@@ -300,34 +300,34 @@ void smoke_Comments_SomeLambda_releaseFfiHandle_nullable(Pointer<Void> handle) =
   _smoke_Comments_SomeLambda_release_handle_nullable(handle);
 // End of Comments_SomeLambda "private" section.
 // Comments "private" section, not exported.
-final _smoke_Comments_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Comments_copy_handle');
-final _smoke_Comments_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_copy_handle'));
+final _smoke_Comments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Comments_release_handle');
-final _smoke_Comments_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_release_handle'));
+final _smoke_Comments_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Comments_get_raw_pointer');
-final _someMethodWithAllComments_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_Comments_get_raw_pointer'));
+final _someMethodWithAllComments_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Comments_someMethodWithAllComments__String_return_release_handle');
-final _someMethodWithAllComments_return_get_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_someMethodWithAllComments__String_return_release_handle'));
+final _someMethodWithAllComments_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Comments_someMethodWithAllComments__String_return_get_result');
-final _someMethodWithAllComments_return_get_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_someMethodWithAllComments__String_return_get_result'));
+final _someMethodWithAllComments_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Comments_someMethodWithAllComments__String_return_get_error');
-final _someMethodWithAllComments_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Comments_someMethodWithAllComments__String_return_get_error'));
+final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Comments_someMethodWithAllComments__String_return_has_error');
+  >('library_smoke_Comments_someMethodWithAllComments__String_return_has_error'));
 class Comments$Impl implements Comments {
   @protected
   Pointer<Void> handle;
@@ -341,7 +341,7 @@ class Comments$Impl implements Comments {
   }
   @override
   bool someMethodWithAllComments(String inputParameter) {
-    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithAllComments__String');
+    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithAllComments__String'));
     final _inputParameter_handle = String_toFfi(inputParameter);
     final _handle = this.handle;
     final __call_result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _inputParameter_handle);
@@ -365,7 +365,7 @@ class Comments$Impl implements Comments {
   }
   @override
   bool someMethodWithInputComments(String input) {
-    final _someMethodWithInputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithInputComments__String');
+    final _someMethodWithInputComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithInputComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithInputComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -378,7 +378,7 @@ class Comments$Impl implements Comments {
   }
   @override
   bool someMethodWithOutputComments(String input) {
-    final _someMethodWithOutputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithOutputComments__String');
+    final _someMethodWithOutputComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithOutputComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithOutputComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -391,7 +391,7 @@ class Comments$Impl implements Comments {
   }
   @override
   bool someMethodWithNoComments(String input) {
-    final _someMethodWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithNoComments__String');
+    final _someMethodWithNoComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithNoComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -404,7 +404,7 @@ class Comments$Impl implements Comments {
   }
   @override
   someMethodWithoutReturnTypeWithAllComments(String input) {
-    final _someMethodWithoutReturnTypeWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithAllComments__String');
+    final _someMethodWithoutReturnTypeWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithAllComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -417,7 +417,7 @@ class Comments$Impl implements Comments {
   }
   @override
   someMethodWithoutReturnTypeWithNoComments(String input) {
-    final _someMethodWithoutReturnTypeWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithNoComments__String');
+    final _someMethodWithoutReturnTypeWithNoComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithNoComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -430,7 +430,7 @@ class Comments$Impl implements Comments {
   }
   @override
   bool someMethodWithoutInputParametersWithAllComments() {
-    final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithAllComments');
+    final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithAllComments'));
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutInputParametersWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -441,7 +441,7 @@ class Comments$Impl implements Comments {
   }
   @override
   bool someMethodWithoutInputParametersWithNoComments() {
-    final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithNoComments');
+    final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithNoComments'));
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutInputParametersWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -452,7 +452,7 @@ class Comments$Impl implements Comments {
   }
   @override
   someMethodWithNothing() {
-    final _someMethodWithNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithNothing');
+    final _someMethodWithNothing_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithNothing'));
     final _handle = this.handle;
     final __result_handle = _someMethodWithNothing_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -463,7 +463,7 @@ class Comments$Impl implements Comments {
   }
   @override
   someMethodWithoutReturnTypeOrInputParameters() {
-    final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutReturnTypeOrInputParameters');
+    final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -474,7 +474,7 @@ class Comments$Impl implements Comments {
   }
   @override
   String oneParameterCommentOnly(String undocumented, String documented) {
-    final _oneParameterCommentOnly_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_oneParameterCommentOnly__String_String');
+    final _oneParameterCommentOnly_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_oneParameterCommentOnly__String_String'));
     final _undocumented_handle = String_toFfi(undocumented);
     final _documented_handle = String_toFfi(documented);
     final _handle = this.handle;
@@ -489,7 +489,7 @@ class Comments$Impl implements Comments {
   }
   @override
   String returnCommentOnly(String undocumented) {
-    final _returnCommentOnly_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_returnCommentOnly__String');
+    final _returnCommentOnly_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_returnCommentOnly__String'));
     final _undocumented_handle = String_toFfi(undocumented);
     final _handle = this.handle;
     final __result_handle = _returnCommentOnly_ffi(_handle, __lib.LibraryContext.isolateId, _undocumented_handle);
@@ -502,7 +502,7 @@ class Comments$Impl implements Comments {
   }
   @override
   bool get isSomeProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_isSomeProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_isSomeProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -513,7 +513,7 @@ class Comments$Impl implements Comments {
   }
   @override
   set isSomeProperty(bool value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Comments_isSomeProperty_set__Boolean');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Comments_isSomeProperty_set__Boolean'));
     final _value_handle = Boolean_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -105,18 +105,18 @@ CommentsInterface_SomeEnum smoke_CommentsInterface_SomeEnum_fromFfi(int handle) 
   }
 }
 void smoke_CommentsInterface_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_CommentsInterface_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsInterface_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_CommentsInterface_SomeEnum_create_handle_nullable');
-final _smoke_CommentsInterface_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsInterface_SomeEnum_create_handle_nullable'));
+final _smoke_CommentsInterface_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CommentsInterface_SomeEnum_release_handle_nullable');
-final _smoke_CommentsInterface_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsInterface_SomeEnum_release_handle_nullable'));
+final _smoke_CommentsInterface_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_CommentsInterface_SomeEnum_get_value_nullable');
+  >('library_smoke_CommentsInterface_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_CommentsInterface_SomeEnum_toFfi_nullable(CommentsInterface_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CommentsInterface_SomeEnum_toFfi(value);
@@ -141,18 +141,18 @@ class CommentsInterface_SomeStruct {
   CommentsInterface_SomeStruct(this.someField);
 }
 // CommentsInterface_SomeStruct "private" section, not exported.
-final _smoke_CommentsInterface_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsInterface_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
-  >('library_smoke_CommentsInterface_SomeStruct_create_handle');
-final _smoke_CommentsInterface_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsInterface_SomeStruct_create_handle'));
+final _smoke_CommentsInterface_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CommentsInterface_SomeStruct_release_handle');
-final _smoke_CommentsInterface_SomeStruct_get_field_someField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsInterface_SomeStruct_release_handle'));
+final _smoke_CommentsInterface_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_CommentsInterface_SomeStruct_get_field_someField');
+  >('library_smoke_CommentsInterface_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_CommentsInterface_SomeStruct_toFfi(CommentsInterface_SomeStruct value) {
   final _someField_handle = Boolean_toFfi(value.someField);
   final _result = _smoke_CommentsInterface_SomeStruct_create_handle(_someField_handle);
@@ -171,18 +171,18 @@ CommentsInterface_SomeStruct smoke_CommentsInterface_SomeStruct_fromFfi(Pointer<
 }
 void smoke_CommentsInterface_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_CommentsInterface_SomeStruct_release_handle(handle);
 // Nullable CommentsInterface_SomeStruct
-final _smoke_CommentsInterface_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsInterface_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CommentsInterface_SomeStruct_create_handle_nullable');
-final _smoke_CommentsInterface_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsInterface_SomeStruct_create_handle_nullable'));
+final _smoke_CommentsInterface_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CommentsInterface_SomeStruct_release_handle_nullable');
-final _smoke_CommentsInterface_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsInterface_SomeStruct_release_handle_nullable'));
+final _smoke_CommentsInterface_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CommentsInterface_SomeStruct_get_value_nullable');
+  >('library_smoke_CommentsInterface_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_CommentsInterface_SomeStruct_toFfi_nullable(CommentsInterface_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CommentsInterface_SomeStruct_toFfi(value);
@@ -201,26 +201,26 @@ void smoke_CommentsInterface_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> 
   _smoke_CommentsInterface_SomeStruct_release_handle_nullable(handle);
 // End of CommentsInterface_SomeStruct "private" section.
 // CommentsInterface "private" section, not exported.
-final _smoke_CommentsInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CommentsInterface_copy_handle');
-final _smoke_CommentsInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsInterface_copy_handle'));
+final _smoke_CommentsInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CommentsInterface_release_handle');
-final _smoke_CommentsInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsInterface_release_handle'));
+final _smoke_CommentsInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
-  >('library_smoke_CommentsInterface_create_proxy');
-final _smoke_CommentsInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsInterface_create_proxy'));
+final _smoke_CommentsInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_CommentsInterface_get_raw_pointer');
-final _smoke_CommentsInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_CommentsInterface_get_raw_pointer'));
+final _smoke_CommentsInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CommentsInterface_get_type_id');
+  >('library_smoke_CommentsInterface_get_type_id'));
 class CommentsInterface$Lambdas implements CommentsInterface {
   bool Function(String) lambda_someMethodWithAllComments;
   bool Function(String) lambda_someMethodWithInputComments;
@@ -311,7 +311,7 @@ class CommentsInterface$Impl implements CommentsInterface {
   }
   @override
   bool someMethodWithAllComments(String input) {
-    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithAllComments__String');
+    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithAllComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -324,7 +324,7 @@ class CommentsInterface$Impl implements CommentsInterface {
   }
   @override
   bool someMethodWithInputComments(String input) {
-    final _someMethodWithInputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithInputComments__String');
+    final _someMethodWithInputComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithInputComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithInputComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -337,7 +337,7 @@ class CommentsInterface$Impl implements CommentsInterface {
   }
   @override
   bool someMethodWithOutputComments(String input) {
-    final _someMethodWithOutputComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithOutputComments__String');
+    final _someMethodWithOutputComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithOutputComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithOutputComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -350,7 +350,7 @@ class CommentsInterface$Impl implements CommentsInterface {
   }
   @override
   bool someMethodWithNoComments(String input) {
-    final _someMethodWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithNoComments__String');
+    final _someMethodWithNoComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithNoComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -363,7 +363,7 @@ class CommentsInterface$Impl implements CommentsInterface {
   }
   @override
   someMethodWithoutReturnTypeWithAllComments(String input) {
-    final _someMethodWithoutReturnTypeWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithAllComments__String');
+    final _someMethodWithoutReturnTypeWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithAllComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -376,7 +376,7 @@ class CommentsInterface$Impl implements CommentsInterface {
   }
   @override
   someMethodWithoutReturnTypeWithNoComments(String input) {
-    final _someMethodWithoutReturnTypeWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithNoComments__String');
+    final _someMethodWithoutReturnTypeWithNoComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithNoComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -389,7 +389,7 @@ class CommentsInterface$Impl implements CommentsInterface {
   }
   @override
   bool someMethodWithoutInputParametersWithAllComments() {
-    final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithAllComments');
+    final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithAllComments'));
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutInputParametersWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -400,7 +400,7 @@ class CommentsInterface$Impl implements CommentsInterface {
   }
   @override
   bool someMethodWithoutInputParametersWithNoComments() {
-    final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithNoComments');
+    final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithNoComments'));
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutInputParametersWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -411,7 +411,7 @@ class CommentsInterface$Impl implements CommentsInterface {
   }
   @override
   someMethodWithNothing() {
-    final _someMethodWithNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithNothing');
+    final _someMethodWithNothing_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithNothing'));
     final _handle = this.handle;
     final __result_handle = _someMethodWithNothing_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -422,7 +422,7 @@ class CommentsInterface$Impl implements CommentsInterface {
   }
   @override
   someMethodWithoutReturnTypeOrInputParameters() {
-    final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeOrInputParameters');
+    final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
     final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -433,7 +433,7 @@ class CommentsInterface$Impl implements CommentsInterface {
   }
   /// Gets some very useful property.
   bool get isSomeProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_isSomeProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_isSomeProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -444,7 +444,7 @@ class CommentsInterface$Impl implements CommentsInterface {
   }
   /// Sets some very useful property.
   set isSomeProperty(bool value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_CommentsInterface_isSomeProperty_set__Boolean');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_CommentsInterface_isSomeProperty_set__Boolean'));
     final _value_handle = Boolean_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -68,18 +68,18 @@ class CommentsLinks_RandomStruct {
   CommentsLinks_RandomStruct(this.randomField);
 }
 // CommentsLinks_RandomStruct "private" section, not exported.
-final _smoke_CommentsLinks_RandomStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsLinks_RandomStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_RandomStruct_create_handle');
-final _smoke_CommentsLinks_RandomStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsLinks_RandomStruct_create_handle'));
+final _smoke_CommentsLinks_RandomStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_RandomStruct_release_handle');
-final _smoke_CommentsLinks_RandomStruct_get_field_randomField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsLinks_RandomStruct_release_handle'));
+final _smoke_CommentsLinks_RandomStruct_get_field_randomField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_RandomStruct_get_field_randomField');
+  >('library_smoke_CommentsLinks_RandomStruct_get_field_randomField'));
 Pointer<Void> smoke_CommentsLinks_RandomStruct_toFfi(CommentsLinks_RandomStruct value) {
   final _randomField_handle = smoke_Comments_SomeStruct_toFfi(value.randomField);
   final _result = _smoke_CommentsLinks_RandomStruct_create_handle(_randomField_handle);
@@ -98,18 +98,18 @@ CommentsLinks_RandomStruct smoke_CommentsLinks_RandomStruct_fromFfi(Pointer<Void
 }
 void smoke_CommentsLinks_RandomStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_CommentsLinks_RandomStruct_release_handle(handle);
 // Nullable CommentsLinks_RandomStruct
-final _smoke_CommentsLinks_RandomStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsLinks_RandomStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_RandomStruct_create_handle_nullable');
-final _smoke_CommentsLinks_RandomStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsLinks_RandomStruct_create_handle_nullable'));
+final _smoke_CommentsLinks_RandomStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_RandomStruct_release_handle_nullable');
-final _smoke_CommentsLinks_RandomStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsLinks_RandomStruct_release_handle_nullable'));
+final _smoke_CommentsLinks_RandomStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_RandomStruct_get_value_nullable');
+  >('library_smoke_CommentsLinks_RandomStruct_get_value_nullable'));
 Pointer<Void> smoke_CommentsLinks_RandomStruct_toFfi_nullable(CommentsLinks_RandomStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CommentsLinks_RandomStruct_toFfi(value);
@@ -128,34 +128,34 @@ void smoke_CommentsLinks_RandomStruct_releaseFfiHandle_nullable(Pointer<Void> ha
   _smoke_CommentsLinks_RandomStruct_release_handle_nullable(handle);
 // End of CommentsLinks_RandomStruct "private" section.
 // CommentsLinks "private" section, not exported.
-final _smoke_CommentsLinks_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsLinks_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_copy_handle');
-final _smoke_CommentsLinks_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsLinks_copy_handle'));
+final _smoke_CommentsLinks_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_release_handle');
-final _smoke_CommentsLinks_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsLinks_release_handle'));
+final _smoke_CommentsLinks_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_CommentsLinks_get_raw_pointer');
-final _randomMethod_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_CommentsLinks_get_raw_pointer'));
+final _randomMethod_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_release_handle');
-final _randomMethod_return_get_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_release_handle'));
+final _randomMethod_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_result');
-final _randomMethod_return_get_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_result'));
+final _randomMethod_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_error');
-final _randomMethod_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_error'));
+final _randomMethod_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_has_error');
+  >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_has_error'));
 class CommentsLinks$Impl implements CommentsLinks {
   @protected
   Pointer<Void> handle;
@@ -169,7 +169,7 @@ class CommentsLinks$Impl implements CommentsLinks {
   }
   @override
   Comments_SomeEnum randomMethod(Comments_SomeEnum inputParameter) {
-    final _randomMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Uint32), Pointer<Void> Function(Pointer<Void>, int, int)>('library_smoke_CommentsLinks_randomMethod__SomeEnum');
+    final _randomMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Uint32), Pointer<Void> Function(Pointer<Void>, int, int)>('library_smoke_CommentsLinks_randomMethod__SomeEnum'));
     final _inputParameter_handle = smoke_Comments_SomeEnum_toFfi(inputParameter);
     final _handle = this.handle;
     final __call_result_handle = _randomMethod_ffi(_handle, __lib.LibraryContext.isolateId, _inputParameter_handle);
@@ -193,7 +193,7 @@ class CommentsLinks$Impl implements CommentsLinks {
   }
   @override
   randomMethod2(String text, bool flag) {
-    final _randomMethod2_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_CommentsLinks_randomMethod__String_Boolean');
+    final _randomMethod2_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_CommentsLinks_randomMethod__String_Boolean'));
     final _text_handle = String_toFfi(text);
     final _flag_handle = Boolean_toFfi(flag);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -65,18 +65,18 @@ DeprecationComments_SomeEnum smoke_DeprecationComments_SomeEnum_fromFfi(int hand
   }
 }
 void smoke_DeprecationComments_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_DeprecationComments_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationComments_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_DeprecationComments_SomeEnum_create_handle_nullable');
-final _smoke_DeprecationComments_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationComments_SomeEnum_create_handle_nullable'));
+final _smoke_DeprecationComments_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DeprecationComments_SomeEnum_release_handle_nullable');
-final _smoke_DeprecationComments_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationComments_SomeEnum_release_handle_nullable'));
+final _smoke_DeprecationComments_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DeprecationComments_SomeEnum_get_value_nullable');
+  >('library_smoke_DeprecationComments_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_DeprecationComments_SomeEnum_toFfi_nullable(DeprecationComments_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecationComments_SomeEnum_toFfi(value);
@@ -108,18 +108,18 @@ class DeprecationComments_SomeStruct {
   DeprecationComments_SomeStruct(this.someField);
 }
 // DeprecationComments_SomeStruct "private" section, not exported.
-final _smoke_DeprecationComments_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationComments_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
-  >('library_smoke_DeprecationComments_SomeStruct_create_handle');
-final _smoke_DeprecationComments_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationComments_SomeStruct_create_handle'));
+final _smoke_DeprecationComments_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DeprecationComments_SomeStruct_release_handle');
-final _smoke_DeprecationComments_SomeStruct_get_field_someField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationComments_SomeStruct_release_handle'));
+final _smoke_DeprecationComments_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DeprecationComments_SomeStruct_get_field_someField');
+  >('library_smoke_DeprecationComments_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_DeprecationComments_SomeStruct_toFfi(DeprecationComments_SomeStruct value) {
   final _someField_handle = Boolean_toFfi(value.someField);
   final _result = _smoke_DeprecationComments_SomeStruct_create_handle(_someField_handle);
@@ -138,18 +138,18 @@ DeprecationComments_SomeStruct smoke_DeprecationComments_SomeStruct_fromFfi(Poin
 }
 void smoke_DeprecationComments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_DeprecationComments_SomeStruct_release_handle(handle);
 // Nullable DeprecationComments_SomeStruct
-final _smoke_DeprecationComments_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationComments_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DeprecationComments_SomeStruct_create_handle_nullable');
-final _smoke_DeprecationComments_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationComments_SomeStruct_create_handle_nullable'));
+final _smoke_DeprecationComments_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DeprecationComments_SomeStruct_release_handle_nullable');
-final _smoke_DeprecationComments_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationComments_SomeStruct_release_handle_nullable'));
+final _smoke_DeprecationComments_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DeprecationComments_SomeStruct_get_value_nullable');
+  >('library_smoke_DeprecationComments_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_DeprecationComments_SomeStruct_toFfi_nullable(DeprecationComments_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecationComments_SomeStruct_toFfi(value);
@@ -168,26 +168,26 @@ void smoke_DeprecationComments_SomeStruct_releaseFfiHandle_nullable(Pointer<Void
   _smoke_DeprecationComments_SomeStruct_release_handle_nullable(handle);
 // End of DeprecationComments_SomeStruct "private" section.
 // DeprecationComments "private" section, not exported.
-final _smoke_DeprecationComments_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DeprecationComments_copy_handle');
-final _smoke_DeprecationComments_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationComments_copy_handle'));
+final _smoke_DeprecationComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DeprecationComments_release_handle');
-final _smoke_DeprecationComments_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationComments_release_handle'));
+final _smoke_DeprecationComments_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer)
-  >('library_smoke_DeprecationComments_create_proxy');
-final _smoke_DeprecationComments_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationComments_create_proxy'));
+final _smoke_DeprecationComments_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_DeprecationComments_get_raw_pointer');
-final _smoke_DeprecationComments_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_DeprecationComments_get_raw_pointer'));
+final _smoke_DeprecationComments_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DeprecationComments_get_type_id');
+  >('library_smoke_DeprecationComments_get_type_id'));
 class DeprecationComments$Lambdas implements DeprecationComments {
   bool Function(String) lambda_someMethodWithAllComments;
   bool Function() lambda_isSomeProperty_get;
@@ -224,7 +224,7 @@ class DeprecationComments$Impl implements DeprecationComments {
   }
   @override
   bool someMethodWithAllComments(String input) {
-    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_someMethodWithAllComments__String');
+    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_someMethodWithAllComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -238,7 +238,7 @@ class DeprecationComments$Impl implements DeprecationComments {
   /// Gets some very useful property.
   @Deprecated("Unfortunately, this property's getter is deprecated.\nUse [isSomeProperty] instead.")
   bool get isSomeProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_isSomeProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_isSomeProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -250,7 +250,7 @@ class DeprecationComments$Impl implements DeprecationComments {
   /// Sets some very useful property.
   @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [isSomeProperty] instead.")
   set isSomeProperty(bool value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationComments_isSomeProperty_set__Boolean');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationComments_isSomeProperty_set__Boolean'));
     final _value_handle = Boolean_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -58,18 +58,18 @@ DeprecationCommentsOnly_SomeEnum smoke_DeprecationCommentsOnly_SomeEnum_fromFfi(
   }
 }
 void smoke_DeprecationCommentsOnly_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_DeprecationCommentsOnly_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationCommentsOnly_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_DeprecationCommentsOnly_SomeEnum_create_handle_nullable');
-final _smoke_DeprecationCommentsOnly_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationCommentsOnly_SomeEnum_create_handle_nullable'));
+final _smoke_DeprecationCommentsOnly_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DeprecationCommentsOnly_SomeEnum_release_handle_nullable');
-final _smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationCommentsOnly_SomeEnum_release_handle_nullable'));
+final _smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable');
+  >('library_smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_DeprecationCommentsOnly_SomeEnum_toFfi_nullable(DeprecationCommentsOnly_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecationCommentsOnly_SomeEnum_toFfi(value);
@@ -94,18 +94,18 @@ class DeprecationCommentsOnly_SomeStruct {
   DeprecationCommentsOnly_SomeStruct(this.someField);
 }
 // DeprecationCommentsOnly_SomeStruct "private" section, not exported.
-final _smoke_DeprecationCommentsOnly_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationCommentsOnly_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
-  >('library_smoke_DeprecationCommentsOnly_SomeStruct_create_handle');
-final _smoke_DeprecationCommentsOnly_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationCommentsOnly_SomeStruct_create_handle'));
+final _smoke_DeprecationCommentsOnly_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DeprecationCommentsOnly_SomeStruct_release_handle');
-final _smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationCommentsOnly_SomeStruct_release_handle'));
+final _smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField');
+  >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_DeprecationCommentsOnly_SomeStruct_toFfi(DeprecationCommentsOnly_SomeStruct value) {
   final _someField_handle = Boolean_toFfi(value.someField);
   final _result = _smoke_DeprecationCommentsOnly_SomeStruct_create_handle(_someField_handle);
@@ -124,18 +124,18 @@ DeprecationCommentsOnly_SomeStruct smoke_DeprecationCommentsOnly_SomeStruct_from
 }
 void smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_DeprecationCommentsOnly_SomeStruct_release_handle(handle);
 // Nullable DeprecationCommentsOnly_SomeStruct
-final _smoke_DeprecationCommentsOnly_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationCommentsOnly_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DeprecationCommentsOnly_SomeStruct_create_handle_nullable');
-final _smoke_DeprecationCommentsOnly_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationCommentsOnly_SomeStruct_create_handle_nullable'));
+final _smoke_DeprecationCommentsOnly_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DeprecationCommentsOnly_SomeStruct_release_handle_nullable');
-final _smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationCommentsOnly_SomeStruct_release_handle_nullable'));
+final _smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable');
+  >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_DeprecationCommentsOnly_SomeStruct_toFfi_nullable(DeprecationCommentsOnly_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecationCommentsOnly_SomeStruct_toFfi(value);
@@ -154,26 +154,26 @@ void smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle_nullable(Pointer<
   _smoke_DeprecationCommentsOnly_SomeStruct_release_handle_nullable(handle);
 // End of DeprecationCommentsOnly_SomeStruct "private" section.
 // DeprecationCommentsOnly "private" section, not exported.
-final _smoke_DeprecationCommentsOnly_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationCommentsOnly_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DeprecationCommentsOnly_copy_handle');
-final _smoke_DeprecationCommentsOnly_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationCommentsOnly_copy_handle'));
+final _smoke_DeprecationCommentsOnly_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DeprecationCommentsOnly_release_handle');
-final _smoke_DeprecationCommentsOnly_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationCommentsOnly_release_handle'));
+final _smoke_DeprecationCommentsOnly_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer)
-  >('library_smoke_DeprecationCommentsOnly_create_proxy');
-final _smoke_DeprecationCommentsOnly_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DeprecationCommentsOnly_create_proxy'));
+final _smoke_DeprecationCommentsOnly_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_DeprecationCommentsOnly_get_raw_pointer');
-final _smoke_DeprecationCommentsOnly_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_DeprecationCommentsOnly_get_raw_pointer'));
+final _smoke_DeprecationCommentsOnly_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DeprecationCommentsOnly_get_type_id');
+  >('library_smoke_DeprecationCommentsOnly_get_type_id'));
 class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
   bool Function(String) lambda_someMethodWithAllComments;
   bool Function() lambda_isSomeProperty_get;
@@ -210,7 +210,7 @@ class DeprecationCommentsOnly$Impl implements DeprecationCommentsOnly {
   }
   @override
   bool someMethodWithAllComments(String input) {
-    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationCommentsOnly_someMethodWithAllComments__String');
+    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationCommentsOnly_someMethodWithAllComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -223,7 +223,7 @@ class DeprecationCommentsOnly$Impl implements DeprecationCommentsOnly {
   }
   @Deprecated("Unfortunately, this property's getter is deprecated.")
   bool get isSomeProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -234,7 +234,7 @@ class DeprecationCommentsOnly$Impl implements DeprecationCommentsOnly {
   }
   @Deprecated("Unfortunately, this property's setter is deprecated.")
   set isSomeProperty(bool value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_set__Boolean');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_set__Boolean'));
     final _value_handle = Boolean_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -17,18 +17,18 @@ abstract class InternalClassWithComments {
   internal_doNothing();
 }
 // InternalClassWithComments "private" section, not exported.
-final _smoke_InternalClassWithComments_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_InternalClassWithComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_InternalClassWithComments_copy_handle');
-final _smoke_InternalClassWithComments_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_InternalClassWithComments_copy_handle'));
+final _smoke_InternalClassWithComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_InternalClassWithComments_release_handle');
-final _smoke_InternalClassWithComments_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_InternalClassWithComments_release_handle'));
+final _smoke_InternalClassWithComments_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_InternalClassWithComments_get_raw_pointer');
+    >('library_smoke_InternalClassWithComments_get_raw_pointer'));
 class InternalClassWithComments$Impl implements InternalClassWithComments {
   @protected
   Pointer<Void> handle;
@@ -42,7 +42,7 @@ class InternalClassWithComments$Impl implements InternalClassWithComments {
   }
   @override
   internal_doNothing() {
-    final _doNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithComments_doNothing');
+    final _doNothing_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithComments_doNothing'));
     final _handle = this.handle;
     final __result_handle = _doNothing_ffi(_handle, __lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -41,18 +41,18 @@ abstract class MultiLineComments {
   double someMethodWithLongComment(String input, double ratio);
 }
 // MultiLineComments "private" section, not exported.
-final _smoke_MultiLineComments_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_MultiLineComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_MultiLineComments_copy_handle');
-final _smoke_MultiLineComments_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_MultiLineComments_copy_handle'));
+final _smoke_MultiLineComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_MultiLineComments_release_handle');
-final _smoke_MultiLineComments_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_MultiLineComments_release_handle'));
+final _smoke_MultiLineComments_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_MultiLineComments_get_raw_pointer');
+    >('library_smoke_MultiLineComments_get_raw_pointer'));
 class MultiLineComments$Impl implements MultiLineComments {
   @protected
   Pointer<Void> handle;
@@ -66,7 +66,7 @@ class MultiLineComments$Impl implements MultiLineComments {
   }
   @override
   double someMethodWithLongComment(String input, double ratio) {
-    final _someMethodWithLongComment_ffi = __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32, Pointer<Void>, Double), double Function(Pointer<Void>, int, Pointer<Void>, double)>('library_smoke_MultiLineComments_someMethodWithLongComment__String_Double');
+    final _someMethodWithLongComment_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32, Pointer<Void>, Double), double Function(Pointer<Void>, int, Pointer<Void>, double)>('library_smoke_MultiLineComments_someMethodWithLongComment__String_Double'));
     final _input_handle = String_toFfi(input);
     final _ratio_handle = (ratio);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -52,18 +52,18 @@ PlatformComments_SomeEnum smoke_PlatformComments_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_PlatformComments_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_PlatformComments_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformComments_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_PlatformComments_SomeEnum_create_handle_nullable');
-final _smoke_PlatformComments_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformComments_SomeEnum_create_handle_nullable'));
+final _smoke_PlatformComments_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_SomeEnum_release_handle_nullable');
-final _smoke_PlatformComments_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformComments_SomeEnum_release_handle_nullable'));
+final _smoke_PlatformComments_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_SomeEnum_get_value_nullable');
+  >('library_smoke_PlatformComments_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_PlatformComments_SomeEnum_toFfi_nullable(PlatformComments_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PlatformComments_SomeEnum_toFfi(value);
@@ -92,18 +92,18 @@ class PlatformComments_Something {
   PlatformComments_Something(this.nothing);
 }
 // PlatformComments_Something "private" section, not exported.
-final _smoke_PlatformComments_Something_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformComments_Something_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_Something_create_handle');
-final _smoke_PlatformComments_Something_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformComments_Something_create_handle'));
+final _smoke_PlatformComments_Something_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_Something_release_handle');
-final _smoke_PlatformComments_Something_get_field_nothing = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformComments_Something_release_handle'));
+final _smoke_PlatformComments_Something_get_field_nothing = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_Something_get_field_nothing');
+  >('library_smoke_PlatformComments_Something_get_field_nothing'));
 Pointer<Void> smoke_PlatformComments_Something_toFfi(PlatformComments_Something value) {
   final _nothing_handle = String_toFfi(value.nothing);
   final _result = _smoke_PlatformComments_Something_create_handle(_nothing_handle);
@@ -122,18 +122,18 @@ PlatformComments_Something smoke_PlatformComments_Something_fromFfi(Pointer<Void
 }
 void smoke_PlatformComments_Something_releaseFfiHandle(Pointer<Void> handle) => _smoke_PlatformComments_Something_release_handle(handle);
 // Nullable PlatformComments_Something
-final _smoke_PlatformComments_Something_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformComments_Something_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_Something_create_handle_nullable');
-final _smoke_PlatformComments_Something_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformComments_Something_create_handle_nullable'));
+final _smoke_PlatformComments_Something_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_Something_release_handle_nullable');
-final _smoke_PlatformComments_Something_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformComments_Something_release_handle_nullable'));
+final _smoke_PlatformComments_Something_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_Something_get_value_nullable');
+  >('library_smoke_PlatformComments_Something_get_value_nullable'));
 Pointer<Void> smoke_PlatformComments_Something_toFfi_nullable(PlatformComments_Something value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PlatformComments_Something_toFfi(value);
@@ -152,34 +152,34 @@ void smoke_PlatformComments_Something_releaseFfiHandle_nullable(Pointer<Void> ha
   _smoke_PlatformComments_Something_release_handle_nullable(handle);
 // End of PlatformComments_Something "private" section.
 // PlatformComments "private" section, not exported.
-final _smoke_PlatformComments_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_copy_handle');
-final _smoke_PlatformComments_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformComments_copy_handle'));
+final _smoke_PlatformComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_release_handle');
-final _smoke_PlatformComments_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformComments_release_handle'));
+final _smoke_PlatformComments_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_PlatformComments_get_raw_pointer');
-final _someMethodWithAllComments_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_PlatformComments_get_raw_pointer'));
+final _someMethodWithAllComments_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_release_handle');
-final _someMethodWithAllComments_return_get_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_release_handle'));
+final _someMethodWithAllComments_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_result');
-final _someMethodWithAllComments_return_get_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_result'));
+final _someMethodWithAllComments_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_error');
-final _someMethodWithAllComments_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_error'));
+final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_has_error');
+  >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_has_error'));
 class PlatformComments$Impl implements PlatformComments {
   @protected
   Pointer<Void> handle;
@@ -193,7 +193,7 @@ class PlatformComments$Impl implements PlatformComments {
   }
   @override
   doNothing() {
-    final _doNothing_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doNothing');
+    final _doNothing_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doNothing'));
     final _handle = this.handle;
     final __result_handle = _doNothing_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -204,7 +204,7 @@ class PlatformComments$Impl implements PlatformComments {
   }
   @override
   doMagic() {
-    final _doMagic_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doMagic');
+    final _doMagic_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doMagic'));
     final _handle = this.handle;
     final __result_handle = _doMagic_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -215,7 +215,7 @@ class PlatformComments$Impl implements PlatformComments {
   }
   @override
   bool someMethodWithAllComments(String input) {
-    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformComments_someMethodWithAllComments__String');
+    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformComments_someMethodWithAllComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __call_result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -239,7 +239,7 @@ class PlatformComments$Impl implements PlatformComments {
   }
   @override
   someDeprecatedMethod() {
-    final _someDeprecatedMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_someDeprecatedMethod');
+    final _someDeprecatedMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_someDeprecatedMethod'));
     final _handle = this.handle;
     final __result_handle = _someDeprecatedMethod_ffi(_handle, __lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -18,34 +18,34 @@ abstract class UnicodeComments {
   bool someMethodWithAllComments(String input);
 }
 // UnicodeComments "private" section, not exported.
-final _smoke_UnicodeComments_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_UnicodeComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_UnicodeComments_copy_handle');
-final _smoke_UnicodeComments_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_UnicodeComments_copy_handle'));
+final _smoke_UnicodeComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_UnicodeComments_release_handle');
-final _smoke_UnicodeComments_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_UnicodeComments_release_handle'));
+final _smoke_UnicodeComments_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_UnicodeComments_get_raw_pointer');
-final _someMethodWithAllComments_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_UnicodeComments_get_raw_pointer'));
+final _someMethodWithAllComments_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_release_handle');
-final _someMethodWithAllComments_return_get_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_release_handle'));
+final _someMethodWithAllComments_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_get_result');
-final _someMethodWithAllComments_return_get_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_get_result'));
+final _someMethodWithAllComments_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_get_error');
-final _someMethodWithAllComments_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_get_error'));
+final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_has_error');
+  >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_has_error'));
 class UnicodeComments$Impl implements UnicodeComments {
   @protected
   Pointer<Void> handle;
@@ -59,7 +59,7 @@ class UnicodeComments$Impl implements UnicodeComments {
   }
   @override
   bool someMethodWithAllComments(String input) {
-    final _someMethodWithAllComments_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_UnicodeComments_someMethodWithAllComments__String');
+    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_UnicodeComments_someMethodWithAllComments__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __call_result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
@@ -15,18 +15,18 @@ abstract class CollectionConstants {
   static final Map<List<String>, Set<String>> mixedConstant = {["foo"]: {"bar"}};
 }
 // CollectionConstants "private" section, not exported.
-final _smoke_CollectionConstants_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_CollectionConstants_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CollectionConstants_copy_handle');
-final _smoke_CollectionConstants_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CollectionConstants_copy_handle'));
+final _smoke_CollectionConstants_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CollectionConstants_release_handle');
-final _smoke_CollectionConstants_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CollectionConstants_release_handle'));
+final _smoke_CollectionConstants_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_CollectionConstants_get_raw_pointer');
+    >('library_smoke_CollectionConstants_get_raw_pointer'));
 class CollectionConstants$Impl implements CollectionConstants {
   @protected
   Pointer<Void> handle;

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants.dart
@@ -33,18 +33,18 @@ StateEnum smoke_Constants_StateEnum_fromFfi(int handle) {
   }
 }
 void smoke_Constants_StateEnum_releaseFfiHandle(int handle) {}
-final _smoke_Constants_StateEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Constants_StateEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Constants_StateEnum_create_handle_nullable');
-final _smoke_Constants_StateEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Constants_StateEnum_create_handle_nullable'));
+final _smoke_Constants_StateEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Constants_StateEnum_release_handle_nullable');
-final _smoke_Constants_StateEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Constants_StateEnum_release_handle_nullable'));
+final _smoke_Constants_StateEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Constants_StateEnum_get_value_nullable');
+  >('library_smoke_Constants_StateEnum_get_value_nullable'));
 Pointer<Void> smoke_Constants_StateEnum_toFfi_nullable(StateEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Constants_StateEnum_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
@@ -47,18 +47,18 @@ ConstantsInterface_StateEnum smoke_ConstantsInterface_StateEnum_fromFfi(int hand
   }
 }
 void smoke_ConstantsInterface_StateEnum_releaseFfiHandle(int handle) {}
-final _smoke_ConstantsInterface_StateEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_ConstantsInterface_StateEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_ConstantsInterface_StateEnum_create_handle_nullable');
-final _smoke_ConstantsInterface_StateEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ConstantsInterface_StateEnum_create_handle_nullable'));
+final _smoke_ConstantsInterface_StateEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ConstantsInterface_StateEnum_release_handle_nullable');
-final _smoke_ConstantsInterface_StateEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ConstantsInterface_StateEnum_release_handle_nullable'));
+final _smoke_ConstantsInterface_StateEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ConstantsInterface_StateEnum_get_value_nullable');
+  >('library_smoke_ConstantsInterface_StateEnum_get_value_nullable'));
 Pointer<Void> smoke_ConstantsInterface_StateEnum_toFfi_nullable(ConstantsInterface_StateEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ConstantsInterface_StateEnum_toFfi(value);
@@ -77,18 +77,18 @@ void smoke_ConstantsInterface_StateEnum_releaseFfiHandle_nullable(Pointer<Void> 
   _smoke_ConstantsInterface_StateEnum_release_handle_nullable(handle);
 // End of ConstantsInterface_StateEnum "private" section.
 // ConstantsInterface "private" section, not exported.
-final _smoke_ConstantsInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ConstantsInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ConstantsInterface_copy_handle');
-final _smoke_ConstantsInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ConstantsInterface_copy_handle'));
+final _smoke_ConstantsInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ConstantsInterface_release_handle');
-final _smoke_ConstantsInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ConstantsInterface_release_handle'));
+final _smoke_ConstantsInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ConstantsInterface_get_raw_pointer');
+    >('library_smoke_ConstantsInterface_get_raw_pointer'));
 class ConstantsInterface$Impl implements ConstantsInterface {
   @protected
   Pointer<Void> handle;

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
@@ -19,22 +19,22 @@ class StructConstants_SomeStruct {
   StructConstants_SomeStruct(this.stringField, this.floatField);
 }
 // StructConstants_SomeStruct "private" section, not exported.
-final _smoke_StructConstants_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructConstants_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Float),
     Pointer<Void> Function(Pointer<Void>, double)
-  >('library_smoke_StructConstants_SomeStruct_create_handle');
-final _smoke_StructConstants_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructConstants_SomeStruct_create_handle'));
+final _smoke_StructConstants_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructConstants_SomeStruct_release_handle');
-final _smoke_StructConstants_SomeStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructConstants_SomeStruct_release_handle'));
+final _smoke_StructConstants_SomeStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructConstants_SomeStruct_get_field_stringField');
-final _smoke_StructConstants_SomeStruct_get_field_floatField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructConstants_SomeStruct_get_field_stringField'));
+final _smoke_StructConstants_SomeStruct_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_StructConstants_SomeStruct_get_field_floatField');
+  >('library_smoke_StructConstants_SomeStruct_get_field_floatField'));
 Pointer<Void> smoke_StructConstants_SomeStruct_toFfi(StructConstants_SomeStruct value) {
   final _stringField_handle = String_toFfi(value.stringField);
   final _floatField_handle = (value.floatField);
@@ -58,18 +58,18 @@ StructConstants_SomeStruct smoke_StructConstants_SomeStruct_fromFfi(Pointer<Void
 }
 void smoke_StructConstants_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructConstants_SomeStruct_release_handle(handle);
 // Nullable StructConstants_SomeStruct
-final _smoke_StructConstants_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructConstants_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructConstants_SomeStruct_create_handle_nullable');
-final _smoke_StructConstants_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructConstants_SomeStruct_create_handle_nullable'));
+final _smoke_StructConstants_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructConstants_SomeStruct_release_handle_nullable');
-final _smoke_StructConstants_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructConstants_SomeStruct_release_handle_nullable'));
+final _smoke_StructConstants_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructConstants_SomeStruct_get_value_nullable');
+  >('library_smoke_StructConstants_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_StructConstants_SomeStruct_toFfi_nullable(StructConstants_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructConstants_SomeStruct_toFfi(value);
@@ -92,18 +92,18 @@ class StructConstants_NestingStruct {
   StructConstants_NestingStruct(this.structField);
 }
 // StructConstants_NestingStruct "private" section, not exported.
-final _smoke_StructConstants_NestingStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructConstants_NestingStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructConstants_NestingStruct_create_handle');
-final _smoke_StructConstants_NestingStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructConstants_NestingStruct_create_handle'));
+final _smoke_StructConstants_NestingStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructConstants_NestingStruct_release_handle');
-final _smoke_StructConstants_NestingStruct_get_field_structField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructConstants_NestingStruct_release_handle'));
+final _smoke_StructConstants_NestingStruct_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructConstants_NestingStruct_get_field_structField');
+  >('library_smoke_StructConstants_NestingStruct_get_field_structField'));
 Pointer<Void> smoke_StructConstants_NestingStruct_toFfi(StructConstants_NestingStruct value) {
   final _structField_handle = smoke_StructConstants_SomeStruct_toFfi(value.structField);
   final _result = _smoke_StructConstants_NestingStruct_create_handle(_structField_handle);
@@ -122,18 +122,18 @@ StructConstants_NestingStruct smoke_StructConstants_NestingStruct_fromFfi(Pointe
 }
 void smoke_StructConstants_NestingStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructConstants_NestingStruct_release_handle(handle);
 // Nullable StructConstants_NestingStruct
-final _smoke_StructConstants_NestingStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructConstants_NestingStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructConstants_NestingStruct_create_handle_nullable');
-final _smoke_StructConstants_NestingStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructConstants_NestingStruct_create_handle_nullable'));
+final _smoke_StructConstants_NestingStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructConstants_NestingStruct_release_handle_nullable');
-final _smoke_StructConstants_NestingStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructConstants_NestingStruct_release_handle_nullable'));
+final _smoke_StructConstants_NestingStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructConstants_NestingStruct_get_value_nullable');
+  >('library_smoke_StructConstants_NestingStruct_get_value_nullable'));
 Pointer<Void> smoke_StructConstants_NestingStruct_toFfi_nullable(StructConstants_NestingStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructConstants_NestingStruct_toFfi(value);
@@ -152,18 +152,18 @@ void smoke_StructConstants_NestingStruct_releaseFfiHandle_nullable(Pointer<Void>
   _smoke_StructConstants_NestingStruct_release_handle_nullable(handle);
 // End of StructConstants_NestingStruct "private" section.
 // StructConstants "private" section, not exported.
-final _smoke_StructConstants_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructConstants_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructConstants_copy_handle');
-final _smoke_StructConstants_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructConstants_copy_handle'));
+final _smoke_StructConstants_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructConstants_release_handle');
-final _smoke_StructConstants_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructConstants_release_handle'));
+final _smoke_StructConstants_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_StructConstants_get_raw_pointer');
+    >('library_smoke_StructConstants_get_raw_pointer'));
 class StructConstants$Impl implements StructConstants {
   @protected
   Pointer<Void> handle;

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -49,18 +49,18 @@ Constructors_ErrorEnum smoke_Constructors_ErrorEnum_fromFfi(int handle) {
   }
 }
 void smoke_Constructors_ErrorEnum_releaseFfiHandle(int handle) {}
-final _smoke_Constructors_ErrorEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Constructors_ErrorEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Constructors_ErrorEnum_create_handle_nullable');
-final _smoke_Constructors_ErrorEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Constructors_ErrorEnum_create_handle_nullable'));
+final _smoke_Constructors_ErrorEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Constructors_ErrorEnum_release_handle_nullable');
-final _smoke_Constructors_ErrorEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Constructors_ErrorEnum_release_handle_nullable'));
+final _smoke_Constructors_ErrorEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Constructors_ErrorEnum_get_value_nullable');
+  >('library_smoke_Constructors_ErrorEnum_get_value_nullable'));
 Pointer<Void> smoke_Constructors_ErrorEnum_toFfi_nullable(Constructors_ErrorEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Constructors_ErrorEnum_toFfi(value);
@@ -83,38 +83,38 @@ class Constructors_ConstructorExplodedException implements Exception {
   Constructors_ConstructorExplodedException(this.error);
 }
 // Constructors "private" section, not exported.
-final _smoke_Constructors_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Constructors_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Constructors_copy_handle');
-final _smoke_Constructors_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Constructors_copy_handle'));
+final _smoke_Constructors_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Constructors_release_handle');
-final _smoke_Constructors_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Constructors_release_handle'));
+final _smoke_Constructors_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Constructors_get_raw_pointer');
-final _smoke_Constructors_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_Constructors_get_raw_pointer'));
+final _smoke_Constructors_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Constructors_get_type_id');
-final _fromString_return_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Constructors_get_type_id'));
+final _fromString_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Constructors_create__String_return_release_handle');
-final _fromString_return_get_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Constructors_create__String_return_release_handle'));
+final _fromString_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Constructors_create__String_return_get_result');
-final _fromString_return_get_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Constructors_create__String_return_get_result'));
+final _fromString_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Constructors_create__String_return_get_error');
-final _fromString_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Constructors_create__String_return_get_error'));
+final _fromString_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Constructors_create__String_return_has_error');
+  >('library_smoke_Constructors_create__String_return_has_error'));
 class Constructors$Impl implements Constructors {
   @protected
   Pointer<Void> handle;
@@ -145,19 +145,19 @@ class Constructors$Impl implements Constructors {
     __lib.reverseCache[_smoke_Constructors_get_raw_pointer(handle)] = this;
   }
   static Pointer<Void> _$init() {
-    final _$init_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Constructors_create');
+    final _$init_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Constructors_create'));
     final __result_handle = _$init_ffi(__lib.LibraryContext.isolateId);
     return __result_handle;
   }
   static Pointer<Void> _fromOther(Constructors other) {
-    final _fromOther_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__Constructors');
+    final _fromOther_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__Constructors'));
     final _other_handle = smoke_Constructors_toFfi(other);
     final __result_handle = _fromOther_ffi(__lib.LibraryContext.isolateId, _other_handle);
     smoke_Constructors_releaseFfiHandle(_other_handle);
     return __result_handle;
   }
   static Pointer<Void> _fromMulti(String foo, int bar) {
-    final _fromMulti_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Uint64), Pointer<Void> Function(int, Pointer<Void>, int)>('library_smoke_Constructors_create__String_ULong');
+    final _fromMulti_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Uint64), Pointer<Void> Function(int, Pointer<Void>, int)>('library_smoke_Constructors_create__String_ULong'));
     final _foo_handle = String_toFfi(foo);
     final _bar_handle = (bar);
     final __result_handle = _fromMulti_ffi(__lib.LibraryContext.isolateId, _foo_handle, _bar_handle);
@@ -166,7 +166,7 @@ class Constructors$Impl implements Constructors {
     return __result_handle;
   }
   static Pointer<Void> _fromString(String input) {
-    final _fromString_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__String');
+    final _fromString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__String'));
     final _input_handle = String_toFfi(input);
     final __call_result_handle = _fromString_ffi(__lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
@@ -184,14 +184,14 @@ class Constructors$Impl implements Constructors {
     return __result_handle;
   }
   static Pointer<Void> _fromList(List<double> input) {
-    final _fromList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__ListOf_1Double');
+    final _fromList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__ListOf_1Double'));
     final _input_handle = ListOf_Double_toFfi(input);
     final __result_handle = _fromList_ffi(__lib.LibraryContext.isolateId, _input_handle);
     ListOf_Double_releaseFfiHandle(_input_handle);
     return __result_handle;
   }
   static Pointer<Void> _create(int input) {
-    final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_Constructors_create__ULong');
+    final _create_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_Constructors_create__ULong'));
     final _input_handle = (input);
     final __result_handle = _create_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -19,18 +19,18 @@ class Dates_DateStruct {
   Dates_DateStruct(this.dateField);
 }
 // Dates_DateStruct "private" section, not exported.
-final _smoke_Dates_DateStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Dates_DateStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64),
     Pointer<Void> Function(int)
-  >('library_smoke_Dates_DateStruct_create_handle');
-final _smoke_Dates_DateStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Dates_DateStruct_create_handle'));
+final _smoke_Dates_DateStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Dates_DateStruct_release_handle');
-final _smoke_Dates_DateStruct_get_field_dateField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Dates_DateStruct_release_handle'));
+final _smoke_Dates_DateStruct_get_field_dateField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Dates_DateStruct_get_field_dateField');
+  >('library_smoke_Dates_DateStruct_get_field_dateField'));
 Pointer<Void> smoke_Dates_DateStruct_toFfi(Dates_DateStruct value) {
   final _dateField_handle = Date_toFfi(value.dateField);
   final _result = _smoke_Dates_DateStruct_create_handle(_dateField_handle);
@@ -49,18 +49,18 @@ Dates_DateStruct smoke_Dates_DateStruct_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Dates_DateStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Dates_DateStruct_release_handle(handle);
 // Nullable Dates_DateStruct
-final _smoke_Dates_DateStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Dates_DateStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Dates_DateStruct_create_handle_nullable');
-final _smoke_Dates_DateStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Dates_DateStruct_create_handle_nullable'));
+final _smoke_Dates_DateStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Dates_DateStruct_release_handle_nullable');
-final _smoke_Dates_DateStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Dates_DateStruct_release_handle_nullable'));
+final _smoke_Dates_DateStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Dates_DateStruct_get_value_nullable');
+  >('library_smoke_Dates_DateStruct_get_value_nullable'));
 Pointer<Void> smoke_Dates_DateStruct_toFfi_nullable(Dates_DateStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Dates_DateStruct_toFfi(value);
@@ -79,18 +79,18 @@ void smoke_Dates_DateStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Dates_DateStruct_release_handle_nullable(handle);
 // End of Dates_DateStruct "private" section.
 // Dates "private" section, not exported.
-final _smoke_Dates_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Dates_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Dates_copy_handle');
-final _smoke_Dates_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Dates_copy_handle'));
+final _smoke_Dates_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Dates_release_handle');
-final _smoke_Dates_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Dates_release_handle'));
+final _smoke_Dates_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Dates_get_raw_pointer');
+    >('library_smoke_Dates_get_raw_pointer'));
 class Dates$Impl implements Dates {
   @protected
   Pointer<Void> handle;
@@ -104,7 +104,7 @@ class Dates$Impl implements Dates {
   }
   @override
   DateTime dateMethod(DateTime input) {
-    final _dateMethod_ffi = __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_Dates_dateMethod__Date');
+    final _dateMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_Dates_dateMethod__Date'));
     final _input_handle = Date_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _dateMethod_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -117,7 +117,7 @@ class Dates$Impl implements Dates {
   }
   @override
   DateTime get dateProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Dates_dateProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Dates_dateProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -128,7 +128,7 @@ class Dates$Impl implements Dates {
   }
   @override
   set dateProperty(DateTime value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint64), void Function(Pointer<Void>, int, int)>('library_smoke_Dates_dateProperty_set__Date');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint64), void Function(Pointer<Void>, int, int)>('library_smoke_Dates_dateProperty_set__Date'));
     final _value_handle = Date_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -43,18 +43,18 @@ DefaultValues_SomeEnum smoke_DefaultValues_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_DefaultValues_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_DefaultValues_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_DefaultValues_SomeEnum_create_handle_nullable');
-final _smoke_DefaultValues_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_SomeEnum_create_handle_nullable'));
+final _smoke_DefaultValues_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_SomeEnum_release_handle_nullable');
-final _smoke_DefaultValues_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_SomeEnum_release_handle_nullable'));
+final _smoke_DefaultValues_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_SomeEnum_get_value_nullable');
+  >('library_smoke_DefaultValues_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_SomeEnum_toFfi_nullable(DefaultValues_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_SomeEnum_toFfi(value);
@@ -102,18 +102,18 @@ DefaultValues_ExternalEnum smoke_DefaultValues_ExternalEnum_fromFfi(int handle) 
   }
 }
 void smoke_DefaultValues_ExternalEnum_releaseFfiHandle(int handle) {}
-final _smoke_DefaultValues_ExternalEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_ExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_DefaultValues_ExternalEnum_create_handle_nullable');
-final _smoke_DefaultValues_ExternalEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_ExternalEnum_create_handle_nullable'));
+final _smoke_DefaultValues_ExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_ExternalEnum_release_handle_nullable');
-final _smoke_DefaultValues_ExternalEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_ExternalEnum_release_handle_nullable'));
+final _smoke_DefaultValues_ExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_ExternalEnum_get_value_nullable');
+  >('library_smoke_DefaultValues_ExternalEnum_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_ExternalEnum_toFfi_nullable(DefaultValues_ExternalEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_ExternalEnum_toFfi(value);
@@ -145,46 +145,46 @@ class DefaultValues_StructWithDefaults {
     : intField = 42, uintField = 4294967295, floatField = 3.14, doubleField = -1.4142, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n", enumField = DefaultValues_SomeEnum.barValue, externalEnumField = DefaultValues_ExternalEnum.anotherValue;
 }
 // DefaultValues_StructWithDefaults "private" section, not exported.
-final _smoke_DefaultValues_StructWithDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Uint32, Float, Double, Uint8, Pointer<Void>, Uint32, Uint32),
     Pointer<Void> Function(int, int, double, double, int, Pointer<Void>, int, int)
-  >('library_smoke_DefaultValues_StructWithDefaults_create_handle');
-final _smoke_DefaultValues_StructWithDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithDefaults_create_handle'));
+final _smoke_DefaultValues_StructWithDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithDefaults_release_handle');
-final _smoke_DefaultValues_StructWithDefaults_get_field_intField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithDefaults_release_handle'));
+final _smoke_DefaultValues_StructWithDefaults_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithDefaults_get_field_intField');
-final _smoke_DefaultValues_StructWithDefaults_get_field_uintField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithDefaults_get_field_intField'));
+final _smoke_DefaultValues_StructWithDefaults_get_field_uintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithDefaults_get_field_uintField');
-final _smoke_DefaultValues_StructWithDefaults_get_field_floatField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithDefaults_get_field_uintField'));
+final _smoke_DefaultValues_StructWithDefaults_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithDefaults_get_field_floatField');
-final _smoke_DefaultValues_StructWithDefaults_get_field_doubleField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithDefaults_get_field_floatField'));
+final _smoke_DefaultValues_StructWithDefaults_get_field_doubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithDefaults_get_field_doubleField');
-final _smoke_DefaultValues_StructWithDefaults_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithDefaults_get_field_doubleField'));
+final _smoke_DefaultValues_StructWithDefaults_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithDefaults_get_field_boolField');
-final _smoke_DefaultValues_StructWithDefaults_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithDefaults_get_field_boolField'));
+final _smoke_DefaultValues_StructWithDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithDefaults_get_field_stringField');
-final _smoke_DefaultValues_StructWithDefaults_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithDefaults_get_field_stringField'));
+final _smoke_DefaultValues_StructWithDefaults_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithDefaults_get_field_enumField');
-final _smoke_DefaultValues_StructWithDefaults_get_field_externalEnumField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithDefaults_get_field_enumField'));
+final _smoke_DefaultValues_StructWithDefaults_get_field_externalEnumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithDefaults_get_field_externalEnumField');
+  >('library_smoke_DefaultValues_StructWithDefaults_get_field_externalEnumField'));
 Pointer<Void> smoke_DefaultValues_StructWithDefaults_toFfi(DefaultValues_StructWithDefaults value) {
   final _intField_handle = (value.intField);
   final _uintField_handle = (value.uintField);
@@ -238,18 +238,18 @@ DefaultValues_StructWithDefaults smoke_DefaultValues_StructWithDefaults_fromFfi(
 }
 void smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithDefaults_release_handle(handle);
 // Nullable DefaultValues_StructWithDefaults
-final _smoke_DefaultValues_StructWithDefaults_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithDefaults_create_handle_nullable');
-final _smoke_DefaultValues_StructWithDefaults_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithDefaults_create_handle_nullable'));
+final _smoke_DefaultValues_StructWithDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithDefaults_release_handle_nullable');
-final _smoke_DefaultValues_StructWithDefaults_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithDefaults_release_handle_nullable'));
+final _smoke_DefaultValues_StructWithDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithDefaults_get_value_nullable');
+  >('library_smoke_DefaultValues_StructWithDefaults_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_StructWithDefaults_toFfi_nullable(DefaultValues_StructWithDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_StructWithDefaults_toFfi(value);
@@ -279,38 +279,38 @@ class DefaultValues_NullableStructWithDefaults {
     : intField = null, uintField = null, floatField = null, boolField = null, stringField = null, enumField = null;
 }
 // DefaultValues_NullableStructWithDefaults "private" section, not exported.
-final _smoke_DefaultValues_NullableStructWithDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_NullableStructWithDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_smoke_DefaultValues_NullableStructWithDefaults_create_handle');
-final _smoke_DefaultValues_NullableStructWithDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_NullableStructWithDefaults_create_handle'));
+final _smoke_DefaultValues_NullableStructWithDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_NullableStructWithDefaults_release_handle');
-final _smoke_DefaultValues_NullableStructWithDefaults_get_field_intField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_NullableStructWithDefaults_release_handle'));
+final _smoke_DefaultValues_NullableStructWithDefaults_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_intField');
-final _smoke_DefaultValues_NullableStructWithDefaults_get_field_uintField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_intField'));
+final _smoke_DefaultValues_NullableStructWithDefaults_get_field_uintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_uintField');
-final _smoke_DefaultValues_NullableStructWithDefaults_get_field_floatField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_uintField'));
+final _smoke_DefaultValues_NullableStructWithDefaults_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_floatField');
-final _smoke_DefaultValues_NullableStructWithDefaults_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_floatField'));
+final _smoke_DefaultValues_NullableStructWithDefaults_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_boolField');
-final _smoke_DefaultValues_NullableStructWithDefaults_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_boolField'));
+final _smoke_DefaultValues_NullableStructWithDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_stringField');
-final _smoke_DefaultValues_NullableStructWithDefaults_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_stringField'));
+final _smoke_DefaultValues_NullableStructWithDefaults_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_enumField');
+  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_enumField'));
 Pointer<Void> smoke_DefaultValues_NullableStructWithDefaults_toFfi(DefaultValues_NullableStructWithDefaults value) {
   final _intField_handle = Int_toFfi_nullable(value.intField);
   final _uintField_handle = UInt_toFfi_nullable(value.uintField);
@@ -354,18 +354,18 @@ DefaultValues_NullableStructWithDefaults smoke_DefaultValues_NullableStructWithD
 }
 void smoke_DefaultValues_NullableStructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_NullableStructWithDefaults_release_handle(handle);
 // Nullable DefaultValues_NullableStructWithDefaults
-final _smoke_DefaultValues_NullableStructWithDefaults_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_NullableStructWithDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_NullableStructWithDefaults_create_handle_nullable');
-final _smoke_DefaultValues_NullableStructWithDefaults_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_NullableStructWithDefaults_create_handle_nullable'));
+final _smoke_DefaultValues_NullableStructWithDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_NullableStructWithDefaults_release_handle_nullable');
-final _smoke_DefaultValues_NullableStructWithDefaults_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_NullableStructWithDefaults_release_handle_nullable'));
+final _smoke_DefaultValues_NullableStructWithDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_value_nullable');
+  >('library_smoke_DefaultValues_NullableStructWithDefaults_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_NullableStructWithDefaults_toFfi_nullable(DefaultValues_NullableStructWithDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_NullableStructWithDefaults_toFfi(value);
@@ -395,38 +395,38 @@ class DefaultValues_StructWithSpecialDefaults {
     : floatNanField = double.nan, floatInfinityField = double.infinity, floatNegativeInfinityField = double.negativeInfinity, doubleNanField = double.nan, doubleInfinityField = double.infinity, doubleNegativeInfinityField = double.negativeInfinity;
 }
 // DefaultValues_StructWithSpecialDefaults "private" section, not exported.
-final _smoke_DefaultValues_StructWithSpecialDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithSpecialDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Float, Float, Float, Double, Double, Double),
     Pointer<Void> Function(double, double, double, double, double, double)
-  >('library_smoke_DefaultValues_StructWithSpecialDefaults_create_handle');
-final _smoke_DefaultValues_StructWithSpecialDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithSpecialDefaults_create_handle'));
+final _smoke_DefaultValues_StructWithSpecialDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithSpecialDefaults_release_handle');
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNanField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithSpecialDefaults_release_handle'));
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNanField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNanField');
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatInfinityField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNanField'));
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatInfinityField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatInfinityField');
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNegativeInfinityField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatInfinityField'));
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNegativeInfinityField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNegativeInfinityField');
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNanField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNegativeInfinityField'));
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNanField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNanField');
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleInfinityField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNanField'));
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleInfinityField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleInfinityField');
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNegativeInfinityField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleInfinityField'));
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNegativeInfinityField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNegativeInfinityField');
+  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNegativeInfinityField'));
 Pointer<Void> smoke_DefaultValues_StructWithSpecialDefaults_toFfi(DefaultValues_StructWithSpecialDefaults value) {
   final _floatNanField_handle = (value.floatNanField);
   final _floatInfinityField_handle = (value.floatInfinityField);
@@ -470,18 +470,18 @@ DefaultValues_StructWithSpecialDefaults smoke_DefaultValues_StructWithSpecialDef
 }
 void smoke_DefaultValues_StructWithSpecialDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithSpecialDefaults_release_handle(handle);
 // Nullable DefaultValues_StructWithSpecialDefaults
-final _smoke_DefaultValues_StructWithSpecialDefaults_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithSpecialDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithSpecialDefaults_create_handle_nullable');
-final _smoke_DefaultValues_StructWithSpecialDefaults_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithSpecialDefaults_create_handle_nullable'));
+final _smoke_DefaultValues_StructWithSpecialDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithSpecialDefaults_release_handle_nullable');
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithSpecialDefaults_release_handle_nullable'));
+final _smoke_DefaultValues_StructWithSpecialDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_value_nullable');
+  >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_StructWithSpecialDefaults_toFfi_nullable(DefaultValues_StructWithSpecialDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_StructWithSpecialDefaults_toFfi(value);
@@ -510,34 +510,34 @@ class DefaultValues_StructWithEmptyDefaults {
     : intsField = [], floatsField = [], mapField = {}, structField = DefaultValues_StructWithDefaults.withDefaults(), setTypeField = {};
 }
 // DefaultValues_StructWithEmptyDefaults "private" section, not exported.
-final _smoke_DefaultValues_StructWithEmptyDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithEmptyDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithEmptyDefaults_create_handle');
-final _smoke_DefaultValues_StructWithEmptyDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithEmptyDefaults_create_handle'));
+final _smoke_DefaultValues_StructWithEmptyDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithEmptyDefaults_release_handle');
-final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_intsField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithEmptyDefaults_release_handle'));
+final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_intsField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_intsField');
-final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_floatsField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_intsField'));
+final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_floatsField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_floatsField');
-final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_mapField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_floatsField'));
+final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_mapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_mapField');
-final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_structField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_mapField'));
+final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_structField');
-final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_structField'));
+final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField');
+  >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField'));
 Pointer<Void> smoke_DefaultValues_StructWithEmptyDefaults_toFfi(DefaultValues_StructWithEmptyDefaults value) {
   final _intsField_handle = ListOf_Int_toFfi(value.intsField);
   final _floatsField_handle = ListOf_Float_toFfi(value.floatsField);
@@ -576,18 +576,18 @@ DefaultValues_StructWithEmptyDefaults smoke_DefaultValues_StructWithEmptyDefault
 }
 void smoke_DefaultValues_StructWithEmptyDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithEmptyDefaults_release_handle(handle);
 // Nullable DefaultValues_StructWithEmptyDefaults
-final _smoke_DefaultValues_StructWithEmptyDefaults_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithEmptyDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithEmptyDefaults_create_handle_nullable');
-final _smoke_DefaultValues_StructWithEmptyDefaults_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithEmptyDefaults_create_handle_nullable'));
+final _smoke_DefaultValues_StructWithEmptyDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithEmptyDefaults_release_handle_nullable');
-final _smoke_DefaultValues_StructWithEmptyDefaults_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithEmptyDefaults_release_handle_nullable'));
+final _smoke_DefaultValues_StructWithEmptyDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_value_nullable');
+  >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_StructWithEmptyDefaults_toFfi_nullable(DefaultValues_StructWithEmptyDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_StructWithEmptyDefaults_toFfi(value);
@@ -615,30 +615,30 @@ class DefaultValues_StructWithTypedefDefaults {
     : longField = 42, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n", enumField = DefaultValues_SomeEnum.barValue;
 }
 // DefaultValues_StructWithTypedefDefaults "private" section, not exported.
-final _smoke_DefaultValues_StructWithTypedefDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithTypedefDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int64, Uint8, Pointer<Void>, Uint32),
     Pointer<Void> Function(int, int, Pointer<Void>, int)
-  >('library_smoke_DefaultValues_StructWithTypedefDefaults_create_handle');
-final _smoke_DefaultValues_StructWithTypedefDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithTypedefDefaults_create_handle'));
+final _smoke_DefaultValues_StructWithTypedefDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithTypedefDefaults_release_handle');
-final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_longField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithTypedefDefaults_release_handle'));
+final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_longField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_longField');
-final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_longField'));
+final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_boolField');
-final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_boolField'));
+final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_stringField');
-final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_stringField'));
+final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_enumField');
+  >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_enumField'));
 Pointer<Void> smoke_DefaultValues_StructWithTypedefDefaults_toFfi(DefaultValues_StructWithTypedefDefaults value) {
   final _longField_handle = (value.longField);
   final _boolField_handle = Boolean_toFfi(value.boolField);
@@ -672,18 +672,18 @@ DefaultValues_StructWithTypedefDefaults smoke_DefaultValues_StructWithTypedefDef
 }
 void smoke_DefaultValues_StructWithTypedefDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithTypedefDefaults_release_handle(handle);
 // Nullable DefaultValues_StructWithTypedefDefaults
-final _smoke_DefaultValues_StructWithTypedefDefaults_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithTypedefDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithTypedefDefaults_create_handle_nullable');
-final _smoke_DefaultValues_StructWithTypedefDefaults_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithTypedefDefaults_create_handle_nullable'));
+final _smoke_DefaultValues_StructWithTypedefDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithTypedefDefaults_release_handle_nullable');
-final _smoke_DefaultValues_StructWithTypedefDefaults_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_StructWithTypedefDefaults_release_handle_nullable'));
+final _smoke_DefaultValues_StructWithTypedefDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_value_nullable');
+  >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_StructWithTypedefDefaults_toFfi_nullable(DefaultValues_StructWithTypedefDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_StructWithTypedefDefaults_toFfi(value);
@@ -702,18 +702,18 @@ void smoke_DefaultValues_StructWithTypedefDefaults_releaseFfiHandle_nullable(Poi
   _smoke_DefaultValues_StructWithTypedefDefaults_release_handle_nullable(handle);
 // End of DefaultValues_StructWithTypedefDefaults "private" section.
 // DefaultValues "private" section, not exported.
-final _smoke_DefaultValues_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_copy_handle');
-final _smoke_DefaultValues_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_copy_handle'));
+final _smoke_DefaultValues_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DefaultValues_release_handle');
-final _smoke_DefaultValues_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DefaultValues_release_handle'));
+final _smoke_DefaultValues_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_DefaultValues_get_raw_pointer');
+    >('library_smoke_DefaultValues_get_raw_pointer'));
 class DefaultValues$Impl implements DefaultValues {
   @protected
   Pointer<Void> handle;
@@ -726,7 +726,7 @@ class DefaultValues$Impl implements DefaultValues {
     handle = null;
   }
   static DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) {
-    final _processStructWithDefaults_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_DefaultValues_processStructWithDefaults__StructWithDefaults');
+    final _processStructWithDefaults_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_DefaultValues_processStructWithDefaults__StructWithDefaults'));
     final _input_handle = smoke_DefaultValues_StructWithDefaults_toFfi(input);
     final __result_handle = _processStructWithDefaults_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_input_handle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
@@ -16,34 +16,34 @@ class StructWithInitializerDefaults {
     : intsField = [4, -2, 42], floatsField = [3.14, double.negativeInfinity], structField = StructWithAnEnum(AnEnum.disabled), setTypeField = {"foo", "bar"}, mapField = {1: "foo", 42: "bar"};
 }
 // StructWithInitializerDefaults "private" section, not exported.
-final _smoke_StructWithInitializerDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithInitializerDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_smoke_StructWithInitializerDefaults_create_handle');
-final _smoke_StructWithInitializerDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithInitializerDefaults_create_handle'));
+final _smoke_StructWithInitializerDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructWithInitializerDefaults_release_handle');
-final _smoke_StructWithInitializerDefaults_get_field_intsField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithInitializerDefaults_release_handle'));
+final _smoke_StructWithInitializerDefaults_get_field_intsField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithInitializerDefaults_get_field_intsField');
-final _smoke_StructWithInitializerDefaults_get_field_floatsField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithInitializerDefaults_get_field_intsField'));
+final _smoke_StructWithInitializerDefaults_get_field_floatsField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithInitializerDefaults_get_field_floatsField');
-final _smoke_StructWithInitializerDefaults_get_field_structField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithInitializerDefaults_get_field_floatsField'));
+final _smoke_StructWithInitializerDefaults_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithInitializerDefaults_get_field_structField');
-final _smoke_StructWithInitializerDefaults_get_field_setTypeField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithInitializerDefaults_get_field_structField'));
+final _smoke_StructWithInitializerDefaults_get_field_setTypeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithInitializerDefaults_get_field_setTypeField');
-final _smoke_StructWithInitializerDefaults_get_field_mapField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithInitializerDefaults_get_field_setTypeField'));
+final _smoke_StructWithInitializerDefaults_get_field_mapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithInitializerDefaults_get_field_mapField');
+  >('library_smoke_StructWithInitializerDefaults_get_field_mapField'));
 Pointer<Void> smoke_StructWithInitializerDefaults_toFfi(StructWithInitializerDefaults value) {
   final _intsField_handle = ListOf_Int_toFfi(value.intsField);
   final _floatsField_handle = ListOf_Float_toFfi(value.floatsField);
@@ -82,18 +82,18 @@ StructWithInitializerDefaults smoke_StructWithInitializerDefaults_fromFfi(Pointe
 }
 void smoke_StructWithInitializerDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithInitializerDefaults_release_handle(handle);
 // Nullable StructWithInitializerDefaults
-final _smoke_StructWithInitializerDefaults_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithInitializerDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithInitializerDefaults_create_handle_nullable');
-final _smoke_StructWithInitializerDefaults_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithInitializerDefaults_create_handle_nullable'));
+final _smoke_StructWithInitializerDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructWithInitializerDefaults_release_handle_nullable');
-final _smoke_StructWithInitializerDefaults_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithInitializerDefaults_release_handle_nullable'));
+final _smoke_StructWithInitializerDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithInitializerDefaults_get_value_nullable');
+  >('library_smoke_StructWithInitializerDefaults_get_value_nullable'));
 Pointer<Void> smoke_StructWithInitializerDefaults_toFfi_nullable(StructWithInitializerDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithInitializerDefaults_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -35,18 +35,18 @@ SomeEnum smoke_TypesWithDefaults_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_TypesWithDefaults_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_TypesWithDefaults_SomeEnum_create_handle_nullable');
-final _smoke_TypesWithDefaults_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_SomeEnum_create_handle_nullable'));
+final _smoke_TypesWithDefaults_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_SomeEnum_release_handle_nullable');
-final _smoke_TypesWithDefaults_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_SomeEnum_release_handle_nullable'));
+final _smoke_TypesWithDefaults_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_SomeEnum_get_value_nullable');
+  >('library_smoke_TypesWithDefaults_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_TypesWithDefaults_SomeEnum_toFfi_nullable(SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypesWithDefaults_SomeEnum_toFfi(value);
@@ -77,42 +77,42 @@ class StructWithDefaults {
     : intField = 42, uintField = 4294967295, floatField = 3.14, doubleField = -1.4142, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n", enumField = SomeEnum.barValue;
 }
 // StructWithDefaults "private" section, not exported.
-final _smoke_TypesWithDefaults_StructWithDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_StructWithDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Uint32, Float, Double, Uint8, Pointer<Void>, Uint32),
     Pointer<Void> Function(int, int, double, double, int, Pointer<Void>, int)
-  >('library_smoke_TypesWithDefaults_StructWithDefaults_create_handle');
-final _smoke_TypesWithDefaults_StructWithDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithDefaults_create_handle'));
+final _smoke_TypesWithDefaults_StructWithDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithDefaults_release_handle');
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_intField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithDefaults_release_handle'));
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_intField');
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_uintField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_intField'));
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_uintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_uintField');
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_floatField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_uintField'));
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_floatField');
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_doubleField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_floatField'));
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_doubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_doubleField');
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_doubleField'));
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_boolField');
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_boolField'));
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_stringField');
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_stringField'));
+final _smoke_TypesWithDefaults_StructWithDefaults_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_enumField');
+  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_enumField'));
 Pointer<Void> smoke_TypesWithDefaults_StructWithDefaults_toFfi(StructWithDefaults value) {
   final _intField_handle = (value.intField);
   final _uintField_handle = (value.uintField);
@@ -161,18 +161,18 @@ StructWithDefaults smoke_TypesWithDefaults_StructWithDefaults_fromFfi(Pointer<Vo
 }
 void smoke_TypesWithDefaults_StructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypesWithDefaults_StructWithDefaults_release_handle(handle);
 // Nullable StructWithDefaults
-final _smoke_TypesWithDefaults_StructWithDefaults_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_StructWithDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithDefaults_create_handle_nullable');
-final _smoke_TypesWithDefaults_StructWithDefaults_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithDefaults_create_handle_nullable'));
+final _smoke_TypesWithDefaults_StructWithDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithDefaults_release_handle_nullable');
-final _smoke_TypesWithDefaults_StructWithDefaults_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithDefaults_release_handle_nullable'));
+final _smoke_TypesWithDefaults_StructWithDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_value_nullable');
+  >('library_smoke_TypesWithDefaults_StructWithDefaults_get_value_nullable'));
 Pointer<Void> smoke_TypesWithDefaults_StructWithDefaults_toFfi_nullable(StructWithDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypesWithDefaults_StructWithDefaults_toFfi(value);
@@ -205,46 +205,46 @@ class ImmutableStructWithDefaults {
     : intField = 42, uintField = uintField, floatField = 3.14, doubleField = -1.4142, boolField = boolField, stringField = "\\Jonny \"Magic\" Smith\n", enumField = SomeEnum.barValue, externalEnumField = DefaultValues_ExternalEnum.anotherValue;
 }
 // ImmutableStructWithDefaults "private" section, not exported.
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Uint32, Float, Double, Uint8, Pointer<Void>, Uint32, Uint32),
     Pointer<Void> Function(int, int, double, double, int, Pointer<Void>, int, int)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle');
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle'));
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle');
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_intField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle'));
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_intField');
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_uintField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_intField'));
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_uintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_uintField');
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_floatField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_uintField'));
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_floatField');
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_doubleField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_floatField'));
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_doubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_doubleField');
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_doubleField'));
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_boolField');
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_boolField'));
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_stringField');
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_stringField'));
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_enumField');
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_externalEnumField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_enumField'));
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_externalEnumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_externalEnumField');
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_externalEnumField'));
 Pointer<Void> smoke_TypesWithDefaults_ImmutableStructWithDefaults_toFfi(ImmutableStructWithDefaults value) {
   final _intField_handle = (value.intField);
   final _uintField_handle = (value.uintField);
@@ -298,18 +298,18 @@ ImmutableStructWithDefaults smoke_TypesWithDefaults_ImmutableStructWithDefaults_
 }
 void smoke_TypesWithDefaults_ImmutableStructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle(handle);
 // Nullable ImmutableStructWithDefaults
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle_nullable');
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle_nullable'));
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle_nullable');
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle_nullable'));
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_value_nullable');
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_value_nullable'));
 Pointer<Void> smoke_TypesWithDefaults_ImmutableStructWithDefaults_toFfi_nullable(ImmutableStructWithDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypesWithDefaults_ImmutableStructWithDefaults_toFfi(value);
@@ -334,18 +334,18 @@ class StructWithAnEnum {
     : config = AnEnum.enabled;
 }
 // StructWithAnEnum "private" section, not exported.
-final _smoke_TypesWithDefaults_StructWithAnEnum_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_StructWithAnEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_TypesWithDefaults_StructWithAnEnum_create_handle');
-final _smoke_TypesWithDefaults_StructWithAnEnum_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithAnEnum_create_handle'));
+final _smoke_TypesWithDefaults_StructWithAnEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithAnEnum_release_handle');
-final _smoke_TypesWithDefaults_StructWithAnEnum_get_field_config = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithAnEnum_release_handle'));
+final _smoke_TypesWithDefaults_StructWithAnEnum_get_field_config = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithAnEnum_get_field_config');
+  >('library_smoke_TypesWithDefaults_StructWithAnEnum_get_field_config'));
 Pointer<Void> smoke_TypesWithDefaults_StructWithAnEnum_toFfi(StructWithAnEnum value) {
   final _config_handle = smoke_AnEnum_AnEnum_toFfi(value.config);
   final _result = _smoke_TypesWithDefaults_StructWithAnEnum_create_handle(_config_handle);
@@ -364,18 +364,18 @@ StructWithAnEnum smoke_TypesWithDefaults_StructWithAnEnum_fromFfi(Pointer<Void> 
 }
 void smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypesWithDefaults_StructWithAnEnum_release_handle(handle);
 // Nullable StructWithAnEnum
-final _smoke_TypesWithDefaults_StructWithAnEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_StructWithAnEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithAnEnum_create_handle_nullable');
-final _smoke_TypesWithDefaults_StructWithAnEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithAnEnum_create_handle_nullable'));
+final _smoke_TypesWithDefaults_StructWithAnEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithAnEnum_release_handle_nullable');
-final _smoke_TypesWithDefaults_StructWithAnEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypesWithDefaults_StructWithAnEnum_release_handle_nullable'));
+final _smoke_TypesWithDefaults_StructWithAnEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypesWithDefaults_StructWithAnEnum_get_value_nullable');
+  >('library_smoke_TypesWithDefaults_StructWithAnEnum_get_value_nullable'));
 Pointer<Void> smoke_TypesWithDefaults_StructWithAnEnum_toFfi_nullable(StructWithAnEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypesWithDefaults_StructWithAnEnum_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_starts_with_one.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_starts_with_one.dart
@@ -32,18 +32,18 @@ EnumStartsWithOne smoke_EnumStartsWithOne_fromFfi(int handle) {
   }
 }
 void smoke_EnumStartsWithOne_releaseFfiHandle(int handle) {}
-final _smoke_EnumStartsWithOne_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_EnumStartsWithOne_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_EnumStartsWithOne_create_handle_nullable');
-final _smoke_EnumStartsWithOne_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EnumStartsWithOne_create_handle_nullable'));
+final _smoke_EnumStartsWithOne_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_EnumStartsWithOne_release_handle_nullable');
-final _smoke_EnumStartsWithOne_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EnumStartsWithOne_release_handle_nullable'));
+final _smoke_EnumStartsWithOne_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_EnumStartsWithOne_get_value_nullable');
+  >('library_smoke_EnumStartsWithOne_get_value_nullable'));
 Pointer<Void> smoke_EnumStartsWithOne_toFfi_nullable(EnumStartsWithOne value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_EnumStartsWithOne_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -45,18 +45,18 @@ Enums_SimpleEnum smoke_Enums_SimpleEnum_fromFfi(int handle) {
   }
 }
 void smoke_Enums_SimpleEnum_releaseFfiHandle(int handle) {}
-final _smoke_Enums_SimpleEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_SimpleEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Enums_SimpleEnum_create_handle_nullable');
-final _smoke_Enums_SimpleEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_SimpleEnum_create_handle_nullable'));
+final _smoke_Enums_SimpleEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Enums_SimpleEnum_release_handle_nullable');
-final _smoke_Enums_SimpleEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_SimpleEnum_release_handle_nullable'));
+final _smoke_Enums_SimpleEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Enums_SimpleEnum_get_value_nullable');
+  >('library_smoke_Enums_SimpleEnum_get_value_nullable'));
 Pointer<Void> smoke_Enums_SimpleEnum_toFfi_nullable(Enums_SimpleEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_SimpleEnum_toFfi(value);
@@ -104,18 +104,18 @@ Enums_InternalErrorCode smoke_Enums_InternalErrorCode_fromFfi(int handle) {
   }
 }
 void smoke_Enums_InternalErrorCode_releaseFfiHandle(int handle) {}
-final _smoke_Enums_InternalErrorCode_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_InternalErrorCode_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Enums_InternalErrorCode_create_handle_nullable');
-final _smoke_Enums_InternalErrorCode_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_InternalErrorCode_create_handle_nullable'));
+final _smoke_Enums_InternalErrorCode_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Enums_InternalErrorCode_release_handle_nullable');
-final _smoke_Enums_InternalErrorCode_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_InternalErrorCode_release_handle_nullable'));
+final _smoke_Enums_InternalErrorCode_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Enums_InternalErrorCode_get_value_nullable');
+  >('library_smoke_Enums_InternalErrorCode_get_value_nullable'));
 Pointer<Void> smoke_Enums_InternalErrorCode_toFfi_nullable(Enums_InternalErrorCode value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_InternalErrorCode_toFfi(value);
@@ -139,22 +139,22 @@ class Enums_ErrorStruct {
   Enums_ErrorStruct(this.type, this.message);
 }
 // Enums_ErrorStruct "private" section, not exported.
-final _smoke_Enums_ErrorStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_ErrorStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32, Pointer<Void>),
     Pointer<Void> Function(int, Pointer<Void>)
-  >('library_smoke_Enums_ErrorStruct_create_handle');
-final _smoke_Enums_ErrorStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_ErrorStruct_create_handle'));
+final _smoke_Enums_ErrorStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Enums_ErrorStruct_release_handle');
-final _smoke_Enums_ErrorStruct_get_field_type = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_ErrorStruct_release_handle'));
+final _smoke_Enums_ErrorStruct_get_field_type = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Enums_ErrorStruct_get_field_type');
-final _smoke_Enums_ErrorStruct_get_field_message = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_ErrorStruct_get_field_type'));
+final _smoke_Enums_ErrorStruct_get_field_message = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Enums_ErrorStruct_get_field_message');
+  >('library_smoke_Enums_ErrorStruct_get_field_message'));
 Pointer<Void> smoke_Enums_ErrorStruct_toFfi(Enums_ErrorStruct value) {
   final _type_handle = smoke_Enums_InternalErrorCode_toFfi(value.type);
   final _message_handle = String_toFfi(value.message);
@@ -178,18 +178,18 @@ Enums_ErrorStruct smoke_Enums_ErrorStruct_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Enums_ErrorStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Enums_ErrorStruct_release_handle(handle);
 // Nullable Enums_ErrorStruct
-final _smoke_Enums_ErrorStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_ErrorStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Enums_ErrorStruct_create_handle_nullable');
-final _smoke_Enums_ErrorStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_ErrorStruct_create_handle_nullable'));
+final _smoke_Enums_ErrorStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Enums_ErrorStruct_release_handle_nullable');
-final _smoke_Enums_ErrorStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_ErrorStruct_release_handle_nullable'));
+final _smoke_Enums_ErrorStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Enums_ErrorStruct_get_value_nullable');
+  >('library_smoke_Enums_ErrorStruct_get_value_nullable'));
 Pointer<Void> smoke_Enums_ErrorStruct_toFfi_nullable(Enums_ErrorStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_ErrorStruct_toFfi(value);
@@ -208,18 +208,18 @@ void smoke_Enums_ErrorStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Enums_ErrorStruct_release_handle_nullable(handle);
 // End of Enums_ErrorStruct "private" section.
 // Enums "private" section, not exported.
-final _smoke_Enums_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Enums_copy_handle');
-final _smoke_Enums_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_copy_handle'));
+final _smoke_Enums_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Enums_release_handle');
-final _smoke_Enums_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_release_handle'));
+final _smoke_Enums_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Enums_get_raw_pointer');
+    >('library_smoke_Enums_get_raw_pointer'));
 class Enums$Impl implements Enums {
   @protected
   Pointer<Void> handle;
@@ -232,7 +232,7 @@ class Enums$Impl implements Enums {
     handle = null;
   }
   static Enums_SimpleEnum methodWithEnumeration(Enums_SimpleEnum input) {
-    final _methodWithEnumeration_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_Enums_methodWithEnumeration__SimpleEnum');
+    final _methodWithEnumeration_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_Enums_methodWithEnumeration__SimpleEnum'));
     final _input_handle = smoke_Enums_SimpleEnum_toFfi(input);
     final __result_handle = _methodWithEnumeration_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Enums_SimpleEnum_releaseFfiHandle(_input_handle);
@@ -243,7 +243,7 @@ class Enums$Impl implements Enums {
     }
   }
   static Enums_InternalErrorCode flipEnumValue(Enums_InternalErrorCode input) {
-    final _flipEnumValue_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_Enums_flipEnumValue__InternalErrorCode');
+    final _flipEnumValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_Enums_flipEnumValue__InternalErrorCode'));
     final _input_handle = smoke_Enums_InternalErrorCode_toFfi(input);
     final __result_handle = _flipEnumValue_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Enums_InternalErrorCode_releaseFfiHandle(_input_handle);
@@ -254,7 +254,7 @@ class Enums$Impl implements Enums {
     }
   }
   static Enums_InternalErrorCode extractEnumFromStruct(Enums_ErrorStruct input) {
-    final _extractEnumFromStruct_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Pointer<Void>), int Function(int, Pointer<Void>)>('library_smoke_Enums_extractEnumFromStruct__ErrorStruct');
+    final _extractEnumFromStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Pointer<Void>), int Function(int, Pointer<Void>)>('library_smoke_Enums_extractEnumFromStruct__ErrorStruct'));
     final _input_handle = smoke_Enums_ErrorStruct_toFfi(input);
     final __result_handle = _extractEnumFromStruct_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Enums_ErrorStruct_releaseFfiHandle(_input_handle);
@@ -265,7 +265,7 @@ class Enums$Impl implements Enums {
     }
   }
   static Enums_ErrorStruct createStructWithEnumInside(Enums_InternalErrorCode type, String message) {
-    final _createStructWithEnumInside_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint32, Pointer<Void>), Pointer<Void> Function(int, int, Pointer<Void>)>('library_smoke_Enums_createStructWithEnumInside__InternalErrorCode_String');
+    final _createStructWithEnumInside_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint32, Pointer<Void>), Pointer<Void> Function(int, int, Pointer<Void>)>('library_smoke_Enums_createStructWithEnumInside__InternalErrorCode_String'));
     final _type_handle = smoke_Enums_InternalErrorCode_toFfi(type);
     final _message_handle = String_toFfi(message);
     final __result_handle = _createStructWithEnumInside_ffi(__lib.LibraryContext.isolateId, _type_handle, _message_handle);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
@@ -36,18 +36,18 @@ SomeEnum smoke_Equatable_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_Equatable_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_Equatable_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Equatable_SomeEnum_create_handle_nullable');
-final _smoke_Equatable_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_SomeEnum_create_handle_nullable'));
+final _smoke_Equatable_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Equatable_SomeEnum_release_handle_nullable');
-final _smoke_Equatable_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_SomeEnum_release_handle_nullable'));
+final _smoke_Equatable_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Equatable_SomeEnum_get_value_nullable');
+  >('library_smoke_Equatable_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_Equatable_SomeEnum_toFfi_nullable(SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Equatable_SomeEnum_toFfi(value);
@@ -110,54 +110,54 @@ class EquatableStruct {
   }
 }
 // EquatableStruct "private" section, not exported.
-final _smoke_Equatable_EquatableStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_EquatableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8, Int32, Int64, Float, Double, Pointer<Void>, Pointer<Void>, Uint32, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(int, int, int, double, double, Pointer<Void>, Pointer<Void>, int, Pointer<Void>, Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_create_handle');
-final _smoke_Equatable_EquatableStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_create_handle'));
+final _smoke_Equatable_EquatableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_release_handle');
-final _smoke_Equatable_EquatableStruct_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_release_handle'));
+final _smoke_Equatable_EquatableStruct_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_get_field_boolField');
-final _smoke_Equatable_EquatableStruct_get_field_intField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_get_field_boolField'));
+final _smoke_Equatable_EquatableStruct_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_get_field_intField');
-final _smoke_Equatable_EquatableStruct_get_field_longField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_get_field_intField'));
+final _smoke_Equatable_EquatableStruct_get_field_longField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_get_field_longField');
-final _smoke_Equatable_EquatableStruct_get_field_floatField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_get_field_longField'));
+final _smoke_Equatable_EquatableStruct_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_get_field_floatField');
-final _smoke_Equatable_EquatableStruct_get_field_doubleField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_get_field_floatField'));
+final _smoke_Equatable_EquatableStruct_get_field_doubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_get_field_doubleField');
-final _smoke_Equatable_EquatableStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_get_field_doubleField'));
+final _smoke_Equatable_EquatableStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_get_field_stringField');
-final _smoke_Equatable_EquatableStruct_get_field_structField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_get_field_stringField'));
+final _smoke_Equatable_EquatableStruct_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_get_field_structField');
-final _smoke_Equatable_EquatableStruct_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_get_field_structField'));
+final _smoke_Equatable_EquatableStruct_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_get_field_enumField');
-final _smoke_Equatable_EquatableStruct_get_field_arrayField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_get_field_enumField'));
+final _smoke_Equatable_EquatableStruct_get_field_arrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_get_field_arrayField');
-final _smoke_Equatable_EquatableStruct_get_field_mapField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_get_field_arrayField'));
+final _smoke_Equatable_EquatableStruct_get_field_mapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_get_field_mapField');
+  >('library_smoke_Equatable_EquatableStruct_get_field_mapField'));
 Pointer<Void> smoke_Equatable_EquatableStruct_toFfi(EquatableStruct value) {
   final _boolField_handle = Boolean_toFfi(value.boolField);
   final _intField_handle = (value.intField);
@@ -221,18 +221,18 @@ EquatableStruct smoke_Equatable_EquatableStruct_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Equatable_EquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Equatable_EquatableStruct_release_handle(handle);
 // Nullable EquatableStruct
-final _smoke_Equatable_EquatableStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_EquatableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_create_handle_nullable');
-final _smoke_Equatable_EquatableStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_create_handle_nullable'));
+final _smoke_Equatable_EquatableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_release_handle_nullable');
-final _smoke_Equatable_EquatableStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableStruct_release_handle_nullable'));
+final _smoke_Equatable_EquatableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableStruct_get_value_nullable');
+  >('library_smoke_Equatable_EquatableStruct_get_value_nullable'));
 Pointer<Void> smoke_Equatable_EquatableStruct_toFfi_nullable(EquatableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Equatable_EquatableStruct_toFfi(value);
@@ -292,50 +292,50 @@ class EquatableNullableStruct {
   }
 }
 // EquatableNullableStruct "private" section, not exported.
-final _smoke_Equatable_EquatableNullableStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_EquatableNullableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_create_handle');
-final _smoke_Equatable_EquatableNullableStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableNullableStruct_create_handle'));
+final _smoke_Equatable_EquatableNullableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_release_handle');
-final _smoke_Equatable_EquatableNullableStruct_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableNullableStruct_release_handle'));
+final _smoke_Equatable_EquatableNullableStruct_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_get_field_boolField');
-final _smoke_Equatable_EquatableNullableStruct_get_field_intField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableNullableStruct_get_field_boolField'));
+final _smoke_Equatable_EquatableNullableStruct_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_get_field_intField');
-final _smoke_Equatable_EquatableNullableStruct_get_field_uintField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableNullableStruct_get_field_intField'));
+final _smoke_Equatable_EquatableNullableStruct_get_field_uintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_get_field_uintField');
-final _smoke_Equatable_EquatableNullableStruct_get_field_floatField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableNullableStruct_get_field_uintField'));
+final _smoke_Equatable_EquatableNullableStruct_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_get_field_floatField');
-final _smoke_Equatable_EquatableNullableStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableNullableStruct_get_field_floatField'));
+final _smoke_Equatable_EquatableNullableStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_get_field_stringField');
-final _smoke_Equatable_EquatableNullableStruct_get_field_structField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableNullableStruct_get_field_stringField'));
+final _smoke_Equatable_EquatableNullableStruct_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_get_field_structField');
-final _smoke_Equatable_EquatableNullableStruct_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableNullableStruct_get_field_structField'));
+final _smoke_Equatable_EquatableNullableStruct_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_get_field_enumField');
-final _smoke_Equatable_EquatableNullableStruct_get_field_arrayField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableNullableStruct_get_field_enumField'));
+final _smoke_Equatable_EquatableNullableStruct_get_field_arrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_get_field_arrayField');
-final _smoke_Equatable_EquatableNullableStruct_get_field_mapField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableNullableStruct_get_field_arrayField'));
+final _smoke_Equatable_EquatableNullableStruct_get_field_mapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_get_field_mapField');
+  >('library_smoke_Equatable_EquatableNullableStruct_get_field_mapField'));
 Pointer<Void> smoke_Equatable_EquatableNullableStruct_toFfi(EquatableNullableStruct value) {
   final _boolField_handle = Boolean_toFfi_nullable(value.boolField);
   final _intField_handle = Int_toFfi_nullable(value.intField);
@@ -394,18 +394,18 @@ EquatableNullableStruct smoke_Equatable_EquatableNullableStruct_fromFfi(Pointer<
 }
 void smoke_Equatable_EquatableNullableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Equatable_EquatableNullableStruct_release_handle(handle);
 // Nullable EquatableNullableStruct
-final _smoke_Equatable_EquatableNullableStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_EquatableNullableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_create_handle_nullable');
-final _smoke_Equatable_EquatableNullableStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableNullableStruct_create_handle_nullable'));
+final _smoke_Equatable_EquatableNullableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_release_handle_nullable');
-final _smoke_Equatable_EquatableNullableStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_EquatableNullableStruct_release_handle_nullable'));
+final _smoke_Equatable_EquatableNullableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_EquatableNullableStruct_get_value_nullable');
+  >('library_smoke_Equatable_EquatableNullableStruct_get_value_nullable'));
 Pointer<Void> smoke_Equatable_EquatableNullableStruct_toFfi_nullable(EquatableNullableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Equatable_EquatableNullableStruct_toFfi(value);
@@ -441,18 +441,18 @@ class NestedEquatableStruct {
   }
 }
 // NestedEquatableStruct "private" section, not exported.
-final _smoke_Equatable_NestedEquatableStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_NestedEquatableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_NestedEquatableStruct_create_handle');
-final _smoke_Equatable_NestedEquatableStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_NestedEquatableStruct_create_handle'));
+final _smoke_Equatable_NestedEquatableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Equatable_NestedEquatableStruct_release_handle');
-final _smoke_Equatable_NestedEquatableStruct_get_field_fooField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_NestedEquatableStruct_release_handle'));
+final _smoke_Equatable_NestedEquatableStruct_get_field_fooField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_NestedEquatableStruct_get_field_fooField');
+  >('library_smoke_Equatable_NestedEquatableStruct_get_field_fooField'));
 Pointer<Void> smoke_Equatable_NestedEquatableStruct_toFfi(NestedEquatableStruct value) {
   final _fooField_handle = String_toFfi(value.fooField);
   final _result = _smoke_Equatable_NestedEquatableStruct_create_handle(_fooField_handle);
@@ -471,18 +471,18 @@ NestedEquatableStruct smoke_Equatable_NestedEquatableStruct_fromFfi(Pointer<Void
 }
 void smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Equatable_NestedEquatableStruct_release_handle(handle);
 // Nullable NestedEquatableStruct
-final _smoke_Equatable_NestedEquatableStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_NestedEquatableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_NestedEquatableStruct_create_handle_nullable');
-final _smoke_Equatable_NestedEquatableStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_NestedEquatableStruct_create_handle_nullable'));
+final _smoke_Equatable_NestedEquatableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Equatable_NestedEquatableStruct_release_handle_nullable');
-final _smoke_Equatable_NestedEquatableStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Equatable_NestedEquatableStruct_release_handle_nullable'));
+final _smoke_Equatable_NestedEquatableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Equatable_NestedEquatableStruct_get_value_nullable');
+  >('library_smoke_Equatable_NestedEquatableStruct_get_value_nullable'));
 Pointer<Void> smoke_Equatable_NestedEquatableStruct_toFfi_nullable(NestedEquatableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Equatable_NestedEquatableStruct_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
@@ -13,29 +13,29 @@ abstract class EquatableInterface {
   void release() {}
 }
 // EquatableInterface "private" section, not exported.
-final _smoke_EquatableInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_EquatableInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_EquatableInterface_copy_handle');
-final _smoke_EquatableInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableInterface_copy_handle'));
+final _smoke_EquatableInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_EquatableInterface_release_handle');
-final _smoke_EquatableInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableInterface_release_handle'));
+final _smoke_EquatableInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer),
     Pointer<Void> Function(int, int, Pointer)
-  >('library_smoke_EquatableInterface_create_proxy');
-final _smoke_EquatableInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableInterface_create_proxy'));
+final _smoke_EquatableInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_EquatableInterface_get_raw_pointer');
-final __are_equal = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_EquatableInterface_get_raw_pointer'));
+final __are_equal = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
-  >('library_smoke_EquatableInterface_are_equal');final _smoke_EquatableInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableInterface_are_equal'));final _smoke_EquatableInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_EquatableInterface_get_type_id');
+  >('library_smoke_EquatableInterface_get_type_id'));
 class EquatableInterface$Impl implements EquatableInterface {
   @protected
   Pointer<Void> handle;

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
@@ -40,34 +40,34 @@ class EquatableStructWithInternalFields {
   }
 }
 // EquatableStructWithInternalFields "private" section, not exported.
-final _smoke_EquatableStructWithInternalFields_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_EquatableStructWithInternalFields_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_smoke_EquatableStructWithInternalFields_create_handle');
-final _smoke_EquatableStructWithInternalFields_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableStructWithInternalFields_create_handle'));
+final _smoke_EquatableStructWithInternalFields_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_EquatableStructWithInternalFields_release_handle');
-final _smoke_EquatableStructWithInternalFields_get_field_publicField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableStructWithInternalFields_release_handle'));
+final _smoke_EquatableStructWithInternalFields_get_field_publicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_EquatableStructWithInternalFields_get_field_publicField');
-final _smoke_EquatableStructWithInternalFields_get_field_internalField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableStructWithInternalFields_get_field_publicField'));
+final _smoke_EquatableStructWithInternalFields_get_field_internalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_EquatableStructWithInternalFields_get_field_internalField');
-final _smoke_EquatableStructWithInternalFields_get_field_internalListField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableStructWithInternalFields_get_field_internalField'));
+final _smoke_EquatableStructWithInternalFields_get_field_internalListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_EquatableStructWithInternalFields_get_field_internalListField');
-final _smoke_EquatableStructWithInternalFields_get_field_internalMapField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableStructWithInternalFields_get_field_internalListField'));
+final _smoke_EquatableStructWithInternalFields_get_field_internalMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_EquatableStructWithInternalFields_get_field_internalMapField');
-final _smoke_EquatableStructWithInternalFields_get_field_internalSetField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableStructWithInternalFields_get_field_internalMapField'));
+final _smoke_EquatableStructWithInternalFields_get_field_internalSetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_EquatableStructWithInternalFields_get_field_internalSetField');
+  >('library_smoke_EquatableStructWithInternalFields_get_field_internalSetField'));
 Pointer<Void> smoke_EquatableStructWithInternalFields_toFfi(EquatableStructWithInternalFields value) {
   final _publicField_handle = String_toFfi(value.publicField);
   final _internalField_handle = String_toFfi(value.internal_internalField);
@@ -106,18 +106,18 @@ EquatableStructWithInternalFields smoke_EquatableStructWithInternalFields_fromFf
 }
 void smoke_EquatableStructWithInternalFields_releaseFfiHandle(Pointer<Void> handle) => _smoke_EquatableStructWithInternalFields_release_handle(handle);
 // Nullable EquatableStructWithInternalFields
-final _smoke_EquatableStructWithInternalFields_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_EquatableStructWithInternalFields_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_EquatableStructWithInternalFields_create_handle_nullable');
-final _smoke_EquatableStructWithInternalFields_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableStructWithInternalFields_create_handle_nullable'));
+final _smoke_EquatableStructWithInternalFields_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_EquatableStructWithInternalFields_release_handle_nullable');
-final _smoke_EquatableStructWithInternalFields_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableStructWithInternalFields_release_handle_nullable'));
+final _smoke_EquatableStructWithInternalFields_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_EquatableStructWithInternalFields_get_value_nullable');
+  >('library_smoke_EquatableStructWithInternalFields_get_value_nullable'));
 Pointer<Void> smoke_EquatableStructWithInternalFields_toFfi_nullable(EquatableStructWithInternalFields value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_EquatableStructWithInternalFields_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/simple_equatable_struct.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/simple_equatable_struct.dart
@@ -33,30 +33,30 @@ class SimpleEquatableStruct {
   }
 }
 // SimpleEquatableStruct "private" section, not exported.
-final _smoke_SimpleEquatableStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_SimpleEquatableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_smoke_SimpleEquatableStruct_create_handle');
-final _smoke_SimpleEquatableStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SimpleEquatableStruct_create_handle'));
+final _smoke_SimpleEquatableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_SimpleEquatableStruct_release_handle');
-final _smoke_SimpleEquatableStruct_get_field_classField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SimpleEquatableStruct_release_handle'));
+final _smoke_SimpleEquatableStruct_get_field_classField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SimpleEquatableStruct_get_field_classField');
-final _smoke_SimpleEquatableStruct_get_field_interfaceField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SimpleEquatableStruct_get_field_classField'));
+final _smoke_SimpleEquatableStruct_get_field_interfaceField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SimpleEquatableStruct_get_field_interfaceField');
-final _smoke_SimpleEquatableStruct_get_field_nullableClassField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SimpleEquatableStruct_get_field_interfaceField'));
+final _smoke_SimpleEquatableStruct_get_field_nullableClassField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SimpleEquatableStruct_get_field_nullableClassField');
-final _smoke_SimpleEquatableStruct_get_field_nullableInterfaceField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SimpleEquatableStruct_get_field_nullableClassField'));
+final _smoke_SimpleEquatableStruct_get_field_nullableInterfaceField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SimpleEquatableStruct_get_field_nullableInterfaceField');
+  >('library_smoke_SimpleEquatableStruct_get_field_nullableInterfaceField'));
 Pointer<Void> smoke_SimpleEquatableStruct_toFfi(SimpleEquatableStruct value) {
   final _classField_handle = smoke_NonEquatableClass_toFfi(value.classField);
   final _interfaceField_handle = smoke_NonEquatableInterface_toFfi(value.interfaceField);
@@ -90,18 +90,18 @@ SimpleEquatableStruct smoke_SimpleEquatableStruct_fromFfi(Pointer<Void> handle) 
 }
 void smoke_SimpleEquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_SimpleEquatableStruct_release_handle(handle);
 // Nullable SimpleEquatableStruct
-final _smoke_SimpleEquatableStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_SimpleEquatableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SimpleEquatableStruct_create_handle_nullable');
-final _smoke_SimpleEquatableStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SimpleEquatableStruct_create_handle_nullable'));
+final _smoke_SimpleEquatableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_SimpleEquatableStruct_release_handle_nullable');
-final _smoke_SimpleEquatableStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SimpleEquatableStruct_release_handle_nullable'));
+final _smoke_SimpleEquatableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SimpleEquatableStruct_get_value_nullable');
+  >('library_smoke_SimpleEquatableStruct_get_value_nullable'));
 Pointer<Void> smoke_SimpleEquatableStruct_toFfi_nullable(SimpleEquatableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SimpleEquatableStruct_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -48,18 +48,18 @@ Errors_InternalErrorCode smoke_Errors_InternalErrorCode_fromFfi(int handle) {
   }
 }
 void smoke_Errors_InternalErrorCode_releaseFfiHandle(int handle) {}
-final _smoke_Errors_InternalErrorCode_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Errors_InternalErrorCode_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Errors_InternalErrorCode_create_handle_nullable');
-final _smoke_Errors_InternalErrorCode_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_InternalErrorCode_create_handle_nullable'));
+final _smoke_Errors_InternalErrorCode_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Errors_InternalErrorCode_release_handle_nullable');
-final _smoke_Errors_InternalErrorCode_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_InternalErrorCode_release_handle_nullable'));
+final _smoke_Errors_InternalErrorCode_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Errors_InternalErrorCode_get_value_nullable');
+  >('library_smoke_Errors_InternalErrorCode_get_value_nullable'));
 Pointer<Void> smoke_Errors_InternalErrorCode_toFfi_nullable(Errors_InternalErrorCode value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Errors_InternalErrorCode_toFfi(value);
@@ -114,18 +114,18 @@ Errors_ExternalErrors smoke_Errors_ExternalErrors_fromFfi(int handle) {
   }
 }
 void smoke_Errors_ExternalErrors_releaseFfiHandle(int handle) {}
-final _smoke_Errors_ExternalErrors_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Errors_ExternalErrors_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Errors_ExternalErrors_create_handle_nullable');
-final _smoke_Errors_ExternalErrors_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_ExternalErrors_create_handle_nullable'));
+final _smoke_Errors_ExternalErrors_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Errors_ExternalErrors_release_handle_nullable');
-final _smoke_Errors_ExternalErrors_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_ExternalErrors_release_handle_nullable'));
+final _smoke_Errors_ExternalErrors_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Errors_ExternalErrors_get_value_nullable');
+  >('library_smoke_Errors_ExternalErrors_get_value_nullable'));
 Pointer<Void> smoke_Errors_ExternalErrors_toFfi_nullable(Errors_ExternalErrors value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Errors_ExternalErrors_toFfi(value);
@@ -152,89 +152,89 @@ class Errors_ExternalException implements Exception {
   Errors_ExternalException(this.error);
 }
 // Errors "private" section, not exported.
-final _smoke_Errors_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Errors_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Errors_copy_handle');
-final _smoke_Errors_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_copy_handle'));
+final _smoke_Errors_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Errors_release_handle');
-final _smoke_Errors_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_release_handle'));
+final _smoke_Errors_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Errors_get_raw_pointer');
-final _methodWithErrors_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_Errors_get_raw_pointer'));
+final _methodWithErrors_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrors_return_release_handle');
+  >('library_smoke_Errors_methodWithErrors_return_release_handle'));
 final _methodWithErrors_return_get_result = (Pointer) {};
-final _methodWithErrors_return_get_error = __lib.nativeLibrary.lookupFunction<
+final _methodWithErrors_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrors_return_get_error');
-final _methodWithErrors_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithErrors_return_get_error'));
+final _methodWithErrors_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrors_return_has_error');
-final _methodWithExternalErrors_return_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithErrors_return_has_error'));
+final _methodWithExternalErrors_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithExternalErrors_return_release_handle');
+  >('library_smoke_Errors_methodWithExternalErrors_return_release_handle'));
 final _methodWithExternalErrors_return_get_result = (Pointer) {};
-final _methodWithExternalErrors_return_get_error = __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrors_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithExternalErrors_return_get_error');
-final _methodWithExternalErrors_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithExternalErrors_return_get_error'));
+final _methodWithExternalErrors_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithExternalErrors_return_has_error');
-final _methodWithErrorsAndReturnValue_return_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithExternalErrors_return_has_error'));
+final _methodWithErrorsAndReturnValue_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_release_handle');
-final _methodWithErrorsAndReturnValue_return_get_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_release_handle'));
+final _methodWithErrorsAndReturnValue_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_get_result');
-final _methodWithErrorsAndReturnValue_return_get_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_get_result'));
+final _methodWithErrorsAndReturnValue_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_get_error');
-final _methodWithErrorsAndReturnValue_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_get_error'));
+final _methodWithErrorsAndReturnValue_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_has_error');
-final _methodWithPayloadError_return_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_has_error'));
+final _methodWithPayloadError_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadError_return_release_handle');
+  >('library_smoke_Errors_methodWithPayloadError_return_release_handle'));
 final _methodWithPayloadError_return_get_result = (Pointer) {};
-final _methodWithPayloadError_return_get_error = __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadError_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadError_return_get_error');
-final _methodWithPayloadError_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithPayloadError_return_get_error'));
+final _methodWithPayloadError_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadError_return_has_error');
-final _methodWithPayloadErrorAndReturnValue_return_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithPayloadError_return_has_error'));
+final _methodWithPayloadErrorAndReturnValue_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_release_handle');
-final _methodWithPayloadErrorAndReturnValue_return_get_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_release_handle'));
+final _methodWithPayloadErrorAndReturnValue_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_get_result');
-final _methodWithPayloadErrorAndReturnValue_return_get_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_get_result'));
+final _methodWithPayloadErrorAndReturnValue_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_get_error');
-final _methodWithPayloadErrorAndReturnValue_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_get_error'));
+final _methodWithPayloadErrorAndReturnValue_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_has_error');
+  >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_has_error'));
 class Errors$Impl implements Errors {
   @protected
   Pointer<Void> handle;
@@ -247,7 +247,7 @@ class Errors$Impl implements Errors {
     handle = null;
   }
   static methodWithErrors() {
-    final _methodWithErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrors');
+    final _methodWithErrors_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrors'));
     final __call_result_handle = _methodWithErrors_ffi(__lib.LibraryContext.isolateId);
     if (_methodWithErrors_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithErrors_return_get_error(__call_result_handle);
@@ -267,7 +267,7 @@ class Errors$Impl implements Errors {
     }
   }
   static methodWithExternalErrors() {
-    final _methodWithExternalErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithExternalErrors');
+    final _methodWithExternalErrors_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithExternalErrors'));
     final __call_result_handle = _methodWithExternalErrors_ffi(__lib.LibraryContext.isolateId);
     if (_methodWithExternalErrors_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithExternalErrors_return_get_error(__call_result_handle);
@@ -287,7 +287,7 @@ class Errors$Impl implements Errors {
     }
   }
   static String methodWithErrorsAndReturnValue() {
-    final _methodWithErrorsAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrorsAndReturnValue');
+    final _methodWithErrorsAndReturnValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrorsAndReturnValue'));
     final __call_result_handle = _methodWithErrorsAndReturnValue_ffi(__lib.LibraryContext.isolateId);
     if (_methodWithErrorsAndReturnValue_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithErrorsAndReturnValue_return_get_error(__call_result_handle);
@@ -307,7 +307,7 @@ class Errors$Impl implements Errors {
     }
   }
   static methodWithPayloadError() {
-    final _methodWithPayloadError_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadError');
+    final _methodWithPayloadError_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadError'));
     final __call_result_handle = _methodWithPayloadError_ffi(__lib.LibraryContext.isolateId);
     if (_methodWithPayloadError_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithPayloadError_return_get_error(__call_result_handle);
@@ -327,7 +327,7 @@ class Errors$Impl implements Errors {
     }
   }
   static String methodWithPayloadErrorAndReturnValue() {
-    final _methodWithPayloadErrorAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadErrorAndReturnValue');
+    final _methodWithPayloadErrorAndReturnValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadErrorAndReturnValue'));
     final __call_result_handle = _methodWithPayloadErrorAndReturnValue_ffi(__lib.LibraryContext.isolateId);
     if (_methodWithPayloadErrorAndReturnValue_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithPayloadErrorAndReturnValue_return_get_error(__call_result_handle);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -63,18 +63,18 @@ ErrorsInterface_InternalError smoke_ErrorsInterface_InternalError_fromFfi(int ha
   }
 }
 void smoke_ErrorsInterface_InternalError_releaseFfiHandle(int handle) {}
-final _smoke_ErrorsInterface_InternalError_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_ErrorsInterface_InternalError_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_ErrorsInterface_InternalError_create_handle_nullable');
-final _smoke_ErrorsInterface_InternalError_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_InternalError_create_handle_nullable'));
+final _smoke_ErrorsInterface_InternalError_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_InternalError_release_handle_nullable');
-final _smoke_ErrorsInterface_InternalError_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_InternalError_release_handle_nullable'));
+final _smoke_ErrorsInterface_InternalError_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_InternalError_get_value_nullable');
+  >('library_smoke_ErrorsInterface_InternalError_get_value_nullable'));
 Pointer<Void> smoke_ErrorsInterface_InternalError_toFfi_nullable(ErrorsInterface_InternalError value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ErrorsInterface_InternalError_toFfi(value);
@@ -129,18 +129,18 @@ ErrorsInterface_ExternalErrors smoke_ErrorsInterface_ExternalErrors_fromFfi(int 
   }
 }
 void smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(int handle) {}
-final _smoke_ErrorsInterface_ExternalErrors_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_ErrorsInterface_ExternalErrors_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_ErrorsInterface_ExternalErrors_create_handle_nullable');
-final _smoke_ErrorsInterface_ExternalErrors_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_ExternalErrors_create_handle_nullable'));
+final _smoke_ErrorsInterface_ExternalErrors_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_ExternalErrors_release_handle_nullable');
-final _smoke_ErrorsInterface_ExternalErrors_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_ExternalErrors_release_handle_nullable'));
+final _smoke_ErrorsInterface_ExternalErrors_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_ExternalErrors_get_value_nullable');
+  >('library_smoke_ErrorsInterface_ExternalErrors_get_value_nullable'));
 Pointer<Void> smoke_ErrorsInterface_ExternalErrors_toFfi_nullable(ErrorsInterface_ExternalErrors value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ErrorsInterface_ExternalErrors_toFfi(value);
@@ -167,97 +167,97 @@ class ErrorsInterface_ExternalException implements Exception {
   ErrorsInterface_ExternalException(this.error);
 }
 // ErrorsInterface "private" section, not exported.
-final _smoke_ErrorsInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ErrorsInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_copy_handle');
-final _smoke_ErrorsInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_copy_handle'));
+final _smoke_ErrorsInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_release_handle');
-final _smoke_ErrorsInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_release_handle'));
+final _smoke_ErrorsInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
-  >('library_smoke_ErrorsInterface_create_proxy');
-final _smoke_ErrorsInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_create_proxy'));
+final _smoke_ErrorsInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ErrorsInterface_get_raw_pointer');
-final _smoke_ErrorsInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_ErrorsInterface_get_raw_pointer'));
+final _smoke_ErrorsInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_get_type_id');
-final _methodWithErrors_return_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_get_type_id'));
+final _methodWithErrors_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithErrors_return_release_handle');
+  >('library_smoke_ErrorsInterface_methodWithErrors_return_release_handle'));
 final _methodWithErrors_return_get_result = (Pointer) {};
-final _methodWithErrors_return_get_error = __lib.nativeLibrary.lookupFunction<
+final _methodWithErrors_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithErrors_return_get_error');
-final _methodWithErrors_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithErrors_return_get_error'));
+final _methodWithErrors_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithErrors_return_has_error');
-final _methodWithExternalErrors_return_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithErrors_return_has_error'));
+final _methodWithExternalErrors_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_release_handle');
+  >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_release_handle'));
 final _methodWithExternalErrors_return_get_result = (Pointer) {};
-final _methodWithExternalErrors_return_get_error = __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrors_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_get_error');
-final _methodWithExternalErrors_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_get_error'));
+final _methodWithExternalErrors_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_has_error');
-final _methodWithErrorsAndReturnValue_return_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_has_error'));
+final _methodWithErrorsAndReturnValue_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_release_handle');
-final _methodWithErrorsAndReturnValue_return_get_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_release_handle'));
+final _methodWithErrorsAndReturnValue_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_get_result');
-final _methodWithErrorsAndReturnValue_return_get_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_get_result'));
+final _methodWithErrorsAndReturnValue_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_get_error');
-final _methodWithErrorsAndReturnValue_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_get_error'));
+final _methodWithErrorsAndReturnValue_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_has_error');
-final _methodWithPayloadError_return_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_has_error'));
+final _methodWithPayloadError_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithPayloadError_return_release_handle');
+  >('library_smoke_ErrorsInterface_methodWithPayloadError_return_release_handle'));
 final _methodWithPayloadError_return_get_result = (Pointer) {};
-final _methodWithPayloadError_return_get_error = __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadError_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithPayloadError_return_get_error');
-final _methodWithPayloadError_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithPayloadError_return_get_error'));
+final _methodWithPayloadError_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithPayloadError_return_has_error');
-final _methodWithPayloadErrorAndReturnValue_return_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithPayloadError_return_has_error'));
+final _methodWithPayloadErrorAndReturnValue_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_release_handle');
-final _methodWithPayloadErrorAndReturnValue_return_get_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_release_handle'));
+final _methodWithPayloadErrorAndReturnValue_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_get_result');
-final _methodWithPayloadErrorAndReturnValue_return_get_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_get_result'));
+final _methodWithPayloadErrorAndReturnValue_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_get_error');
-final _methodWithPayloadErrorAndReturnValue_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_get_error'));
+final _methodWithPayloadErrorAndReturnValue_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_has_error');
+  >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_has_error'));
 class ErrorsInterface$Lambdas implements ErrorsInterface {
   void Function() lambda_methodWithErrors;
   void Function() lambda_methodWithExternalErrors;
@@ -308,7 +308,7 @@ class ErrorsInterface$Impl implements ErrorsInterface {
   }
   @override
   methodWithErrors() {
-    final _methodWithErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrors');
+    final _methodWithErrors_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrors'));
     final _handle = this.handle;
     final __call_result_handle = _methodWithErrors_ffi(_handle, __lib.LibraryContext.isolateId);
     if (_methodWithErrors_return_has_error(__call_result_handle) != 0) {
@@ -330,7 +330,7 @@ class ErrorsInterface$Impl implements ErrorsInterface {
   }
   @override
   methodWithExternalErrors() {
-    final _methodWithExternalErrors_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithExternalErrors');
+    final _methodWithExternalErrors_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithExternalErrors'));
     final _handle = this.handle;
     final __call_result_handle = _methodWithExternalErrors_ffi(_handle, __lib.LibraryContext.isolateId);
     if (_methodWithExternalErrors_return_has_error(__call_result_handle) != 0) {
@@ -352,7 +352,7 @@ class ErrorsInterface$Impl implements ErrorsInterface {
   }
   @override
   String methodWithErrorsAndReturnValue() {
-    final _methodWithErrorsAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue');
+    final _methodWithErrorsAndReturnValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue'));
     final _handle = this.handle;
     final __call_result_handle = _methodWithErrorsAndReturnValue_ffi(_handle, __lib.LibraryContext.isolateId);
     if (_methodWithErrorsAndReturnValue_return_has_error(__call_result_handle) != 0) {
@@ -374,7 +374,7 @@ class ErrorsInterface$Impl implements ErrorsInterface {
   }
   @override
   static methodWithPayloadError() {
-    final _methodWithPayloadError_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadError');
+    final _methodWithPayloadError_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadError'));
     final __call_result_handle = _methodWithPayloadError_ffi(__lib.LibraryContext.isolateId);
     if (_methodWithPayloadError_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithPayloadError_return_get_error(__call_result_handle);
@@ -395,7 +395,7 @@ class ErrorsInterface$Impl implements ErrorsInterface {
   }
   @override
   static String methodWithPayloadErrorAndReturnValue() {
-    final _methodWithPayloadErrorAndReturnValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue');
+    final _methodWithPayloadErrorAndReturnValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue'));
     final __call_result_handle = _methodWithPayloadErrorAndReturnValue_ffi(__lib.LibraryContext.isolateId);
     if (_methodWithPayloadErrorAndReturnValue_return_has_error(__call_result_handle) != 0) {
         final __error_handle = _methodWithPayloadErrorAndReturnValue_return_get_error(__call_result_handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -20,38 +20,38 @@ abstract class Class implements Interface {
   set property(Enum value);
 }
 // Class "private" section, not exported.
-final _package_Class_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _package_Class_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_package_Class_copy_handle');
-final _package_Class_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Class_copy_handle'));
+final _package_Class_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_package_Class_release_handle');
-final _package_Class_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Class_release_handle'));
+final _package_Class_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_package_Class_get_raw_pointer');
-final _package_Class_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_package_Class_get_raw_pointer'));
+final _package_Class_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_package_Class_get_type_id');
-final _fun_return_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Class_get_type_id'));
+final _fun_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_release_handle');
-final _fun_return_get_result = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_release_handle'));
+final _fun_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_get_result');
-final _fun_return_get_error = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_get_result'));
+final _fun_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_get_error');
-final _fun_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_get_error'));
+final _fun_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_has_error');
+  >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_has_error'));
 class Class$Impl implements Class {
   @protected
   Pointer<Void> handle;
@@ -67,13 +67,13 @@ class Class$Impl implements Class {
     __lib.reverseCache[_package_Class_get_raw_pointer(handle)] = this;
   }
   static Pointer<Void> _constructor() {
-    final _constructor_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_package_Class_constructor');
+    final _constructor_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_package_Class_constructor'));
     final __result_handle = _constructor_ffi(__lib.LibraryContext.isolateId);
     return __result_handle;
   }
   @override
   Struct fun(List<Struct> double) {
-    final _fun_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_package_Class_fun__ListOf_1package_1Types_1Struct');
+    final _fun_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_package_Class_fun__ListOf_1package_1Types_1Struct'));
     final _double_handle = ListOf_package_Types_Struct_toFfi(double);
     final _handle = this.handle;
     final __call_result_handle = _fun_ffi(_handle, __lib.LibraryContext.isolateId, _double_handle);
@@ -97,7 +97,7 @@ class Class$Impl implements Class {
   }
   @override
   Enum get property {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_package_Class_property_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_package_Class_property_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -108,7 +108,7 @@ class Class$Impl implements Class {
   }
   @override
   set property(Enum value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_package_Class_property_set__enum');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_package_Class_property_set__enum'));
     final _value_handle = package_Types_Enum_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
@@ -13,26 +13,26 @@ abstract class Interface {
   void release() {}
 }
 // Interface "private" section, not exported.
-final _package_Interface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _package_Interface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_package_Interface_copy_handle');
-final _package_Interface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Interface_copy_handle'));
+final _package_Interface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_package_Interface_release_handle');
-final _package_Interface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Interface_release_handle'));
+final _package_Interface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer),
     Pointer<Void> Function(int, int, Pointer)
-  >('library_package_Interface_create_proxy');
-final _package_Interface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Interface_create_proxy'));
+final _package_Interface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_package_Interface_get_raw_pointer');
-final _package_Interface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_package_Interface_get_raw_pointer'));
+final _package_Interface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_package_Interface_get_type_id');
+  >('library_package_Interface_get_type_id'));
 class Interface$Impl implements Interface {
   @protected
   Pointer<Void> handle;

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
@@ -25,18 +25,18 @@ Enum package_Types_Enum_fromFfi(int handle) {
   }
 }
 void package_Types_Enum_releaseFfiHandle(int handle) {}
-final _package_Types_Enum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _package_Types_Enum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_package_Types_Enum_create_handle_nullable');
-final _package_Types_Enum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Types_Enum_create_handle_nullable'));
+final _package_Types_Enum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_package_Types_Enum_release_handle_nullable');
-final _package_Types_Enum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Types_Enum_release_handle_nullable'));
+final _package_Types_Enum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_package_Types_Enum_get_value_nullable');
+  >('library_package_Types_Enum_get_value_nullable'));
 Pointer<Void> package_Types_Enum_toFfi_nullable(Enum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = package_Types_Enum_toFfi(value);
@@ -65,18 +65,18 @@ class Struct {
     : null = Enum.naN;
 }
 // Struct "private" section, not exported.
-final _package_Types_Struct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _package_Types_Struct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_package_Types_Struct_create_handle');
-final _package_Types_Struct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Types_Struct_create_handle'));
+final _package_Types_Struct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_package_Types_Struct_release_handle');
-final _package_Types_Struct_get_field_null = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Types_Struct_release_handle'));
+final _package_Types_Struct_get_field_null = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_package_Types_Struct_get_field_null');
+  >('library_package_Types_Struct_get_field_null'));
 Pointer<Void> package_Types_Struct_toFfi(Struct value) {
   final _null_handle = package_Types_Enum_toFfi(value.null);
   final _result = _package_Types_Struct_create_handle(_null_handle);
@@ -95,18 +95,18 @@ Struct package_Types_Struct_fromFfi(Pointer<Void> handle) {
 }
 void package_Types_Struct_releaseFfiHandle(Pointer<Void> handle) => _package_Types_Struct_release_handle(handle);
 // Nullable Struct
-final _package_Types_Struct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _package_Types_Struct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_package_Types_Struct_create_handle_nullable');
-final _package_Types_Struct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Types_Struct_create_handle_nullable'));
+final _package_Types_Struct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_package_Types_Struct_release_handle_nullable');
-final _package_Types_Struct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_package_Types_Struct_release_handle_nullable'));
+final _package_Types_Struct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_package_Types_Struct_get_value_nullable');
+  >('library_package_Types_Struct_get_value_nullable'));
 Pointer<Void> package_Types_Struct_toFfi_nullable(Struct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = package_Types_Struct_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
@@ -9,38 +9,38 @@ import 'package:library/src/smoke/rectangle_int_.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-final _ListOf_Byte_create_handle = __lib.nativeLibrary.lookupFunction<
+final _ListOf_Byte_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_ListOf_Byte_create_handle');
-final _ListOf_Byte_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Byte_create_handle'));
+final _ListOf_Byte_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ListOf_Byte_release_handle');
-final _ListOf_Byte_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Byte_release_handle'));
+final _ListOf_Byte_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int8),
     void Function(Pointer<Void>, int)
-  >('library_ListOf_Byte_insert');
-final _ListOf_Byte_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Byte_insert'));
+final _ListOf_Byte_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_ListOf_Byte_iterator');
-final _ListOf_Byte_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_Byte_iterator'));
+final _ListOf_Byte_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_ListOf_Byte_iterator_release_handle');
-final _ListOf_Byte_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_Byte_iterator_release_handle'));
+final _ListOf_Byte_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_ListOf_Byte_iterator_is_valid');
-final _ListOf_Byte_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_Byte_iterator_is_valid'));
+final _ListOf_Byte_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_ListOf_Byte_iterator_increment');
-final _ListOf_Byte_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_Byte_iterator_increment'));
+final _ListOf_Byte_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_ListOf_Byte_iterator_get');
+>('library_ListOf_Byte_iterator_get'));
 Pointer<Void> ListOf_Byte_toFfi(List<int> value) {
   final _result = _ListOf_Byte_create_handle();
   for (final element in value) {
@@ -66,18 +66,18 @@ List<int> ListOf_Byte_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void ListOf_Byte_releaseFfiHandle(Pointer<Void> handle) => _ListOf_Byte_release_handle(handle);
-final _ListOf_Byte_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _ListOf_Byte_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_ListOf_Byte_create_handle_nullable');
-final _ListOf_Byte_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Byte_create_handle_nullable'));
+final _ListOf_Byte_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ListOf_Byte_release_handle_nullable');
-final _ListOf_Byte_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Byte_release_handle_nullable'));
+final _ListOf_Byte_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_ListOf_Byte_get_value_nullable');
+  >('library_ListOf_Byte_get_value_nullable'));
 Pointer<Void> ListOf_Byte_toFfi_nullable(List<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = ListOf_Byte_toFfi(value);
@@ -94,38 +94,38 @@ List<int> ListOf_Byte_fromFfi_nullable(Pointer<Void> handle) {
 }
 void ListOf_Byte_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _ListOf_Byte_release_handle_nullable(handle);
-final _ListOf_String_create_handle = __lib.nativeLibrary.lookupFunction<
+final _ListOf_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_ListOf_String_create_handle');
-final _ListOf_String_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_create_handle'));
+final _ListOf_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ListOf_String_release_handle');
-final _ListOf_String_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_release_handle'));
+final _ListOf_String_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_ListOf_String_insert');
-final _ListOf_String_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_insert'));
+final _ListOf_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_ListOf_String_iterator');
-final _ListOf_String_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_String_iterator'));
+final _ListOf_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_ListOf_String_iterator_release_handle');
-final _ListOf_String_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_String_iterator_release_handle'));
+final _ListOf_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_ListOf_String_iterator_is_valid');
-final _ListOf_String_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_String_iterator_is_valid'));
+final _ListOf_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_ListOf_String_iterator_increment');
-final _ListOf_String_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_String_iterator_increment'));
+final _ListOf_String_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_ListOf_String_iterator_get');
+>('library_ListOf_String_iterator_get'));
 Pointer<Void> ListOf_String_toFfi(List<String> value) {
   final _result = _ListOf_String_create_handle();
   for (final element in value) {
@@ -151,18 +151,18 @@ List<String> ListOf_String_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void ListOf_String_releaseFfiHandle(Pointer<Void> handle) => _ListOf_String_release_handle(handle);
-final _ListOf_String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _ListOf_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_ListOf_String_create_handle_nullable');
-final _ListOf_String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_create_handle_nullable'));
+final _ListOf_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ListOf_String_release_handle_nullable');
-final _ListOf_String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_release_handle_nullable'));
+final _ListOf_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_ListOf_String_get_value_nullable');
+  >('library_ListOf_String_get_value_nullable'));
 Pointer<Void> ListOf_String_toFfi_nullable(List<String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = ListOf_String_toFfi(value);
@@ -179,38 +179,38 @@ List<String> ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
 }
 void ListOf_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _ListOf_String_release_handle_nullable(handle);
-final _ListOf_smoke_DateInterval_create_handle = __lib.nativeLibrary.lookupFunction<
+final _ListOf_smoke_DateInterval_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_ListOf_smoke_DateInterval_create_handle');
-final _ListOf_smoke_DateInterval_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_smoke_DateInterval_create_handle'));
+final _ListOf_smoke_DateInterval_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ListOf_smoke_DateInterval_release_handle');
-final _ListOf_smoke_DateInterval_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_smoke_DateInterval_release_handle'));
+final _ListOf_smoke_DateInterval_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_ListOf_smoke_DateInterval_insert');
-final _ListOf_smoke_DateInterval_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_smoke_DateInterval_insert'));
+final _ListOf_smoke_DateInterval_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_ListOf_smoke_DateInterval_iterator');
-final _ListOf_smoke_DateInterval_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_smoke_DateInterval_iterator'));
+final _ListOf_smoke_DateInterval_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_ListOf_smoke_DateInterval_iterator_release_handle');
-final _ListOf_smoke_DateInterval_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_smoke_DateInterval_iterator_release_handle'));
+final _ListOf_smoke_DateInterval_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_ListOf_smoke_DateInterval_iterator_is_valid');
-final _ListOf_smoke_DateInterval_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_smoke_DateInterval_iterator_is_valid'));
+final _ListOf_smoke_DateInterval_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_ListOf_smoke_DateInterval_iterator_increment');
-final _ListOf_smoke_DateInterval_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_smoke_DateInterval_iterator_increment'));
+final _ListOf_smoke_DateInterval_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_ListOf_smoke_DateInterval_iterator_get');
+>('library_ListOf_smoke_DateInterval_iterator_get'));
 Pointer<Void> ListOf_smoke_DateInterval_toFfi(List<DateInterval> value) {
   final _result = _ListOf_smoke_DateInterval_create_handle();
   for (final element in value) {
@@ -236,18 +236,18 @@ List<DateInterval> ListOf_smoke_DateInterval_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void ListOf_smoke_DateInterval_releaseFfiHandle(Pointer<Void> handle) => _ListOf_smoke_DateInterval_release_handle(handle);
-final _ListOf_smoke_DateInterval_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _ListOf_smoke_DateInterval_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_ListOf_smoke_DateInterval_create_handle_nullable');
-final _ListOf_smoke_DateInterval_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_smoke_DateInterval_create_handle_nullable'));
+final _ListOf_smoke_DateInterval_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ListOf_smoke_DateInterval_release_handle_nullable');
-final _ListOf_smoke_DateInterval_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_smoke_DateInterval_release_handle_nullable'));
+final _ListOf_smoke_DateInterval_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_ListOf_smoke_DateInterval_get_value_nullable');
+  >('library_ListOf_smoke_DateInterval_get_value_nullable'));
 Pointer<Void> ListOf_smoke_DateInterval_toFfi_nullable(List<DateInterval> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = ListOf_smoke_DateInterval_toFfi(value);
@@ -264,38 +264,38 @@ List<DateInterval> ListOf_smoke_DateInterval_fromFfi_nullable(Pointer<Void> hand
 }
 void ListOf_smoke_DateInterval_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _ListOf_smoke_DateInterval_release_handle_nullable(handle);
-final _ListOf_smoke_Rectangle_create_handle = __lib.nativeLibrary.lookupFunction<
+final _ListOf_smoke_Rectangle_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_ListOf_smoke_Rectangle_create_handle');
-final _ListOf_smoke_Rectangle_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_smoke_Rectangle_create_handle'));
+final _ListOf_smoke_Rectangle_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ListOf_smoke_Rectangle_release_handle');
-final _ListOf_smoke_Rectangle_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_smoke_Rectangle_release_handle'));
+final _ListOf_smoke_Rectangle_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_ListOf_smoke_Rectangle_insert');
-final _ListOf_smoke_Rectangle_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_smoke_Rectangle_insert'));
+final _ListOf_smoke_Rectangle_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_ListOf_smoke_Rectangle_iterator');
-final _ListOf_smoke_Rectangle_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_smoke_Rectangle_iterator'));
+final _ListOf_smoke_Rectangle_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_ListOf_smoke_Rectangle_iterator_release_handle');
-final _ListOf_smoke_Rectangle_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_smoke_Rectangle_iterator_release_handle'));
+final _ListOf_smoke_Rectangle_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_ListOf_smoke_Rectangle_iterator_is_valid');
-final _ListOf_smoke_Rectangle_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_smoke_Rectangle_iterator_is_valid'));
+final _ListOf_smoke_Rectangle_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_ListOf_smoke_Rectangle_iterator_increment');
-final _ListOf_smoke_Rectangle_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_smoke_Rectangle_iterator_increment'));
+final _ListOf_smoke_Rectangle_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_ListOf_smoke_Rectangle_iterator_get');
+>('library_ListOf_smoke_Rectangle_iterator_get'));
 Pointer<Void> ListOf_smoke_Rectangle_toFfi(List<math.Rectangle<int>> value) {
   final _result = _ListOf_smoke_Rectangle_create_handle();
   for (final element in value) {
@@ -321,18 +321,18 @@ List<math.Rectangle<int>> ListOf_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void ListOf_smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _ListOf_smoke_Rectangle_release_handle(handle);
-final _ListOf_smoke_Rectangle_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _ListOf_smoke_Rectangle_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_ListOf_smoke_Rectangle_create_handle_nullable');
-final _ListOf_smoke_Rectangle_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_smoke_Rectangle_create_handle_nullable'));
+final _ListOf_smoke_Rectangle_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ListOf_smoke_Rectangle_release_handle_nullable');
-final _ListOf_smoke_Rectangle_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_smoke_Rectangle_release_handle_nullable'));
+final _ListOf_smoke_Rectangle_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_ListOf_smoke_Rectangle_get_value_nullable');
+  >('library_ListOf_smoke_Rectangle_get_value_nullable'));
 Pointer<Void> ListOf_smoke_Rectangle_toFfi_nullable(List<math.Rectangle<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = ListOf_smoke_Rectangle_toFfi(value);
@@ -349,42 +349,42 @@ List<math.Rectangle<int>> ListOf_smoke_Rectangle_fromFfi_nullable(Pointer<Void> 
 }
 void ListOf_smoke_Rectangle_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _ListOf_smoke_Rectangle_release_handle_nullable(handle);
-final _MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle = __lib.nativeLibrary.lookupFunction<
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle');
-final _MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle'));
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle');
-final _MapOf_smoke_CompressionState_to_smoke_Rectangle_put = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle'));
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
-  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_put');
-final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_put'));
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator');
-final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator'));
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_release_handle');
-final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_release_handle'));
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_is_valid');
-final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_is_valid'));
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_increment');
-final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_increment'));
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_key');
-final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_key'));
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_value');
+>('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_value'));
 Pointer<Void> MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi(Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> value) {
   final _result = _MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle();
   for (final entry in value.entries) {
@@ -415,18 +415,18 @@ Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> MapOf_smoke_Com
   return result;
 }
 void MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle(handle);
-final _MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle_nullable');
-final _MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle_nullable'));
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle_nullable');
-final _MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle_nullable'));
+final _MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable');
+  >('library_MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable'));
 Pointer<Void> MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi_nullable(Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi(value);
@@ -443,42 +443,42 @@ Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> MapOf_smoke_Com
 }
 void MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle_nullable(handle);
-final _MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle = __lib.nativeLibrary.lookupFunction<
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle');
-final _MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle'));
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle');
-final _MapOf_smoke_Persistence_to_smoke_DateInterval_put = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle'));
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
-  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_put');
-final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_put'));
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator');
-final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator'));
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_release_handle');
-final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_release_handle'));
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_is_valid');
-final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_is_valid'));
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_increment');
-final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_increment'));
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_key');
-final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_key'));
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_value');
+>('library_MapOf_smoke_Persistence_to_smoke_DateInterval_iterator_get_value'));
 Pointer<Void> MapOf_smoke_Persistence_to_smoke_DateInterval_toFfi(Map<Persistence, DateInterval> value) {
   final _result = _MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle();
   for (final entry in value.entries) {
@@ -509,18 +509,18 @@ Map<Persistence, DateInterval> MapOf_smoke_Persistence_to_smoke_DateInterval_fro
   return result;
 }
 void MapOf_smoke_Persistence_to_smoke_DateInterval_releaseFfiHandle(Pointer<Void> handle) => _MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle(handle);
-final _MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle_nullable');
-final _MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_create_handle_nullable'));
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle_nullable');
-final _MapOf_smoke_Persistence_to_smoke_DateInterval_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle_nullable'));
+final _MapOf_smoke_Persistence_to_smoke_DateInterval_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_get_value_nullable');
+  >('library_MapOf_smoke_Persistence_to_smoke_DateInterval_get_value_nullable'));
 Pointer<Void> MapOf_smoke_Persistence_to_smoke_DateInterval_toFfi_nullable(Map<Persistence, DateInterval> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = MapOf_smoke_Persistence_to_smoke_DateInterval_toFfi(value);
@@ -537,38 +537,38 @@ Map<Persistence, DateInterval> MapOf_smoke_Persistence_to_smoke_DateInterval_fro
 }
 void MapOf_smoke_Persistence_to_smoke_DateInterval_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _MapOf_smoke_Persistence_to_smoke_DateInterval_release_handle_nullable(handle);
-final _SetOf_smoke_DateInterval_create_handle = __lib.nativeLibrary.lookupFunction<
+final _SetOf_smoke_DateInterval_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_SetOf_smoke_DateInterval_create_handle');
-final _SetOf_smoke_DateInterval_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_DateInterval_create_handle'));
+final _SetOf_smoke_DateInterval_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_SetOf_smoke_DateInterval_release_handle');
-final _SetOf_smoke_DateInterval_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_DateInterval_release_handle'));
+final _SetOf_smoke_DateInterval_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_SetOf_smoke_DateInterval_insert');
-final _SetOf_smoke_DateInterval_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_DateInterval_insert'));
+final _SetOf_smoke_DateInterval_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_SetOf_smoke_DateInterval_iterator');
-final _SetOf_smoke_DateInterval_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_SetOf_smoke_DateInterval_iterator'));
+final _SetOf_smoke_DateInterval_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_SetOf_smoke_DateInterval_iterator_release_handle');
-final _SetOf_smoke_DateInterval_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_SetOf_smoke_DateInterval_iterator_release_handle'));
+final _SetOf_smoke_DateInterval_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_SetOf_smoke_DateInterval_iterator_is_valid');
-final _SetOf_smoke_DateInterval_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_SetOf_smoke_DateInterval_iterator_is_valid'));
+final _SetOf_smoke_DateInterval_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_SetOf_smoke_DateInterval_iterator_increment');
-final _SetOf_smoke_DateInterval_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_SetOf_smoke_DateInterval_iterator_increment'));
+final _SetOf_smoke_DateInterval_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_SetOf_smoke_DateInterval_iterator_get');
+>('library_SetOf_smoke_DateInterval_iterator_get'));
 Pointer<Void> SetOf_smoke_DateInterval_toFfi(Set<DateInterval> value) {
   final _result = _SetOf_smoke_DateInterval_create_handle();
   for (final element in value) {
@@ -594,18 +594,18 @@ Set<DateInterval> SetOf_smoke_DateInterval_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void SetOf_smoke_DateInterval_releaseFfiHandle(Pointer<Void> handle) => _SetOf_smoke_DateInterval_release_handle(handle);
-final _SetOf_smoke_DateInterval_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _SetOf_smoke_DateInterval_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_SetOf_smoke_DateInterval_create_handle_nullable');
-final _SetOf_smoke_DateInterval_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_DateInterval_create_handle_nullable'));
+final _SetOf_smoke_DateInterval_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_SetOf_smoke_DateInterval_release_handle_nullable');
-final _SetOf_smoke_DateInterval_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_DateInterval_release_handle_nullable'));
+final _SetOf_smoke_DateInterval_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_SetOf_smoke_DateInterval_get_value_nullable');
+  >('library_SetOf_smoke_DateInterval_get_value_nullable'));
 Pointer<Void> SetOf_smoke_DateInterval_toFfi_nullable(Set<DateInterval> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = SetOf_smoke_DateInterval_toFfi(value);
@@ -622,38 +622,38 @@ Set<DateInterval> SetOf_smoke_DateInterval_fromFfi_nullable(Pointer<Void> handle
 }
 void SetOf_smoke_DateInterval_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _SetOf_smoke_DateInterval_release_handle_nullable(handle);
-final _SetOf_smoke_Rectangle_create_handle = __lib.nativeLibrary.lookupFunction<
+final _SetOf_smoke_Rectangle_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_SetOf_smoke_Rectangle_create_handle');
-final _SetOf_smoke_Rectangle_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_Rectangle_create_handle'));
+final _SetOf_smoke_Rectangle_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_SetOf_smoke_Rectangle_release_handle');
-final _SetOf_smoke_Rectangle_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_Rectangle_release_handle'));
+final _SetOf_smoke_Rectangle_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_SetOf_smoke_Rectangle_insert');
-final _SetOf_smoke_Rectangle_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_Rectangle_insert'));
+final _SetOf_smoke_Rectangle_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_SetOf_smoke_Rectangle_iterator');
-final _SetOf_smoke_Rectangle_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_SetOf_smoke_Rectangle_iterator'));
+final _SetOf_smoke_Rectangle_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_SetOf_smoke_Rectangle_iterator_release_handle');
-final _SetOf_smoke_Rectangle_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_SetOf_smoke_Rectangle_iterator_release_handle'));
+final _SetOf_smoke_Rectangle_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_SetOf_smoke_Rectangle_iterator_is_valid');
-final _SetOf_smoke_Rectangle_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_SetOf_smoke_Rectangle_iterator_is_valid'));
+final _SetOf_smoke_Rectangle_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_SetOf_smoke_Rectangle_iterator_increment');
-final _SetOf_smoke_Rectangle_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_SetOf_smoke_Rectangle_iterator_increment'));
+final _SetOf_smoke_Rectangle_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_SetOf_smoke_Rectangle_iterator_get');
+>('library_SetOf_smoke_Rectangle_iterator_get'));
 Pointer<Void> SetOf_smoke_Rectangle_toFfi(Set<math.Rectangle<int>> value) {
   final _result = _SetOf_smoke_Rectangle_create_handle();
   for (final element in value) {
@@ -679,18 +679,18 @@ Set<math.Rectangle<int>> SetOf_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void SetOf_smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _SetOf_smoke_Rectangle_release_handle(handle);
-final _SetOf_smoke_Rectangle_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _SetOf_smoke_Rectangle_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_SetOf_smoke_Rectangle_create_handle_nullable');
-final _SetOf_smoke_Rectangle_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_Rectangle_create_handle_nullable'));
+final _SetOf_smoke_Rectangle_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_SetOf_smoke_Rectangle_release_handle_nullable');
-final _SetOf_smoke_Rectangle_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_Rectangle_release_handle_nullable'));
+final _SetOf_smoke_Rectangle_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_SetOf_smoke_Rectangle_get_value_nullable');
+  >('library_SetOf_smoke_Rectangle_get_value_nullable'));
 Pointer<Void> SetOf_smoke_Rectangle_toFfi_nullable(Set<math.Rectangle<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = SetOf_smoke_Rectangle_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -42,18 +42,18 @@ Enums_ExternalEnum smoke_Enums_ExternalEnum_fromFfi(int handle) {
   }
 }
 void smoke_Enums_ExternalEnum_releaseFfiHandle(int handle) {}
-final _smoke_Enums_ExternalEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_ExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Enums_ExternalEnum_create_handle_nullable');
-final _smoke_Enums_ExternalEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_ExternalEnum_create_handle_nullable'));
+final _smoke_Enums_ExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Enums_ExternalEnum_release_handle_nullable');
-final _smoke_Enums_ExternalEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_ExternalEnum_release_handle_nullable'));
+final _smoke_Enums_ExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Enums_ExternalEnum_get_value_nullable');
+  >('library_smoke_Enums_ExternalEnum_get_value_nullable'));
 Pointer<Void> smoke_Enums_ExternalEnum_toFfi_nullable(Enums_ExternalEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_ExternalEnum_toFfi(value);
@@ -101,18 +101,18 @@ Enums_VeryExternalEnum smoke_Enums_VeryExternalEnum_fromFfi(int handle) {
   }
 }
 void smoke_Enums_VeryExternalEnum_releaseFfiHandle(int handle) {}
-final _smoke_Enums_VeryExternalEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_VeryExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Enums_VeryExternalEnum_create_handle_nullable');
-final _smoke_Enums_VeryExternalEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_VeryExternalEnum_create_handle_nullable'));
+final _smoke_Enums_VeryExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Enums_VeryExternalEnum_release_handle_nullable');
-final _smoke_Enums_VeryExternalEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_VeryExternalEnum_release_handle_nullable'));
+final _smoke_Enums_VeryExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Enums_VeryExternalEnum_get_value_nullable');
+  >('library_smoke_Enums_VeryExternalEnum_get_value_nullable'));
 Pointer<Void> smoke_Enums_VeryExternalEnum_toFfi_nullable(Enums_VeryExternalEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_VeryExternalEnum_toFfi(value);
@@ -131,18 +131,18 @@ void smoke_Enums_VeryExternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle
   _smoke_Enums_VeryExternalEnum_release_handle_nullable(handle);
 // End of Enums_VeryExternalEnum "private" section.
 // Enums "private" section, not exported.
-final _smoke_Enums_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Enums_copy_handle');
-final _smoke_Enums_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_copy_handle'));
+final _smoke_Enums_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Enums_release_handle');
-final _smoke_Enums_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Enums_release_handle'));
+final _smoke_Enums_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Enums_get_raw_pointer');
+    >('library_smoke_Enums_get_raw_pointer'));
 class Enums$Impl implements Enums {
   @protected
   Pointer<Void> handle;
@@ -155,7 +155,7 @@ class Enums$Impl implements Enums {
     handle = null;
   }
   static methodWithExternalEnum(Enums_ExternalEnum input) {
-    final _methodWithExternalEnum_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Int32, Uint32), void Function(int, int)>('library_smoke_Enums_methodWithExternalEnum__External_1Enum');
+    final _methodWithExternalEnum_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Uint32), void Function(int, int)>('library_smoke_Enums_methodWithExternalEnum__External_1Enum'));
     final _input_handle = smoke_Enums_ExternalEnum_toFfi(input);
     final __result_handle = _methodWithExternalEnum_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Enums_ExternalEnum_releaseFfiHandle(_input_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -36,18 +36,18 @@ ExternalClass_SomeEnum smoke_ExternalClass_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_ExternalClass_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_ExternalClass_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalClass_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_ExternalClass_SomeEnum_create_handle_nullable');
-final _smoke_ExternalClass_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalClass_SomeEnum_create_handle_nullable'));
+final _smoke_ExternalClass_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ExternalClass_SomeEnum_release_handle_nullable');
-final _smoke_ExternalClass_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalClass_SomeEnum_release_handle_nullable'));
+final _smoke_ExternalClass_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ExternalClass_SomeEnum_get_value_nullable');
+  >('library_smoke_ExternalClass_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_ExternalClass_SomeEnum_toFfi_nullable(ExternalClass_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExternalClass_SomeEnum_toFfi(value);
@@ -70,18 +70,18 @@ class ExternalClass_SomeStruct {
   ExternalClass_SomeStruct(this.someField);
 }
 // ExternalClass_SomeStruct "private" section, not exported.
-final _smoke_ExternalClass_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalClass_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ExternalClass_SomeStruct_create_handle');
-final _smoke_ExternalClass_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalClass_SomeStruct_create_handle'));
+final _smoke_ExternalClass_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ExternalClass_SomeStruct_release_handle');
-final _smoke_ExternalClass_SomeStruct_get_field_someField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalClass_SomeStruct_release_handle'));
+final _smoke_ExternalClass_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ExternalClass_SomeStruct_get_field_someField');
+  >('library_smoke_ExternalClass_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_ExternalClass_SomeStruct_toFfi(ExternalClass_SomeStruct value) {
   final _someField_handle = String_toFfi(value.someField);
   final _result = _smoke_ExternalClass_SomeStruct_create_handle(_someField_handle);
@@ -100,18 +100,18 @@ ExternalClass_SomeStruct smoke_ExternalClass_SomeStruct_fromFfi(Pointer<Void> ha
 }
 void smoke_ExternalClass_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ExternalClass_SomeStruct_release_handle(handle);
 // Nullable ExternalClass_SomeStruct
-final _smoke_ExternalClass_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalClass_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ExternalClass_SomeStruct_create_handle_nullable');
-final _smoke_ExternalClass_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalClass_SomeStruct_create_handle_nullable'));
+final _smoke_ExternalClass_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ExternalClass_SomeStruct_release_handle_nullable');
-final _smoke_ExternalClass_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalClass_SomeStruct_release_handle_nullable'));
+final _smoke_ExternalClass_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ExternalClass_SomeStruct_get_value_nullable');
+  >('library_smoke_ExternalClass_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_ExternalClass_SomeStruct_toFfi_nullable(ExternalClass_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExternalClass_SomeStruct_toFfi(value);
@@ -130,18 +130,18 @@ void smoke_ExternalClass_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> hand
   _smoke_ExternalClass_SomeStruct_release_handle_nullable(handle);
 // End of ExternalClass_SomeStruct "private" section.
 // ExternalClass "private" section, not exported.
-final _smoke_ExternalClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ExternalClass_copy_handle');
-final _smoke_ExternalClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalClass_copy_handle'));
+final _smoke_ExternalClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ExternalClass_release_handle');
-final _smoke_ExternalClass_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalClass_release_handle'));
+final _smoke_ExternalClass_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ExternalClass_get_raw_pointer');
+    >('library_smoke_ExternalClass_get_raw_pointer'));
 class ExternalClass$Impl implements ExternalClass {
   @protected
   Pointer<Void> handle;
@@ -155,7 +155,7 @@ class ExternalClass$Impl implements ExternalClass {
   }
   @override
   someMethod(int someParameter) {
-    final _someMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalClass_someMethod__Byte');
+    final _someMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalClass_someMethod__Byte'));
     final _someParameter_handle = (someParameter);
     final _handle = this.handle;
     final __result_handle = _someMethod_ffi(_handle, __lib.LibraryContext.isolateId, _someParameter_handle);
@@ -168,7 +168,7 @@ class ExternalClass$Impl implements ExternalClass {
   }
   @override
   String get someProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalClass_someProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalClass_someProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -45,18 +45,18 @@ ExternalInterface_SomeEnum smoke_ExternalInterface_SomeEnum_fromFfi(int handle) 
   }
 }
 void smoke_ExternalInterface_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_ExternalInterface_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalInterface_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_ExternalInterface_SomeEnum_create_handle_nullable');
-final _smoke_ExternalInterface_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalInterface_SomeEnum_create_handle_nullable'));
+final _smoke_ExternalInterface_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ExternalInterface_SomeEnum_release_handle_nullable');
-final _smoke_ExternalInterface_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalInterface_SomeEnum_release_handle_nullable'));
+final _smoke_ExternalInterface_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ExternalInterface_SomeEnum_get_value_nullable');
+  >('library_smoke_ExternalInterface_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_ExternalInterface_SomeEnum_toFfi_nullable(ExternalInterface_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExternalInterface_SomeEnum_toFfi(value);
@@ -79,18 +79,18 @@ class ExternalInterface_SomeStruct {
   ExternalInterface_SomeStruct(this.someField);
 }
 // ExternalInterface_SomeStruct "private" section, not exported.
-final _smoke_ExternalInterface_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalInterface_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ExternalInterface_SomeStruct_create_handle');
-final _smoke_ExternalInterface_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalInterface_SomeStruct_create_handle'));
+final _smoke_ExternalInterface_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ExternalInterface_SomeStruct_release_handle');
-final _smoke_ExternalInterface_SomeStruct_get_field_someField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalInterface_SomeStruct_release_handle'));
+final _smoke_ExternalInterface_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ExternalInterface_SomeStruct_get_field_someField');
+  >('library_smoke_ExternalInterface_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_ExternalInterface_SomeStruct_toFfi(ExternalInterface_SomeStruct value) {
   final _someField_handle = String_toFfi(value.someField);
   final _result = _smoke_ExternalInterface_SomeStruct_create_handle(_someField_handle);
@@ -109,18 +109,18 @@ ExternalInterface_SomeStruct smoke_ExternalInterface_SomeStruct_fromFfi(Pointer<
 }
 void smoke_ExternalInterface_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ExternalInterface_SomeStruct_release_handle(handle);
 // Nullable ExternalInterface_SomeStruct
-final _smoke_ExternalInterface_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalInterface_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ExternalInterface_SomeStruct_create_handle_nullable');
-final _smoke_ExternalInterface_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalInterface_SomeStruct_create_handle_nullable'));
+final _smoke_ExternalInterface_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ExternalInterface_SomeStruct_release_handle_nullable');
-final _smoke_ExternalInterface_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalInterface_SomeStruct_release_handle_nullable'));
+final _smoke_ExternalInterface_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ExternalInterface_SomeStruct_get_value_nullable');
+  >('library_smoke_ExternalInterface_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_ExternalInterface_SomeStruct_toFfi_nullable(ExternalInterface_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExternalInterface_SomeStruct_toFfi(value);
@@ -139,26 +139,26 @@ void smoke_ExternalInterface_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> 
   _smoke_ExternalInterface_SomeStruct_release_handle_nullable(handle);
 // End of ExternalInterface_SomeStruct "private" section.
 // ExternalInterface "private" section, not exported.
-final _smoke_ExternalInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ExternalInterface_copy_handle');
-final _smoke_ExternalInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalInterface_copy_handle'));
+final _smoke_ExternalInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ExternalInterface_release_handle');
-final _smoke_ExternalInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalInterface_release_handle'));
+final _smoke_ExternalInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer)
-  >('library_smoke_ExternalInterface_create_proxy');
-final _smoke_ExternalInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ExternalInterface_create_proxy'));
+final _smoke_ExternalInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ExternalInterface_get_raw_pointer');
-final _smoke_ExternalInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_ExternalInterface_get_raw_pointer'));
+final _smoke_ExternalInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ExternalInterface_get_type_id');
+  >('library_smoke_ExternalInterface_get_type_id'));
 class ExternalInterface$Lambdas implements ExternalInterface {
   void Function(int) lambda_someMethod;
   String Function() lambda_someProperty_get;
@@ -190,7 +190,7 @@ class ExternalInterface$Impl implements ExternalInterface {
   }
   @override
   someMethod(int someParameter) {
-    final _someMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalInterface_someMethod__Byte');
+    final _someMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalInterface_someMethod__Byte'));
     final _someParameter_handle = (someParameter);
     final _handle = this.handle;
     final __result_handle = _someMethod_ffi(_handle, __lib.LibraryContext.isolateId, _someParameter_handle);
@@ -202,7 +202,7 @@ class ExternalInterface$Impl implements ExternalInterface {
     }
   }
   String get someProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalInterface_someProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalInterface_someProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
@@ -35,18 +35,18 @@ bar.HttpClientResponseCompressionState smoke_CompressionState_fromFfi(int handle
   }
 }
 void smoke_CompressionState_releaseFfiHandle(int handle) {}
-final _smoke_CompressionState_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_CompressionState_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_CompressionState_create_handle_nullable');
-final _smoke_CompressionState_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CompressionState_create_handle_nullable'));
+final _smoke_CompressionState_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CompressionState_release_handle_nullable');
-final _smoke_CompressionState_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CompressionState_release_handle_nullable'));
+final _smoke_CompressionState_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_CompressionState_get_value_nullable');
+  >('library_smoke_CompressionState_get_value_nullable'));
 Pointer<Void> smoke_CompressionState_toFfi_nullable(bar.HttpClientResponseCompressionState value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CompressionState_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
@@ -14,30 +14,30 @@ class int_internal {
     : red = red, green = green, blue = blue, alpha = 0;
 }
 // int "private" section, not exported.
-final _smoke_DartColor_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_DartColor_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Float, Float, Float, Float),
     Pointer<Void> Function(double, double, double, double)
-  >('library_smoke_DartColor_create_handle');
-final _smoke_DartColor_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DartColor_create_handle'));
+final _smoke_DartColor_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DartColor_release_handle');
-final _smoke_DartColor_get_field_red = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DartColor_release_handle'));
+final _smoke_DartColor_get_field_red = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_DartColor_get_field_red');
-final _smoke_DartColor_get_field_green = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DartColor_get_field_red'));
+final _smoke_DartColor_get_field_green = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_DartColor_get_field_green');
-final _smoke_DartColor_get_field_blue = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DartColor_get_field_green'));
+final _smoke_DartColor_get_field_blue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_DartColor_get_field_blue');
-final _smoke_DartColor_get_field_alpha = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DartColor_get_field_blue'));
+final _smoke_DartColor_get_field_alpha = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_DartColor_get_field_alpha');
+  >('library_smoke_DartColor_get_field_alpha'));
 Pointer<Void> smoke_DartColor_toFfi(int value_ext) {
   final value = ColorConverter.convertToInternal(value_ext);
   final _red_handle = (value.red);
@@ -73,18 +73,18 @@ int smoke_DartColor_fromFfi(Pointer<Void> handle) {
 }
 void smoke_DartColor_releaseFfiHandle(Pointer<Void> handle) => _smoke_DartColor_release_handle(handle);
 // Nullable int
-final _smoke_DartColor_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DartColor_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DartColor_create_handle_nullable');
-final _smoke_DartColor_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DartColor_create_handle_nullable'));
+final _smoke_DartColor_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DartColor_release_handle_nullable');
-final _smoke_DartColor_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DartColor_release_handle_nullable'));
+final _smoke_DartColor_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_DartColor_get_value_nullable');
+  >('library_smoke_DartColor_get_value_nullable'));
 Pointer<Void> smoke_DartColor_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DartColor_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
@@ -5,30 +5,30 @@ import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 // Rectangle<int> "private" section, not exported.
-final _smoke_Rectangle_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Rectangle_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Int32, Int32, Int32),
     Pointer<Void> Function(int, int, int, int)
-  >('library_smoke_Rectangle_create_handle');
-final _smoke_Rectangle_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Rectangle_create_handle'));
+final _smoke_Rectangle_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Rectangle_release_handle');
-final _smoke_Rectangle_get_field_left = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Rectangle_release_handle'));
+final _smoke_Rectangle_get_field_left = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Rectangle_get_field_left');
-final _smoke_Rectangle_get_field_top = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Rectangle_get_field_left'));
+final _smoke_Rectangle_get_field_top = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Rectangle_get_field_top');
-final _smoke_Rectangle_get_field_width = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Rectangle_get_field_top'));
+final _smoke_Rectangle_get_field_width = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Rectangle_get_field_width');
-final _smoke_Rectangle_get_field_height = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Rectangle_get_field_width'));
+final _smoke_Rectangle_get_field_height = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Rectangle_get_field_height');
+  >('library_smoke_Rectangle_get_field_height'));
 Pointer<Void> smoke_Rectangle_toFfi(math.Rectangle<int> value) {
   final _left_handle = (value.left);
   final _top_handle = (value.top);
@@ -62,18 +62,18 @@ math.Rectangle<int> smoke_Rectangle_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _smoke_Rectangle_release_handle(handle);
 // Nullable Rectangle<int>
-final _smoke_Rectangle_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Rectangle_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Rectangle_create_handle_nullable');
-final _smoke_Rectangle_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Rectangle_create_handle_nullable'));
+final _smoke_Rectangle_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Rectangle_release_handle_nullable');
-final _smoke_Rectangle_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Rectangle_release_handle_nullable'));
+final _smoke_Rectangle_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Rectangle_get_value_nullable');
+  >('library_smoke_Rectangle_get_value_nullable'));
 Pointer<Void> smoke_Rectangle_toFfi_nullable(math.Rectangle<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Rectangle_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
@@ -48,18 +48,18 @@ String smoke_DartSeason_fromFfi(int handle) {
   }
 }
 void smoke_DartSeason_releaseFfiHandle(int handle) {}
-final _smoke_DartSeason_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_DartSeason_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_DartSeason_create_handle_nullable');
-final _smoke_DartSeason_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DartSeason_create_handle_nullable'));
+final _smoke_DartSeason_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_DartSeason_release_handle_nullable');
-final _smoke_DartSeason_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_DartSeason_release_handle_nullable'));
+final _smoke_DartSeason_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_DartSeason_get_value_nullable');
+  >('library_smoke_DartSeason_get_value_nullable'));
 Pointer<Void> smoke_DartSeason_toFfi_nullable(String value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DartSeason_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
@@ -22,30 +22,30 @@ class Structs_ExternalStruct {
   Structs_ExternalStruct(this.stringField, this.externalStringField, this.externalArrayField, this.externalStructField);
 }
 // Structs_ExternalStruct "private" section, not exported.
-final _smoke_Structs_ExternalStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_ExternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_smoke_Structs_ExternalStruct_create_handle');
-final _smoke_Structs_ExternalStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_ExternalStruct_create_handle'));
+final _smoke_Structs_ExternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_ExternalStruct_release_handle');
-final _smoke_Structs_ExternalStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_ExternalStruct_release_handle'));
+final _smoke_Structs_ExternalStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_ExternalStruct_get_field_stringField');
-final _smoke_Structs_ExternalStruct_get_field_externalStringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_ExternalStruct_get_field_stringField'));
+final _smoke_Structs_ExternalStruct_get_field_externalStringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_ExternalStruct_get_field_externalStringField');
-final _smoke_Structs_ExternalStruct_get_field_externalArrayField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_ExternalStruct_get_field_externalStringField'));
+final _smoke_Structs_ExternalStruct_get_field_externalArrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_ExternalStruct_get_field_externalArrayField');
-final _smoke_Structs_ExternalStruct_get_field_externalStructField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_ExternalStruct_get_field_externalArrayField'));
+final _smoke_Structs_ExternalStruct_get_field_externalStructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_ExternalStruct_get_field_externalStructField');
+  >('library_smoke_Structs_ExternalStruct_get_field_externalStructField'));
 Pointer<Void> smoke_Structs_ExternalStruct_toFfi(Structs_ExternalStruct value) {
   final _stringField_handle = String_toFfi(value.stringField);
   final _externalStringField_handle = String_toFfi(value.externalStringField);
@@ -79,18 +79,18 @@ Structs_ExternalStruct smoke_Structs_ExternalStruct_fromFfi(Pointer<Void> handle
 }
 void smoke_Structs_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_ExternalStruct_release_handle(handle);
 // Nullable Structs_ExternalStruct
-final _smoke_Structs_ExternalStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_ExternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_ExternalStruct_create_handle_nullable');
-final _smoke_Structs_ExternalStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_ExternalStruct_create_handle_nullable'));
+final _smoke_Structs_ExternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_ExternalStruct_release_handle_nullable');
-final _smoke_Structs_ExternalStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_ExternalStruct_release_handle_nullable'));
+final _smoke_Structs_ExternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_ExternalStruct_get_value_nullable');
+  >('library_smoke_Structs_ExternalStruct_get_value_nullable'));
 Pointer<Void> smoke_Structs_ExternalStruct_toFfi_nullable(Structs_ExternalStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_ExternalStruct_toFfi(value);
@@ -113,18 +113,18 @@ class Structs_AnotherExternalStruct {
   Structs_AnotherExternalStruct(this.intField);
 }
 // Structs_AnotherExternalStruct "private" section, not exported.
-final _smoke_Structs_AnotherExternalStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_AnotherExternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int8),
     Pointer<Void> Function(int)
-  >('library_smoke_Structs_AnotherExternalStruct_create_handle');
-final _smoke_Structs_AnotherExternalStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AnotherExternalStruct_create_handle'));
+final _smoke_Structs_AnotherExternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_AnotherExternalStruct_release_handle');
-final _smoke_Structs_AnotherExternalStruct_get_field_intField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AnotherExternalStruct_release_handle'));
+final _smoke_Structs_AnotherExternalStruct_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Structs_AnotherExternalStruct_get_field_intField');
+  >('library_smoke_Structs_AnotherExternalStruct_get_field_intField'));
 Pointer<Void> smoke_Structs_AnotherExternalStruct_toFfi(Structs_AnotherExternalStruct value) {
   final _intField_handle = (value.intField);
   final _result = _smoke_Structs_AnotherExternalStruct_create_handle(_intField_handle);
@@ -143,18 +143,18 @@ Structs_AnotherExternalStruct smoke_Structs_AnotherExternalStruct_fromFfi(Pointe
 }
 void smoke_Structs_AnotherExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_AnotherExternalStruct_release_handle(handle);
 // Nullable Structs_AnotherExternalStruct
-final _smoke_Structs_AnotherExternalStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_AnotherExternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_AnotherExternalStruct_create_handle_nullable');
-final _smoke_Structs_AnotherExternalStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AnotherExternalStruct_create_handle_nullable'));
+final _smoke_Structs_AnotherExternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_AnotherExternalStruct_release_handle_nullable');
-final _smoke_Structs_AnotherExternalStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AnotherExternalStruct_release_handle_nullable'));
+final _smoke_Structs_AnotherExternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_AnotherExternalStruct_get_value_nullable');
+  >('library_smoke_Structs_AnotherExternalStruct_get_value_nullable'));
 Pointer<Void> smoke_Structs_AnotherExternalStruct_toFfi_nullable(Structs_AnotherExternalStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_AnotherExternalStruct_toFfi(value);
@@ -173,18 +173,18 @@ void smoke_Structs_AnotherExternalStruct_releaseFfiHandle_nullable(Pointer<Void>
   _smoke_Structs_AnotherExternalStruct_release_handle_nullable(handle);
 // End of Structs_AnotherExternalStruct "private" section.
 // Structs "private" section, not exported.
-final _smoke_Structs_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_copy_handle');
-final _smoke_Structs_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_copy_handle'));
+final _smoke_Structs_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_release_handle');
-final _smoke_Structs_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_release_handle'));
+final _smoke_Structs_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Structs_get_raw_pointer');
+    >('library_smoke_Structs_get_raw_pointer'));
 class Structs$Impl implements Structs {
   @protected
   Pointer<Void> handle;
@@ -197,7 +197,7 @@ class Structs$Impl implements Structs {
     handle = null;
   }
   static Structs_ExternalStruct getExternalStruct() {
-    final _getExternalStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getExternalStruct');
+    final _getExternalStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getExternalStruct'));
     final __result_handle = _getExternalStruct_ffi(__lib.LibraryContext.isolateId);
     try {
       return smoke_Structs_ExternalStruct_fromFfi(__result_handle);
@@ -206,7 +206,7 @@ class Structs$Impl implements Structs {
     }
   }
   static Structs_AnotherExternalStruct getAnotherExternalStruct() {
-    final _getAnotherExternalStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getAnotherExternalStruct');
+    final _getAnotherExternalStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getAnotherExternalStruct'));
     final __result_handle = _getAnotherExternalStruct_ffi(__lib.LibraryContext.isolateId);
     try {
       return smoke_Structs_AnotherExternalStruct_fromFfi(__result_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -21,18 +21,18 @@ abstract class UseDartExternalTypes {
   static String seasonRoundTrip(String input) => UseDartExternalTypes$Impl.seasonRoundTrip(input);
 }
 // UseDartExternalTypes "private" section, not exported.
-final _smoke_UseDartExternalTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_UseDartExternalTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_UseDartExternalTypes_copy_handle');
-final _smoke_UseDartExternalTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_UseDartExternalTypes_copy_handle'));
+final _smoke_UseDartExternalTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_UseDartExternalTypes_release_handle');
-final _smoke_UseDartExternalTypes_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_UseDartExternalTypes_release_handle'));
+final _smoke_UseDartExternalTypes_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_UseDartExternalTypes_get_raw_pointer');
+    >('library_smoke_UseDartExternalTypes_get_raw_pointer'));
 class UseDartExternalTypes$Impl implements UseDartExternalTypes {
   @protected
   Pointer<Void> handle;
@@ -45,7 +45,7 @@ class UseDartExternalTypes$Impl implements UseDartExternalTypes {
     handle = null;
   }
   static math.Rectangle<int> rectangleRoundTrip(math.Rectangle<int> input) {
-    final _rectangleRoundTrip_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_rectangleRoundTrip__Rectangle');
+    final _rectangleRoundTrip_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_rectangleRoundTrip__Rectangle'));
     final _input_handle = smoke_Rectangle_toFfi(input);
     final __result_handle = _rectangleRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Rectangle_releaseFfiHandle(_input_handle);
@@ -56,7 +56,7 @@ class UseDartExternalTypes$Impl implements UseDartExternalTypes {
     }
   }
   static bar.HttpClientResponseCompressionState compressionStateRoundTrip(bar.HttpClientResponseCompressionState input) {
-    final _compressionStateRoundTrip_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_compressionStateRoundTrip__CompressionState');
+    final _compressionStateRoundTrip_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_compressionStateRoundTrip__CompressionState'));
     final _input_handle = smoke_CompressionState_toFfi(input);
     final __result_handle = _compressionStateRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_CompressionState_releaseFfiHandle(_input_handle);
@@ -67,7 +67,7 @@ class UseDartExternalTypes$Impl implements UseDartExternalTypes {
     }
   }
   static int colorRoundTrip(int input) {
-    final _colorRoundTrip_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_colorRoundTrip__DartColor');
+    final _colorRoundTrip_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_colorRoundTrip__DartColor'));
     final _input_handle = smoke_DartColor_toFfi(input);
     final __result_handle = _colorRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_DartColor_releaseFfiHandle(_input_handle);
@@ -78,7 +78,7 @@ class UseDartExternalTypes$Impl implements UseDartExternalTypes {
     }
   }
   static String seasonRoundTrip(String input) {
-    final _seasonRoundTrip_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_seasonRoundTrip__DartSeason');
+    final _seasonRoundTrip_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_seasonRoundTrip__DartSeason'));
     final _input_handle = smoke_DartSeason_toFfi(input);
     final __result_handle = _seasonRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_DartSeason_releaseFfiHandle(_input_handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/generic_types__conversion.dart
@@ -8,38 +8,38 @@ import 'package:library/src/smoke/yet_another_dummy_class.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-final _foobar_ListOf_Float_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_Float_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_Float_create_handle');
-final _foobar_ListOf_Float_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_Float_create_handle'));
+final _foobar_ListOf_Float_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_Float_release_handle');
-final _foobar_ListOf_Float_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_Float_release_handle'));
+final _foobar_ListOf_Float_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Float),
     void Function(Pointer<Void>, double)
-  >('library_foobar_ListOf_Float_insert');
-final _foobar_ListOf_Float_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_Float_insert'));
+final _foobar_ListOf_Float_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_Float_iterator');
-final _foobar_ListOf_Float_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_Float_iterator'));
+final _foobar_ListOf_Float_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_Float_iterator_release_handle');
-final _foobar_ListOf_Float_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_Float_iterator_release_handle'));
+final _foobar_ListOf_Float_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_Float_iterator_is_valid');
-final _foobar_ListOf_Float_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_Float_iterator_is_valid'));
+final _foobar_ListOf_Float_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_Float_iterator_increment');
-final _foobar_ListOf_Float_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_Float_iterator_increment'));
+final _foobar_ListOf_Float_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
->('library_foobar_ListOf_Float_iterator_get');
+>('library_foobar_ListOf_Float_iterator_get'));
 Pointer<Void> foobar_ListOf_Float_toFfi(List<double> value) {
   final _result = _foobar_ListOf_Float_create_handle();
   for (final element in value) {
@@ -65,18 +65,18 @@ List<double> foobar_ListOf_Float_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_ListOf_Float_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_Float_release_handle(handle);
-final _foobar_ListOf_Float_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_Float_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_Float_create_handle_nullable');
-final _foobar_ListOf_Float_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_Float_create_handle_nullable'));
+final _foobar_ListOf_Float_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_Float_release_handle_nullable');
-final _foobar_ListOf_Float_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_Float_release_handle_nullable'));
+final _foobar_ListOf_Float_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_Float_get_value_nullable');
+  >('library_foobar_ListOf_Float_get_value_nullable'));
 Pointer<Void> foobar_ListOf_Float_toFfi_nullable(List<double> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_Float_toFfi(value);
@@ -93,38 +93,38 @@ List<double> foobar_ListOf_Float_fromFfi_nullable(Pointer<Void> handle) {
 }
 void foobar_ListOf_Float_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_Float_release_handle_nullable(handle);
-final _foobar_ListOf_Int_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_Int_create_handle');
-final _foobar_ListOf_Int_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_Int_create_handle'));
+final _foobar_ListOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_Int_release_handle');
-final _foobar_ListOf_Int_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_Int_release_handle'));
+final _foobar_ListOf_Int_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32),
     void Function(Pointer<Void>, int)
-  >('library_foobar_ListOf_Int_insert');
-final _foobar_ListOf_Int_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_Int_insert'));
+final _foobar_ListOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_Int_iterator');
-final _foobar_ListOf_Int_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_Int_iterator'));
+final _foobar_ListOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_Int_iterator_release_handle');
-final _foobar_ListOf_Int_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_Int_iterator_release_handle'));
+final _foobar_ListOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_Int_iterator_is_valid');
-final _foobar_ListOf_Int_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_Int_iterator_is_valid'));
+final _foobar_ListOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_Int_iterator_increment');
-final _foobar_ListOf_Int_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_Int_iterator_increment'));
+final _foobar_ListOf_Int_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_ListOf_Int_iterator_get');
+>('library_foobar_ListOf_Int_iterator_get'));
 Pointer<Void> foobar_ListOf_Int_toFfi(List<int> value) {
   final _result = _foobar_ListOf_Int_create_handle();
   for (final element in value) {
@@ -150,18 +150,18 @@ List<int> foobar_ListOf_Int_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_ListOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_Int_release_handle(handle);
-final _foobar_ListOf_Int_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_Int_create_handle_nullable');
-final _foobar_ListOf_Int_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_Int_create_handle_nullable'));
+final _foobar_ListOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_Int_release_handle_nullable');
-final _foobar_ListOf_Int_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_Int_release_handle_nullable'));
+final _foobar_ListOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_Int_get_value_nullable');
+  >('library_foobar_ListOf_Int_get_value_nullable'));
 Pointer<Void> foobar_ListOf_Int_toFfi_nullable(List<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_Int_toFfi(value);
@@ -178,38 +178,38 @@ List<int> foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
 }
 void foobar_ListOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_Int_release_handle_nullable(handle);
-final _foobar_ListOf_String_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_String_create_handle');
-final _foobar_ListOf_String_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_String_create_handle'));
+final _foobar_ListOf_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_String_release_handle');
-final _foobar_ListOf_String_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_String_release_handle'));
+final _foobar_ListOf_String_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_ListOf_String_insert');
-final _foobar_ListOf_String_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_String_insert'));
+final _foobar_ListOf_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_String_iterator');
-final _foobar_ListOf_String_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_String_iterator'));
+final _foobar_ListOf_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_String_iterator_release_handle');
-final _foobar_ListOf_String_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_String_iterator_release_handle'));
+final _foobar_ListOf_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_String_iterator_is_valid');
-final _foobar_ListOf_String_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_String_iterator_is_valid'));
+final _foobar_ListOf_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_String_iterator_increment');
-final _foobar_ListOf_String_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_String_iterator_increment'));
+final _foobar_ListOf_String_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_String_iterator_get');
+>('library_foobar_ListOf_String_iterator_get'));
 Pointer<Void> foobar_ListOf_String_toFfi(List<String> value) {
   final _result = _foobar_ListOf_String_create_handle();
   for (final element in value) {
@@ -235,18 +235,18 @@ List<String> foobar_ListOf_String_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_ListOf_String_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_String_release_handle(handle);
-final _foobar_ListOf_String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_String_create_handle_nullable');
-final _foobar_ListOf_String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_String_create_handle_nullable'));
+final _foobar_ListOf_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_String_release_handle_nullable');
-final _foobar_ListOf_String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_String_release_handle_nullable'));
+final _foobar_ListOf_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_String_get_value_nullable');
+  >('library_foobar_ListOf_String_get_value_nullable'));
 Pointer<Void> foobar_ListOf_String_toFfi_nullable(List<String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_String_toFfi(value);
@@ -263,38 +263,38 @@ List<String> foobar_ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
 }
 void foobar_ListOf_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_String_release_handle_nullable(handle);
-final _foobar_ListOf_UByte_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_UByte_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_UByte_create_handle');
-final _foobar_ListOf_UByte_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_UByte_create_handle'));
+final _foobar_ListOf_UByte_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_UByte_release_handle');
-final _foobar_ListOf_UByte_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_UByte_release_handle'));
+final _foobar_ListOf_UByte_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint8),
     void Function(Pointer<Void>, int)
-  >('library_foobar_ListOf_UByte_insert');
-final _foobar_ListOf_UByte_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_UByte_insert'));
+final _foobar_ListOf_UByte_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_UByte_iterator');
-final _foobar_ListOf_UByte_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_UByte_iterator'));
+final _foobar_ListOf_UByte_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_UByte_iterator_release_handle');
-final _foobar_ListOf_UByte_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_UByte_iterator_release_handle'));
+final _foobar_ListOf_UByte_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_UByte_iterator_is_valid');
-final _foobar_ListOf_UByte_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_UByte_iterator_is_valid'));
+final _foobar_ListOf_UByte_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_UByte_iterator_increment');
-final _foobar_ListOf_UByte_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_UByte_iterator_increment'));
+final _foobar_ListOf_UByte_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_ListOf_UByte_iterator_get');
+>('library_foobar_ListOf_UByte_iterator_get'));
 Pointer<Void> foobar_ListOf_UByte_toFfi(List<int> value) {
   final _result = _foobar_ListOf_UByte_create_handle();
   for (final element in value) {
@@ -320,18 +320,18 @@ List<int> foobar_ListOf_UByte_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_ListOf_UByte_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_UByte_release_handle(handle);
-final _foobar_ListOf_UByte_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_UByte_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_UByte_create_handle_nullable');
-final _foobar_ListOf_UByte_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_UByte_create_handle_nullable'));
+final _foobar_ListOf_UByte_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_UByte_release_handle_nullable');
-final _foobar_ListOf_UByte_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_UByte_release_handle_nullable'));
+final _foobar_ListOf_UByte_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_UByte_get_value_nullable');
+  >('library_foobar_ListOf_UByte_get_value_nullable'));
 Pointer<Void> foobar_ListOf_UByte_toFfi_nullable(List<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_UByte_toFfi(value);
@@ -348,38 +348,38 @@ List<int> foobar_ListOf_UByte_fromFfi_nullable(Pointer<Void> handle) {
 }
 void foobar_ListOf_UByte_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_UByte_release_handle_nullable(handle);
-final _foobar_ListOf_foobar_ListOf_Int_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_foobar_ListOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_foobar_ListOf_Int_create_handle');
-final _foobar_ListOf_foobar_ListOf_Int_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_ListOf_Int_create_handle'));
+final _foobar_ListOf_foobar_ListOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_foobar_ListOf_Int_release_handle');
-final _foobar_ListOf_foobar_ListOf_Int_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_ListOf_Int_release_handle'));
+final _foobar_ListOf_foobar_ListOf_Int_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_ListOf_foobar_ListOf_Int_insert');
-final _foobar_ListOf_foobar_ListOf_Int_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_ListOf_Int_insert'));
+final _foobar_ListOf_foobar_ListOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_foobar_ListOf_Int_iterator');
-final _foobar_ListOf_foobar_ListOf_Int_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_foobar_ListOf_Int_iterator'));
+final _foobar_ListOf_foobar_ListOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_foobar_ListOf_Int_iterator_release_handle');
-final _foobar_ListOf_foobar_ListOf_Int_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_foobar_ListOf_Int_iterator_release_handle'));
+final _foobar_ListOf_foobar_ListOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_foobar_ListOf_Int_iterator_is_valid');
-final _foobar_ListOf_foobar_ListOf_Int_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_foobar_ListOf_Int_iterator_is_valid'));
+final _foobar_ListOf_foobar_ListOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_foobar_ListOf_Int_iterator_increment');
-final _foobar_ListOf_foobar_ListOf_Int_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_foobar_ListOf_Int_iterator_increment'));
+final _foobar_ListOf_foobar_ListOf_Int_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_foobar_ListOf_Int_iterator_get');
+>('library_foobar_ListOf_foobar_ListOf_Int_iterator_get'));
 Pointer<Void> foobar_ListOf_foobar_ListOf_Int_toFfi(List<List<int>> value) {
   final _result = _foobar_ListOf_foobar_ListOf_Int_create_handle();
   for (final element in value) {
@@ -405,18 +405,18 @@ List<List<int>> foobar_ListOf_foobar_ListOf_Int_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_foobar_ListOf_Int_release_handle(handle);
-final _foobar_ListOf_foobar_ListOf_Int_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_foobar_ListOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_foobar_ListOf_Int_create_handle_nullable');
-final _foobar_ListOf_foobar_ListOf_Int_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_ListOf_Int_create_handle_nullable'));
+final _foobar_ListOf_foobar_ListOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_foobar_ListOf_Int_release_handle_nullable');
-final _foobar_ListOf_foobar_ListOf_Int_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_ListOf_Int_release_handle_nullable'));
+final _foobar_ListOf_foobar_ListOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_foobar_ListOf_Int_get_value_nullable');
+  >('library_foobar_ListOf_foobar_ListOf_Int_get_value_nullable'));
 Pointer<Void> foobar_ListOf_foobar_ListOf_Int_toFfi_nullable(List<List<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_foobar_ListOf_Int_toFfi(value);
@@ -433,38 +433,38 @@ List<List<int>> foobar_ListOf_foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> h
 }
 void foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_foobar_ListOf_Int_release_handle_nullable(handle);
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle');
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle'));
+final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle');
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle'));
+final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_insert');
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_insert'));
+final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator');
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator'));
+final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle');
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle'));
+final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid');
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid'));
+final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_increment');
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_increment'));
+final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_get');
+>('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_get'));
 Pointer<Void> foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi(List<Map<int, bool>> value) {
   final _result = _foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle();
   for (final element in value) {
@@ -490,18 +490,18 @@ List<Map<int, bool>> foobar_ListOf_foobar_MapOf_Int_to_Boolean_fromFfi(Pointer<V
   return result;
 }
 void foobar_ListOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle(handle);
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable');
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable'));
+final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable');
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable'));
+final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_get_value_nullable');
+  >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi_nullable(List<Map<int, bool>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi(value);
@@ -518,38 +518,38 @@ List<Map<int, bool>> foobar_ListOf_foobar_MapOf_Int_to_Boolean_fromFfi_nullable(
 }
 void foobar_ListOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable(handle);
-final _foobar_ListOf_foobar_SetOf_Int_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_foobar_SetOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_foobar_SetOf_Int_create_handle');
-final _foobar_ListOf_foobar_SetOf_Int_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_SetOf_Int_create_handle'));
+final _foobar_ListOf_foobar_SetOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_foobar_SetOf_Int_release_handle');
-final _foobar_ListOf_foobar_SetOf_Int_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_SetOf_Int_release_handle'));
+final _foobar_ListOf_foobar_SetOf_Int_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_ListOf_foobar_SetOf_Int_insert');
-final _foobar_ListOf_foobar_SetOf_Int_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_SetOf_Int_insert'));
+final _foobar_ListOf_foobar_SetOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_foobar_SetOf_Int_iterator');
-final _foobar_ListOf_foobar_SetOf_Int_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_foobar_SetOf_Int_iterator'));
+final _foobar_ListOf_foobar_SetOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_foobar_SetOf_Int_iterator_release_handle');
-final _foobar_ListOf_foobar_SetOf_Int_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_foobar_SetOf_Int_iterator_release_handle'));
+final _foobar_ListOf_foobar_SetOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_foobar_SetOf_Int_iterator_is_valid');
-final _foobar_ListOf_foobar_SetOf_Int_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_foobar_SetOf_Int_iterator_is_valid'));
+final _foobar_ListOf_foobar_SetOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_foobar_SetOf_Int_iterator_increment');
-final _foobar_ListOf_foobar_SetOf_Int_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_foobar_SetOf_Int_iterator_increment'));
+final _foobar_ListOf_foobar_SetOf_Int_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_foobar_SetOf_Int_iterator_get');
+>('library_foobar_ListOf_foobar_SetOf_Int_iterator_get'));
 Pointer<Void> foobar_ListOf_foobar_SetOf_Int_toFfi(List<Set<int>> value) {
   final _result = _foobar_ListOf_foobar_SetOf_Int_create_handle();
   for (final element in value) {
@@ -575,18 +575,18 @@ List<Set<int>> foobar_ListOf_foobar_SetOf_Int_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_ListOf_foobar_SetOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_foobar_SetOf_Int_release_handle(handle);
-final _foobar_ListOf_foobar_SetOf_Int_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_foobar_SetOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_foobar_SetOf_Int_create_handle_nullable');
-final _foobar_ListOf_foobar_SetOf_Int_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_SetOf_Int_create_handle_nullable'));
+final _foobar_ListOf_foobar_SetOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_foobar_SetOf_Int_release_handle_nullable');
-final _foobar_ListOf_foobar_SetOf_Int_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_foobar_SetOf_Int_release_handle_nullable'));
+final _foobar_ListOf_foobar_SetOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_foobar_SetOf_Int_get_value_nullable');
+  >('library_foobar_ListOf_foobar_SetOf_Int_get_value_nullable'));
 Pointer<Void> foobar_ListOf_foobar_SetOf_Int_toFfi_nullable(List<Set<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_foobar_SetOf_Int_toFfi(value);
@@ -603,38 +603,38 @@ List<Set<int>> foobar_ListOf_foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> han
 }
 void foobar_ListOf_foobar_SetOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_foobar_SetOf_Int_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_AnotherDummyClass_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_AnotherDummyClass_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_smoke_AnotherDummyClass_create_handle');
-final _foobar_ListOf_smoke_AnotherDummyClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_AnotherDummyClass_create_handle'));
+final _foobar_ListOf_smoke_AnotherDummyClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_AnotherDummyClass_release_handle');
-final _foobar_ListOf_smoke_AnotherDummyClass_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_AnotherDummyClass_release_handle'));
+final _foobar_ListOf_smoke_AnotherDummyClass_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_ListOf_smoke_AnotherDummyClass_insert');
-final _foobar_ListOf_smoke_AnotherDummyClass_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_AnotherDummyClass_insert'));
+final _foobar_ListOf_smoke_AnotherDummyClass_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_AnotherDummyClass_iterator');
-final _foobar_ListOf_smoke_AnotherDummyClass_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_AnotherDummyClass_iterator'));
+final _foobar_ListOf_smoke_AnotherDummyClass_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_release_handle');
-final _foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_release_handle'));
+final _foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid');
-final _foobar_ListOf_smoke_AnotherDummyClass_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid'));
+final _foobar_ListOf_smoke_AnotherDummyClass_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_increment');
-final _foobar_ListOf_smoke_AnotherDummyClass_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_increment'));
+final _foobar_ListOf_smoke_AnotherDummyClass_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_get');
+>('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_AnotherDummyClass_toFfi(List<AnotherDummyClass> value) {
   final _result = _foobar_ListOf_smoke_AnotherDummyClass_create_handle();
   for (final element in value) {
@@ -660,18 +660,18 @@ List<AnotherDummyClass> foobar_ListOf_smoke_AnotherDummyClass_fromFfi(Pointer<Vo
   return result;
 }
 void foobar_ListOf_smoke_AnotherDummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_AnotherDummyClass_release_handle(handle);
-final _foobar_ListOf_smoke_AnotherDummyClass_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_AnotherDummyClass_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_AnotherDummyClass_create_handle_nullable');
-final _foobar_ListOf_smoke_AnotherDummyClass_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_AnotherDummyClass_create_handle_nullable'));
+final _foobar_ListOf_smoke_AnotherDummyClass_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_AnotherDummyClass_release_handle_nullable');
-final _foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_AnotherDummyClass_release_handle_nullable'));
+final _foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable');
+  >('library_foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_AnotherDummyClass_toFfi_nullable(List<AnotherDummyClass> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_AnotherDummyClass_toFfi(value);
@@ -688,38 +688,38 @@ List<AnotherDummyClass> foobar_ListOf_smoke_AnotherDummyClass_fromFfi_nullable(P
 }
 void foobar_ListOf_smoke_AnotherDummyClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_smoke_AnotherDummyClass_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_DummyClass_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_DummyClass_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_smoke_DummyClass_create_handle');
-final _foobar_ListOf_smoke_DummyClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_DummyClass_create_handle'));
+final _foobar_ListOf_smoke_DummyClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_DummyClass_release_handle');
-final _foobar_ListOf_smoke_DummyClass_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_DummyClass_release_handle'));
+final _foobar_ListOf_smoke_DummyClass_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_ListOf_smoke_DummyClass_insert');
-final _foobar_ListOf_smoke_DummyClass_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_DummyClass_insert'));
+final _foobar_ListOf_smoke_DummyClass_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_DummyClass_iterator');
-final _foobar_ListOf_smoke_DummyClass_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_DummyClass_iterator'));
+final _foobar_ListOf_smoke_DummyClass_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_DummyClass_iterator_release_handle');
-final _foobar_ListOf_smoke_DummyClass_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_DummyClass_iterator_release_handle'));
+final _foobar_ListOf_smoke_DummyClass_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_smoke_DummyClass_iterator_is_valid');
-final _foobar_ListOf_smoke_DummyClass_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_DummyClass_iterator_is_valid'));
+final _foobar_ListOf_smoke_DummyClass_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_DummyClass_iterator_increment');
-final _foobar_ListOf_smoke_DummyClass_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_DummyClass_iterator_increment'));
+final _foobar_ListOf_smoke_DummyClass_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_DummyClass_iterator_get');
+>('library_foobar_ListOf_smoke_DummyClass_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_DummyClass_toFfi(List<DummyClass> value) {
   final _result = _foobar_ListOf_smoke_DummyClass_create_handle();
   for (final element in value) {
@@ -745,18 +745,18 @@ List<DummyClass> foobar_ListOf_smoke_DummyClass_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_ListOf_smoke_DummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_DummyClass_release_handle(handle);
-final _foobar_ListOf_smoke_DummyClass_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_DummyClass_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_DummyClass_create_handle_nullable');
-final _foobar_ListOf_smoke_DummyClass_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_DummyClass_create_handle_nullable'));
+final _foobar_ListOf_smoke_DummyClass_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_DummyClass_release_handle_nullable');
-final _foobar_ListOf_smoke_DummyClass_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_DummyClass_release_handle_nullable'));
+final _foobar_ListOf_smoke_DummyClass_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_DummyClass_get_value_nullable');
+  >('library_foobar_ListOf_smoke_DummyClass_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_DummyClass_toFfi_nullable(List<DummyClass> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_DummyClass_toFfi(value);
@@ -773,38 +773,38 @@ List<DummyClass> foobar_ListOf_smoke_DummyClass_fromFfi_nullable(Pointer<Void> h
 }
 void foobar_ListOf_smoke_DummyClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_smoke_DummyClass_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_DummyInterface_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_DummyInterface_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_smoke_DummyInterface_create_handle');
-final _foobar_ListOf_smoke_DummyInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_DummyInterface_create_handle'));
+final _foobar_ListOf_smoke_DummyInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_DummyInterface_release_handle');
-final _foobar_ListOf_smoke_DummyInterface_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_DummyInterface_release_handle'));
+final _foobar_ListOf_smoke_DummyInterface_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_ListOf_smoke_DummyInterface_insert');
-final _foobar_ListOf_smoke_DummyInterface_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_DummyInterface_insert'));
+final _foobar_ListOf_smoke_DummyInterface_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_DummyInterface_iterator');
-final _foobar_ListOf_smoke_DummyInterface_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_DummyInterface_iterator'));
+final _foobar_ListOf_smoke_DummyInterface_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_DummyInterface_iterator_release_handle');
-final _foobar_ListOf_smoke_DummyInterface_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_DummyInterface_iterator_release_handle'));
+final _foobar_ListOf_smoke_DummyInterface_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_smoke_DummyInterface_iterator_is_valid');
-final _foobar_ListOf_smoke_DummyInterface_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_DummyInterface_iterator_is_valid'));
+final _foobar_ListOf_smoke_DummyInterface_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_DummyInterface_iterator_increment');
-final _foobar_ListOf_smoke_DummyInterface_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_DummyInterface_iterator_increment'));
+final _foobar_ListOf_smoke_DummyInterface_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_DummyInterface_iterator_get');
+>('library_foobar_ListOf_smoke_DummyInterface_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_DummyInterface_toFfi(List<DummyInterface> value) {
   final _result = _foobar_ListOf_smoke_DummyInterface_create_handle();
   for (final element in value) {
@@ -830,18 +830,18 @@ List<DummyInterface> foobar_ListOf_smoke_DummyInterface_fromFfi(Pointer<Void> ha
   return result;
 }
 void foobar_ListOf_smoke_DummyInterface_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_DummyInterface_release_handle(handle);
-final _foobar_ListOf_smoke_DummyInterface_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_DummyInterface_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_DummyInterface_create_handle_nullable');
-final _foobar_ListOf_smoke_DummyInterface_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_DummyInterface_create_handle_nullable'));
+final _foobar_ListOf_smoke_DummyInterface_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_DummyInterface_release_handle_nullable');
-final _foobar_ListOf_smoke_DummyInterface_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_DummyInterface_release_handle_nullable'));
+final _foobar_ListOf_smoke_DummyInterface_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_DummyInterface_get_value_nullable');
+  >('library_foobar_ListOf_smoke_DummyInterface_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_DummyInterface_toFfi_nullable(List<DummyInterface> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_DummyInterface_toFfi(value);
@@ -858,38 +858,38 @@ List<DummyInterface> foobar_ListOf_smoke_DummyInterface_fromFfi_nullable(Pointer
 }
 void foobar_ListOf_smoke_DummyInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_smoke_DummyInterface_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_insert');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_insert'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get');
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(List<GenericTypesWithCompoundTypes_BasicStruct> value) {
   final _result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle();
   for (final element in value) {
@@ -915,18 +915,18 @@ List<GenericTypesWithCompoundTypes_BasicStruct> foobar_ListOf_smoke_GenericTypes
   return result;
 }
 void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable');
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi_nullable(List<GenericTypesWithCompoundTypes_BasicStruct> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(value);
@@ -943,38 +943,38 @@ List<GenericTypesWithCompoundTypes_BasicStruct> foobar_ListOf_smoke_GenericTypes
 }
 void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32),
     void Function(Pointer<Void>, int)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get');
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(List<GenericTypesWithCompoundTypes_ExternalEnum> value) {
   final _result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle();
   for (final element in value) {
@@ -1000,18 +1000,18 @@ List<GenericTypesWithCompoundTypes_ExternalEnum> foobar_ListOf_smoke_GenericType
   return result;
 }
 void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable');
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(List<GenericTypesWithCompoundTypes_ExternalEnum> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(value);
@@ -1028,38 +1028,38 @@ List<GenericTypesWithCompoundTypes_ExternalEnum> foobar_ListOf_smoke_GenericType
 }
 void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_insert');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_insert'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get');
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(List<GenericTypesWithCompoundTypes_ExternalStruct> value) {
   final _result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle();
   for (final element in value) {
@@ -1085,18 +1085,18 @@ List<GenericTypesWithCompoundTypes_ExternalStruct> foobar_ListOf_smoke_GenericTy
   return result;
 }
 void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable');
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi_nullable(List<GenericTypesWithCompoundTypes_ExternalStruct> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(value);
@@ -1113,38 +1113,38 @@ List<GenericTypesWithCompoundTypes_ExternalStruct> foobar_ListOf_smoke_GenericTy
 }
 void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32),
     void Function(Pointer<Void>, int)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get');
+>('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(List<GenericTypesWithCompoundTypes_SomeEnum> value) {
   final _result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle();
   for (final element in value) {
@@ -1170,18 +1170,18 @@ List<GenericTypesWithCompoundTypes_SomeEnum> foobar_ListOf_smoke_GenericTypesWit
   return result;
 }
 void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable');
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable'));
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable');
+  >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(List<GenericTypesWithCompoundTypes_SomeEnum> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(value);
@@ -1198,38 +1198,38 @@ List<GenericTypesWithCompoundTypes_SomeEnum> foobar_ListOf_smoke_GenericTypesWit
 }
 void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_YetAnotherDummyClass_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_YetAnotherDummyClass_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_ListOf_smoke_YetAnotherDummyClass_create_handle');
-final _foobar_ListOf_smoke_YetAnotherDummyClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_YetAnotherDummyClass_create_handle'));
+final _foobar_ListOf_smoke_YetAnotherDummyClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_YetAnotherDummyClass_release_handle');
-final _foobar_ListOf_smoke_YetAnotherDummyClass_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_YetAnotherDummyClass_release_handle'));
+final _foobar_ListOf_smoke_YetAnotherDummyClass_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_ListOf_smoke_YetAnotherDummyClass_insert');
-final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_YetAnotherDummyClass_insert'));
+final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator');
-final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator'));
+final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_release_handle');
-final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_release_handle'));
+final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_is_valid');
-final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_is_valid'));
+final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_increment');
-final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_increment'));
+final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_get');
+>('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_YetAnotherDummyClass_toFfi(List<YetAnotherDummyClass> value) {
   final _result = _foobar_ListOf_smoke_YetAnotherDummyClass_create_handle();
   for (final element in value) {
@@ -1255,18 +1255,18 @@ List<YetAnotherDummyClass> foobar_ListOf_smoke_YetAnotherDummyClass_fromFfi(Poin
   return result;
 }
 void foobar_ListOf_smoke_YetAnotherDummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_YetAnotherDummyClass_release_handle(handle);
-final _foobar_ListOf_smoke_YetAnotherDummyClass_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_YetAnotherDummyClass_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_YetAnotherDummyClass_create_handle_nullable');
-final _foobar_ListOf_smoke_YetAnotherDummyClass_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_YetAnotherDummyClass_create_handle_nullable'));
+final _foobar_ListOf_smoke_YetAnotherDummyClass_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_YetAnotherDummyClass_release_handle_nullable');
-final _foobar_ListOf_smoke_YetAnotherDummyClass_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_ListOf_smoke_YetAnotherDummyClass_release_handle_nullable'));
+final _foobar_ListOf_smoke_YetAnotherDummyClass_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_ListOf_smoke_YetAnotherDummyClass_get_value_nullable');
+  >('library_foobar_ListOf_smoke_YetAnotherDummyClass_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_YetAnotherDummyClass_toFfi_nullable(List<YetAnotherDummyClass> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_YetAnotherDummyClass_toFfi(value);
@@ -1283,42 +1283,42 @@ List<YetAnotherDummyClass> foobar_ListOf_smoke_YetAnotherDummyClass_fromFfi_null
 }
 void foobar_ListOf_smoke_YetAnotherDummyClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_ListOf_smoke_YetAnotherDummyClass_release_handle_nullable(handle);
-final _foobar_MapOf_Float_to_Double_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Float_to_Double_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_Float_to_Double_create_handle');
-final _foobar_MapOf_Float_to_Double_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Float_to_Double_create_handle'));
+final _foobar_MapOf_Float_to_Double_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Float_to_Double_release_handle');
-final _foobar_MapOf_Float_to_Double_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Float_to_Double_release_handle'));
+final _foobar_MapOf_Float_to_Double_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Float, Double),
     void Function(Pointer<Void>, double, double)
-  >('library_foobar_MapOf_Float_to_Double_put');
-final _foobar_MapOf_Float_to_Double_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Float_to_Double_put'));
+final _foobar_MapOf_Float_to_Double_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Float_to_Double_iterator');
-final _foobar_MapOf_Float_to_Double_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Float_to_Double_iterator'));
+final _foobar_MapOf_Float_to_Double_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Float_to_Double_iterator_release_handle');
-final _foobar_MapOf_Float_to_Double_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Float_to_Double_iterator_release_handle'));
+final _foobar_MapOf_Float_to_Double_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_Float_to_Double_iterator_is_valid');
-final _foobar_MapOf_Float_to_Double_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Float_to_Double_iterator_is_valid'));
+final _foobar_MapOf_Float_to_Double_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Float_to_Double_iterator_increment');
-final _foobar_MapOf_Float_to_Double_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Float_to_Double_iterator_increment'));
+final _foobar_MapOf_Float_to_Double_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
->('library_foobar_MapOf_Float_to_Double_iterator_get_key');
-final _foobar_MapOf_Float_to_Double_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Float_to_Double_iterator_get_key'));
+final _foobar_MapOf_Float_to_Double_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
->('library_foobar_MapOf_Float_to_Double_iterator_get_value');
+>('library_foobar_MapOf_Float_to_Double_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Float_to_Double_toFfi(Map<double, double> value) {
   final _result = _foobar_MapOf_Float_to_Double_create_handle();
   for (final entry in value.entries) {
@@ -1349,18 +1349,18 @@ Map<double, double> foobar_MapOf_Float_to_Double_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_MapOf_Float_to_Double_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Float_to_Double_release_handle(handle);
-final _foobar_MapOf_Float_to_Double_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Float_to_Double_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Float_to_Double_create_handle_nullable');
-final _foobar_MapOf_Float_to_Double_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Float_to_Double_create_handle_nullable'));
+final _foobar_MapOf_Float_to_Double_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Float_to_Double_release_handle_nullable');
-final _foobar_MapOf_Float_to_Double_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Float_to_Double_release_handle_nullable'));
+final _foobar_MapOf_Float_to_Double_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Float_to_Double_get_value_nullable');
+  >('library_foobar_MapOf_Float_to_Double_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Float_to_Double_toFfi_nullable(Map<double, double> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Float_to_Double_toFfi(value);
@@ -1377,42 +1377,42 @@ Map<double, double> foobar_MapOf_Float_to_Double_fromFfi_nullable(Pointer<Void> 
 }
 void foobar_MapOf_Float_to_Double_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_Float_to_Double_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_Boolean_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_Int_to_Boolean_create_handle');
-final _foobar_MapOf_Int_to_Boolean_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_Boolean_create_handle'));
+final _foobar_MapOf_Int_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_Boolean_release_handle');
-final _foobar_MapOf_Int_to_Boolean_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_Boolean_release_handle'));
+final _foobar_MapOf_Int_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Uint8),
     void Function(Pointer<Void>, int, int)
-  >('library_foobar_MapOf_Int_to_Boolean_put');
-final _foobar_MapOf_Int_to_Boolean_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_Boolean_put'));
+final _foobar_MapOf_Int_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_Boolean_iterator');
-final _foobar_MapOf_Int_to_Boolean_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_Boolean_iterator'));
+final _foobar_MapOf_Int_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_Boolean_iterator_release_handle');
-final _foobar_MapOf_Int_to_Boolean_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_Boolean_iterator_release_handle'));
+final _foobar_MapOf_Int_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_Int_to_Boolean_iterator_is_valid');
-final _foobar_MapOf_Int_to_Boolean_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_Boolean_iterator_is_valid'));
+final _foobar_MapOf_Int_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_Boolean_iterator_increment');
-final _foobar_MapOf_Int_to_Boolean_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_Boolean_iterator_increment'));
+final _foobar_MapOf_Int_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_Boolean_iterator_get_key');
-final _foobar_MapOf_Int_to_Boolean_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_Boolean_iterator_get_key'));
+final _foobar_MapOf_Int_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_Boolean_iterator_get_value');
+>('library_foobar_MapOf_Int_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_Boolean_toFfi(Map<int, bool> value) {
   final _result = _foobar_MapOf_Int_to_Boolean_create_handle();
   for (final entry in value.entries) {
@@ -1443,18 +1443,18 @@ Map<int, bool> foobar_MapOf_Int_to_Boolean_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_MapOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_Boolean_release_handle(handle);
-final _foobar_MapOf_Int_to_Boolean_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_Boolean_create_handle_nullable');
-final _foobar_MapOf_Int_to_Boolean_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_Boolean_create_handle_nullable'));
+final _foobar_MapOf_Int_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_Boolean_release_handle_nullable');
-final _foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_Boolean_release_handle_nullable'));
+final _foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_Boolean_get_value_nullable');
+  >('library_foobar_MapOf_Int_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_Boolean_toFfi_nullable(Map<int, bool> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_Boolean_toFfi(value);
@@ -1471,42 +1471,42 @@ Map<int, bool> foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle
 }
 void foobar_MapOf_Int_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_Int_to_Boolean_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle');
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle'));
+final _foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle');
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle'));
+final _foobar_MapOf_Int_to_foobar_ListOf_Int_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_put');
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_put'));
+final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator');
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator'));
+final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_release_handle');
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_release_handle'));
+final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_is_valid');
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_is_valid'));
+final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_increment');
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_increment'));
+final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_key');
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_key'));
+final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_value');
+>('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_foobar_ListOf_Int_toFfi(Map<int, List<int>> value) {
   final _result = _foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle();
   for (final entry in value.entries) {
@@ -1537,18 +1537,18 @@ Map<int, List<int>> foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi(Pointer<Void> 
   return result;
 }
 void foobar_MapOf_Int_to_foobar_ListOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle(handle);
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle_nullable');
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle_nullable'));
+final _foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle_nullable');
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle_nullable'));
+final _foobar_MapOf_Int_to_foobar_ListOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_get_value_nullable');
+  >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_foobar_ListOf_Int_toFfi_nullable(Map<int, List<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_foobar_ListOf_Int_toFfi(value);
@@ -1565,42 +1565,42 @@ Map<int, List<int>> foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi_nullable(Point
 }
 void foobar_MapOf_Int_to_foobar_ListOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle');
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle'));
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle');
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle'));
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_put');
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_put'));
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator');
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator'));
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_release_handle');
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_release_handle'));
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_is_valid');
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_is_valid'));
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_increment');
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_increment'));
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_key');
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_key'));
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_value');
+>('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_toFfi(Map<int, Map<int, bool>> value) {
   final _result = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle();
   for (final entry in value.entries) {
@@ -1631,18 +1631,18 @@ Map<int, Map<int, bool>> foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_fromFfi
   return result;
 }
 void foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle(handle);
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle_nullable');
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle_nullable'));
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle_nullable');
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle_nullable'));
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_get_value_nullable');
+  >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_toFfi_nullable(Map<int, Map<int, bool>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_toFfi(value);
@@ -1659,42 +1659,42 @@ Map<int, Map<int, bool>> foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_fromFfi
 }
 void foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle');
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle'));
+final _foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle');
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle'));
+final _foobar_MapOf_Int_to_foobar_SetOf_Int_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_put');
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_put'));
+final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator');
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator'));
+final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_release_handle');
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_release_handle'));
+final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_is_valid');
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_is_valid'));
+final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_increment');
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_increment'));
+final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_key');
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_key'));
+final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_value');
+>('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_foobar_SetOf_Int_toFfi(Map<int, Set<int>> value) {
   final _result = _foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle();
   for (final entry in value.entries) {
@@ -1725,18 +1725,18 @@ Map<int, Set<int>> foobar_MapOf_Int_to_foobar_SetOf_Int_fromFfi(Pointer<Void> ha
   return result;
 }
 void foobar_MapOf_Int_to_foobar_SetOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle(handle);
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle_nullable');
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle_nullable'));
+final _foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle_nullable');
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle_nullable'));
+final _foobar_MapOf_Int_to_foobar_SetOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_get_value_nullable');
+  >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_foobar_SetOf_Int_toFfi_nullable(Map<int, Set<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_foobar_SetOf_Int_toFfi(value);
@@ -1753,42 +1753,42 @@ Map<int, Set<int>> foobar_MapOf_Int_to_foobar_SetOf_Int_fromFfi_nullable(Pointer
 }
 void foobar_MapOf_Int_to_foobar_SetOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_smoke_DummyClass_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_DummyClass_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_Int_to_smoke_DummyClass_create_handle');
-final _foobar_MapOf_Int_to_smoke_DummyClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_DummyClass_create_handle'));
+final _foobar_MapOf_Int_to_smoke_DummyClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_DummyClass_release_handle');
-final _foobar_MapOf_Int_to_smoke_DummyClass_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_DummyClass_release_handle'));
+final _foobar_MapOf_Int_to_smoke_DummyClass_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_DummyClass_put');
-final _foobar_MapOf_Int_to_smoke_DummyClass_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_DummyClass_put'));
+final _foobar_MapOf_Int_to_smoke_DummyClass_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator');
-final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator'));
+final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_release_handle');
-final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_release_handle'));
+final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_is_valid');
-final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_is_valid'));
+final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_increment');
-final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_increment'));
+final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_key');
-final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_key'));
+final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_value');
+>('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_DummyClass_toFfi(Map<int, DummyClass> value) {
   final _result = _foobar_MapOf_Int_to_smoke_DummyClass_create_handle();
   for (final entry in value.entries) {
@@ -1819,18 +1819,18 @@ Map<int, DummyClass> foobar_MapOf_Int_to_smoke_DummyClass_fromFfi(Pointer<Void> 
   return result;
 }
 void foobar_MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_smoke_DummyClass_release_handle(handle);
-final _foobar_MapOf_Int_to_smoke_DummyClass_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_DummyClass_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_DummyClass_create_handle_nullable');
-final _foobar_MapOf_Int_to_smoke_DummyClass_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_DummyClass_create_handle_nullable'));
+final _foobar_MapOf_Int_to_smoke_DummyClass_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_DummyClass_release_handle_nullable');
-final _foobar_MapOf_Int_to_smoke_DummyClass_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_DummyClass_release_handle_nullable'));
+final _foobar_MapOf_Int_to_smoke_DummyClass_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_DummyClass_get_value_nullable');
+  >('library_foobar_MapOf_Int_to_smoke_DummyClass_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_DummyClass_toFfi_nullable(Map<int, DummyClass> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_smoke_DummyClass_toFfi(value);
@@ -1847,42 +1847,42 @@ Map<int, DummyClass> foobar_MapOf_Int_to_smoke_DummyClass_fromFfi_nullable(Point
 }
 void foobar_MapOf_Int_to_smoke_DummyClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_Int_to_smoke_DummyClass_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_smoke_DummyInterface_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_DummyInterface_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_Int_to_smoke_DummyInterface_create_handle');
-final _foobar_MapOf_Int_to_smoke_DummyInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_DummyInterface_create_handle'));
+final _foobar_MapOf_Int_to_smoke_DummyInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_DummyInterface_release_handle');
-final _foobar_MapOf_Int_to_smoke_DummyInterface_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_DummyInterface_release_handle'));
+final _foobar_MapOf_Int_to_smoke_DummyInterface_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_DummyInterface_put');
-final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_DummyInterface_put'));
+final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator');
-final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator'));
+final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_release_handle');
-final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_release_handle'));
+final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_is_valid');
-final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_is_valid'));
+final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_increment');
-final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_increment'));
+final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_key');
-final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_key'));
+final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_value');
+>('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_DummyInterface_toFfi(Map<int, DummyInterface> value) {
   final _result = _foobar_MapOf_Int_to_smoke_DummyInterface_create_handle();
   for (final entry in value.entries) {
@@ -1913,18 +1913,18 @@ Map<int, DummyInterface> foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi(Pointe
   return result;
 }
 void foobar_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_smoke_DummyInterface_release_handle(handle);
-final _foobar_MapOf_Int_to_smoke_DummyInterface_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_DummyInterface_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_DummyInterface_create_handle_nullable');
-final _foobar_MapOf_Int_to_smoke_DummyInterface_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_DummyInterface_create_handle_nullable'));
+final _foobar_MapOf_Int_to_smoke_DummyInterface_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_DummyInterface_release_handle_nullable');
-final _foobar_MapOf_Int_to_smoke_DummyInterface_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_DummyInterface_release_handle_nullable'));
+final _foobar_MapOf_Int_to_smoke_DummyInterface_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_DummyInterface_get_value_nullable');
+  >('library_foobar_MapOf_Int_to_smoke_DummyInterface_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_DummyInterface_toFfi_nullable(Map<int, DummyInterface> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_smoke_DummyInterface_toFfi(value);
@@ -1941,42 +1941,42 @@ Map<int, DummyInterface> foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi_nullab
 }
 void foobar_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_Int_to_smoke_DummyInterface_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Uint32),
     void Function(Pointer<Void>, int, int)
-  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_put');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_put'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_key');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_key'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_value');
+>('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(Map<int, GenericTypesWithCompoundTypes_ExternalEnum> value) {
   final _result = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle();
   for (final entry in value.entries) {
@@ -2007,18 +2007,18 @@ Map<int, GenericTypesWithCompoundTypes_ExternalEnum> foobar_MapOf_Int_to_smoke_G
   return result;
 }
 void foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(handle);
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable');
+  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(Map<int, GenericTypesWithCompoundTypes_ExternalEnum> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(value);
@@ -2035,42 +2035,42 @@ Map<int, GenericTypesWithCompoundTypes_ExternalEnum> foobar_MapOf_Int_to_smoke_G
 }
 void foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Uint32),
     void Function(Pointer<Void>, int, int)
-  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_put');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_put'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_key');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_key'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_value');
+>('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(Map<int, GenericTypesWithCompoundTypes_SomeEnum> value) {
   final _result = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle();
   for (final entry in value.entries) {
@@ -2101,18 +2101,18 @@ Map<int, GenericTypesWithCompoundTypes_SomeEnum> foobar_MapOf_Int_to_smoke_Gener
   return result;
 }
 void foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(handle);
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable');
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable'));
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable');
+  >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(Map<int, GenericTypesWithCompoundTypes_SomeEnum> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(value);
@@ -2129,42 +2129,42 @@ Map<int, GenericTypesWithCompoundTypes_SomeEnum> foobar_MapOf_Int_to_smoke_Gener
 }
 void foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable(handle);
-final _foobar_MapOf_String_to_String_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_String_to_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_String_to_String_create_handle');
-final _foobar_MapOf_String_to_String_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_String_create_handle'));
+final _foobar_MapOf_String_to_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_String_to_String_release_handle');
-final _foobar_MapOf_String_to_String_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_String_release_handle'));
+final _foobar_MapOf_String_to_String_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_foobar_MapOf_String_to_String_put');
-final _foobar_MapOf_String_to_String_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_String_put'));
+final _foobar_MapOf_String_to_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_String_iterator');
-final _foobar_MapOf_String_to_String_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_String_iterator'));
+final _foobar_MapOf_String_to_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_String_iterator_release_handle');
-final _foobar_MapOf_String_to_String_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_String_iterator_release_handle'));
+final _foobar_MapOf_String_to_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_String_to_String_iterator_is_valid');
-final _foobar_MapOf_String_to_String_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_String_iterator_is_valid'));
+final _foobar_MapOf_String_to_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_String_iterator_increment');
-final _foobar_MapOf_String_to_String_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_String_iterator_increment'));
+final _foobar_MapOf_String_to_String_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_String_iterator_get_key');
-final _foobar_MapOf_String_to_String_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_String_iterator_get_key'));
+final _foobar_MapOf_String_to_String_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_String_iterator_get_value');
+>('library_foobar_MapOf_String_to_String_iterator_get_value'));
 Pointer<Void> foobar_MapOf_String_to_String_toFfi(Map<String, String> value) {
   final _result = _foobar_MapOf_String_to_String_create_handle();
   for (final entry in value.entries) {
@@ -2195,18 +2195,18 @@ Map<String, String> foobar_MapOf_String_to_String_fromFfi(Pointer<Void> handle) 
   return result;
 }
 void foobar_MapOf_String_to_String_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_String_to_String_release_handle(handle);
-final _foobar_MapOf_String_to_String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_String_to_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_String_to_String_create_handle_nullable');
-final _foobar_MapOf_String_to_String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_String_create_handle_nullable'));
+final _foobar_MapOf_String_to_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_String_to_String_release_handle_nullable');
-final _foobar_MapOf_String_to_String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_String_release_handle_nullable'));
+final _foobar_MapOf_String_to_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_String_to_String_get_value_nullable');
+  >('library_foobar_MapOf_String_to_String_get_value_nullable'));
 Pointer<Void> foobar_MapOf_String_to_String_toFfi_nullable(Map<String, String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_String_to_String_toFfi(value);
@@ -2223,42 +2223,42 @@ Map<String, String> foobar_MapOf_String_to_String_fromFfi_nullable(Pointer<Void>
 }
 void foobar_MapOf_String_to_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_String_to_String_release_handle_nullable(handle);
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_put');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_put'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_key');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_key'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_value');
+>('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_value'));
 Pointer<Void> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(Map<String, GenericTypesWithCompoundTypes_BasicStruct> value) {
   final _result = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle();
   for (final entry in value.entries) {
@@ -2289,18 +2289,18 @@ Map<String, GenericTypesWithCompoundTypes_BasicStruct> foobar_MapOf_String_to_sm
   return result;
 }
 void foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(handle);
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable');
+  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable'));
 Pointer<Void> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi_nullable(Map<String, GenericTypesWithCompoundTypes_BasicStruct> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(value);
@@ -2317,42 +2317,42 @@ Map<String, GenericTypesWithCompoundTypes_BasicStruct> foobar_MapOf_String_to_sm
 }
 void foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable(handle);
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_put');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_put'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_key');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_key'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_value');
+>('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_value'));
 Pointer<Void> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(Map<String, GenericTypesWithCompoundTypes_ExternalStruct> value) {
   final _result = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle();
   for (final entry in value.entries) {
@@ -2383,18 +2383,18 @@ Map<String, GenericTypesWithCompoundTypes_ExternalStruct> foobar_MapOf_String_to
   return result;
 }
 void foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(handle);
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable');
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable'));
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable');
+  >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable'));
 Pointer<Void> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi_nullable(Map<String, GenericTypesWithCompoundTypes_ExternalStruct> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(value);
@@ -2411,42 +2411,42 @@ Map<String, GenericTypesWithCompoundTypes_ExternalStruct> foobar_MapOf_String_to
 }
 void foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable(handle);
-final _foobar_MapOf_UByte_to_String_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_UByte_to_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_UByte_to_String_create_handle');
-final _foobar_MapOf_UByte_to_String_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_UByte_to_String_create_handle'));
+final _foobar_MapOf_UByte_to_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_UByte_to_String_release_handle');
-final _foobar_MapOf_UByte_to_String_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_UByte_to_String_release_handle'));
+final _foobar_MapOf_UByte_to_String_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint8, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
-  >('library_foobar_MapOf_UByte_to_String_put');
-final _foobar_MapOf_UByte_to_String_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_UByte_to_String_put'));
+final _foobar_MapOf_UByte_to_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_UByte_to_String_iterator');
-final _foobar_MapOf_UByte_to_String_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_UByte_to_String_iterator'));
+final _foobar_MapOf_UByte_to_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_UByte_to_String_iterator_release_handle');
-final _foobar_MapOf_UByte_to_String_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_UByte_to_String_iterator_release_handle'));
+final _foobar_MapOf_UByte_to_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_UByte_to_String_iterator_is_valid');
-final _foobar_MapOf_UByte_to_String_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_UByte_to_String_iterator_is_valid'));
+final _foobar_MapOf_UByte_to_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_UByte_to_String_iterator_increment');
-final _foobar_MapOf_UByte_to_String_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_UByte_to_String_iterator_increment'));
+final _foobar_MapOf_UByte_to_String_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_UByte_to_String_iterator_get_key');
-final _foobar_MapOf_UByte_to_String_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_UByte_to_String_iterator_get_key'));
+final _foobar_MapOf_UByte_to_String_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_UByte_to_String_iterator_get_value');
+>('library_foobar_MapOf_UByte_to_String_iterator_get_value'));
 Pointer<Void> foobar_MapOf_UByte_to_String_toFfi(Map<int, String> value) {
   final _result = _foobar_MapOf_UByte_to_String_create_handle();
   for (final entry in value.entries) {
@@ -2477,18 +2477,18 @@ Map<int, String> foobar_MapOf_UByte_to_String_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_MapOf_UByte_to_String_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_UByte_to_String_release_handle(handle);
-final _foobar_MapOf_UByte_to_String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_UByte_to_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_UByte_to_String_create_handle_nullable');
-final _foobar_MapOf_UByte_to_String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_UByte_to_String_create_handle_nullable'));
+final _foobar_MapOf_UByte_to_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_UByte_to_String_release_handle_nullable');
-final _foobar_MapOf_UByte_to_String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_UByte_to_String_release_handle_nullable'));
+final _foobar_MapOf_UByte_to_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_UByte_to_String_get_value_nullable');
+  >('library_foobar_MapOf_UByte_to_String_get_value_nullable'));
 Pointer<Void> foobar_MapOf_UByte_to_String_toFfi_nullable(Map<int, String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_UByte_to_String_toFfi(value);
@@ -2505,42 +2505,42 @@ Map<int, String> foobar_MapOf_UByte_to_String_fromFfi_nullable(Pointer<Void> han
 }
 void foobar_MapOf_UByte_to_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_UByte_to_String_release_handle_nullable(handle);
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle');
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle'));
+final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle');
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle'));
+final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>, Uint8),
     void Function(Pointer<Void>, Pointer<Void>, int)
-  >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_put');
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_put'));
+final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator');
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator'));
+final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_release_handle');
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_release_handle'));
+final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_is_valid');
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_is_valid'));
+final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_increment');
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_increment'));
+final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_key');
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_key'));
+final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_value');
+>('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_foobar_ListOf_Int_to_Boolean_toFfi(Map<List<int>, bool> value) {
   final _result = _foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle();
   for (final entry in value.entries) {
@@ -2571,18 +2571,18 @@ Map<List<int>, bool> foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi(Pointer<V
   return result;
 }
 void foobar_MapOf_foobar_ListOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle(handle);
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle_nullable');
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle_nullable'));
+final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle_nullable');
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle_nullable'));
+final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_get_value_nullable');
+  >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_foobar_ListOf_Int_to_Boolean_toFfi_nullable(Map<List<int>, bool> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_foobar_ListOf_Int_to_Boolean_toFfi(value);
@@ -2599,42 +2599,42 @@ Map<List<int>, bool> foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi_nullable(
 }
 void foobar_MapOf_foobar_ListOf_Int_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle_nullable(handle);
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle');
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle'));
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle');
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle'));
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>, Uint8),
     void Function(Pointer<Void>, Pointer<Void>, int)
-  >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_put');
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_put'));
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator');
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator'));
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_release_handle');
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_release_handle'));
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_is_valid');
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_is_valid'));
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_increment');
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_increment'));
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_key');
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_key'));
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_value');
+>('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_toFfi(Map<Map<int, bool>, bool> value) {
   final _result = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle();
   for (final entry in value.entries) {
@@ -2665,18 +2665,18 @@ Map<Map<int, bool>, bool> foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fr
   return result;
 }
 void foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle(handle);
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle_nullable');
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle_nullable'));
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle_nullable');
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle_nullable'));
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_get_value_nullable');
+  >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_toFfi_nullable(Map<Map<int, bool>, bool> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_toFfi(value);
@@ -2693,42 +2693,42 @@ Map<Map<int, bool>, bool> foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fr
 }
 void foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle_nullable(handle);
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle');
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle'));
+final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle');
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle'));
+final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>, Uint8),
     void Function(Pointer<Void>, Pointer<Void>, int)
-  >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_put');
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_put'));
+final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator');
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator'));
+final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_release_handle');
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_release_handle'));
+final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_is_valid');
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_is_valid'));
+final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_increment');
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_increment'));
+final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_key');
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_key'));
+final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_value');
+>('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_foobar_SetOf_Int_to_Boolean_toFfi(Map<Set<int>, bool> value) {
   final _result = _foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle();
   for (final entry in value.entries) {
@@ -2759,18 +2759,18 @@ Map<Set<int>, bool> foobar_MapOf_foobar_SetOf_Int_to_Boolean_fromFfi(Pointer<Voi
   return result;
 }
 void foobar_MapOf_foobar_SetOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle(handle);
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle_nullable');
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle_nullable'));
+final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle_nullable');
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle_nullable'));
+final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_get_value_nullable');
+  >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_foobar_SetOf_Int_to_Boolean_toFfi_nullable(Map<Set<int>, bool> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_foobar_SetOf_Int_to_Boolean_toFfi(value);
@@ -2787,42 +2787,42 @@ Map<Set<int>, bool> foobar_MapOf_foobar_SetOf_Int_to_Boolean_fromFfi_nullable(Po
 }
 void foobar_MapOf_foobar_SetOf_Int_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle_nullable(handle);
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32, Uint8),
     void Function(Pointer<Void>, int, int)
-  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_put');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_put'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_release_handle');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_release_handle'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_is_valid');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_is_valid'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_increment');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_increment'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_key');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_key'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_value');
+>('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_toFfi(Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> value) {
   final _result = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle();
   for (final entry in value.entries) {
@@ -2853,18 +2853,18 @@ Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> foobar_MapOf_smoke_Generic
   return result;
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle(handle);
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle_nullable');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle_nullable'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle_nullable');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle_nullable'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_get_value_nullable');
+  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_toFfi_nullable(Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_toFfi(value);
@@ -2881,42 +2881,42 @@ Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> foobar_MapOf_smoke_Generic
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle_nullable(handle);
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_put = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32, Uint8),
     void Function(Pointer<Void>, int, int)
-  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_put');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_put'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_release_handle');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_release_handle'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_is_valid');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_is_valid'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_increment');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_increment'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_key');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_key'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_value');
+>('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> value) {
   final _result = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle();
   for (final entry in value.entries) {
@@ -2947,18 +2947,18 @@ Map<GenericTypesWithCompoundTypes_SomeEnum, bool> foobar_MapOf_smoke_GenericType
   return result;
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle(handle);
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle_nullable');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle_nullable'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle_nullable');
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle_nullable'));
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_get_value_nullable');
+  >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi_nullable(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(value);
@@ -2975,38 +2975,38 @@ Map<GenericTypesWithCompoundTypes_SomeEnum, bool> foobar_MapOf_smoke_GenericType
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle_nullable(handle);
-final _foobar_SetOf_Float_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_Float_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_SetOf_Float_create_handle');
-final _foobar_SetOf_Float_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_Float_create_handle'));
+final _foobar_SetOf_Float_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_Float_release_handle');
-final _foobar_SetOf_Float_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_Float_release_handle'));
+final _foobar_SetOf_Float_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Float),
     void Function(Pointer<Void>, double)
-  >('library_foobar_SetOf_Float_insert');
-final _foobar_SetOf_Float_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_Float_insert'));
+final _foobar_SetOf_Float_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_Float_iterator');
-final _foobar_SetOf_Float_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_Float_iterator'));
+final _foobar_SetOf_Float_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_Float_iterator_release_handle');
-final _foobar_SetOf_Float_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_Float_iterator_release_handle'));
+final _foobar_SetOf_Float_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_SetOf_Float_iterator_is_valid');
-final _foobar_SetOf_Float_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_Float_iterator_is_valid'));
+final _foobar_SetOf_Float_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_Float_iterator_increment');
-final _foobar_SetOf_Float_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_Float_iterator_increment'));
+final _foobar_SetOf_Float_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
->('library_foobar_SetOf_Float_iterator_get');
+>('library_foobar_SetOf_Float_iterator_get'));
 Pointer<Void> foobar_SetOf_Float_toFfi(Set<double> value) {
   final _result = _foobar_SetOf_Float_create_handle();
   for (final element in value) {
@@ -3032,18 +3032,18 @@ Set<double> foobar_SetOf_Float_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_SetOf_Float_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_Float_release_handle(handle);
-final _foobar_SetOf_Float_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_Float_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_Float_create_handle_nullable');
-final _foobar_SetOf_Float_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_Float_create_handle_nullable'));
+final _foobar_SetOf_Float_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_Float_release_handle_nullable');
-final _foobar_SetOf_Float_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_Float_release_handle_nullable'));
+final _foobar_SetOf_Float_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_Float_get_value_nullable');
+  >('library_foobar_SetOf_Float_get_value_nullable'));
 Pointer<Void> foobar_SetOf_Float_toFfi_nullable(Set<double> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_Float_toFfi(value);
@@ -3060,38 +3060,38 @@ Set<double> foobar_SetOf_Float_fromFfi_nullable(Pointer<Void> handle) {
 }
 void foobar_SetOf_Float_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_SetOf_Float_release_handle_nullable(handle);
-final _foobar_SetOf_Int_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_SetOf_Int_create_handle');
-final _foobar_SetOf_Int_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_Int_create_handle'));
+final _foobar_SetOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_Int_release_handle');
-final _foobar_SetOf_Int_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_Int_release_handle'));
+final _foobar_SetOf_Int_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32),
     void Function(Pointer<Void>, int)
-  >('library_foobar_SetOf_Int_insert');
-final _foobar_SetOf_Int_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_Int_insert'));
+final _foobar_SetOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_Int_iterator');
-final _foobar_SetOf_Int_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_Int_iterator'));
+final _foobar_SetOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_Int_iterator_release_handle');
-final _foobar_SetOf_Int_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_Int_iterator_release_handle'));
+final _foobar_SetOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_SetOf_Int_iterator_is_valid');
-final _foobar_SetOf_Int_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_Int_iterator_is_valid'));
+final _foobar_SetOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_Int_iterator_increment');
-final _foobar_SetOf_Int_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_Int_iterator_increment'));
+final _foobar_SetOf_Int_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_SetOf_Int_iterator_get');
+>('library_foobar_SetOf_Int_iterator_get'));
 Pointer<Void> foobar_SetOf_Int_toFfi(Set<int> value) {
   final _result = _foobar_SetOf_Int_create_handle();
   for (final element in value) {
@@ -3117,18 +3117,18 @@ Set<int> foobar_SetOf_Int_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_SetOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_Int_release_handle(handle);
-final _foobar_SetOf_Int_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_Int_create_handle_nullable');
-final _foobar_SetOf_Int_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_Int_create_handle_nullable'));
+final _foobar_SetOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_Int_release_handle_nullable');
-final _foobar_SetOf_Int_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_Int_release_handle_nullable'));
+final _foobar_SetOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_Int_get_value_nullable');
+  >('library_foobar_SetOf_Int_get_value_nullable'));
 Pointer<Void> foobar_SetOf_Int_toFfi_nullable(Set<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_Int_toFfi(value);
@@ -3145,38 +3145,38 @@ Set<int> foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
 }
 void foobar_SetOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_SetOf_Int_release_handle_nullable(handle);
-final _foobar_SetOf_String_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_SetOf_String_create_handle');
-final _foobar_SetOf_String_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_String_create_handle'));
+final _foobar_SetOf_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_String_release_handle');
-final _foobar_SetOf_String_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_String_release_handle'));
+final _foobar_SetOf_String_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_SetOf_String_insert');
-final _foobar_SetOf_String_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_String_insert'));
+final _foobar_SetOf_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_String_iterator');
-final _foobar_SetOf_String_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_String_iterator'));
+final _foobar_SetOf_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_String_iterator_release_handle');
-final _foobar_SetOf_String_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_String_iterator_release_handle'));
+final _foobar_SetOf_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_SetOf_String_iterator_is_valid');
-final _foobar_SetOf_String_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_String_iterator_is_valid'));
+final _foobar_SetOf_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_String_iterator_increment');
-final _foobar_SetOf_String_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_String_iterator_increment'));
+final _foobar_SetOf_String_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_String_iterator_get');
+>('library_foobar_SetOf_String_iterator_get'));
 Pointer<Void> foobar_SetOf_String_toFfi(Set<String> value) {
   final _result = _foobar_SetOf_String_create_handle();
   for (final element in value) {
@@ -3202,18 +3202,18 @@ Set<String> foobar_SetOf_String_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_SetOf_String_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_String_release_handle(handle);
-final _foobar_SetOf_String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_String_create_handle_nullable');
-final _foobar_SetOf_String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_String_create_handle_nullable'));
+final _foobar_SetOf_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_String_release_handle_nullable');
-final _foobar_SetOf_String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_String_release_handle_nullable'));
+final _foobar_SetOf_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_String_get_value_nullable');
+  >('library_foobar_SetOf_String_get_value_nullable'));
 Pointer<Void> foobar_SetOf_String_toFfi_nullable(Set<String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_String_toFfi(value);
@@ -3230,38 +3230,38 @@ Set<String> foobar_SetOf_String_fromFfi_nullable(Pointer<Void> handle) {
 }
 void foobar_SetOf_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_SetOf_String_release_handle_nullable(handle);
-final _foobar_SetOf_UByte_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_UByte_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_SetOf_UByte_create_handle');
-final _foobar_SetOf_UByte_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_UByte_create_handle'));
+final _foobar_SetOf_UByte_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_UByte_release_handle');
-final _foobar_SetOf_UByte_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_UByte_release_handle'));
+final _foobar_SetOf_UByte_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint8),
     void Function(Pointer<Void>, int)
-  >('library_foobar_SetOf_UByte_insert');
-final _foobar_SetOf_UByte_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_UByte_insert'));
+final _foobar_SetOf_UByte_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_UByte_iterator');
-final _foobar_SetOf_UByte_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_UByte_iterator'));
+final _foobar_SetOf_UByte_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_UByte_iterator_release_handle');
-final _foobar_SetOf_UByte_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_UByte_iterator_release_handle'));
+final _foobar_SetOf_UByte_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_SetOf_UByte_iterator_is_valid');
-final _foobar_SetOf_UByte_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_UByte_iterator_is_valid'));
+final _foobar_SetOf_UByte_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_UByte_iterator_increment');
-final _foobar_SetOf_UByte_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_UByte_iterator_increment'));
+final _foobar_SetOf_UByte_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_SetOf_UByte_iterator_get');
+>('library_foobar_SetOf_UByte_iterator_get'));
 Pointer<Void> foobar_SetOf_UByte_toFfi(Set<int> value) {
   final _result = _foobar_SetOf_UByte_create_handle();
   for (final element in value) {
@@ -3287,18 +3287,18 @@ Set<int> foobar_SetOf_UByte_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_SetOf_UByte_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_UByte_release_handle(handle);
-final _foobar_SetOf_UByte_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_UByte_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_UByte_create_handle_nullable');
-final _foobar_SetOf_UByte_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_UByte_create_handle_nullable'));
+final _foobar_SetOf_UByte_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_UByte_release_handle_nullable');
-final _foobar_SetOf_UByte_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_UByte_release_handle_nullable'));
+final _foobar_SetOf_UByte_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_UByte_get_value_nullable');
+  >('library_foobar_SetOf_UByte_get_value_nullable'));
 Pointer<Void> foobar_SetOf_UByte_toFfi_nullable(Set<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_UByte_toFfi(value);
@@ -3315,38 +3315,38 @@ Set<int> foobar_SetOf_UByte_fromFfi_nullable(Pointer<Void> handle) {
 }
 void foobar_SetOf_UByte_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_SetOf_UByte_release_handle_nullable(handle);
-final _foobar_SetOf_foobar_ListOf_Int_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_foobar_ListOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_SetOf_foobar_ListOf_Int_create_handle');
-final _foobar_SetOf_foobar_ListOf_Int_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_ListOf_Int_create_handle'));
+final _foobar_SetOf_foobar_ListOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_foobar_ListOf_Int_release_handle');
-final _foobar_SetOf_foobar_ListOf_Int_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_ListOf_Int_release_handle'));
+final _foobar_SetOf_foobar_ListOf_Int_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_SetOf_foobar_ListOf_Int_insert');
-final _foobar_SetOf_foobar_ListOf_Int_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_ListOf_Int_insert'));
+final _foobar_SetOf_foobar_ListOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_foobar_ListOf_Int_iterator');
-final _foobar_SetOf_foobar_ListOf_Int_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_foobar_ListOf_Int_iterator'));
+final _foobar_SetOf_foobar_ListOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_foobar_ListOf_Int_iterator_release_handle');
-final _foobar_SetOf_foobar_ListOf_Int_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_foobar_ListOf_Int_iterator_release_handle'));
+final _foobar_SetOf_foobar_ListOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_SetOf_foobar_ListOf_Int_iterator_is_valid');
-final _foobar_SetOf_foobar_ListOf_Int_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_foobar_ListOf_Int_iterator_is_valid'));
+final _foobar_SetOf_foobar_ListOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_foobar_ListOf_Int_iterator_increment');
-final _foobar_SetOf_foobar_ListOf_Int_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_foobar_ListOf_Int_iterator_increment'));
+final _foobar_SetOf_foobar_ListOf_Int_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_foobar_ListOf_Int_iterator_get');
+>('library_foobar_SetOf_foobar_ListOf_Int_iterator_get'));
 Pointer<Void> foobar_SetOf_foobar_ListOf_Int_toFfi(Set<List<int>> value) {
   final _result = _foobar_SetOf_foobar_ListOf_Int_create_handle();
   for (final element in value) {
@@ -3372,18 +3372,18 @@ Set<List<int>> foobar_SetOf_foobar_ListOf_Int_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_SetOf_foobar_ListOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_foobar_ListOf_Int_release_handle(handle);
-final _foobar_SetOf_foobar_ListOf_Int_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_foobar_ListOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_foobar_ListOf_Int_create_handle_nullable');
-final _foobar_SetOf_foobar_ListOf_Int_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_ListOf_Int_create_handle_nullable'));
+final _foobar_SetOf_foobar_ListOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_foobar_ListOf_Int_release_handle_nullable');
-final _foobar_SetOf_foobar_ListOf_Int_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_ListOf_Int_release_handle_nullable'));
+final _foobar_SetOf_foobar_ListOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_foobar_ListOf_Int_get_value_nullable');
+  >('library_foobar_SetOf_foobar_ListOf_Int_get_value_nullable'));
 Pointer<Void> foobar_SetOf_foobar_ListOf_Int_toFfi_nullable(Set<List<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_foobar_ListOf_Int_toFfi(value);
@@ -3400,38 +3400,38 @@ Set<List<int>> foobar_SetOf_foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> han
 }
 void foobar_SetOf_foobar_ListOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_SetOf_foobar_ListOf_Int_release_handle_nullable(handle);
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle');
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle'));
+final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle');
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle'));
+final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_insert');
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_insert'));
+final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator');
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator'));
+final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle');
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle'));
+final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid');
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid'));
+final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_increment');
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_increment'));
+final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_get');
+>('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_get'));
 Pointer<Void> foobar_SetOf_foobar_MapOf_Int_to_Boolean_toFfi(Set<Map<int, bool>> value) {
   final _result = _foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle();
   for (final element in value) {
@@ -3457,18 +3457,18 @@ Set<Map<int, bool>> foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi(Pointer<Voi
   return result;
 }
 void foobar_SetOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle(handle);
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable');
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable'));
+final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable');
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable'));
+final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_get_value_nullable');
+  >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_SetOf_foobar_MapOf_Int_to_Boolean_toFfi_nullable(Set<Map<int, bool>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_foobar_MapOf_Int_to_Boolean_toFfi(value);
@@ -3485,38 +3485,38 @@ Set<Map<int, bool>> foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Po
 }
 void foobar_SetOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable(handle);
-final _foobar_SetOf_foobar_SetOf_Int_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_foobar_SetOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_SetOf_foobar_SetOf_Int_create_handle');
-final _foobar_SetOf_foobar_SetOf_Int_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_SetOf_Int_create_handle'));
+final _foobar_SetOf_foobar_SetOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_foobar_SetOf_Int_release_handle');
-final _foobar_SetOf_foobar_SetOf_Int_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_SetOf_Int_release_handle'));
+final _foobar_SetOf_foobar_SetOf_Int_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_foobar_SetOf_foobar_SetOf_Int_insert');
-final _foobar_SetOf_foobar_SetOf_Int_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_SetOf_Int_insert'));
+final _foobar_SetOf_foobar_SetOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_foobar_SetOf_Int_iterator');
-final _foobar_SetOf_foobar_SetOf_Int_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_foobar_SetOf_Int_iterator'));
+final _foobar_SetOf_foobar_SetOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_foobar_SetOf_Int_iterator_release_handle');
-final _foobar_SetOf_foobar_SetOf_Int_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_foobar_SetOf_Int_iterator_release_handle'));
+final _foobar_SetOf_foobar_SetOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_SetOf_foobar_SetOf_Int_iterator_is_valid');
-final _foobar_SetOf_foobar_SetOf_Int_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_foobar_SetOf_Int_iterator_is_valid'));
+final _foobar_SetOf_foobar_SetOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_foobar_SetOf_Int_iterator_increment');
-final _foobar_SetOf_foobar_SetOf_Int_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_foobar_SetOf_Int_iterator_increment'));
+final _foobar_SetOf_foobar_SetOf_Int_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_foobar_SetOf_Int_iterator_get');
+>('library_foobar_SetOf_foobar_SetOf_Int_iterator_get'));
 Pointer<Void> foobar_SetOf_foobar_SetOf_Int_toFfi(Set<Set<int>> value) {
   final _result = _foobar_SetOf_foobar_SetOf_Int_create_handle();
   for (final element in value) {
@@ -3542,18 +3542,18 @@ Set<Set<int>> foobar_SetOf_foobar_SetOf_Int_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_foobar_SetOf_Int_release_handle(handle);
-final _foobar_SetOf_foobar_SetOf_Int_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_foobar_SetOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_foobar_SetOf_Int_create_handle_nullable');
-final _foobar_SetOf_foobar_SetOf_Int_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_SetOf_Int_create_handle_nullable'));
+final _foobar_SetOf_foobar_SetOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_foobar_SetOf_Int_release_handle_nullable');
-final _foobar_SetOf_foobar_SetOf_Int_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_foobar_SetOf_Int_release_handle_nullable'));
+final _foobar_SetOf_foobar_SetOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_foobar_SetOf_Int_get_value_nullable');
+  >('library_foobar_SetOf_foobar_SetOf_Int_get_value_nullable'));
 Pointer<Void> foobar_SetOf_foobar_SetOf_Int_toFfi_nullable(Set<Set<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_foobar_SetOf_Int_toFfi(value);
@@ -3570,38 +3570,38 @@ Set<Set<int>> foobar_SetOf_foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handl
 }
 void foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_SetOf_foobar_SetOf_Int_release_handle_nullable(handle);
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32),
     void Function(Pointer<Void>, int)
-  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get');
+>('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get'));
 Pointer<Void> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(Set<GenericTypesWithCompoundTypes_ExternalEnum> value) {
   final _result = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle();
   for (final element in value) {
@@ -3627,18 +3627,18 @@ Set<GenericTypesWithCompoundTypes_ExternalEnum> foobar_SetOf_smoke_GenericTypesW
   return result;
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(handle);
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable');
+  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
 Pointer<Void> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(Set<GenericTypesWithCompoundTypes_ExternalEnum> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(value);
@@ -3655,38 +3655,38 @@ Set<GenericTypesWithCompoundTypes_ExternalEnum> foobar_SetOf_smoke_GenericTypesW
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(handle);
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32),
     void Function(Pointer<Void>, int)
-  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get');
+>('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get'));
 Pointer<Void> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(Set<GenericTypesWithCompoundTypes_SomeEnum> value) {
   final _result = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle();
   for (final element in value) {
@@ -3712,18 +3712,18 @@ Set<GenericTypesWithCompoundTypes_SomeEnum> foobar_SetOf_smoke_GenericTypesWithC
   return result;
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(handle);
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable');
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable'));
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable');
+  >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
 Pointer<Void> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(Set<GenericTypesWithCompoundTypes_SomeEnum> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -31,26 +31,26 @@ class GenericTypesWithBasicTypes_StructWithGenerics {
   GenericTypesWithBasicTypes_StructWithGenerics(this.numbersList, this.numbersMap, this.numbersSet);
 }
 // GenericTypesWithBasicTypes_StructWithGenerics "private" section, not exported.
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle');
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle'));
+final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle');
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersList = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle'));
+final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersList = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersList');
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersMap = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersList'));
+final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersMap = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersMap');
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersSet = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersMap'));
+final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersSet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersSet');
+  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersSet'));
 Pointer<Void> smoke_GenericTypesWithBasicTypes_StructWithGenerics_toFfi(GenericTypesWithBasicTypes_StructWithGenerics value) {
   final _numbersList_handle = foobar_ListOf_UByte_toFfi(value.numbersList);
   final _numbersMap_handle = foobar_MapOf_UByte_to_String_toFfi(value.numbersMap);
@@ -79,18 +79,18 @@ GenericTypesWithBasicTypes_StructWithGenerics smoke_GenericTypesWithBasicTypes_S
 }
 void smoke_GenericTypesWithBasicTypes_StructWithGenerics_releaseFfiHandle(Pointer<Void> handle) => _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle(handle);
 // Nullable GenericTypesWithBasicTypes_StructWithGenerics
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle_nullable');
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle_nullable'));
+final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle_nullable');
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle_nullable'));
+final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_value_nullable');
+  >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_value_nullable'));
 Pointer<Void> smoke_GenericTypesWithBasicTypes_StructWithGenerics_toFfi_nullable(GenericTypesWithBasicTypes_StructWithGenerics value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithBasicTypes_StructWithGenerics_toFfi(value);
@@ -109,18 +109,18 @@ void smoke_GenericTypesWithBasicTypes_StructWithGenerics_releaseFfiHandle_nullab
   _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle_nullable(handle);
 // End of GenericTypesWithBasicTypes_StructWithGenerics "private" section.
 // GenericTypesWithBasicTypes "private" section, not exported.
-final _smoke_GenericTypesWithBasicTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithBasicTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithBasicTypes_copy_handle');
-final _smoke_GenericTypesWithBasicTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithBasicTypes_copy_handle'));
+final _smoke_GenericTypesWithBasicTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithBasicTypes_release_handle');
-final _smoke_GenericTypesWithBasicTypes_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithBasicTypes_release_handle'));
+final _smoke_GenericTypesWithBasicTypes_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_GenericTypesWithBasicTypes_get_raw_pointer');
+    >('library_smoke_GenericTypesWithBasicTypes_get_raw_pointer'));
 class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   @protected
   Pointer<Void> handle;
@@ -134,7 +134,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
   @override
   List<int> methodWithList(List<int> input) {
-    final _methodWithList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithList__ListOf_1Int');
+    final _methodWithList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithList__ListOf_1Int'));
     final _input_handle = foobar_ListOf_Int_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -147,7 +147,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
   @override
   Map<int, bool> methodWithMap(Map<int, bool> input) {
-    final _methodWithMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMap__MapOf_1Int_1to_1Boolean');
+    final _methodWithMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMap__MapOf_1Int_1to_1Boolean'));
     final _input_handle = foobar_MapOf_Int_to_Boolean_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -160,7 +160,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
   @override
   Set<int> methodWithSet(Set<int> input) {
-    final _methodWithSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSet__SetOf_1Int');
+    final _methodWithSet_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSet__SetOf_1Int'));
     final _input_handle = foobar_SetOf_Int_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithSet_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -173,7 +173,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
   @override
   List<String> methodWithListTypeAlias(List<String> input) {
-    final _methodWithListTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias__ListOf_1String');
+    final _methodWithListTypeAlias_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias__ListOf_1String'));
     final _input_handle = foobar_ListOf_String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithListTypeAlias_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -186,7 +186,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
   @override
   Map<String, String> methodWithMapTypeAlias(Map<String, String> input) {
-    final _methodWithMapTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias__MapOf_1String_1to_1String');
+    final _methodWithMapTypeAlias_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias__MapOf_1String_1to_1String'));
     final _input_handle = foobar_MapOf_String_to_String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithMapTypeAlias_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -199,7 +199,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
   @override
   Set<String> methodWithSetTypeAlias(Set<String> input) {
-    final _methodWithSetTypeAlias_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias__SetOf_1String');
+    final _methodWithSetTypeAlias_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias__SetOf_1String'));
     final _input_handle = foobar_SetOf_String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithSetTypeAlias_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -212,7 +212,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
   @override
   List<double> get listProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_listProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_listProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -223,7 +223,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
   @override
   set listProperty(List<double> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_listProperty_set__ListOf_1Float');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_listProperty_set__ListOf_1Float'));
     final _value_handle = foobar_ListOf_Float_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -236,7 +236,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
   @override
   Map<double, double> get mapProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -247,7 +247,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
   @override
   set mapProperty(Map<double, double> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_set__MapOf_1Float_1to_1Double');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_set__MapOf_1Float_1to_1Double'));
     final _value_handle = foobar_MapOf_Float_to_Double_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -260,7 +260,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
   @override
   Set<double> get setProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_setProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_setProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -271,7 +271,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
   @override
   set setProperty(Set<double> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_setProperty_set__SetOf_1Float');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_setProperty_set__SetOf_1Float'));
     final _value_handle = foobar_SetOf_Float_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -52,18 +52,18 @@ GenericTypesWithCompoundTypes_SomeEnum smoke_GenericTypesWithCompoundTypes_SomeE
   }
 }
 void smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable');
-final _smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable'));
+final _smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable');
-final _smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable'));
+final _smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable');
+  >('library_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(GenericTypesWithCompoundTypes_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(value);
@@ -111,18 +111,18 @@ GenericTypesWithCompoundTypes_ExternalEnum smoke_GenericTypesWithCompoundTypes_E
   }
 }
 void smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(int handle) {}
-final _smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable');
-final _smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable'));
+final _smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable');
-final _smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable'));
+final _smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable');
+  >('library_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(GenericTypesWithCompoundTypes_ExternalEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(value);
@@ -145,18 +145,18 @@ class GenericTypesWithCompoundTypes_BasicStruct {
   GenericTypesWithCompoundTypes_BasicStruct(this.value);
 }
 // GenericTypesWithCompoundTypes_BasicStruct "private" section, not exported.
-final _smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
-  >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle');
-final _smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle'));
+final _smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle');
-final _smoke_GenericTypesWithCompoundTypes_BasicStruct_get_field_value = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle'));
+final _smoke_GenericTypesWithCompoundTypes_BasicStruct_get_field_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_field_value');
+  >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_field_value'));
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(GenericTypesWithCompoundTypes_BasicStruct value) {
   final _value_handle = (value.value);
   final _result = _smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle(_value_handle);
@@ -175,18 +175,18 @@ GenericTypesWithCompoundTypes_BasicStruct smoke_GenericTypesWithCompoundTypes_Ba
 }
 void smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(handle);
 // Nullable GenericTypesWithCompoundTypes_BasicStruct
-final _smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable');
-final _smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable'));
+final _smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable');
-final _smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable'));
+final _smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable');
+  >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable'));
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi_nullable(GenericTypesWithCompoundTypes_BasicStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(value);
@@ -209,18 +209,18 @@ class GenericTypesWithCompoundTypes_ExternalStruct {
   GenericTypesWithCompoundTypes_ExternalStruct(this.string);
 }
 // GenericTypesWithCompoundTypes_ExternalStruct "private" section, not exported.
-final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle');
-final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle'));
+final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle');
-final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_field_string = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle'));
+final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_field_string = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_field_string');
+  >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_field_string'));
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(GenericTypesWithCompoundTypes_ExternalStruct value) {
   final _string_handle = String_toFfi(value.string);
   final _result = _smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle(_string_handle);
@@ -239,18 +239,18 @@ GenericTypesWithCompoundTypes_ExternalStruct smoke_GenericTypesWithCompoundTypes
 }
 void smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(handle);
 // Nullable GenericTypesWithCompoundTypes_ExternalStruct
-final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable');
-final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable'));
+final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable');
-final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable'));
+final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable');
+  >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable'));
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi_nullable(GenericTypesWithCompoundTypes_ExternalStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(value);
@@ -269,18 +269,18 @@ void smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle_nullabl
   _smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable(handle);
 // End of GenericTypesWithCompoundTypes_ExternalStruct "private" section.
 // GenericTypesWithCompoundTypes "private" section, not exported.
-final _smoke_GenericTypesWithCompoundTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_copy_handle');
-final _smoke_GenericTypesWithCompoundTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_copy_handle'));
+final _smoke_GenericTypesWithCompoundTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithCompoundTypes_release_handle');
-final _smoke_GenericTypesWithCompoundTypes_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithCompoundTypes_release_handle'));
+final _smoke_GenericTypesWithCompoundTypes_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_GenericTypesWithCompoundTypes_get_raw_pointer');
+    >('library_smoke_GenericTypesWithCompoundTypes_get_raw_pointer'));
 class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundTypes {
   @protected
   Pointer<Void> handle;
@@ -294,7 +294,7 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
   }
   @override
   List<GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructList(List<GenericTypesWithCompoundTypes_BasicStruct> input) {
-    final _methodWithStructList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct');
+    final _methodWithStructList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct'));
     final _input_handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithStructList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -307,7 +307,7 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
   }
   @override
   Map<String, GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructMap(Map<String, GenericTypesWithCompoundTypes_BasicStruct> input) {
-    final _methodWithStructMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructMap__MapOf_1String_1to_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct');
+    final _methodWithStructMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructMap__MapOf_1String_1to_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct'));
     final _input_handle = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithStructMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -320,7 +320,7 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
   }
   @override
   List<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumList(List<GenericTypesWithCompoundTypes_SomeEnum> input) {
-    final _methodWithEnumList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
+    final _methodWithEnumList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum'));
     final _input_handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithEnumList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -333,7 +333,7 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
   }
   @override
   Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> methodWithEnumMapKey(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> input) {
-    final _methodWithEnumMapKey_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey__MapOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum_1to_1Boolean');
+    final _methodWithEnumMapKey_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey__MapOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum_1to_1Boolean'));
     final _input_handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithEnumMapKey_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -346,7 +346,7 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
   }
   @override
   Map<int, GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumMapValue(Map<int, GenericTypesWithCompoundTypes_SomeEnum> input) {
-    final _methodWithEnumMapValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue__MapOf_1Int_1to_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
+    final _methodWithEnumMapValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue__MapOf_1Int_1to_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum'));
     final _input_handle = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithEnumMapValue_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -359,7 +359,7 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
   }
   @override
   Set<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumSet(Set<GenericTypesWithCompoundTypes_SomeEnum> input) {
-    final _methodWithEnumSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumSet__SetOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum');
+    final _methodWithEnumSet_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumSet__SetOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum'));
     final _input_handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithEnumSet_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -372,7 +372,7 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
   }
   @override
   List<DummyInterface> methodWithInstancesList(List<DummyClass> input) {
-    final _methodWithInstancesList_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesList__ListOf_1smoke_1DummyClass');
+    final _methodWithInstancesList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesList__ListOf_1smoke_1DummyClass'));
     final _input_handle = foobar_ListOf_smoke_DummyClass_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithInstancesList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -385,7 +385,7 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
   }
   @override
   Map<int, DummyInterface> methodWithInstancesMap(Map<int, DummyClass> input) {
-    final _methodWithInstancesMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap__MapOf_1Int_1to_1smoke_1DummyClass');
+    final _methodWithInstancesMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap__MapOf_1Int_1to_1smoke_1DummyClass'));
     final _input_handle = foobar_MapOf_Int_to_smoke_DummyClass_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithInstancesMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -20,18 +20,18 @@ abstract class GenericTypesWithGenericTypes {
   Map<List<int>, bool> methodWithMapGenericKeys(Map<Set<int>, bool> input);
 }
 // GenericTypesWithGenericTypes "private" section, not exported.
-final _smoke_GenericTypesWithGenericTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithGenericTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithGenericTypes_copy_handle');
-final _smoke_GenericTypesWithGenericTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithGenericTypes_copy_handle'));
+final _smoke_GenericTypesWithGenericTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_GenericTypesWithGenericTypes_release_handle');
-final _smoke_GenericTypesWithGenericTypes_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_GenericTypesWithGenericTypes_release_handle'));
+final _smoke_GenericTypesWithGenericTypes_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_GenericTypesWithGenericTypes_get_raw_pointer');
+    >('library_smoke_GenericTypesWithGenericTypes_get_raw_pointer'));
 class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes {
   @protected
   Pointer<Void> handle;
@@ -45,7 +45,7 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
   }
   @override
   List<List<int>> methodWithListOfLists(List<List<int>> input) {
-    final _methodWithListOfLists_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListOfLists__ListOf_1foobar_1ListOf_1Int');
+    final _methodWithListOfLists_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListOfLists__ListOf_1foobar_1ListOf_1Int'));
     final _input_handle = foobar_ListOf_foobar_ListOf_Int_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithListOfLists_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -58,7 +58,7 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
   }
   @override
   Map<Map<int, bool>, bool> methodWithMapOfMaps(Map<int, Map<int, bool>> input) {
-    final _methodWithMapOfMaps_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps__MapOf_1Int_1to_1foobar_1MapOf_1Int_1to_1Boolean');
+    final _methodWithMapOfMaps_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps__MapOf_1Int_1to_1foobar_1MapOf_1Int_1to_1Boolean'));
     final _input_handle = foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithMapOfMaps_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -71,7 +71,7 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
   }
   @override
   Set<Set<int>> methodWithSetOfSets(Set<Set<int>> input) {
-    final _methodWithSetOfSets_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithSetOfSets__SetOf_1foobar_1SetOf_1Int');
+    final _methodWithSetOfSets_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithSetOfSets__SetOf_1foobar_1SetOf_1Int'));
     final _input_handle = foobar_SetOf_foobar_SetOf_Int_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithSetOfSets_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -84,7 +84,7 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
   }
   @override
   Map<int, List<int>> methodWithListAndMap(List<Map<int, bool>> input) {
-    final _methodWithListAndMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListAndMap__ListOf_1foobar_1MapOf_1Int_1to_1Boolean');
+    final _methodWithListAndMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListAndMap__ListOf_1foobar_1MapOf_1Int_1to_1Boolean'));
     final _input_handle = foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithListAndMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -97,7 +97,7 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
   }
   @override
   Set<List<int>> methodWithListAndSet(List<Set<int>> input) {
-    final _methodWithListAndSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListAndSet__ListOf_1foobar_1SetOf_1Int');
+    final _methodWithListAndSet_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListAndSet__ListOf_1foobar_1SetOf_1Int'));
     final _input_handle = foobar_ListOf_foobar_SetOf_Int_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithListAndSet_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -110,7 +110,7 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
   }
   @override
   Set<Map<int, bool>> methodWithMapAndSet(Map<int, Set<int>> input) {
-    final _methodWithMapAndSet_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapAndSet__MapOf_1Int_1to_1foobar_1SetOf_1Int');
+    final _methodWithMapAndSet_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapAndSet__MapOf_1Int_1to_1foobar_1SetOf_1Int'));
     final _input_handle = foobar_MapOf_Int_to_foobar_SetOf_Int_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithMapAndSet_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -123,7 +123,7 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
   }
   @override
   Map<List<int>, bool> methodWithMapGenericKeys(Map<Set<int>, bool> input) {
-    final _methodWithMapGenericKeys_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys__MapOf_1foobar_1SetOf_1Int_1to_1Boolean');
+    final _methodWithMapGenericKeys_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys__MapOf_1foobar_1SetOf_1Int_1to_1Boolean'));
     final _input_handle = foobar_MapOf_foobar_SetOf_Int_to_Boolean_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _methodWithMapGenericKeys_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -15,22 +15,22 @@ abstract class ChildClassFromClass implements ParentClass {
   childClassMethod();
 }
 // ChildClassFromClass "private" section, not exported.
-final _smoke_ChildClassFromClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ChildClassFromClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ChildClassFromClass_copy_handle');
-final _smoke_ChildClassFromClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ChildClassFromClass_copy_handle'));
+final _smoke_ChildClassFromClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ChildClassFromClass_release_handle');
-final _smoke_ChildClassFromClass_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ChildClassFromClass_release_handle'));
+final _smoke_ChildClassFromClass_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ChildClassFromClass_get_raw_pointer');
-final _smoke_ChildClassFromClass_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_ChildClassFromClass_get_raw_pointer'));
+final _smoke_ChildClassFromClass_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ChildClassFromClass_get_type_id');
+  >('library_smoke_ChildClassFromClass_get_type_id'));
 class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFromClass {
   ChildClassFromClass$Impl(Pointer<Void> handle) : super(handle);
   @override
@@ -42,7 +42,7 @@ class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFro
   }
   @override
   childClassMethod() {
-    final _childClassMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromClass_childClassMethod');
+    final _childClassMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromClass_childClassMethod'));
     final _handle = this.handle;
     final __result_handle = _childClassMethod_ffi(_handle, __lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -15,22 +15,22 @@ abstract class ChildClassFromInterface implements ParentInterface {
   childClassMethod();
 }
 // ChildClassFromInterface "private" section, not exported.
-final _smoke_ChildClassFromInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ChildClassFromInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ChildClassFromInterface_copy_handle');
-final _smoke_ChildClassFromInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ChildClassFromInterface_copy_handle'));
+final _smoke_ChildClassFromInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ChildClassFromInterface_release_handle');
-final _smoke_ChildClassFromInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ChildClassFromInterface_release_handle'));
+final _smoke_ChildClassFromInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ChildClassFromInterface_get_raw_pointer');
-final _smoke_ChildClassFromInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_ChildClassFromInterface_get_raw_pointer'));
+final _smoke_ChildClassFromInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ChildClassFromInterface_get_type_id');
+  >('library_smoke_ChildClassFromInterface_get_type_id'));
 class ChildClassFromInterface$Impl implements ChildClassFromInterface {
   @protected
   Pointer<Void> handle;
@@ -44,7 +44,7 @@ class ChildClassFromInterface$Impl implements ChildClassFromInterface {
   }
   @override
   childClassMethod() {
-    final _childClassMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_childClassMethod');
+    final _childClassMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_childClassMethod'));
     final _handle = this.handle;
     final __result_handle = _childClassMethod_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -55,7 +55,7 @@ class ChildClassFromInterface$Impl implements ChildClassFromInterface {
   }
   @override
   rootMethod() {
-    final _rootMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod');
+    final _rootMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
     final __result_handle = _rootMethod_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -66,7 +66,7 @@ class ChildClassFromInterface$Impl implements ChildClassFromInterface {
   }
   @override
   String get rootProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -77,7 +77,7 @@ class ChildClassFromInterface$Impl implements ChildClassFromInterface {
   }
   @override
   set rootProperty(String value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
     final _value_handle = String_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -27,26 +27,26 @@ abstract class ChildInterface implements ParentInterface {
   childMethod();
 }
 // ChildInterface "private" section, not exported.
-final _smoke_ChildInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ChildInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ChildInterface_copy_handle');
-final _smoke_ChildInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ChildInterface_copy_handle'));
+final _smoke_ChildInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ChildInterface_release_handle');
-final _smoke_ChildInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ChildInterface_release_handle'));
+final _smoke_ChildInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer)
-  >('library_smoke_ChildInterface_create_proxy');
-final _smoke_ChildInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ChildInterface_create_proxy'));
+final _smoke_ChildInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ChildInterface_get_raw_pointer');
-final _smoke_ChildInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_ChildInterface_get_raw_pointer'));
+final _smoke_ChildInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ChildInterface_get_type_id');
+  >('library_smoke_ChildInterface_get_type_id'));
 class ChildInterface$Lambdas extends ParentInterface$Lambdas implements ChildInterface {
   void Function() lambda_childMethod;
   ChildInterface$Lambdas(
@@ -78,7 +78,7 @@ class ChildInterface$Impl extends ParentInterface$Impl implements ChildInterface
   }
   @override
   childMethod() {
-    final _childMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildInterface_childMethod');
+    final _childMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildInterface_childMethod'));
     final _handle = this.handle;
     final __result_handle = _childMethod_ffi(_handle, __lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -16,22 +16,22 @@ abstract class ChildWithParentClassReferences implements ParentWithClassReferenc
   void release();
 }
 // ChildWithParentClassReferences "private" section, not exported.
-final _smoke_ChildWithParentClassReferences_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ChildWithParentClassReferences_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ChildWithParentClassReferences_copy_handle');
-final _smoke_ChildWithParentClassReferences_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ChildWithParentClassReferences_copy_handle'));
+final _smoke_ChildWithParentClassReferences_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ChildWithParentClassReferences_release_handle');
-final _smoke_ChildWithParentClassReferences_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ChildWithParentClassReferences_release_handle'));
+final _smoke_ChildWithParentClassReferences_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ChildWithParentClassReferences_get_raw_pointer');
-final _smoke_ChildWithParentClassReferences_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_ChildWithParentClassReferences_get_raw_pointer'));
+final _smoke_ChildWithParentClassReferences_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ChildWithParentClassReferences_get_type_id');
+  >('library_smoke_ChildWithParentClassReferences_get_type_id'));
 class ChildWithParentClassReferences$Impl implements ChildWithParentClassReferences {
   @protected
   Pointer<Void> handle;
@@ -45,7 +45,7 @@ class ChildWithParentClassReferences$Impl implements ChildWithParentClassReferen
   }
   @override
   ChildClassFromClass classFunction() {
-    final _classFunction_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classFunction');
+    final _classFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classFunction'));
     final _handle = this.handle;
     final __result_handle = _classFunction_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -56,7 +56,7 @@ class ChildWithParentClassReferences$Impl implements ChildWithParentClassReferen
   }
   @override
   ParentClass get classProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -67,7 +67,7 @@ class ChildWithParentClassReferences$Impl implements ChildWithParentClassReferen
   }
   @override
   set classProperty(ParentClass value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentWithClassReferences_classProperty_set__ParentClass');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentWithClassReferences_classProperty_set__ParentClass'));
     final _value_handle = smoke_ParentClass_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -14,22 +14,22 @@ abstract class ParentClass {
   rootMethod();
 }
 // ParentClass "private" section, not exported.
-final _smoke_ParentClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ParentClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ParentClass_copy_handle');
-final _smoke_ParentClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ParentClass_copy_handle'));
+final _smoke_ParentClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ParentClass_release_handle');
-final _smoke_ParentClass_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ParentClass_release_handle'));
+final _smoke_ParentClass_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ParentClass_get_raw_pointer');
-final _smoke_ParentClass_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_ParentClass_get_raw_pointer'));
+final _smoke_ParentClass_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ParentClass_get_type_id');
+  >('library_smoke_ParentClass_get_type_id'));
 class ParentClass$Impl implements ParentClass {
   @protected
   Pointer<Void> handle;
@@ -43,7 +43,7 @@ class ParentClass$Impl implements ParentClass {
   }
   @override
   rootMethod() {
-    final _rootMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentClass_rootMethod');
+    final _rootMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentClass_rootMethod'));
     final _handle = this.handle;
     final __result_handle = _rootMethod_ffi(_handle, __lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -26,26 +26,26 @@ abstract class ParentInterface {
   set rootProperty(String value);
 }
 // ParentInterface "private" section, not exported.
-final _smoke_ParentInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ParentInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ParentInterface_copy_handle');
-final _smoke_ParentInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ParentInterface_copy_handle'));
+final _smoke_ParentInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ParentInterface_release_handle');
-final _smoke_ParentInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ParentInterface_release_handle'));
+final _smoke_ParentInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer)
-  >('library_smoke_ParentInterface_create_proxy');
-final _smoke_ParentInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ParentInterface_create_proxy'));
+final _smoke_ParentInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ParentInterface_get_raw_pointer');
-final _smoke_ParentInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_ParentInterface_get_raw_pointer'));
+final _smoke_ParentInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ParentInterface_get_type_id');
+  >('library_smoke_ParentInterface_get_type_id'));
 class ParentInterface$Lambdas implements ParentInterface {
   void Function() lambda_rootMethod;
   String Function() lambda_rootProperty_get;
@@ -82,7 +82,7 @@ class ParentInterface$Impl implements ParentInterface {
   }
   @override
   rootMethod() {
-    final _rootMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod');
+    final _rootMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
     final __result_handle = _rootMethod_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -92,7 +92,7 @@ class ParentInterface$Impl implements ParentInterface {
     }
   }
   String get rootProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -102,7 +102,7 @@ class ParentInterface$Impl implements ParentInterface {
     }
   }
   set rootProperty(String value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
     final _value_handle = String_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
@@ -14,18 +14,18 @@ abstract class SimpleClass {
   SimpleClass useSimpleClass(SimpleClass input);
 }
 // SimpleClass "private" section, not exported.
-final _smoke_SimpleClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_SimpleClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SimpleClass_copy_handle');
-final _smoke_SimpleClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SimpleClass_copy_handle'));
+final _smoke_SimpleClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_SimpleClass_release_handle');
-final _smoke_SimpleClass_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SimpleClass_release_handle'));
+final _smoke_SimpleClass_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_SimpleClass_get_raw_pointer');
+    >('library_smoke_SimpleClass_get_raw_pointer'));
 class SimpleClass$Impl implements SimpleClass {
   @protected
   Pointer<Void> handle;
@@ -39,7 +39,7 @@ class SimpleClass$Impl implements SimpleClass {
   }
   @override
   String getStringValue() {
-    final _getStringValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SimpleClass_getStringValue');
+    final _getStringValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SimpleClass_getStringValue'));
     final _handle = this.handle;
     final __result_handle = _getStringValue_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -50,7 +50,7 @@ class SimpleClass$Impl implements SimpleClass {
   }
   @override
   SimpleClass useSimpleClass(SimpleClass input) {
-    final _useSimpleClass_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SimpleClass_useSimpleClass__SimpleClass');
+    final _useSimpleClass_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SimpleClass_useSimpleClass__SimpleClass'));
     final _input_handle = smoke_SimpleClass_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _useSimpleClass_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -23,26 +23,26 @@ abstract class SimpleInterface {
   SimpleInterface useSimpleInterface(SimpleInterface input);
 }
 // SimpleInterface "private" section, not exported.
-final _smoke_SimpleInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_SimpleInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SimpleInterface_copy_handle');
-final _smoke_SimpleInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SimpleInterface_copy_handle'));
+final _smoke_SimpleInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_SimpleInterface_release_handle');
-final _smoke_SimpleInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SimpleInterface_release_handle'));
+final _smoke_SimpleInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer)
-  >('library_smoke_SimpleInterface_create_proxy');
-final _smoke_SimpleInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SimpleInterface_create_proxy'));
+final _smoke_SimpleInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_SimpleInterface_get_raw_pointer');
-final _smoke_SimpleInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_SimpleInterface_get_raw_pointer'));
+final _smoke_SimpleInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SimpleInterface_get_type_id');
+  >('library_smoke_SimpleInterface_get_type_id'));
 class SimpleInterface$Lambdas implements SimpleInterface {
   String Function() lambda_getStringValue;
   SimpleInterface Function(SimpleInterface) lambda_useSimpleInterface;
@@ -75,7 +75,7 @@ class SimpleInterface$Impl implements SimpleInterface {
   }
   @override
   String getStringValue() {
-    final _getStringValue_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SimpleInterface_getStringValue');
+    final _getStringValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SimpleInterface_getStringValue'));
     final _handle = this.handle;
     final __result_handle = _getStringValue_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -86,7 +86,7 @@ class SimpleInterface$Impl implements SimpleInterface {
   }
   @override
   SimpleInterface useSimpleInterface(SimpleInterface input) {
-    final _useSimpleInterface_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SimpleInterface_useSimpleInterface__SimpleInterface');
+    final _useSimpleInterface_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SimpleInterface_useSimpleInterface__SimpleInterface'));
     final _input_handle = smoke_SimpleInterface_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _useSimpleInterface_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_class.dart
@@ -8,18 +8,18 @@ class StructWithClass {
   StructWithClass(this.classInstance);
 }
 // StructWithClass "private" section, not exported.
-final _smoke_StructWithClass_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithClass_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithClass_create_handle');
-final _smoke_StructWithClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithClass_create_handle'));
+final _smoke_StructWithClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructWithClass_release_handle');
-final _smoke_StructWithClass_get_field_classInstance = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithClass_release_handle'));
+final _smoke_StructWithClass_get_field_classInstance = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithClass_get_field_classInstance');
+  >('library_smoke_StructWithClass_get_field_classInstance'));
 Pointer<Void> smoke_StructWithClass_toFfi(StructWithClass value) {
   final _classInstance_handle = smoke_SimpleClass_toFfi(value.classInstance);
   final _result = _smoke_StructWithClass_create_handle(_classInstance_handle);
@@ -38,18 +38,18 @@ StructWithClass smoke_StructWithClass_fromFfi(Pointer<Void> handle) {
 }
 void smoke_StructWithClass_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithClass_release_handle(handle);
 // Nullable StructWithClass
-final _smoke_StructWithClass_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithClass_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithClass_create_handle_nullable');
-final _smoke_StructWithClass_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithClass_create_handle_nullable'));
+final _smoke_StructWithClass_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructWithClass_release_handle_nullable');
-final _smoke_StructWithClass_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithClass_release_handle_nullable'));
+final _smoke_StructWithClass_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithClass_get_value_nullable');
+  >('library_smoke_StructWithClass_get_value_nullable'));
 Pointer<Void> smoke_StructWithClass_toFfi_nullable(StructWithClass value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithClass_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_interface.dart
@@ -8,18 +8,18 @@ class StructWithInterface {
   StructWithInterface(this.interfaceInstance);
 }
 // StructWithInterface "private" section, not exported.
-final _smoke_StructWithInterface_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithInterface_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithInterface_create_handle');
-final _smoke_StructWithInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithInterface_create_handle'));
+final _smoke_StructWithInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructWithInterface_release_handle');
-final _smoke_StructWithInterface_get_field_interfaceInstance = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithInterface_release_handle'));
+final _smoke_StructWithInterface_get_field_interfaceInstance = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithInterface_get_field_interfaceInstance');
+  >('library_smoke_StructWithInterface_get_field_interfaceInstance'));
 Pointer<Void> smoke_StructWithInterface_toFfi(StructWithInterface value) {
   final _interfaceInstance_handle = smoke_SimpleInterface_toFfi(value.interfaceInstance);
   final _result = _smoke_StructWithInterface_create_handle(_interfaceInstance_handle);
@@ -38,18 +38,18 @@ StructWithInterface smoke_StructWithInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_StructWithInterface_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithInterface_release_handle(handle);
 // Nullable StructWithInterface
-final _smoke_StructWithInterface_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithInterface_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithInterface_create_handle_nullable');
-final _smoke_StructWithInterface_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithInterface_create_handle_nullable'));
+final _smoke_StructWithInterface_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructWithInterface_release_handle_nullable');
-final _smoke_StructWithInterface_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructWithInterface_release_handle_nullable'));
+final _smoke_StructWithInterface_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructWithInterface_get_value_nullable');
+  >('library_smoke_StructWithInterface_get_value_nullable'));
 Pointer<Void> smoke_StructWithInterface_toFfi_nullable(StructWithInterface value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithInterface_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -15,29 +15,29 @@ abstract class ClassWithInternalLambda {
 /// @nodoc
 typedef ClassWithInternalLambda_InternalLambda = bool Function(String);
 // ClassWithInternalLambda_InternalLambda "private" section, not exported.
-final _smoke_ClassWithInternalLambda_InternalLambda_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ClassWithInternalLambda_InternalLambda_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ClassWithInternalLambda_InternalLambda_copy_handle');
-final _smoke_ClassWithInternalLambda_InternalLambda_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ClassWithInternalLambda_InternalLambda_copy_handle'));
+final _smoke_ClassWithInternalLambda_InternalLambda_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ClassWithInternalLambda_InternalLambda_release_handle');
-final _smoke_ClassWithInternalLambda_InternalLambda_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ClassWithInternalLambda_InternalLambda_release_handle'));
+final _smoke_ClassWithInternalLambda_InternalLambda_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_ClassWithInternalLambda_InternalLambda_create_proxy');
-final _smoke_ClassWithInternalLambda_InternalLambda_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ClassWithInternalLambda_InternalLambda_create_proxy'));
+final _smoke_ClassWithInternalLambda_InternalLambda_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ClassWithInternalLambda_InternalLambda_get_raw_pointer');
+    >('library_smoke_ClassWithInternalLambda_InternalLambda_get_raw_pointer'));
 class ClassWithInternalLambda_InternalLambda$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   ClassWithInternalLambda_InternalLambda$Impl(this.handle);
   void release() => _smoke_ClassWithInternalLambda_InternalLambda_release_handle(handle);
   bool internal_call(String p0) {
-    final _call_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_InternalLambda_call__String');
+    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_InternalLambda_call__String'));
     final _p0_handle = String_toFfi(p0);
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
@@ -82,18 +82,18 @@ ClassWithInternalLambda_InternalLambda smoke_ClassWithInternalLambda_InternalLam
 void smoke_ClassWithInternalLambda_InternalLambda_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ClassWithInternalLambda_InternalLambda_release_handle(handle);
 // Nullable ClassWithInternalLambda_InternalLambda
-final _smoke_ClassWithInternalLambda_InternalLambda_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_ClassWithInternalLambda_InternalLambda_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ClassWithInternalLambda_InternalLambda_create_handle_nullable');
-final _smoke_ClassWithInternalLambda_InternalLambda_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ClassWithInternalLambda_InternalLambda_create_handle_nullable'));
+final _smoke_ClassWithInternalLambda_InternalLambda_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ClassWithInternalLambda_InternalLambda_release_handle_nullable');
-final _smoke_ClassWithInternalLambda_InternalLambda_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ClassWithInternalLambda_InternalLambda_release_handle_nullable'));
+final _smoke_ClassWithInternalLambda_InternalLambda_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ClassWithInternalLambda_InternalLambda_get_value_nullable');
+  >('library_smoke_ClassWithInternalLambda_InternalLambda_get_value_nullable'));
 Pointer<Void> smoke_ClassWithInternalLambda_InternalLambda_toFfi_nullable(ClassWithInternalLambda_InternalLambda value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ClassWithInternalLambda_InternalLambda_toFfi(value);
@@ -112,18 +112,18 @@ void smoke_ClassWithInternalLambda_InternalLambda_releaseFfiHandle_nullable(Poin
   _smoke_ClassWithInternalLambda_InternalLambda_release_handle_nullable(handle);
 // End of ClassWithInternalLambda_InternalLambda "private" section.
 // ClassWithInternalLambda "private" section, not exported.
-final _smoke_ClassWithInternalLambda_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ClassWithInternalLambda_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ClassWithInternalLambda_copy_handle');
-final _smoke_ClassWithInternalLambda_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ClassWithInternalLambda_copy_handle'));
+final _smoke_ClassWithInternalLambda_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ClassWithInternalLambda_release_handle');
-final _smoke_ClassWithInternalLambda_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ClassWithInternalLambda_release_handle'));
+final _smoke_ClassWithInternalLambda_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ClassWithInternalLambda_get_raw_pointer');
+    >('library_smoke_ClassWithInternalLambda_get_raw_pointer'));
 class ClassWithInternalLambda$Impl implements ClassWithInternalLambda {
   @protected
   Pointer<Void> handle;
@@ -136,7 +136,7 @@ class ClassWithInternalLambda$Impl implements ClassWithInternalLambda {
     handle = null;
   }
   static bool invokeInternalLambda(ClassWithInternalLambda_InternalLambda lambda, String value) {
-    final _invokeInternalLambda_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Pointer<Void>, Pointer<Void>), int Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_invokeInternalLambda__InternalLambda_String');
+    final _invokeInternalLambda_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Pointer<Void>, Pointer<Void>), int Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_invokeInternalLambda__InternalLambda_String'));
     final _lambda_handle = smoke_ClassWithInternalLambda_InternalLambda_toFfi(lambda);
     final _value_handle = String_toFfi(value);
     final __result_handle = _invokeInternalLambda_ffi(__lib.LibraryContext.isolateId, _lambda_handle, _value_handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -16,29 +16,29 @@ abstract class Lambdas {
 }
 typedef Lambdas_Producer = String Function();
 // Lambdas_Producer "private" section, not exported.
-final _smoke_Lambdas_Producer_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_Producer_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Producer_copy_handle');
-final _smoke_Lambdas_Producer_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Producer_copy_handle'));
+final _smoke_Lambdas_Producer_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Producer_release_handle');
-final _smoke_Lambdas_Producer_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Producer_release_handle'));
+final _smoke_Lambdas_Producer_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_Lambdas_Producer_create_proxy');
-final _smoke_Lambdas_Producer_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Producer_create_proxy'));
+final _smoke_Lambdas_Producer_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Lambdas_Producer_get_raw_pointer');
+    >('library_smoke_Lambdas_Producer_get_raw_pointer'));
 class Lambdas_Producer$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_Producer$Impl(this.handle);
   void release() => _smoke_Lambdas_Producer_release_handle(handle);
   String call() {
-    final _call_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Lambdas_Producer_call');
+    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Lambdas_Producer_call'));
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -80,18 +80,18 @@ Lambdas_Producer smoke_Lambdas_Producer_fromFfi(Pointer<Void> handle) {
 void smoke_Lambdas_Producer_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Lambdas_Producer_release_handle(handle);
 // Nullable Lambdas_Producer
-final _smoke_Lambdas_Producer_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_Producer_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Producer_create_handle_nullable');
-final _smoke_Lambdas_Producer_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Producer_create_handle_nullable'));
+final _smoke_Lambdas_Producer_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Producer_release_handle_nullable');
-final _smoke_Lambdas_Producer_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Producer_release_handle_nullable'));
+final _smoke_Lambdas_Producer_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Producer_get_value_nullable');
+  >('library_smoke_Lambdas_Producer_get_value_nullable'));
 Pointer<Void> smoke_Lambdas_Producer_toFfi_nullable(Lambdas_Producer value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_Producer_toFfi(value);
@@ -112,29 +112,29 @@ void smoke_Lambdas_Producer_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 /// Should confuse everyone thoroughly
 typedef Lambdas_Confuser = Lambdas_Producer Function(String);
 // Lambdas_Confuser "private" section, not exported.
-final _smoke_Lambdas_Confuser_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_Confuser_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Confuser_copy_handle');
-final _smoke_Lambdas_Confuser_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Confuser_copy_handle'));
+final _smoke_Lambdas_Confuser_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Confuser_release_handle');
-final _smoke_Lambdas_Confuser_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Confuser_release_handle'));
+final _smoke_Lambdas_Confuser_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_Lambdas_Confuser_create_proxy');
-final _smoke_Lambdas_Confuser_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Confuser_create_proxy'));
+final _smoke_Lambdas_Confuser_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Lambdas_Confuser_get_raw_pointer');
+    >('library_smoke_Lambdas_Confuser_get_raw_pointer'));
 class Lambdas_Confuser$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_Confuser$Impl(this.handle);
   void release() => _smoke_Lambdas_Confuser_release_handle(handle);
   Lambdas_Producer call(String p0) {
-    final _call_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_Confuser_call__String');
+    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_Confuser_call__String'));
     final _p0_handle = String_toFfi(p0);
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
@@ -179,18 +179,18 @@ Lambdas_Confuser smoke_Lambdas_Confuser_fromFfi(Pointer<Void> handle) {
 void smoke_Lambdas_Confuser_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Lambdas_Confuser_release_handle(handle);
 // Nullable Lambdas_Confuser
-final _smoke_Lambdas_Confuser_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_Confuser_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Confuser_create_handle_nullable');
-final _smoke_Lambdas_Confuser_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Confuser_create_handle_nullable'));
+final _smoke_Lambdas_Confuser_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Confuser_release_handle_nullable');
-final _smoke_Lambdas_Confuser_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Confuser_release_handle_nullable'));
+final _smoke_Lambdas_Confuser_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Confuser_get_value_nullable');
+  >('library_smoke_Lambdas_Confuser_get_value_nullable'));
 Pointer<Void> smoke_Lambdas_Confuser_toFfi_nullable(Lambdas_Confuser value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_Confuser_toFfi(value);
@@ -210,29 +210,29 @@ void smoke_Lambdas_Confuser_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 // End of Lambdas_Confuser "private" section.
 typedef Lambdas_Consumer = void Function(String);
 // Lambdas_Consumer "private" section, not exported.
-final _smoke_Lambdas_Consumer_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_Consumer_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Consumer_copy_handle');
-final _smoke_Lambdas_Consumer_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Consumer_copy_handle'));
+final _smoke_Lambdas_Consumer_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Consumer_release_handle');
-final _smoke_Lambdas_Consumer_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Consumer_release_handle'));
+final _smoke_Lambdas_Consumer_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_Lambdas_Consumer_create_proxy');
-final _smoke_Lambdas_Consumer_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Consumer_create_proxy'));
+final _smoke_Lambdas_Consumer_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Lambdas_Consumer_get_raw_pointer');
+    >('library_smoke_Lambdas_Consumer_get_raw_pointer'));
 class Lambdas_Consumer$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_Consumer$Impl(this.handle);
   void release() => _smoke_Lambdas_Consumer_release_handle(handle);
   call(String p0) {
-    final _call_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_Consumer_call__String');
+    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_Consumer_call__String'));
     final _p0_handle = String_toFfi(p0);
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
@@ -275,18 +275,18 @@ Lambdas_Consumer smoke_Lambdas_Consumer_fromFfi(Pointer<Void> handle) {
 void smoke_Lambdas_Consumer_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Lambdas_Consumer_release_handle(handle);
 // Nullable Lambdas_Consumer
-final _smoke_Lambdas_Consumer_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_Consumer_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Consumer_create_handle_nullable');
-final _smoke_Lambdas_Consumer_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Consumer_create_handle_nullable'));
+final _smoke_Lambdas_Consumer_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Consumer_release_handle_nullable');
-final _smoke_Lambdas_Consumer_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Consumer_release_handle_nullable'));
+final _smoke_Lambdas_Consumer_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Consumer_get_value_nullable');
+  >('library_smoke_Lambdas_Consumer_get_value_nullable'));
 Pointer<Void> smoke_Lambdas_Consumer_toFfi_nullable(Lambdas_Consumer value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_Consumer_toFfi(value);
@@ -306,29 +306,29 @@ void smoke_Lambdas_Consumer_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 // End of Lambdas_Consumer "private" section.
 typedef Lambdas_Indexer = int Function(String, double);
 // Lambdas_Indexer "private" section, not exported.
-final _smoke_Lambdas_Indexer_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_Indexer_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Indexer_copy_handle');
-final _smoke_Lambdas_Indexer_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Indexer_copy_handle'));
+final _smoke_Lambdas_Indexer_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Indexer_release_handle');
-final _smoke_Lambdas_Indexer_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Indexer_release_handle'));
+final _smoke_Lambdas_Indexer_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_Lambdas_Indexer_create_proxy');
-final _smoke_Lambdas_Indexer_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Indexer_create_proxy'));
+final _smoke_Lambdas_Indexer_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Lambdas_Indexer_get_raw_pointer');
+    >('library_smoke_Lambdas_Indexer_get_raw_pointer'));
 class Lambdas_Indexer$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_Indexer$Impl(this.handle);
   void release() => _smoke_Lambdas_Indexer_release_handle(handle);
   int call(String p0, double p1) {
-    final _call_ffi = __lib.nativeLibrary.lookupFunction<Int32 Function(Pointer<Void>, Int32, Pointer<Void>, Float), int Function(Pointer<Void>, int, Pointer<Void>, double)>('library_smoke_Lambdas_Indexer_call__String_Float');
+    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Pointer<Void>, Int32, Pointer<Void>, Float), int Function(Pointer<Void>, int, Pointer<Void>, double)>('library_smoke_Lambdas_Indexer_call__String_Float'));
     final _p0_handle = String_toFfi(p0);
     final _p1_handle = (p1);
     final _handle = this.handle;
@@ -376,18 +376,18 @@ Lambdas_Indexer smoke_Lambdas_Indexer_fromFfi(Pointer<Void> handle) {
 void smoke_Lambdas_Indexer_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Lambdas_Indexer_release_handle(handle);
 // Nullable Lambdas_Indexer
-final _smoke_Lambdas_Indexer_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_Indexer_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Indexer_create_handle_nullable');
-final _smoke_Lambdas_Indexer_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Indexer_create_handle_nullable'));
+final _smoke_Lambdas_Indexer_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Indexer_release_handle_nullable');
-final _smoke_Lambdas_Indexer_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_Indexer_release_handle_nullable'));
+final _smoke_Lambdas_Indexer_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_Indexer_get_value_nullable');
+  >('library_smoke_Lambdas_Indexer_get_value_nullable'));
 Pointer<Void> smoke_Lambdas_Indexer_toFfi_nullable(Lambdas_Indexer value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_Indexer_toFfi(value);
@@ -407,29 +407,29 @@ void smoke_Lambdas_Indexer_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 // End of Lambdas_Indexer "private" section.
 typedef Lambdas_NullableConfuser = Lambdas_Producer Function(String);
 // Lambdas_NullableConfuser "private" section, not exported.
-final _smoke_Lambdas_NullableConfuser_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_NullableConfuser_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_NullableConfuser_copy_handle');
-final _smoke_Lambdas_NullableConfuser_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_NullableConfuser_copy_handle'));
+final _smoke_Lambdas_NullableConfuser_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Lambdas_NullableConfuser_release_handle');
-final _smoke_Lambdas_NullableConfuser_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_NullableConfuser_release_handle'));
+final _smoke_Lambdas_NullableConfuser_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_Lambdas_NullableConfuser_create_proxy');
-final _smoke_Lambdas_NullableConfuser_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_NullableConfuser_create_proxy'));
+final _smoke_Lambdas_NullableConfuser_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Lambdas_NullableConfuser_get_raw_pointer');
+    >('library_smoke_Lambdas_NullableConfuser_get_raw_pointer'));
 class Lambdas_NullableConfuser$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_NullableConfuser$Impl(this.handle);
   void release() => _smoke_Lambdas_NullableConfuser_release_handle(handle);
   Lambdas_Producer call(String p0) {
-    final _call_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_NullableConfuser_call__String');
+    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_NullableConfuser_call__String'));
     final _p0_handle = String_toFfi_nullable(p0);
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
@@ -474,18 +474,18 @@ Lambdas_NullableConfuser smoke_Lambdas_NullableConfuser_fromFfi(Pointer<Void> ha
 void smoke_Lambdas_NullableConfuser_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Lambdas_NullableConfuser_release_handle(handle);
 // Nullable Lambdas_NullableConfuser
-final _smoke_Lambdas_NullableConfuser_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_NullableConfuser_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_NullableConfuser_create_handle_nullable');
-final _smoke_Lambdas_NullableConfuser_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_NullableConfuser_create_handle_nullable'));
+final _smoke_Lambdas_NullableConfuser_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Lambdas_NullableConfuser_release_handle_nullable');
-final _smoke_Lambdas_NullableConfuser_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_NullableConfuser_release_handle_nullable'));
+final _smoke_Lambdas_NullableConfuser_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_NullableConfuser_get_value_nullable');
+  >('library_smoke_Lambdas_NullableConfuser_get_value_nullable'));
 Pointer<Void> smoke_Lambdas_NullableConfuser_toFfi_nullable(Lambdas_NullableConfuser value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_NullableConfuser_toFfi(value);
@@ -504,18 +504,18 @@ void smoke_Lambdas_NullableConfuser_releaseFfiHandle_nullable(Pointer<Void> hand
   _smoke_Lambdas_NullableConfuser_release_handle_nullable(handle);
 // End of Lambdas_NullableConfuser "private" section.
 // Lambdas "private" section, not exported.
-final _smoke_Lambdas_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Lambdas_copy_handle');
-final _smoke_Lambdas_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_copy_handle'));
+final _smoke_Lambdas_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Lambdas_release_handle');
-final _smoke_Lambdas_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Lambdas_release_handle'));
+final _smoke_Lambdas_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Lambdas_get_raw_pointer');
+    >('library_smoke_Lambdas_get_raw_pointer'));
 class Lambdas$Impl implements Lambdas {
   @protected
   Pointer<Void> handle;
@@ -529,7 +529,7 @@ class Lambdas$Impl implements Lambdas {
   }
   @override
   Lambdas_Producer deconfuse(String value, Lambdas_Confuser confuser) {
-    final _deconfuse_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_deconfuse__String_Confuser');
+    final _deconfuse_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_deconfuse__String_Confuser'));
     final _value_handle = String_toFfi(value);
     final _confuser_handle = smoke_Lambdas_Confuser_toFfi(confuser);
     final _handle = this.handle;
@@ -543,7 +543,7 @@ class Lambdas$Impl implements Lambdas {
     }
   }
   static Map<int, String> fuse(List<String> items, Lambdas_Indexer callback) {
-    final _fuse_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_fuse__ListOf_1String_Indexer');
+    final _fuse_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_fuse__ListOf_1String_Indexer'));
     final _items_handle = ListOf_String_toFfi(items);
     final _callback_handle = smoke_Lambdas_Indexer_toFfi(callback);
     final __result_handle = _fuse_ffi(__lib.LibraryContext.isolateId, _items_handle, _callback_handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -17,29 +17,29 @@ abstract class LambdasWithStructuredTypes {
 }
 typedef LambdasWithStructuredTypes_ClassCallback = void Function(LambdasInterface);
 // LambdasWithStructuredTypes_ClassCallback "private" section, not exported.
-final _smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle');
-final _smoke_LambdasWithStructuredTypes_ClassCallback_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle'));
+final _smoke_LambdasWithStructuredTypes_ClassCallback_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_ClassCallback_release_handle');
-final _smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LambdasWithStructuredTypes_ClassCallback_release_handle'));
+final _smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy');
-final _smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy'));
+final _smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer');
+    >('library_smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer'));
 class LambdasWithStructuredTypes_ClassCallback$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   LambdasWithStructuredTypes_ClassCallback$Impl(this.handle);
   void release() => _smoke_LambdasWithStructuredTypes_ClassCallback_release_handle(handle);
   call(LambdasInterface p0) {
-    final _call_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_ClassCallback_call__LambdasInterface');
+    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_ClassCallback_call__LambdasInterface'));
     final _p0_handle = smoke_LambdasInterface_toFfi(p0);
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
@@ -82,18 +82,18 @@ LambdasWithStructuredTypes_ClassCallback smoke_LambdasWithStructuredTypes_ClassC
 void smoke_LambdasWithStructuredTypes_ClassCallback_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_LambdasWithStructuredTypes_ClassCallback_release_handle(handle);
 // Nullable LambdasWithStructuredTypes_ClassCallback
-final _smoke_LambdasWithStructuredTypes_ClassCallback_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_LambdasWithStructuredTypes_ClassCallback_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_ClassCallback_create_handle_nullable');
-final _smoke_LambdasWithStructuredTypes_ClassCallback_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LambdasWithStructuredTypes_ClassCallback_create_handle_nullable'));
+final _smoke_LambdasWithStructuredTypes_ClassCallback_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_ClassCallback_release_handle_nullable');
-final _smoke_LambdasWithStructuredTypes_ClassCallback_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LambdasWithStructuredTypes_ClassCallback_release_handle_nullable'));
+final _smoke_LambdasWithStructuredTypes_ClassCallback_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_ClassCallback_get_value_nullable');
+  >('library_smoke_LambdasWithStructuredTypes_ClassCallback_get_value_nullable'));
 Pointer<Void> smoke_LambdasWithStructuredTypes_ClassCallback_toFfi_nullable(LambdasWithStructuredTypes_ClassCallback value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(value);
@@ -113,29 +113,29 @@ void smoke_LambdasWithStructuredTypes_ClassCallback_releaseFfiHandle_nullable(Po
 // End of LambdasWithStructuredTypes_ClassCallback "private" section.
 typedef LambdasWithStructuredTypes_StructCallback = void Function(LambdasDeclarationOrder_SomeStruct);
 // LambdasWithStructuredTypes_StructCallback "private" section, not exported.
-final _smoke_LambdasWithStructuredTypes_StructCallback_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_LambdasWithStructuredTypes_StructCallback_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_StructCallback_copy_handle');
-final _smoke_LambdasWithStructuredTypes_StructCallback_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LambdasWithStructuredTypes_StructCallback_copy_handle'));
+final _smoke_LambdasWithStructuredTypes_StructCallback_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_StructCallback_release_handle');
-final _smoke_LambdasWithStructuredTypes_StructCallback_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LambdasWithStructuredTypes_StructCallback_release_handle'));
+final _smoke_LambdasWithStructuredTypes_StructCallback_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_LambdasWithStructuredTypes_StructCallback_create_proxy');
-final _smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LambdasWithStructuredTypes_StructCallback_create_proxy'));
+final _smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer');
+    >('library_smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer'));
 class LambdasWithStructuredTypes_StructCallback$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   LambdasWithStructuredTypes_StructCallback$Impl(this.handle);
   void release() => _smoke_LambdasWithStructuredTypes_StructCallback_release_handle(handle);
   call(LambdasDeclarationOrder_SomeStruct p0) {
-    final _call_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_StructCallback_call__SomeStruct');
+    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_StructCallback_call__SomeStruct'));
     final _p0_handle = smoke_LambdasDeclarationOrder_SomeStruct_toFfi(p0);
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
@@ -178,18 +178,18 @@ LambdasWithStructuredTypes_StructCallback smoke_LambdasWithStructuredTypes_Struc
 void smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_LambdasWithStructuredTypes_StructCallback_release_handle(handle);
 // Nullable LambdasWithStructuredTypes_StructCallback
-final _smoke_LambdasWithStructuredTypes_StructCallback_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_LambdasWithStructuredTypes_StructCallback_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_StructCallback_create_handle_nullable');
-final _smoke_LambdasWithStructuredTypes_StructCallback_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LambdasWithStructuredTypes_StructCallback_create_handle_nullable'));
+final _smoke_LambdasWithStructuredTypes_StructCallback_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_StructCallback_release_handle_nullable');
-final _smoke_LambdasWithStructuredTypes_StructCallback_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LambdasWithStructuredTypes_StructCallback_release_handle_nullable'));
+final _smoke_LambdasWithStructuredTypes_StructCallback_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_StructCallback_get_value_nullable');
+  >('library_smoke_LambdasWithStructuredTypes_StructCallback_get_value_nullable'));
 Pointer<Void> smoke_LambdasWithStructuredTypes_StructCallback_toFfi_nullable(LambdasWithStructuredTypes_StructCallback value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_LambdasWithStructuredTypes_StructCallback_toFfi(value);
@@ -208,18 +208,18 @@ void smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle_nullable(P
   _smoke_LambdasWithStructuredTypes_StructCallback_release_handle_nullable(handle);
 // End of LambdasWithStructuredTypes_StructCallback "private" section.
 // LambdasWithStructuredTypes "private" section, not exported.
-final _smoke_LambdasWithStructuredTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_LambdasWithStructuredTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_copy_handle');
-final _smoke_LambdasWithStructuredTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LambdasWithStructuredTypes_copy_handle'));
+final _smoke_LambdasWithStructuredTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_LambdasWithStructuredTypes_release_handle');
-final _smoke_LambdasWithStructuredTypes_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LambdasWithStructuredTypes_release_handle'));
+final _smoke_LambdasWithStructuredTypes_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_LambdasWithStructuredTypes_get_raw_pointer');
+    >('library_smoke_LambdasWithStructuredTypes_get_raw_pointer'));
 class LambdasWithStructuredTypes$Impl implements LambdasWithStructuredTypes {
   @protected
   Pointer<Void> handle;
@@ -233,7 +233,7 @@ class LambdasWithStructuredTypes$Impl implements LambdasWithStructuredTypes {
   }
   @override
   doClassStuff(LambdasWithStructuredTypes_ClassCallback callback) {
-    final _doClassStuff_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doClassStuff__ClassCallback');
+    final _doClassStuff_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doClassStuff__ClassCallback'));
     final _callback_handle = smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(callback);
     final _handle = this.handle;
     final __result_handle = _doClassStuff_ffi(_handle, __lib.LibraryContext.isolateId, _callback_handle);
@@ -246,7 +246,7 @@ class LambdasWithStructuredTypes$Impl implements LambdasWithStructuredTypes {
   }
   @override
   doStructStuff(LambdasWithStructuredTypes_StructCallback callback) {
-    final _doStructStuff_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doStructStuff__StructCallback');
+    final _doStructStuff_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doStructStuff__StructCallback'));
     final _callback_handle = smoke_LambdasWithStructuredTypes_StructCallback_toFfi(callback);
     final _handle = this.handle;
     final __result_handle = _doStructStuff_ffi(_handle, __lib.LibraryContext.isolateId, _callback_handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
@@ -6,29 +6,29 @@ import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 typedef StandaloneProducer = String Function();
 // StandaloneProducer "private" section, not exported.
-final _smoke_StandaloneProducer_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_StandaloneProducer_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StandaloneProducer_copy_handle');
-final _smoke_StandaloneProducer_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StandaloneProducer_copy_handle'));
+final _smoke_StandaloneProducer_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StandaloneProducer_release_handle');
-final _smoke_StandaloneProducer_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StandaloneProducer_release_handle'));
+final _smoke_StandaloneProducer_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_StandaloneProducer_create_proxy');
-final _smoke_StandaloneProducer_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StandaloneProducer_create_proxy'));
+final _smoke_StandaloneProducer_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_StandaloneProducer_get_raw_pointer');
+    >('library_smoke_StandaloneProducer_get_raw_pointer'));
 class StandaloneProducer$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   StandaloneProducer$Impl(this.handle);
   void release() => _smoke_StandaloneProducer_release_handle(handle);
   String call() {
-    final _call_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_StandaloneProducer_call');
+    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_StandaloneProducer_call'));
     final _handle = this.handle;
     final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -70,18 +70,18 @@ StandaloneProducer smoke_StandaloneProducer_fromFfi(Pointer<Void> handle) {
 void smoke_StandaloneProducer_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_StandaloneProducer_release_handle(handle);
 // Nullable StandaloneProducer
-final _smoke_StandaloneProducer_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_StandaloneProducer_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StandaloneProducer_create_handle_nullable');
-final _smoke_StandaloneProducer_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StandaloneProducer_create_handle_nullable'));
+final _smoke_StandaloneProducer_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StandaloneProducer_release_handle_nullable');
-final _smoke_StandaloneProducer_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StandaloneProducer_release_handle_nullable'));
+final _smoke_StandaloneProducer_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StandaloneProducer_get_value_nullable');
+  >('library_smoke_StandaloneProducer_get_value_nullable'));
 Pointer<Void> smoke_StandaloneProducer_toFfi_nullable(StandaloneProducer value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StandaloneProducer_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -41,18 +41,18 @@ class CalculatorListener_ResultStruct {
   CalculatorListener_ResultStruct(this.result);
 }
 // CalculatorListener_ResultStruct "private" section, not exported.
-final _smoke_CalculatorListener_ResultStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_CalculatorListener_ResultStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
-  >('library_smoke_CalculatorListener_ResultStruct_create_handle');
-final _smoke_CalculatorListener_ResultStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CalculatorListener_ResultStruct_create_handle'));
+final _smoke_CalculatorListener_ResultStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CalculatorListener_ResultStruct_release_handle');
-final _smoke_CalculatorListener_ResultStruct_get_field_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CalculatorListener_ResultStruct_release_handle'));
+final _smoke_CalculatorListener_ResultStruct_get_field_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_CalculatorListener_ResultStruct_get_field_result');
+  >('library_smoke_CalculatorListener_ResultStruct_get_field_result'));
 Pointer<Void> smoke_CalculatorListener_ResultStruct_toFfi(CalculatorListener_ResultStruct value) {
   final _result_handle = (value.result);
   final _result = _smoke_CalculatorListener_ResultStruct_create_handle(_result_handle);
@@ -71,18 +71,18 @@ CalculatorListener_ResultStruct smoke_CalculatorListener_ResultStruct_fromFfi(Po
 }
 void smoke_CalculatorListener_ResultStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_CalculatorListener_ResultStruct_release_handle(handle);
 // Nullable CalculatorListener_ResultStruct
-final _smoke_CalculatorListener_ResultStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_CalculatorListener_ResultStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CalculatorListener_ResultStruct_create_handle_nullable');
-final _smoke_CalculatorListener_ResultStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CalculatorListener_ResultStruct_create_handle_nullable'));
+final _smoke_CalculatorListener_ResultStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CalculatorListener_ResultStruct_release_handle_nullable');
-final _smoke_CalculatorListener_ResultStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CalculatorListener_ResultStruct_release_handle_nullable'));
+final _smoke_CalculatorListener_ResultStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CalculatorListener_ResultStruct_get_value_nullable');
+  >('library_smoke_CalculatorListener_ResultStruct_get_value_nullable'));
 Pointer<Void> smoke_CalculatorListener_ResultStruct_toFfi_nullable(CalculatorListener_ResultStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CalculatorListener_ResultStruct_toFfi(value);
@@ -101,26 +101,26 @@ void smoke_CalculatorListener_ResultStruct_releaseFfiHandle_nullable(Pointer<Voi
   _smoke_CalculatorListener_ResultStruct_release_handle_nullable(handle);
 // End of CalculatorListener_ResultStruct "private" section.
 // CalculatorListener "private" section, not exported.
-final _smoke_CalculatorListener_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_CalculatorListener_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CalculatorListener_copy_handle');
-final _smoke_CalculatorListener_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CalculatorListener_copy_handle'));
+final _smoke_CalculatorListener_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CalculatorListener_release_handle');
-final _smoke_CalculatorListener_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CalculatorListener_release_handle'));
+final _smoke_CalculatorListener_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
-  >('library_smoke_CalculatorListener_create_proxy');
-final _smoke_CalculatorListener_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CalculatorListener_create_proxy'));
+final _smoke_CalculatorListener_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_CalculatorListener_get_raw_pointer');
-final _smoke_CalculatorListener_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_CalculatorListener_get_raw_pointer'));
+final _smoke_CalculatorListener_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CalculatorListener_get_type_id');
+  >('library_smoke_CalculatorListener_get_type_id'));
 class CalculatorListener$Lambdas implements CalculatorListener {
   void Function(double) lambda_onCalculationResult;
   void Function(double) lambda_onCalculationResultConst;
@@ -177,7 +177,7 @@ class CalculatorListener$Impl implements CalculatorListener {
   }
   @override
   onCalculationResult(double calculationResult) {
-    final _onCalculationResult_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResult__Double');
+    final _onCalculationResult_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResult__Double'));
     final _calculationResult_handle = (calculationResult);
     final _handle = this.handle;
     final __result_handle = _onCalculationResult_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
@@ -190,7 +190,7 @@ class CalculatorListener$Impl implements CalculatorListener {
   }
   @override
   onCalculationResultConst(double calculationResult) {
-    final _onCalculationResultConst_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResultConst__Double');
+    final _onCalculationResultConst_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResultConst__Double'));
     final _calculationResult_handle = (calculationResult);
     final _handle = this.handle;
     final __result_handle = _onCalculationResultConst_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
@@ -203,7 +203,7 @@ class CalculatorListener$Impl implements CalculatorListener {
   }
   @override
   onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult) {
-    final _onCalculationResultStruct_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultStruct__ResultStruct');
+    final _onCalculationResultStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultStruct__ResultStruct'));
     final _calculationResult_handle = smoke_CalculatorListener_ResultStruct_toFfi(calculationResult);
     final _handle = this.handle;
     final __result_handle = _onCalculationResultStruct_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
@@ -216,7 +216,7 @@ class CalculatorListener$Impl implements CalculatorListener {
   }
   @override
   onCalculationResultArray(List<double> calculationResult) {
-    final _onCalculationResultArray_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultArray__ListOf_1Double');
+    final _onCalculationResultArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultArray__ListOf_1Double'));
     final _calculationResult_handle = ListOf_Double_toFfi(calculationResult);
     final _handle = this.handle;
     final __result_handle = _onCalculationResultArray_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
@@ -229,7 +229,7 @@ class CalculatorListener$Impl implements CalculatorListener {
   }
   @override
   onCalculationResultMap(Map<String, double> calculationResults) {
-    final _onCalculationResultMap_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultMap__MapOf_1String_1to_1Double');
+    final _onCalculationResultMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultMap__MapOf_1String_1to_1Double'));
     final _calculationResults_handle = MapOf_String_to_Double_toFfi(calculationResults);
     final _handle = this.handle;
     final __result_handle = _onCalculationResultMap_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResults_handle);
@@ -242,7 +242,7 @@ class CalculatorListener$Impl implements CalculatorListener {
   }
   @override
   onCalculationResultInstance(CalculationResult calculationResult) {
-    final _onCalculationResultInstance_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultInstance__CalculationResult');
+    final _onCalculationResultInstance_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultInstance__CalculationResult'));
     final _calculationResult_handle = smoke_CalculationResult_toFfi(calculationResult);
     final _handle = this.handle;
     final __result_handle = _onCalculationResultInstance_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -91,18 +91,18 @@ ListenerWithProperties_ResultEnum smoke_ListenerWithProperties_ResultEnum_fromFf
   }
 }
 void smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(int handle) {}
-final _smoke_ListenerWithProperties_ResultEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenerWithProperties_ResultEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_ListenerWithProperties_ResultEnum_create_handle_nullable');
-final _smoke_ListenerWithProperties_ResultEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenerWithProperties_ResultEnum_create_handle_nullable'));
+final _smoke_ListenerWithProperties_ResultEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ListenerWithProperties_ResultEnum_release_handle_nullable');
-final _smoke_ListenerWithProperties_ResultEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenerWithProperties_ResultEnum_release_handle_nullable'));
+final _smoke_ListenerWithProperties_ResultEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ListenerWithProperties_ResultEnum_get_value_nullable');
+  >('library_smoke_ListenerWithProperties_ResultEnum_get_value_nullable'));
 Pointer<Void> smoke_ListenerWithProperties_ResultEnum_toFfi_nullable(ListenerWithProperties_ResultEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ListenerWithProperties_ResultEnum_toFfi(value);
@@ -125,18 +125,18 @@ class ListenerWithProperties_ResultStruct {
   ListenerWithProperties_ResultStruct(this.result);
 }
 // ListenerWithProperties_ResultStruct "private" section, not exported.
-final _smoke_ListenerWithProperties_ResultStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenerWithProperties_ResultStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
-  >('library_smoke_ListenerWithProperties_ResultStruct_create_handle');
-final _smoke_ListenerWithProperties_ResultStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenerWithProperties_ResultStruct_create_handle'));
+final _smoke_ListenerWithProperties_ResultStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ListenerWithProperties_ResultStruct_release_handle');
-final _smoke_ListenerWithProperties_ResultStruct_get_field_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenerWithProperties_ResultStruct_release_handle'));
+final _smoke_ListenerWithProperties_ResultStruct_get_field_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_ListenerWithProperties_ResultStruct_get_field_result');
+  >('library_smoke_ListenerWithProperties_ResultStruct_get_field_result'));
 Pointer<Void> smoke_ListenerWithProperties_ResultStruct_toFfi(ListenerWithProperties_ResultStruct value) {
   final _result_handle = (value.result);
   final _result = _smoke_ListenerWithProperties_ResultStruct_create_handle(_result_handle);
@@ -155,18 +155,18 @@ ListenerWithProperties_ResultStruct smoke_ListenerWithProperties_ResultStruct_fr
 }
 void smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ListenerWithProperties_ResultStruct_release_handle(handle);
 // Nullable ListenerWithProperties_ResultStruct
-final _smoke_ListenerWithProperties_ResultStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenerWithProperties_ResultStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ListenerWithProperties_ResultStruct_create_handle_nullable');
-final _smoke_ListenerWithProperties_ResultStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenerWithProperties_ResultStruct_create_handle_nullable'));
+final _smoke_ListenerWithProperties_ResultStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ListenerWithProperties_ResultStruct_release_handle_nullable');
-final _smoke_ListenerWithProperties_ResultStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenerWithProperties_ResultStruct_release_handle_nullable'));
+final _smoke_ListenerWithProperties_ResultStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ListenerWithProperties_ResultStruct_get_value_nullable');
+  >('library_smoke_ListenerWithProperties_ResultStruct_get_value_nullable'));
 Pointer<Void> smoke_ListenerWithProperties_ResultStruct_toFfi_nullable(ListenerWithProperties_ResultStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ListenerWithProperties_ResultStruct_toFfi(value);
@@ -185,26 +185,26 @@ void smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle_nullable(Pointer
   _smoke_ListenerWithProperties_ResultStruct_release_handle_nullable(handle);
 // End of ListenerWithProperties_ResultStruct "private" section.
 // ListenerWithProperties "private" section, not exported.
-final _smoke_ListenerWithProperties_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenerWithProperties_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ListenerWithProperties_copy_handle');
-final _smoke_ListenerWithProperties_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenerWithProperties_copy_handle'));
+final _smoke_ListenerWithProperties_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ListenerWithProperties_release_handle');
-final _smoke_ListenerWithProperties_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenerWithProperties_release_handle'));
+final _smoke_ListenerWithProperties_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
-  >('library_smoke_ListenerWithProperties_create_proxy');
-final _smoke_ListenerWithProperties_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenerWithProperties_create_proxy'));
+final _smoke_ListenerWithProperties_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ListenerWithProperties_get_raw_pointer');
-final _smoke_ListenerWithProperties_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_ListenerWithProperties_get_raw_pointer'));
+final _smoke_ListenerWithProperties_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ListenerWithProperties_get_type_id');
+  >('library_smoke_ListenerWithProperties_get_type_id'));
 class ListenerWithProperties$Lambdas implements ListenerWithProperties {
   String Function() lambda_message_get;
   void Function(String) lambda_message_set;
@@ -294,7 +294,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     handle = null;
   }
   String get message {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_message_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_message_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -304,7 +304,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   set message(String value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_message_set__String');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_message_set__String'));
     final _value_handle = String_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -316,7 +316,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   CalculationResult get packedMessage {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_packedMessage_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_packedMessage_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -326,7 +326,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   set packedMessage(CalculationResult value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_packedMessage_set__CalculationResult');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_packedMessage_set__CalculationResult'));
     final _value_handle = smoke_CalculationResult_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -338,7 +338,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   ListenerWithProperties_ResultStruct get structuredMessage {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_structuredMessage_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_structuredMessage_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -348,7 +348,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   set structuredMessage(ListenerWithProperties_ResultStruct value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_structuredMessage_set__ResultStruct');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_structuredMessage_set__ResultStruct'));
     final _value_handle = smoke_ListenerWithProperties_ResultStruct_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -360,7 +360,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   ListenerWithProperties_ResultEnum get enumeratedMessage {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -370,7 +370,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   set enumeratedMessage(ListenerWithProperties_ResultEnum value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_set__ResultEnum');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_set__ResultEnum'));
     final _value_handle = smoke_ListenerWithProperties_ResultEnum_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -382,7 +382,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   List<String> get arrayedMessage {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_arrayedMessage_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_arrayedMessage_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -392,7 +392,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   set arrayedMessage(List<String> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_arrayedMessage_set__ListOf_1String');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_arrayedMessage_set__ListOf_1String'));
     final _value_handle = ListOf_String_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -404,7 +404,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   Map<String, double> get mappedMessage {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_mappedMessage_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_mappedMessage_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -414,7 +414,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   set mappedMessage(Map<String, double> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_mappedMessage_set__MapOf_1String_1to_1Double');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_mappedMessage_set__MapOf_1String_1to_1Double'));
     final _value_handle = MapOf_String_to_Double_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -426,7 +426,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   Uint8List get bufferedMessage {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_bufferedMessage_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_bufferedMessage_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -436,7 +436,7 @@ class ListenerWithProperties$Impl implements ListenerWithProperties {
     }
   }
   set bufferedMessage(Uint8List value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_bufferedMessage_set__Blob');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_bufferedMessage_set__Blob'));
     final _value_handle = Blob_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -69,18 +69,18 @@ ListenersWithReturnValues_ResultEnum smoke_ListenersWithReturnValues_ResultEnum_
   }
 }
 void smoke_ListenersWithReturnValues_ResultEnum_releaseFfiHandle(int handle) {}
-final _smoke_ListenersWithReturnValues_ResultEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenersWithReturnValues_ResultEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_ListenersWithReturnValues_ResultEnum_create_handle_nullable');
-final _smoke_ListenersWithReturnValues_ResultEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenersWithReturnValues_ResultEnum_create_handle_nullable'));
+final _smoke_ListenersWithReturnValues_ResultEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ListenersWithReturnValues_ResultEnum_release_handle_nullable');
-final _smoke_ListenersWithReturnValues_ResultEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenersWithReturnValues_ResultEnum_release_handle_nullable'));
+final _smoke_ListenersWithReturnValues_ResultEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_ListenersWithReturnValues_ResultEnum_get_value_nullable');
+  >('library_smoke_ListenersWithReturnValues_ResultEnum_get_value_nullable'));
 Pointer<Void> smoke_ListenersWithReturnValues_ResultEnum_toFfi_nullable(ListenersWithReturnValues_ResultEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ListenersWithReturnValues_ResultEnum_toFfi(value);
@@ -103,18 +103,18 @@ class ListenersWithReturnValues_ResultStruct {
   ListenersWithReturnValues_ResultStruct(this.result);
 }
 // ListenersWithReturnValues_ResultStruct "private" section, not exported.
-final _smoke_ListenersWithReturnValues_ResultStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenersWithReturnValues_ResultStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
-  >('library_smoke_ListenersWithReturnValues_ResultStruct_create_handle');
-final _smoke_ListenersWithReturnValues_ResultStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenersWithReturnValues_ResultStruct_create_handle'));
+final _smoke_ListenersWithReturnValues_ResultStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ListenersWithReturnValues_ResultStruct_release_handle');
-final _smoke_ListenersWithReturnValues_ResultStruct_get_field_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenersWithReturnValues_ResultStruct_release_handle'));
+final _smoke_ListenersWithReturnValues_ResultStruct_get_field_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_ListenersWithReturnValues_ResultStruct_get_field_result');
+  >('library_smoke_ListenersWithReturnValues_ResultStruct_get_field_result'));
 Pointer<Void> smoke_ListenersWithReturnValues_ResultStruct_toFfi(ListenersWithReturnValues_ResultStruct value) {
   final _result_handle = (value.result);
   final _result = _smoke_ListenersWithReturnValues_ResultStruct_create_handle(_result_handle);
@@ -133,18 +133,18 @@ ListenersWithReturnValues_ResultStruct smoke_ListenersWithReturnValues_ResultStr
 }
 void smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ListenersWithReturnValues_ResultStruct_release_handle(handle);
 // Nullable ListenersWithReturnValues_ResultStruct
-final _smoke_ListenersWithReturnValues_ResultStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenersWithReturnValues_ResultStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ListenersWithReturnValues_ResultStruct_create_handle_nullable');
-final _smoke_ListenersWithReturnValues_ResultStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenersWithReturnValues_ResultStruct_create_handle_nullable'));
+final _smoke_ListenersWithReturnValues_ResultStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ListenersWithReturnValues_ResultStruct_release_handle_nullable');
-final _smoke_ListenersWithReturnValues_ResultStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenersWithReturnValues_ResultStruct_release_handle_nullable'));
+final _smoke_ListenersWithReturnValues_ResultStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ListenersWithReturnValues_ResultStruct_get_value_nullable');
+  >('library_smoke_ListenersWithReturnValues_ResultStruct_get_value_nullable'));
 Pointer<Void> smoke_ListenersWithReturnValues_ResultStruct_toFfi_nullable(ListenersWithReturnValues_ResultStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ListenersWithReturnValues_ResultStruct_toFfi(value);
@@ -163,26 +163,26 @@ void smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle_nullable(Poin
   _smoke_ListenersWithReturnValues_ResultStruct_release_handle_nullable(handle);
 // End of ListenersWithReturnValues_ResultStruct "private" section.
 // ListenersWithReturnValues "private" section, not exported.
-final _smoke_ListenersWithReturnValues_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenersWithReturnValues_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ListenersWithReturnValues_copy_handle');
-final _smoke_ListenersWithReturnValues_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenersWithReturnValues_copy_handle'));
+final _smoke_ListenersWithReturnValues_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_ListenersWithReturnValues_release_handle');
-final _smoke_ListenersWithReturnValues_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenersWithReturnValues_release_handle'));
+final _smoke_ListenersWithReturnValues_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
-  >('library_smoke_ListenersWithReturnValues_create_proxy');
-final _smoke_ListenersWithReturnValues_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_ListenersWithReturnValues_create_proxy'));
+final _smoke_ListenersWithReturnValues_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_ListenersWithReturnValues_get_raw_pointer');
-final _smoke_ListenersWithReturnValues_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_ListenersWithReturnValues_get_raw_pointer'));
+final _smoke_ListenersWithReturnValues_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_ListenersWithReturnValues_get_type_id');
+  >('library_smoke_ListenersWithReturnValues_get_type_id'));
 class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
   double Function() lambda_fetchDataDouble;
   String Function() lambda_fetchDataString;
@@ -245,7 +245,7 @@ class ListenersWithReturnValues$Impl implements ListenersWithReturnValues {
   }
   @override
   double fetchDataDouble() {
-    final _fetchDataDouble_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataDouble');
+    final _fetchDataDouble_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataDouble'));
     final _handle = this.handle;
     final __result_handle = _fetchDataDouble_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -256,7 +256,7 @@ class ListenersWithReturnValues$Impl implements ListenersWithReturnValues {
   }
   @override
   String fetchDataString() {
-    final _fetchDataString_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataString');
+    final _fetchDataString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataString'));
     final _handle = this.handle;
     final __result_handle = _fetchDataString_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -267,7 +267,7 @@ class ListenersWithReturnValues$Impl implements ListenersWithReturnValues {
   }
   @override
   ListenersWithReturnValues_ResultStruct fetchDataStruct() {
-    final _fetchDataStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataStruct');
+    final _fetchDataStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataStruct'));
     final _handle = this.handle;
     final __result_handle = _fetchDataStruct_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -278,7 +278,7 @@ class ListenersWithReturnValues$Impl implements ListenersWithReturnValues {
   }
   @override
   ListenersWithReturnValues_ResultEnum fetchDataEnum() {
-    final _fetchDataEnum_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataEnum');
+    final _fetchDataEnum_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataEnum'));
     final _handle = this.handle;
     final __result_handle = _fetchDataEnum_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -289,7 +289,7 @@ class ListenersWithReturnValues$Impl implements ListenersWithReturnValues {
   }
   @override
   List<double> fetchDataArray() {
-    final _fetchDataArray_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataArray');
+    final _fetchDataArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataArray'));
     final _handle = this.handle;
     final __result_handle = _fetchDataArray_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -300,7 +300,7 @@ class ListenersWithReturnValues$Impl implements ListenersWithReturnValues {
   }
   @override
   Map<String, double> fetchDataMap() {
-    final _fetchDataMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataMap');
+    final _fetchDataMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataMap'));
     final _handle = this.handle;
     final __result_handle = _fetchDataMap_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -311,7 +311,7 @@ class ListenersWithReturnValues$Impl implements ListenersWithReturnValues {
   }
   @override
   CalculationResult fetchDataInstance() {
-    final _fetchDataInstance_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataInstance');
+    final _fetchDataInstance_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataInstance'));
     final _handle = this.handle;
     final __result_handle = _fetchDataInstance_ffi(_handle, __lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -20,18 +20,18 @@ class Locales_LocaleStruct {
   Locales_LocaleStruct(this.localeField);
 }
 // Locales_LocaleStruct "private" section, not exported.
-final _smoke_Locales_LocaleStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Locales_LocaleStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Locales_LocaleStruct_create_handle');
-final _smoke_Locales_LocaleStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Locales_LocaleStruct_create_handle'));
+final _smoke_Locales_LocaleStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Locales_LocaleStruct_release_handle');
-final _smoke_Locales_LocaleStruct_get_field_localeField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Locales_LocaleStruct_release_handle'));
+final _smoke_Locales_LocaleStruct_get_field_localeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Locales_LocaleStruct_get_field_localeField');
+  >('library_smoke_Locales_LocaleStruct_get_field_localeField'));
 Pointer<Void> smoke_Locales_LocaleStruct_toFfi(Locales_LocaleStruct value) {
   final _localeField_handle = Locale_toFfi(value.localeField);
   final _result = _smoke_Locales_LocaleStruct_create_handle(_localeField_handle);
@@ -50,18 +50,18 @@ Locales_LocaleStruct smoke_Locales_LocaleStruct_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Locales_LocaleStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Locales_LocaleStruct_release_handle(handle);
 // Nullable Locales_LocaleStruct
-final _smoke_Locales_LocaleStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Locales_LocaleStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Locales_LocaleStruct_create_handle_nullable');
-final _smoke_Locales_LocaleStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Locales_LocaleStruct_create_handle_nullable'));
+final _smoke_Locales_LocaleStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Locales_LocaleStruct_release_handle_nullable');
-final _smoke_Locales_LocaleStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Locales_LocaleStruct_release_handle_nullable'));
+final _smoke_Locales_LocaleStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Locales_LocaleStruct_get_value_nullable');
+  >('library_smoke_Locales_LocaleStruct_get_value_nullable'));
 Pointer<Void> smoke_Locales_LocaleStruct_toFfi_nullable(Locales_LocaleStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Locales_LocaleStruct_toFfi(value);
@@ -80,18 +80,18 @@ void smoke_Locales_LocaleStruct_releaseFfiHandle_nullable(Pointer<Void> handle) 
   _smoke_Locales_LocaleStruct_release_handle_nullable(handle);
 // End of Locales_LocaleStruct "private" section.
 // Locales "private" section, not exported.
-final _smoke_Locales_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Locales_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Locales_copy_handle');
-final _smoke_Locales_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Locales_copy_handle'));
+final _smoke_Locales_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Locales_release_handle');
-final _smoke_Locales_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Locales_release_handle'));
+final _smoke_Locales_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Locales_get_raw_pointer');
+    >('library_smoke_Locales_get_raw_pointer'));
 class Locales$Impl implements Locales {
   @protected
   Pointer<Void> handle;
@@ -105,7 +105,7 @@ class Locales$Impl implements Locales {
   }
   @override
   Locale localeMethod(Locale input) {
-    final _localeMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeMethod__Locale');
+    final _localeMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeMethod__Locale'));
     final _input_handle = Locale_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _localeMethod_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -118,7 +118,7 @@ class Locales$Impl implements Locales {
   }
   @override
   Locale get localeProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Locales_localeProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Locales_localeProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -129,7 +129,7 @@ class Locales$Impl implements Locales {
   }
   @override
   set localeProperty(Locale value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeProperty_set__Locale');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeProperty_set__Locale'));
     final _value_handle = Locale_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -28,22 +28,22 @@ class MethodOverloads_Point {
   MethodOverloads_Point(this.x, this.y);
 }
 // MethodOverloads_Point "private" section, not exported.
-final _smoke_MethodOverloads_Point_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_MethodOverloads_Point_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double, Double),
     Pointer<Void> Function(double, double)
-  >('library_smoke_MethodOverloads_Point_create_handle');
-final _smoke_MethodOverloads_Point_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_MethodOverloads_Point_create_handle'));
+final _smoke_MethodOverloads_Point_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_MethodOverloads_Point_release_handle');
-final _smoke_MethodOverloads_Point_get_field_x = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_MethodOverloads_Point_release_handle'));
+final _smoke_MethodOverloads_Point_get_field_x = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_MethodOverloads_Point_get_field_x');
-final _smoke_MethodOverloads_Point_get_field_y = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_MethodOverloads_Point_get_field_x'));
+final _smoke_MethodOverloads_Point_get_field_y = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_MethodOverloads_Point_get_field_y');
+  >('library_smoke_MethodOverloads_Point_get_field_y'));
 Pointer<Void> smoke_MethodOverloads_Point_toFfi(MethodOverloads_Point value) {
   final _x_handle = (value.x);
   final _y_handle = (value.y);
@@ -67,18 +67,18 @@ MethodOverloads_Point smoke_MethodOverloads_Point_fromFfi(Pointer<Void> handle) 
 }
 void smoke_MethodOverloads_Point_releaseFfiHandle(Pointer<Void> handle) => _smoke_MethodOverloads_Point_release_handle(handle);
 // Nullable MethodOverloads_Point
-final _smoke_MethodOverloads_Point_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_MethodOverloads_Point_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_MethodOverloads_Point_create_handle_nullable');
-final _smoke_MethodOverloads_Point_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_MethodOverloads_Point_create_handle_nullable'));
+final _smoke_MethodOverloads_Point_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_MethodOverloads_Point_release_handle_nullable');
-final _smoke_MethodOverloads_Point_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_MethodOverloads_Point_release_handle_nullable'));
+final _smoke_MethodOverloads_Point_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_MethodOverloads_Point_get_value_nullable');
+  >('library_smoke_MethodOverloads_Point_get_value_nullable'));
 Pointer<Void> smoke_MethodOverloads_Point_toFfi_nullable(MethodOverloads_Point value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_MethodOverloads_Point_toFfi(value);
@@ -97,18 +97,18 @@ void smoke_MethodOverloads_Point_releaseFfiHandle_nullable(Pointer<Void> handle)
   _smoke_MethodOverloads_Point_release_handle_nullable(handle);
 // End of MethodOverloads_Point "private" section.
 // MethodOverloads "private" section, not exported.
-final _smoke_MethodOverloads_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_MethodOverloads_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_MethodOverloads_copy_handle');
-final _smoke_MethodOverloads_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_MethodOverloads_copy_handle'));
+final _smoke_MethodOverloads_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_MethodOverloads_release_handle');
-final _smoke_MethodOverloads_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_MethodOverloads_release_handle'));
+final _smoke_MethodOverloads_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_MethodOverloads_get_raw_pointer');
+    >('library_smoke_MethodOverloads_get_raw_pointer'));
 class MethodOverloads$Impl implements MethodOverloads {
   @protected
   Pointer<Void> handle;
@@ -122,7 +122,7 @@ class MethodOverloads$Impl implements MethodOverloads {
   }
   @override
   bool isBoolean(bool input) {
-    final _isBoolean_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8), int Function(Pointer<Void>, int, int)>('library_smoke_MethodOverloads_isBoolean__Boolean');
+    final _isBoolean_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8), int Function(Pointer<Void>, int, int)>('library_smoke_MethodOverloads_isBoolean__Boolean'));
     final _input_handle = Boolean_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _isBoolean_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -135,7 +135,7 @@ class MethodOverloads$Impl implements MethodOverloads {
   }
   @override
   bool isBooleanByte(int input) {
-    final _isBooleanByte_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Int8), int Function(Pointer<Void>, int, int)>('library_smoke_MethodOverloads_isBoolean__Byte');
+    final _isBooleanByte_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Int8), int Function(Pointer<Void>, int, int)>('library_smoke_MethodOverloads_isBoolean__Byte'));
     final _input_handle = (input);
     final _handle = this.handle;
     final __result_handle = _isBooleanByte_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -148,7 +148,7 @@ class MethodOverloads$Impl implements MethodOverloads {
   }
   @override
   bool isBooleanString(String input) {
-    final _isBooleanString_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__String');
+    final _isBooleanString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _isBooleanString_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -161,7 +161,7 @@ class MethodOverloads$Impl implements MethodOverloads {
   }
   @override
   bool isBooleanPoint(MethodOverloads_Point input) {
-    final _isBooleanPoint_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Point');
+    final _isBooleanPoint_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Point'));
     final _input_handle = smoke_MethodOverloads_Point_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _isBooleanPoint_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -174,7 +174,7 @@ class MethodOverloads$Impl implements MethodOverloads {
   }
   @override
   bool isBooleanMulti(bool input1, int input2, String input3, MethodOverloads_Point input4) {
-    final _isBooleanMulti_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8, Int8, Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, int, int, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Boolean_Byte_String_Point');
+    final _isBooleanMulti_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8, Int8, Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, int, int, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Boolean_Byte_String_Point'));
     final _input1_handle = Boolean_toFfi(input1);
     final _input2_handle = (input2);
     final _input3_handle = String_toFfi(input3);
@@ -193,7 +193,7 @@ class MethodOverloads$Impl implements MethodOverloads {
   }
   @override
   bool isBooleanStringArray(List<String> input) {
-    final _isBooleanStringArray_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_1String');
+    final _isBooleanStringArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_1String'));
     final _input_handle = ListOf_String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _isBooleanStringArray_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -206,7 +206,7 @@ class MethodOverloads$Impl implements MethodOverloads {
   }
   @override
   bool isBooleanIntArray(List<int> input) {
-    final _isBooleanIntArray_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_1Byte');
+    final _isBooleanIntArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_1Byte'));
     final _input_handle = ListOf_Byte_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _isBooleanIntArray_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -219,7 +219,7 @@ class MethodOverloads$Impl implements MethodOverloads {
   }
   @override
   bool isBooleanConst() {
-    final _isBooleanConst_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_MethodOverloads_isBoolean');
+    final _isBooleanConst_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_MethodOverloads_isBoolean'));
     final _handle = this.handle;
     final __result_handle = _isBooleanConst_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -230,7 +230,7 @@ class MethodOverloads$Impl implements MethodOverloads {
   }
   @override
   bool isFloatString(String input) {
-    final _isFloatString_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__String');
+    final _isFloatString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _isFloatString_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -243,7 +243,7 @@ class MethodOverloads$Impl implements MethodOverloads {
   }
   @override
   bool isFloatList(List<int> input) {
-    final _isFloatList_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__ListOf_1Byte');
+    final _isFloatList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__ListOf_1Byte'));
     final _input_handle = ListOf_Byte_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _isFloatList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -16,18 +16,18 @@ abstract class SpecialNames {
   Uppercase();
 }
 // SpecialNames "private" section, not exported.
-final _smoke_SpecialNames_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_SpecialNames_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SpecialNames_copy_handle');
-final _smoke_SpecialNames_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SpecialNames_copy_handle'));
+final _smoke_SpecialNames_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_SpecialNames_release_handle');
-final _smoke_SpecialNames_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SpecialNames_release_handle'));
+final _smoke_SpecialNames_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_SpecialNames_get_raw_pointer');
+    >('library_smoke_SpecialNames_get_raw_pointer'));
 class SpecialNames$Impl implements SpecialNames {
   @protected
   Pointer<Void> handle;
@@ -41,7 +41,7 @@ class SpecialNames$Impl implements SpecialNames {
   }
   @override
   create() {
-    final _create_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_create');
+    final _create_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_create'));
     final _handle = this.handle;
     final __result_handle = _create_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -52,7 +52,7 @@ class SpecialNames$Impl implements SpecialNames {
   }
   @override
   reallyRelease() {
-    final _reallyRelease_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_release');
+    final _reallyRelease_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_release'));
     final _handle = this.handle;
     final __result_handle = _reallyRelease_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -63,7 +63,7 @@ class SpecialNames$Impl implements SpecialNames {
   }
   @override
   createProxy() {
-    final _createProxy_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_createProxy');
+    final _createProxy_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_createProxy'));
     final _handle = this.handle;
     final __result_handle = _createProxy_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -74,7 +74,7 @@ class SpecialNames$Impl implements SpecialNames {
   }
   @override
   Uppercase() {
-    final _Uppercase_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_Uppercase');
+    final _Uppercase_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_Uppercase'));
     final _handle = this.handle;
     final __result_handle = _Uppercase_ffi(_handle, __lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_enum.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_enum.dart
@@ -33,18 +33,18 @@ FreeEnum smoke_FreeEnum_fromFfi(int handle) {
   }
 }
 void smoke_FreeEnum_releaseFfiHandle(int handle) {}
-final _smoke_FreeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_FreeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_FreeEnum_create_handle_nullable');
-final _smoke_FreeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_FreeEnum_create_handle_nullable'));
+final _smoke_FreeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_FreeEnum_release_handle_nullable');
-final _smoke_FreeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_FreeEnum_release_handle_nullable'));
+final _smoke_FreeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_FreeEnum_get_value_nullable');
+  >('library_smoke_FreeEnum_get_value_nullable'));
 Pointer<Void> smoke_FreeEnum_toFfi_nullable(FreeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_FreeEnum_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_point.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_point.dart
@@ -10,7 +10,7 @@ class FreePoint {
   FreePoint(this.x, this.y);
   static final FreeEnum aBar = FreeEnum.bar;
   FreePoint flip() {
-    final _flip_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_FreePoint_flip');
+    final _flip_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_FreePoint_flip'));
     final _handle = smoke_FreePoint_toFfi(this);
     final __result_handle = _flip_ffi(_handle, __lib.LibraryContext.isolateId);
     smoke_FreePoint_releaseFfiHandle(_handle);
@@ -22,22 +22,22 @@ class FreePoint {
   }
 }
 // FreePoint "private" section, not exported.
-final _smoke_FreePoint_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_FreePoint_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double, Double),
     Pointer<Void> Function(double, double)
-  >('library_smoke_FreePoint_create_handle');
-final _smoke_FreePoint_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_FreePoint_create_handle'));
+final _smoke_FreePoint_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_FreePoint_release_handle');
-final _smoke_FreePoint_get_field_x = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_FreePoint_release_handle'));
+final _smoke_FreePoint_get_field_x = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_FreePoint_get_field_x');
-final _smoke_FreePoint_get_field_y = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_FreePoint_get_field_x'));
+final _smoke_FreePoint_get_field_y = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_FreePoint_get_field_y');
+  >('library_smoke_FreePoint_get_field_y'));
 Pointer<Void> smoke_FreePoint_toFfi(FreePoint value) {
   final _x_handle = (value.x);
   final _y_handle = (value.y);
@@ -61,18 +61,18 @@ FreePoint smoke_FreePoint_fromFfi(Pointer<Void> handle) {
 }
 void smoke_FreePoint_releaseFfiHandle(Pointer<Void> handle) => _smoke_FreePoint_release_handle(handle);
 // Nullable FreePoint
-final _smoke_FreePoint_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_FreePoint_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_FreePoint_create_handle_nullable');
-final _smoke_FreePoint_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_FreePoint_create_handle_nullable'));
+final _smoke_FreePoint_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_FreePoint_release_handle_nullable');
-final _smoke_FreePoint_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_FreePoint_release_handle_nullable'));
+final _smoke_FreePoint_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_FreePoint_get_value_nullable');
+  >('library_smoke_FreePoint_get_value_nullable'));
 Pointer<Void> smoke_FreePoint_toFfi_nullable(FreePoint value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_FreePoint_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -51,18 +51,18 @@ LevelOne_LevelTwo_LevelThree_LevelFourEnum smoke_LevelOne_LevelTwo_LevelThree_Le
   }
 }
 void smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_releaseFfiHandle(int handle) {}
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_create_handle_nullable');
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_create_handle_nullable'));
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_release_handle_nullable');
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_release_handle_nullable'));
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable');
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable'));
 Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_toFfi_nullable(LevelOne_LevelTwo_LevelThree_LevelFourEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_toFfi(value);
@@ -85,7 +85,7 @@ class LevelOne_LevelTwo_LevelThree_LevelFour {
   LevelOne_LevelTwo_LevelThree_LevelFour(this.stringField);
   static final bool foo = false;
   static LevelOne_LevelTwo_LevelThree_LevelFour fooFactory() {
-    final _fooFactory_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fooFactory');
+    final _fooFactory_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fooFactory'));
     final __result_handle = _fooFactory_ffi(__lib.LibraryContext.isolateId);
     try {
       return smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi(__result_handle);
@@ -95,18 +95,18 @@ class LevelOne_LevelTwo_LevelThree_LevelFour {
   }
 }
 // LevelOne_LevelTwo_LevelThree_LevelFour "private" section, not exported.
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle');
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle'));
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle');
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle'));
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField');
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField'));
 Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi(LevelOne_LevelTwo_LevelThree_LevelFour value) {
   final _stringField_handle = String_toFfi(value.stringField);
   final _result = _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle(_stringField_handle);
@@ -125,18 +125,18 @@ LevelOne_LevelTwo_LevelThree_LevelFour smoke_LevelOne_LevelTwo_LevelThree_LevelF
 }
 void smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(Pointer<Void> handle) => _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle(handle);
 // Nullable LevelOne_LevelTwo_LevelThree_LevelFour
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle_nullable');
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle_nullable'));
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable');
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable'));
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable');
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable'));
 Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi_nullable(LevelOne_LevelTwo_LevelThree_LevelFour value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi(value);
@@ -155,18 +155,18 @@ void smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle_nullable(Poin
   _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable(handle);
 // End of LevelOne_LevelTwo_LevelThree_LevelFour "private" section.
 // LevelOne_LevelTwo_LevelThree "private" section, not exported.
-final _smoke_LevelOne_LevelTwo_LevelThree_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_LevelOne_LevelTwo_LevelThree_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_copy_handle');
-final _smoke_LevelOne_LevelTwo_LevelThree_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_copy_handle'));
+final _smoke_LevelOne_LevelTwo_LevelThree_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_LevelThree_release_handle');
-final _smoke_LevelOne_LevelTwo_LevelThree_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LevelOne_LevelTwo_LevelThree_release_handle'));
+final _smoke_LevelOne_LevelTwo_LevelThree_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_LevelOne_LevelTwo_LevelThree_get_raw_pointer');
+    >('library_smoke_LevelOne_LevelTwo_LevelThree_get_raw_pointer'));
 class LevelOne_LevelTwo_LevelThree$Impl implements LevelOne_LevelTwo_LevelThree {
   @protected
   Pointer<Void> handle;
@@ -180,7 +180,7 @@ class LevelOne_LevelTwo_LevelThree$Impl implements LevelOne_LevelTwo_LevelThree 
   }
   @override
   OuterInterface_InnerClass foo(OuterClass_InnerInterface input) {
-    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LevelOne_LevelTwo_LevelThree_foo__InnerInterface');
+    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LevelOne_LevelTwo_LevelThree_foo__InnerInterface'));
     final _input_handle = smoke_OuterClass_InnerInterface_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -213,18 +213,18 @@ void smoke_LevelOne_LevelTwo_LevelThree_releaseFfiHandle_nullable(Pointer<Void> 
   _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
 // End of LevelOne_LevelTwo_LevelThree "private" section.
 // LevelOne_LevelTwo "private" section, not exported.
-final _smoke_LevelOne_LevelTwo_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_LevelOne_LevelTwo_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_copy_handle');
-final _smoke_LevelOne_LevelTwo_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LevelOne_LevelTwo_copy_handle'));
+final _smoke_LevelOne_LevelTwo_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_LevelOne_LevelTwo_release_handle');
-final _smoke_LevelOne_LevelTwo_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LevelOne_LevelTwo_release_handle'));
+final _smoke_LevelOne_LevelTwo_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_LevelOne_LevelTwo_get_raw_pointer');
+    >('library_smoke_LevelOne_LevelTwo_get_raw_pointer'));
 class LevelOne_LevelTwo$Impl implements LevelOne_LevelTwo {
   @protected
   Pointer<Void> handle;
@@ -258,18 +258,18 @@ void smoke_LevelOne_LevelTwo_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_LevelOne_LevelTwo_release_handle(handle);
 // End of LevelOne_LevelTwo "private" section.
 // LevelOne "private" section, not exported.
-final _smoke_LevelOne_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_LevelOne_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_LevelOne_copy_handle');
-final _smoke_LevelOne_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LevelOne_copy_handle'));
+final _smoke_LevelOne_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_LevelOne_release_handle');
-final _smoke_LevelOne_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_LevelOne_release_handle'));
+final _smoke_LevelOne_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_LevelOne_get_raw_pointer');
+    >('library_smoke_LevelOne_get_raw_pointer'));
 class LevelOne$Impl implements LevelOne {
   @protected
   Pointer<Void> handle;

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -22,18 +22,18 @@ abstract class OuterClass_InnerClass {
   String foo(String input);
 }
 // OuterClass_InnerClass "private" section, not exported.
-final _smoke_OuterClass_InnerClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterClass_InnerClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_OuterClass_InnerClass_copy_handle');
-final _smoke_OuterClass_InnerClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterClass_InnerClass_copy_handle'));
+final _smoke_OuterClass_InnerClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_OuterClass_InnerClass_release_handle');
-final _smoke_OuterClass_InnerClass_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterClass_InnerClass_release_handle'));
+final _smoke_OuterClass_InnerClass_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_OuterClass_InnerClass_get_raw_pointer');
+    >('library_smoke_OuterClass_InnerClass_get_raw_pointer'));
 class OuterClass_InnerClass$Impl implements OuterClass_InnerClass {
   @protected
   Pointer<Void> handle;
@@ -47,7 +47,7 @@ class OuterClass_InnerClass$Impl implements OuterClass_InnerClass {
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_InnerClass_foo__String');
+    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_InnerClass_foo__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -94,26 +94,26 @@ abstract class OuterClass_InnerInterface {
   String foo(String input);
 }
 // OuterClass_InnerInterface "private" section, not exported.
-final _smoke_OuterClass_InnerInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterClass_InnerInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_OuterClass_InnerInterface_copy_handle');
-final _smoke_OuterClass_InnerInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterClass_InnerInterface_copy_handle'));
+final _smoke_OuterClass_InnerInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_OuterClass_InnerInterface_release_handle');
-final _smoke_OuterClass_InnerInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterClass_InnerInterface_release_handle'));
+final _smoke_OuterClass_InnerInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_OuterClass_InnerInterface_create_proxy');
-final _smoke_OuterClass_InnerInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterClass_InnerInterface_create_proxy'));
+final _smoke_OuterClass_InnerInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_OuterClass_InnerInterface_get_raw_pointer');
-final _smoke_OuterClass_InnerInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_OuterClass_InnerInterface_get_raw_pointer'));
+final _smoke_OuterClass_InnerInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_OuterClass_InnerInterface_get_type_id');
+  >('library_smoke_OuterClass_InnerInterface_get_type_id'));
 class OuterClass_InnerInterface$Lambdas implements OuterClass_InnerInterface {
   String Function(String) lambda_foo;
   OuterClass_InnerInterface$Lambdas(
@@ -140,7 +140,7 @@ class OuterClass_InnerInterface$Impl implements OuterClass_InnerInterface {
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_InnerInterface_foo__String');
+    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_InnerInterface_foo__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -197,18 +197,18 @@ void smoke_OuterClass_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> han
   _smoke_OuterClass_InnerInterface_release_handle(handle);
 // End of OuterClass_InnerInterface "private" section.
 // OuterClass "private" section, not exported.
-final _smoke_OuterClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_OuterClass_copy_handle');
-final _smoke_OuterClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterClass_copy_handle'));
+final _smoke_OuterClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_OuterClass_release_handle');
-final _smoke_OuterClass_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterClass_release_handle'));
+final _smoke_OuterClass_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_OuterClass_get_raw_pointer');
+    >('library_smoke_OuterClass_get_raw_pointer'));
 class OuterClass$Impl implements OuterClass {
   @protected
   Pointer<Void> handle;
@@ -222,7 +222,7 @@ class OuterClass$Impl implements OuterClass {
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_foo__String');
+    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_foo__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -28,18 +28,18 @@ abstract class OuterInterface_InnerClass {
   String foo(String input);
 }
 // OuterInterface_InnerClass "private" section, not exported.
-final _smoke_OuterInterface_InnerClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterInterface_InnerClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_OuterInterface_InnerClass_copy_handle');
-final _smoke_OuterInterface_InnerClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterInterface_InnerClass_copy_handle'));
+final _smoke_OuterInterface_InnerClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_OuterInterface_InnerClass_release_handle');
-final _smoke_OuterInterface_InnerClass_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterInterface_InnerClass_release_handle'));
+final _smoke_OuterInterface_InnerClass_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_OuterInterface_InnerClass_get_raw_pointer');
+    >('library_smoke_OuterInterface_InnerClass_get_raw_pointer'));
 class OuterInterface_InnerClass$Impl implements OuterInterface_InnerClass {
   @protected
   Pointer<Void> handle;
@@ -53,7 +53,7 @@ class OuterInterface_InnerClass$Impl implements OuterInterface_InnerClass {
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_InnerClass_foo__String');
+    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_InnerClass_foo__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -100,26 +100,26 @@ abstract class OuterInterface_InnerInterface {
   String foo(String input);
 }
 // OuterInterface_InnerInterface "private" section, not exported.
-final _smoke_OuterInterface_InnerInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterInterface_InnerInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_OuterInterface_InnerInterface_copy_handle');
-final _smoke_OuterInterface_InnerInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterInterface_InnerInterface_copy_handle'));
+final _smoke_OuterInterface_InnerInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_OuterInterface_InnerInterface_release_handle');
-final _smoke_OuterInterface_InnerInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterInterface_InnerInterface_release_handle'));
+final _smoke_OuterInterface_InnerInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_OuterInterface_InnerInterface_create_proxy');
-final _smoke_OuterInterface_InnerInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterInterface_InnerInterface_create_proxy'));
+final _smoke_OuterInterface_InnerInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_OuterInterface_InnerInterface_get_raw_pointer');
-final _smoke_OuterInterface_InnerInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_OuterInterface_InnerInterface_get_raw_pointer'));
+final _smoke_OuterInterface_InnerInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_OuterInterface_InnerInterface_get_type_id');
+  >('library_smoke_OuterInterface_InnerInterface_get_type_id'));
 class OuterInterface_InnerInterface$Lambdas implements OuterInterface_InnerInterface {
   String Function(String) lambda_foo;
   OuterInterface_InnerInterface$Lambdas(
@@ -146,7 +146,7 @@ class OuterInterface_InnerInterface$Impl implements OuterInterface_InnerInterfac
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_InnerInterface_foo__String');
+    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_InnerInterface_foo__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -203,26 +203,26 @@ void smoke_OuterInterface_InnerInterface_releaseFfiHandle_nullable(Pointer<Void>
   _smoke_OuterInterface_InnerInterface_release_handle(handle);
 // End of OuterInterface_InnerInterface "private" section.
 // OuterInterface "private" section, not exported.
-final _smoke_OuterInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_OuterInterface_copy_handle');
-final _smoke_OuterInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterInterface_copy_handle'));
+final _smoke_OuterInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_OuterInterface_release_handle');
-final _smoke_OuterInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterInterface_release_handle'));
+final _smoke_OuterInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_OuterInterface_create_proxy');
-final _smoke_OuterInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_OuterInterface_create_proxy'));
+final _smoke_OuterInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_OuterInterface_get_raw_pointer');
-final _smoke_OuterInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_OuterInterface_get_raw_pointer'));
+final _smoke_OuterInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_OuterInterface_get_type_id');
+  >('library_smoke_OuterInterface_get_type_id'));
 class OuterInterface$Lambdas implements OuterInterface {
   String Function(String) lambda_foo;
   OuterInterface$Lambdas(
@@ -249,7 +249,7 @@ class OuterInterface$Impl implements OuterInterface {
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_foo__String');
+    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_foo__String'));
     final _input_handle = String_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -16,34 +16,34 @@ abstract class UseFreeTypes {
   DateTime doStuff(FreePoint point, FreeEnum mode);
 }
 // UseFreeTypes "private" section, not exported.
-final _smoke_UseFreeTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_UseFreeTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_UseFreeTypes_copy_handle');
-final _smoke_UseFreeTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_UseFreeTypes_copy_handle'));
+final _smoke_UseFreeTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_UseFreeTypes_release_handle');
-final _smoke_UseFreeTypes_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_UseFreeTypes_release_handle'));
+final _smoke_UseFreeTypes_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_UseFreeTypes_get_raw_pointer');
-final _doStuff_return_release_handle = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_UseFreeTypes_get_raw_pointer'));
+final _doStuff_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_release_handle');
-final _doStuff_return_get_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_release_handle'));
+final _doStuff_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_get_result');
-final _doStuff_return_get_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_get_result'));
+final _doStuff_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_get_error');
-final _doStuff_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_get_error'));
+final _doStuff_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_has_error');
+  >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_has_error'));
 class UseFreeTypes$Impl implements UseFreeTypes {
   @protected
   Pointer<Void> handle;
@@ -57,7 +57,7 @@ class UseFreeTypes$Impl implements UseFreeTypes {
   }
   @override
   DateTime doStuff(FreePoint point, FreeEnum mode) {
-    final _doStuff_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum');
+    final _doStuff_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum'));
     final _point_handle = smoke_FreePoint_toFfi(point);
     final _mode_handle = smoke_FreeEnum_toFfi(mode);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/generic_types__conversion.dart
@@ -4,38 +4,38 @@ import 'package:library/src/smoke/nullable.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-final _ListOf_Nullable_Date_create_handle = __lib.nativeLibrary.lookupFunction<
+final _ListOf_Nullable_Date_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_ListOf_Nullable_Date_create_handle');
-final _ListOf_Nullable_Date_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Nullable_Date_create_handle'));
+final _ListOf_Nullable_Date_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ListOf_Nullable_Date_release_handle');
-final _ListOf_Nullable_Date_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Nullable_Date_release_handle'));
+final _ListOf_Nullable_Date_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_ListOf_Nullable_Date_insert');
-final _ListOf_Nullable_Date_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Nullable_Date_insert'));
+final _ListOf_Nullable_Date_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_ListOf_Nullable_Date_iterator');
-final _ListOf_Nullable_Date_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_Nullable_Date_iterator'));
+final _ListOf_Nullable_Date_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_ListOf_Nullable_Date_iterator_release_handle');
-final _ListOf_Nullable_Date_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_Nullable_Date_iterator_release_handle'));
+final _ListOf_Nullable_Date_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_ListOf_Nullable_Date_iterator_is_valid');
-final _ListOf_Nullable_Date_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_Nullable_Date_iterator_is_valid'));
+final _ListOf_Nullable_Date_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_ListOf_Nullable_Date_iterator_increment');
-final _ListOf_Nullable_Date_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_Nullable_Date_iterator_increment'));
+final _ListOf_Nullable_Date_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_ListOf_Nullable_Date_iterator_get');
+>('library_ListOf_Nullable_Date_iterator_get'));
 Pointer<Void> ListOf_Nullable_Date_toFfi(List<DateTime> value) {
   final _result = _ListOf_Nullable_Date_create_handle();
   for (final element in value) {
@@ -61,18 +61,18 @@ List<DateTime> ListOf_Nullable_Date_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void ListOf_Nullable_Date_releaseFfiHandle(Pointer<Void> handle) => _ListOf_Nullable_Date_release_handle(handle);
-final _ListOf_Nullable_Date_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _ListOf_Nullable_Date_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_ListOf_Nullable_Date_create_handle_nullable');
-final _ListOf_Nullable_Date_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Nullable_Date_create_handle_nullable'));
+final _ListOf_Nullable_Date_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ListOf_Nullable_Date_release_handle_nullable');
-final _ListOf_Nullable_Date_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_Nullable_Date_release_handle_nullable'));
+final _ListOf_Nullable_Date_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_ListOf_Nullable_Date_get_value_nullable');
+  >('library_ListOf_Nullable_Date_get_value_nullable'));
 Pointer<Void> ListOf_Nullable_Date_toFfi_nullable(List<DateTime> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = ListOf_Nullable_Date_toFfi(value);
@@ -89,38 +89,38 @@ List<DateTime> ListOf_Nullable_Date_fromFfi_nullable(Pointer<Void> handle) {
 }
 void ListOf_Nullable_Date_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _ListOf_Nullable_Date_release_handle_nullable(handle);
-final _ListOf_String_create_handle = __lib.nativeLibrary.lookupFunction<
+final _ListOf_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_ListOf_String_create_handle');
-final _ListOf_String_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_create_handle'));
+final _ListOf_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ListOf_String_release_handle');
-final _ListOf_String_insert = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_release_handle'));
+final _ListOf_String_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
-  >('library_ListOf_String_insert');
-final _ListOf_String_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_insert'));
+final _ListOf_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_ListOf_String_iterator');
-final _ListOf_String_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_String_iterator'));
+final _ListOf_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_ListOf_String_iterator_release_handle');
-final _ListOf_String_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_String_iterator_release_handle'));
+final _ListOf_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_ListOf_String_iterator_is_valid');
-final _ListOf_String_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_String_iterator_is_valid'));
+final _ListOf_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_ListOf_String_iterator_increment');
-final _ListOf_String_iterator_get = __lib.nativeLibrary.lookupFunction<
+>('library_ListOf_String_iterator_increment'));
+final _ListOf_String_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_ListOf_String_iterator_get');
+>('library_ListOf_String_iterator_get'));
 Pointer<Void> ListOf_String_toFfi(List<String> value) {
   final _result = _ListOf_String_create_handle();
   for (final element in value) {
@@ -146,18 +146,18 @@ List<String> ListOf_String_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void ListOf_String_releaseFfiHandle(Pointer<Void> handle) => _ListOf_String_release_handle(handle);
-final _ListOf_String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _ListOf_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_ListOf_String_create_handle_nullable');
-final _ListOf_String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_create_handle_nullable'));
+final _ListOf_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_ListOf_String_release_handle_nullable');
-final _ListOf_String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_ListOf_String_release_handle_nullable'));
+final _ListOf_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_ListOf_String_get_value_nullable');
+  >('library_ListOf_String_get_value_nullable'));
 Pointer<Void> ListOf_String_toFfi_nullable(List<String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = ListOf_String_toFfi(value);
@@ -174,42 +174,42 @@ List<String> ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
 }
 void ListOf_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _ListOf_String_release_handle_nullable(handle);
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle'));
+final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle'));
+final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
-  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put'));
+final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator'));
+final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle'));
+final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid'));
+final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment'));
+final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key'));
+final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value');
+>('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value'));
 Pointer<Void> MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi(Map<int, Nullable_SomeStruct> value) {
   final _result = _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle();
   for (final entry in value.entries) {
@@ -240,18 +240,18 @@ Map<int, Nullable_SomeStruct> MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fr
   return result;
 }
 void MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle(handle);
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable'));
+final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable');
-final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable'));
+final _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable');
+  >('library_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable'));
 Pointer<Void> MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi_nullable(Map<int, Nullable_SomeStruct> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi(value);
@@ -268,42 +268,42 @@ Map<int, Nullable_SomeStruct> MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fr
 }
 void MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable(handle);
-final _MapOf_Long_to_String_create_handle = __lib.nativeLibrary.lookupFunction<
+final _MapOf_Long_to_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_MapOf_Long_to_String_create_handle');
-final _MapOf_Long_to_String_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Long_to_String_create_handle'));
+final _MapOf_Long_to_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_MapOf_Long_to_String_release_handle');
-final _MapOf_Long_to_String_put = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Long_to_String_release_handle'));
+final _MapOf_Long_to_String_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int64, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
-  >('library_MapOf_Long_to_String_put');
-final _MapOf_Long_to_String_iterator = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Long_to_String_put'));
+final _MapOf_Long_to_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_MapOf_Long_to_String_iterator');
-final _MapOf_Long_to_String_iterator_release_handle = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Long_to_String_iterator'));
+final _MapOf_Long_to_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_MapOf_Long_to_String_iterator_release_handle');
-final _MapOf_Long_to_String_iterator_is_valid = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Long_to_String_iterator_release_handle'));
+final _MapOf_Long_to_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_MapOf_Long_to_String_iterator_is_valid');
-final _MapOf_Long_to_String_iterator_increment = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Long_to_String_iterator_is_valid'));
+final _MapOf_Long_to_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_MapOf_Long_to_String_iterator_increment');
-final _MapOf_Long_to_String_iterator_get_key = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Long_to_String_iterator_increment'));
+final _MapOf_Long_to_String_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
->('library_MapOf_Long_to_String_iterator_get_key');
-final _MapOf_Long_to_String_iterator_get_value = __lib.nativeLibrary.lookupFunction<
+>('library_MapOf_Long_to_String_iterator_get_key'));
+final _MapOf_Long_to_String_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_MapOf_Long_to_String_iterator_get_value');
+>('library_MapOf_Long_to_String_iterator_get_value'));
 Pointer<Void> MapOf_Long_to_String_toFfi(Map<int, String> value) {
   final _result = _MapOf_Long_to_String_create_handle();
   for (final entry in value.entries) {
@@ -334,18 +334,18 @@ Map<int, String> MapOf_Long_to_String_fromFfi(Pointer<Void> handle) {
   return result;
 }
 void MapOf_Long_to_String_releaseFfiHandle(Pointer<Void> handle) => _MapOf_Long_to_String_release_handle(handle);
-final _MapOf_Long_to_String_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _MapOf_Long_to_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_MapOf_Long_to_String_create_handle_nullable');
-final _MapOf_Long_to_String_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Long_to_String_create_handle_nullable'));
+final _MapOf_Long_to_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_MapOf_Long_to_String_release_handle_nullable');
-final _MapOf_Long_to_String_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_MapOf_Long_to_String_release_handle_nullable'));
+final _MapOf_Long_to_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_MapOf_Long_to_String_get_value_nullable');
+  >('library_MapOf_Long_to_String_get_value_nullable'));
 Pointer<Void> MapOf_Long_to_String_toFfi_nullable(Map<int, String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = MapOf_Long_to_String_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -73,18 +73,18 @@ Nullable_SomeEnum smoke_Nullable_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_Nullable_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_Nullable_SomeEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Nullable_SomeEnum_create_handle_nullable');
-final _smoke_Nullable_SomeEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_SomeEnum_create_handle_nullable'));
+final _smoke_Nullable_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Nullable_SomeEnum_release_handle_nullable');
-final _smoke_Nullable_SomeEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_SomeEnum_release_handle_nullable'));
+final _smoke_Nullable_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Nullable_SomeEnum_get_value_nullable');
+  >('library_smoke_Nullable_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_Nullable_SomeEnum_toFfi_nullable(Nullable_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Nullable_SomeEnum_toFfi(value);
@@ -107,18 +107,18 @@ class Nullable_SomeStruct {
   Nullable_SomeStruct(this.stringField);
 }
 // Nullable_SomeStruct "private" section, not exported.
-final _smoke_Nullable_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_SomeStruct_create_handle');
-final _smoke_Nullable_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_SomeStruct_create_handle'));
+final _smoke_Nullable_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Nullable_SomeStruct_release_handle');
-final _smoke_Nullable_SomeStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_SomeStruct_release_handle'));
+final _smoke_Nullable_SomeStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_SomeStruct_get_field_stringField');
+  >('library_smoke_Nullable_SomeStruct_get_field_stringField'));
 Pointer<Void> smoke_Nullable_SomeStruct_toFfi(Nullable_SomeStruct value) {
   final _stringField_handle = String_toFfi(value.stringField);
   final _result = _smoke_Nullable_SomeStruct_create_handle(_stringField_handle);
@@ -137,18 +137,18 @@ Nullable_SomeStruct smoke_Nullable_SomeStruct_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Nullable_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Nullable_SomeStruct_release_handle(handle);
 // Nullable Nullable_SomeStruct
-final _smoke_Nullable_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_SomeStruct_create_handle_nullable');
-final _smoke_Nullable_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_SomeStruct_create_handle_nullable'));
+final _smoke_Nullable_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Nullable_SomeStruct_release_handle_nullable');
-final _smoke_Nullable_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_SomeStruct_release_handle_nullable'));
+final _smoke_Nullable_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_SomeStruct_get_value_nullable');
+  >('library_smoke_Nullable_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_Nullable_SomeStruct_toFfi_nullable(Nullable_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Nullable_SomeStruct_toFfi(value);
@@ -179,50 +179,50 @@ class Nullable_NullableStruct {
   Nullable_NullableStruct(this.stringField, this.boolField, this.doubleField, this.structField, this.enumField, this.arrayField, this.inlineArrayField, this.mapField, this.instanceField);
 }
 // Nullable_NullableStruct "private" section, not exported.
-final _smoke_Nullable_NullableStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_NullableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_create_handle');
-final _smoke_Nullable_NullableStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableStruct_create_handle'));
+final _smoke_Nullable_NullableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_release_handle');
-final _smoke_Nullable_NullableStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableStruct_release_handle'));
+final _smoke_Nullable_NullableStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_get_field_stringField');
-final _smoke_Nullable_NullableStruct_get_field_boolField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableStruct_get_field_stringField'));
+final _smoke_Nullable_NullableStruct_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_get_field_boolField');
-final _smoke_Nullable_NullableStruct_get_field_doubleField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableStruct_get_field_boolField'));
+final _smoke_Nullable_NullableStruct_get_field_doubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_get_field_doubleField');
-final _smoke_Nullable_NullableStruct_get_field_structField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableStruct_get_field_doubleField'));
+final _smoke_Nullable_NullableStruct_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_get_field_structField');
-final _smoke_Nullable_NullableStruct_get_field_enumField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableStruct_get_field_structField'));
+final _smoke_Nullable_NullableStruct_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_get_field_enumField');
-final _smoke_Nullable_NullableStruct_get_field_arrayField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableStruct_get_field_enumField'));
+final _smoke_Nullable_NullableStruct_get_field_arrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_get_field_arrayField');
-final _smoke_Nullable_NullableStruct_get_field_inlineArrayField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableStruct_get_field_arrayField'));
+final _smoke_Nullable_NullableStruct_get_field_inlineArrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_get_field_inlineArrayField');
-final _smoke_Nullable_NullableStruct_get_field_mapField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableStruct_get_field_inlineArrayField'));
+final _smoke_Nullable_NullableStruct_get_field_mapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_get_field_mapField');
-final _smoke_Nullable_NullableStruct_get_field_instanceField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableStruct_get_field_mapField'));
+final _smoke_Nullable_NullableStruct_get_field_instanceField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_get_field_instanceField');
+  >('library_smoke_Nullable_NullableStruct_get_field_instanceField'));
 Pointer<Void> smoke_Nullable_NullableStruct_toFfi(Nullable_NullableStruct value) {
   final _stringField_handle = String_toFfi_nullable(value.stringField);
   final _boolField_handle = Boolean_toFfi_nullable(value.boolField);
@@ -281,18 +281,18 @@ Nullable_NullableStruct smoke_Nullable_NullableStruct_fromFfi(Pointer<Void> hand
 }
 void smoke_Nullable_NullableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Nullable_NullableStruct_release_handle(handle);
 // Nullable Nullable_NullableStruct
-final _smoke_Nullable_NullableStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_NullableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_create_handle_nullable');
-final _smoke_Nullable_NullableStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableStruct_create_handle_nullable'));
+final _smoke_Nullable_NullableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_release_handle_nullable');
-final _smoke_Nullable_NullableStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableStruct_release_handle_nullable'));
+final _smoke_Nullable_NullableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableStruct_get_value_nullable');
+  >('library_smoke_Nullable_NullableStruct_get_value_nullable'));
 Pointer<Void> smoke_Nullable_NullableStruct_toFfi_nullable(Nullable_NullableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Nullable_NullableStruct_toFfi(value);
@@ -322,46 +322,46 @@ class Nullable_NullableIntsStruct {
   Nullable_NullableIntsStruct(this.int8Field, this.int16Field, this.int32Field, this.int64Field, this.uint8Field, this.uint16Field, this.uint32Field, this.uint64Field);
 }
 // Nullable_NullableIntsStruct "private" section, not exported.
-final _smoke_Nullable_NullableIntsStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_NullableIntsStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_create_handle');
-final _smoke_Nullable_NullableIntsStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableIntsStruct_create_handle'));
+final _smoke_Nullable_NullableIntsStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_release_handle');
-final _smoke_Nullable_NullableIntsStruct_get_field_int8Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableIntsStruct_release_handle'));
+final _smoke_Nullable_NullableIntsStruct_get_field_int8Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_get_field_int8Field');
-final _smoke_Nullable_NullableIntsStruct_get_field_int16Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableIntsStruct_get_field_int8Field'));
+final _smoke_Nullable_NullableIntsStruct_get_field_int16Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_get_field_int16Field');
-final _smoke_Nullable_NullableIntsStruct_get_field_int32Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableIntsStruct_get_field_int16Field'));
+final _smoke_Nullable_NullableIntsStruct_get_field_int32Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_get_field_int32Field');
-final _smoke_Nullable_NullableIntsStruct_get_field_int64Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableIntsStruct_get_field_int32Field'));
+final _smoke_Nullable_NullableIntsStruct_get_field_int64Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_get_field_int64Field');
-final _smoke_Nullable_NullableIntsStruct_get_field_uint8Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableIntsStruct_get_field_int64Field'));
+final _smoke_Nullable_NullableIntsStruct_get_field_uint8Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_get_field_uint8Field');
-final _smoke_Nullable_NullableIntsStruct_get_field_uint16Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableIntsStruct_get_field_uint8Field'));
+final _smoke_Nullable_NullableIntsStruct_get_field_uint16Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_get_field_uint16Field');
-final _smoke_Nullable_NullableIntsStruct_get_field_uint32Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableIntsStruct_get_field_uint16Field'));
+final _smoke_Nullable_NullableIntsStruct_get_field_uint32Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_get_field_uint32Field');
-final _smoke_Nullable_NullableIntsStruct_get_field_uint64Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableIntsStruct_get_field_uint32Field'));
+final _smoke_Nullable_NullableIntsStruct_get_field_uint64Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_get_field_uint64Field');
+  >('library_smoke_Nullable_NullableIntsStruct_get_field_uint64Field'));
 Pointer<Void> smoke_Nullable_NullableIntsStruct_toFfi(Nullable_NullableIntsStruct value) {
   final _int8Field_handle = Byte_toFfi_nullable(value.int8Field);
   final _int16Field_handle = Short_toFfi_nullable(value.int16Field);
@@ -415,18 +415,18 @@ Nullable_NullableIntsStruct smoke_Nullable_NullableIntsStruct_fromFfi(Pointer<Vo
 }
 void smoke_Nullable_NullableIntsStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Nullable_NullableIntsStruct_release_handle(handle);
 // Nullable Nullable_NullableIntsStruct
-final _smoke_Nullable_NullableIntsStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_NullableIntsStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_create_handle_nullable');
-final _smoke_Nullable_NullableIntsStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableIntsStruct_create_handle_nullable'));
+final _smoke_Nullable_NullableIntsStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_release_handle_nullable');
-final _smoke_Nullable_NullableIntsStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_NullableIntsStruct_release_handle_nullable'));
+final _smoke_Nullable_NullableIntsStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_NullableIntsStruct_get_value_nullable');
+  >('library_smoke_Nullable_NullableIntsStruct_get_value_nullable'));
 Pointer<Void> smoke_Nullable_NullableIntsStruct_toFfi_nullable(Nullable_NullableIntsStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Nullable_NullableIntsStruct_toFfi(value);
@@ -445,18 +445,18 @@ void smoke_Nullable_NullableIntsStruct_releaseFfiHandle_nullable(Pointer<Void> h
   _smoke_Nullable_NullableIntsStruct_release_handle_nullable(handle);
 // End of Nullable_NullableIntsStruct "private" section.
 // Nullable "private" section, not exported.
-final _smoke_Nullable_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Nullable_copy_handle');
-final _smoke_Nullable_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_copy_handle'));
+final _smoke_Nullable_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Nullable_release_handle');
-final _smoke_Nullable_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Nullable_release_handle'));
+final _smoke_Nullable_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Nullable_get_raw_pointer');
+    >('library_smoke_Nullable_get_raw_pointer'));
 class Nullable$Impl implements Nullable {
   @protected
   Pointer<Void> handle;
@@ -470,7 +470,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   String methodWithString(String input) {
-    final _methodWithString_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithString__String');
+    final _methodWithString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithString__String'));
     final _input_handle = String_toFfi_nullable(input);
     final _handle = this.handle;
     final __result_handle = _methodWithString_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -483,7 +483,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   bool methodWithBoolean(bool input) {
-    final _methodWithBoolean_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithBoolean__Boolean');
+    final _methodWithBoolean_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithBoolean__Boolean'));
     final _input_handle = Boolean_toFfi_nullable(input);
     final _handle = this.handle;
     final __result_handle = _methodWithBoolean_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -496,7 +496,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   double methodWithDouble(double input) {
-    final _methodWithDouble_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithDouble__Double');
+    final _methodWithDouble_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithDouble__Double'));
     final _input_handle = Double_toFfi_nullable(input);
     final _handle = this.handle;
     final __result_handle = _methodWithDouble_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -509,7 +509,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   int methodWithInt(int input) {
-    final _methodWithInt_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInt__Long');
+    final _methodWithInt_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInt__Long'));
     final _input_handle = Long_toFfi_nullable(input);
     final _handle = this.handle;
     final __result_handle = _methodWithInt_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -522,7 +522,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   Nullable_SomeStruct methodWithSomeStruct(Nullable_SomeStruct input) {
-    final _methodWithSomeStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeStruct__SomeStruct');
+    final _methodWithSomeStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeStruct__SomeStruct'));
     final _input_handle = smoke_Nullable_SomeStruct_toFfi_nullable(input);
     final _handle = this.handle;
     final __result_handle = _methodWithSomeStruct_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -535,7 +535,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   Nullable_SomeEnum methodWithSomeEnum(Nullable_SomeEnum input) {
-    final _methodWithSomeEnum_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeEnum__SomeEnum');
+    final _methodWithSomeEnum_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeEnum__SomeEnum'));
     final _input_handle = smoke_Nullable_SomeEnum_toFfi_nullable(input);
     final _handle = this.handle;
     final __result_handle = _methodWithSomeEnum_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -548,7 +548,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   List<String> methodWithSomeArray(List<String> input) {
-    final _methodWithSomeArray_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeArray__ListOf_1String');
+    final _methodWithSomeArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeArray__ListOf_1String'));
     final _input_handle = ListOf_String_toFfi_nullable(input);
     final _handle = this.handle;
     final __result_handle = _methodWithSomeArray_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -561,7 +561,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   List<String> methodWithInlineArray(List<String> input) {
-    final _methodWithInlineArray_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInlineArray__ListOf_1String');
+    final _methodWithInlineArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInlineArray__ListOf_1String'));
     final _input_handle = ListOf_String_toFfi_nullable(input);
     final _handle = this.handle;
     final __result_handle = _methodWithInlineArray_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -574,7 +574,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   Map<int, String> methodWithSomeMap(Map<int, String> input) {
-    final _methodWithSomeMap_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeMap__MapOf_1Long_1to_1String');
+    final _methodWithSomeMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeMap__MapOf_1Long_1to_1String'));
     final _input_handle = MapOf_Long_to_String_toFfi_nullable(input);
     final _handle = this.handle;
     final __result_handle = _methodWithSomeMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -587,7 +587,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   SomeInterface methodWithInstance(SomeInterface input) {
-    final _methodWithInstance_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInstance__SomeInterface');
+    final _methodWithInstance_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInstance__SomeInterface'));
     final _input_handle = smoke_SomeInterface_toFfi_nullable(input);
     final _handle = this.handle;
     final __result_handle = _methodWithInstance_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -600,7 +600,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   String get stringProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_stringProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_stringProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -611,7 +611,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   set stringProperty(String value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_stringProperty_set__String');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_stringProperty_set__String'));
     final _value_handle = String_toFfi_nullable(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -624,7 +624,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   bool get isBoolProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_isBoolProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_isBoolProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -635,7 +635,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   set isBoolProperty(bool value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_isBoolProperty_set__Boolean');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_isBoolProperty_set__Boolean'));
     final _value_handle = Boolean_toFfi_nullable(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -648,7 +648,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   double get doubleProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_doubleProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_doubleProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -659,7 +659,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   set doubleProperty(double value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_doubleProperty_set__Double');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_doubleProperty_set__Double'));
     final _value_handle = Double_toFfi_nullable(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -672,7 +672,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   int get intProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_intProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_intProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -683,7 +683,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   set intProperty(int value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_intProperty_set__Long');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_intProperty_set__Long'));
     final _value_handle = Long_toFfi_nullable(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -696,7 +696,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   Nullable_SomeStruct get structProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_structProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_structProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -707,7 +707,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   set structProperty(Nullable_SomeStruct value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_structProperty_set__SomeStruct');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_structProperty_set__SomeStruct'));
     final _value_handle = smoke_Nullable_SomeStruct_toFfi_nullable(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -720,7 +720,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   Nullable_SomeEnum get enumProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_enumProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_enumProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -731,7 +731,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   set enumProperty(Nullable_SomeEnum value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_enumProperty_set__SomeEnum');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_enumProperty_set__SomeEnum'));
     final _value_handle = smoke_Nullable_SomeEnum_toFfi_nullable(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -744,7 +744,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   List<String> get arrayProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_arrayProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_arrayProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -755,7 +755,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   set arrayProperty(List<String> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_arrayProperty_set__ListOf_1String');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_arrayProperty_set__ListOf_1String'));
     final _value_handle = ListOf_String_toFfi_nullable(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -768,7 +768,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   List<String> get inlineArrayProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_inlineArrayProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_inlineArrayProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -779,7 +779,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   set inlineArrayProperty(List<String> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_inlineArrayProperty_set__ListOf_1String');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_inlineArrayProperty_set__ListOf_1String'));
     final _value_handle = ListOf_String_toFfi_nullable(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -792,7 +792,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   Map<int, String> get mapProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_mapProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_mapProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -803,7 +803,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   set mapProperty(Map<int, String> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_mapProperty_set__MapOf_1Long_1to_1String');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_mapProperty_set__MapOf_1Long_1to_1String'));
     final _value_handle = MapOf_Long_to_String_toFfi_nullable(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -816,7 +816,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   SomeInterface get instanceProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_instanceProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_instanceProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -827,7 +827,7 @@ class Nullable$Impl implements Nullable {
   }
   @override
   set instanceProperty(SomeInterface value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_instanceProperty_set__SomeInterface');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_instanceProperty_set__SomeInterface'));
     final _value_handle = smoke_SomeInterface_toFfi_nullable(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
@@ -17,18 +17,18 @@ class NestedPackages_SomeStruct {
   NestedPackages_SomeStruct(this.someField);
 }
 // NestedPackages_SomeStruct "private" section, not exported.
-final _smoke_off_NestedPackages_SomeStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_off_NestedPackages_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_off_NestedPackages_SomeStruct_create_handle');
-final _smoke_off_NestedPackages_SomeStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_off_NestedPackages_SomeStruct_create_handle'));
+final _smoke_off_NestedPackages_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_off_NestedPackages_SomeStruct_release_handle');
-final _smoke_off_NestedPackages_SomeStruct_get_field_someField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_off_NestedPackages_SomeStruct_release_handle'));
+final _smoke_off_NestedPackages_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_off_NestedPackages_SomeStruct_get_field_someField');
+  >('library_smoke_off_NestedPackages_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_off_NestedPackages_SomeStruct_toFfi(NestedPackages_SomeStruct value) {
   final _someField_handle = String_toFfi(value.someField);
   final _result = _smoke_off_NestedPackages_SomeStruct_create_handle(_someField_handle);
@@ -47,18 +47,18 @@ NestedPackages_SomeStruct smoke_off_NestedPackages_SomeStruct_fromFfi(Pointer<Vo
 }
 void smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_off_NestedPackages_SomeStruct_release_handle(handle);
 // Nullable NestedPackages_SomeStruct
-final _smoke_off_NestedPackages_SomeStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_off_NestedPackages_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_off_NestedPackages_SomeStruct_create_handle_nullable');
-final _smoke_off_NestedPackages_SomeStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_off_NestedPackages_SomeStruct_create_handle_nullable'));
+final _smoke_off_NestedPackages_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_off_NestedPackages_SomeStruct_release_handle_nullable');
-final _smoke_off_NestedPackages_SomeStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_off_NestedPackages_SomeStruct_release_handle_nullable'));
+final _smoke_off_NestedPackages_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_off_NestedPackages_SomeStruct_get_value_nullable');
+  >('library_smoke_off_NestedPackages_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_off_NestedPackages_SomeStruct_toFfi_nullable(NestedPackages_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_off_NestedPackages_SomeStruct_toFfi(value);
@@ -77,18 +77,18 @@ void smoke_off_NestedPackages_SomeStruct_releaseFfiHandle_nullable(Pointer<Void>
   _smoke_off_NestedPackages_SomeStruct_release_handle_nullable(handle);
 // End of NestedPackages_SomeStruct "private" section.
 // NestedPackages "private" section, not exported.
-final _smoke_off_NestedPackages_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_off_NestedPackages_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_off_NestedPackages_copy_handle');
-final _smoke_off_NestedPackages_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_off_NestedPackages_copy_handle'));
+final _smoke_off_NestedPackages_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_off_NestedPackages_release_handle');
-final _smoke_off_NestedPackages_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_off_NestedPackages_release_handle'));
+final _smoke_off_NestedPackages_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_off_NestedPackages_get_raw_pointer');
+    >('library_smoke_off_NestedPackages_get_raw_pointer'));
 class NestedPackages$Impl implements NestedPackages {
   @protected
   Pointer<Void> handle;
@@ -101,7 +101,7 @@ class NestedPackages$Impl implements NestedPackages {
     handle = null;
   }
   static NestedPackages_SomeStruct basicMethod(NestedPackages_SomeStruct input) {
-    final _basicMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_off_NestedPackages_basicMethod__SomeStruct');
+    final _basicMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_off_NestedPackages_basicMethod__SomeStruct'));
     final _input_handle = smoke_off_NestedPackages_SomeStruct_toFfi(input);
     final __result_handle = _basicMethod_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(_input_handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -17,18 +17,18 @@ abstract class weeInterface {
   set WEE_PROPERTY(int value);
 }
 // weeInterface "private" section, not exported.
-final _smoke_PlatformNamesInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformNamesInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformNamesInterface_copy_handle');
-final _smoke_PlatformNamesInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformNamesInterface_copy_handle'));
+final _smoke_PlatformNamesInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PlatformNamesInterface_release_handle');
-final _smoke_PlatformNamesInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformNamesInterface_release_handle'));
+final _smoke_PlatformNamesInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_PlatformNamesInterface_get_raw_pointer');
+    >('library_smoke_PlatformNamesInterface_get_raw_pointer'));
 class weeInterface$Impl implements weeInterface {
   @protected
   Pointer<Void> handle;
@@ -45,7 +45,7 @@ class weeInterface$Impl implements weeInterface {
   }
   @override
   weeStruct WeeMethod(String WeeParameter) {
-    final _WeeMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesInterface_basicMethod__String');
+    final _WeeMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesInterface_basicMethod__String'));
     final _WeeParameter_handle = String_toFfi(WeeParameter);
     final _handle = this.handle;
     final __result_handle = _WeeMethod_ffi(_handle, __lib.LibraryContext.isolateId, _WeeParameter_handle);
@@ -57,7 +57,7 @@ class weeInterface$Impl implements weeInterface {
     }
   }
   static Pointer<Void> _make(String makeParameter) {
-    final _make_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_PlatformNamesInterface_create__String');
+    final _make_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_PlatformNamesInterface_create__String'));
     final _makeParameter_handle = String_toFfi(makeParameter);
     final __result_handle = _make_ffi(__lib.LibraryContext.isolateId, _makeParameter_handle);
     String_releaseFfiHandle(_makeParameter_handle);
@@ -65,7 +65,7 @@ class weeInterface$Impl implements weeInterface {
   }
   @override
   int get WEE_PROPERTY {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_PlatformNamesInterface_basicProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_PlatformNamesInterface_basicProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -76,7 +76,7 @@ class weeInterface$Impl implements weeInterface {
   }
   @override
   set WEE_PROPERTY(int value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_PlatformNamesInterface_basicProperty_set__UInt');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_PlatformNamesInterface_basicProperty_set__UInt'));
     final _value_handle = (value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -20,26 +20,26 @@ abstract class weeListener {
   WeeMethod(String WeeParameter);
 }
 // weeListener "private" section, not exported.
-final _smoke_PlatformNamesListener_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformNamesListener_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformNamesListener_copy_handle');
-final _smoke_PlatformNamesListener_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformNamesListener_copy_handle'));
+final _smoke_PlatformNamesListener_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PlatformNamesListener_release_handle');
-final _smoke_PlatformNamesListener_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformNamesListener_release_handle'));
+final _smoke_PlatformNamesListener_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
-  >('library_smoke_PlatformNamesListener_create_proxy');
-final _smoke_PlatformNamesListener_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformNamesListener_create_proxy'));
+final _smoke_PlatformNamesListener_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_PlatformNamesListener_get_raw_pointer');
-final _smoke_PlatformNamesListener_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_PlatformNamesListener_get_raw_pointer'));
+final _smoke_PlatformNamesListener_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformNamesListener_get_type_id');
+  >('library_smoke_PlatformNamesListener_get_type_id'));
 class weeListener$Lambdas implements weeListener {
   void Function(String) lambda_WeeMethod;
   weeListener$Lambdas(
@@ -66,7 +66,7 @@ class weeListener$Impl implements weeListener {
   }
   @override
   WeeMethod(String WeeParameter) {
-    final _WeeMethod_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesListener_basicMethod__String');
+    final _WeeMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesListener_basicMethod__String'));
     final _WeeParameter_handle = String_toFfi(WeeParameter);
     final _handle = this.handle;
     final __result_handle = _WeeMethod_ffi(_handle, __lib.LibraryContext.isolateId, _WeeParameter_handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
@@ -26,18 +26,18 @@ werrEnum smoke_PlatformNames_BasicEnum_fromFfi(int handle) {
   }
 }
 void smoke_PlatformNames_BasicEnum_releaseFfiHandle(int handle) {}
-final _smoke_PlatformNames_BasicEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformNames_BasicEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_PlatformNames_BasicEnum_create_handle_nullable');
-final _smoke_PlatformNames_BasicEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformNames_BasicEnum_create_handle_nullable'));
+final _smoke_PlatformNames_BasicEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PlatformNames_BasicEnum_release_handle_nullable');
-final _smoke_PlatformNames_BasicEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformNames_BasicEnum_release_handle_nullable'));
+final _smoke_PlatformNames_BasicEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_PlatformNames_BasicEnum_get_value_nullable');
+  >('library_smoke_PlatformNames_BasicEnum_get_value_nullable'));
 Pointer<Void> smoke_PlatformNames_BasicEnum_toFfi_nullable(werrEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PlatformNames_BasicEnum_toFfi(value);
@@ -61,7 +61,7 @@ class weeStruct {
   weeStruct._copy(weeStruct _other) : this._(_other.WEE_FIELD);
   weeStruct(String WeeParameter) : this._copy(_WeeCreate(WeeParameter));
   static weeStruct _WeeCreate(String WeeParameter) {
-    final _WeeCreate_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_PlatformNames_BasicStruct_make__String');
+    final _WeeCreate_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_PlatformNames_BasicStruct_make__String'));
     final _WeeParameter_handle = String_toFfi(WeeParameter);
     final __result_handle = _WeeCreate_ffi(__lib.LibraryContext.isolateId, _WeeParameter_handle);
     String_releaseFfiHandle(_WeeParameter_handle);
@@ -73,18 +73,18 @@ class weeStruct {
   }
 }
 // weeStruct "private" section, not exported.
-final _smoke_PlatformNames_BasicStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformNames_BasicStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformNames_BasicStruct_create_handle');
-final _smoke_PlatformNames_BasicStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformNames_BasicStruct_create_handle'));
+final _smoke_PlatformNames_BasicStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PlatformNames_BasicStruct_release_handle');
-final _smoke_PlatformNames_BasicStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformNames_BasicStruct_release_handle'));
+final _smoke_PlatformNames_BasicStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformNames_BasicStruct_get_field_stringField');
+  >('library_smoke_PlatformNames_BasicStruct_get_field_stringField'));
 Pointer<Void> smoke_PlatformNames_BasicStruct_toFfi(weeStruct value) {
   final _WEE_FIELD_handle = String_toFfi(value.WEE_FIELD);
   final _result = _smoke_PlatformNames_BasicStruct_create_handle(_WEE_FIELD_handle);
@@ -103,18 +103,18 @@ weeStruct smoke_PlatformNames_BasicStruct_fromFfi(Pointer<Void> handle) {
 }
 void smoke_PlatformNames_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PlatformNames_BasicStruct_release_handle(handle);
 // Nullable weeStruct
-final _smoke_PlatformNames_BasicStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformNames_BasicStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformNames_BasicStruct_create_handle_nullable');
-final _smoke_PlatformNames_BasicStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformNames_BasicStruct_create_handle_nullable'));
+final _smoke_PlatformNames_BasicStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PlatformNames_BasicStruct_release_handle_nullable');
-final _smoke_PlatformNames_BasicStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PlatformNames_BasicStruct_release_handle_nullable'));
+final _smoke_PlatformNames_BasicStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PlatformNames_BasicStruct_get_value_nullable');
+  >('library_smoke_PlatformNames_BasicStruct_get_value_nullable'));
 Pointer<Void> smoke_PlatformNames_BasicStruct_toFfi_nullable(weeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PlatformNames_BasicStruct_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
@@ -16,18 +16,18 @@ abstract class CachedProperties {
   static Uint8List get staticCachedProperty => CachedProperties$Impl.staticCachedProperty;
 }
 // CachedProperties "private" section, not exported.
-final _smoke_CachedProperties_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_CachedProperties_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_CachedProperties_copy_handle');
-final _smoke_CachedProperties_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CachedProperties_copy_handle'));
+final _smoke_CachedProperties_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_CachedProperties_release_handle');
-final _smoke_CachedProperties_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_CachedProperties_release_handle'));
+final _smoke_CachedProperties_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_CachedProperties_get_raw_pointer');
+    >('library_smoke_CachedProperties_get_raw_pointer'));
 class CachedProperties$Impl implements CachedProperties {
   @protected
   Pointer<Void> handle;
@@ -44,7 +44,7 @@ class CachedProperties$Impl implements CachedProperties {
   @override
   List<String> get cachedProperty {
     if (!_is_cached_cachedProperty) {
-      final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_CachedProperties_cachedProperty_get');
+      final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_CachedProperties_cachedProperty_get'));
       final __result_handle = _get_ffi(this.handle, __lib.LibraryContext.isolateId);
       try {
         _cache_cachedProperty = ListOf_String_fromFfi(__result_handle);
@@ -59,7 +59,7 @@ class CachedProperties$Impl implements CachedProperties {
   static bool _is_cached_staticCachedProperty = false;
   static Uint8List get staticCachedProperty {
     if (!_is_cached_staticCachedProperty) {
-      final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_CachedProperties_staticCachedProperty_get');
+      final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_CachedProperties_staticCachedProperty_get'));
       final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
       try {
         _cache_staticCachedProperty = Blob_fromFfi(__result_handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -62,18 +62,18 @@ Properties_InternalErrorCode smoke_Properties_InternalErrorCode_fromFfi(int hand
   }
 }
 void smoke_Properties_InternalErrorCode_releaseFfiHandle(int handle) {}
-final _smoke_Properties_InternalErrorCode_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Properties_InternalErrorCode_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Properties_InternalErrorCode_create_handle_nullable');
-final _smoke_Properties_InternalErrorCode_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Properties_InternalErrorCode_create_handle_nullable'));
+final _smoke_Properties_InternalErrorCode_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Properties_InternalErrorCode_release_handle_nullable');
-final _smoke_Properties_InternalErrorCode_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Properties_InternalErrorCode_release_handle_nullable'));
+final _smoke_Properties_InternalErrorCode_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Properties_InternalErrorCode_get_value_nullable');
+  >('library_smoke_Properties_InternalErrorCode_get_value_nullable'));
 Pointer<Void> smoke_Properties_InternalErrorCode_toFfi_nullable(Properties_InternalErrorCode value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Properties_InternalErrorCode_toFfi(value);
@@ -96,18 +96,18 @@ class Properties_ExampleStruct {
   Properties_ExampleStruct(this.value);
 }
 // Properties_ExampleStruct "private" section, not exported.
-final _smoke_Properties_ExampleStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Properties_ExampleStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
-  >('library_smoke_Properties_ExampleStruct_create_handle');
-final _smoke_Properties_ExampleStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Properties_ExampleStruct_create_handle'));
+final _smoke_Properties_ExampleStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Properties_ExampleStruct_release_handle');
-final _smoke_Properties_ExampleStruct_get_field_value = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Properties_ExampleStruct_release_handle'));
+final _smoke_Properties_ExampleStruct_get_field_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_Properties_ExampleStruct_get_field_value');
+  >('library_smoke_Properties_ExampleStruct_get_field_value'));
 Pointer<Void> smoke_Properties_ExampleStruct_toFfi(Properties_ExampleStruct value) {
   final _value_handle = (value.value);
   final _result = _smoke_Properties_ExampleStruct_create_handle(_value_handle);
@@ -126,18 +126,18 @@ Properties_ExampleStruct smoke_Properties_ExampleStruct_fromFfi(Pointer<Void> ha
 }
 void smoke_Properties_ExampleStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Properties_ExampleStruct_release_handle(handle);
 // Nullable Properties_ExampleStruct
-final _smoke_Properties_ExampleStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Properties_ExampleStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Properties_ExampleStruct_create_handle_nullable');
-final _smoke_Properties_ExampleStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Properties_ExampleStruct_create_handle_nullable'));
+final _smoke_Properties_ExampleStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Properties_ExampleStruct_release_handle_nullable');
-final _smoke_Properties_ExampleStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Properties_ExampleStruct_release_handle_nullable'));
+final _smoke_Properties_ExampleStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Properties_ExampleStruct_get_value_nullable');
+  >('library_smoke_Properties_ExampleStruct_get_value_nullable'));
 Pointer<Void> smoke_Properties_ExampleStruct_toFfi_nullable(Properties_ExampleStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Properties_ExampleStruct_toFfi(value);
@@ -156,18 +156,18 @@ void smoke_Properties_ExampleStruct_releaseFfiHandle_nullable(Pointer<Void> hand
   _smoke_Properties_ExampleStruct_release_handle_nullable(handle);
 // End of Properties_ExampleStruct "private" section.
 // Properties "private" section, not exported.
-final _smoke_Properties_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Properties_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Properties_copy_handle');
-final _smoke_Properties_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Properties_copy_handle'));
+final _smoke_Properties_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Properties_release_handle');
-final _smoke_Properties_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Properties_release_handle'));
+final _smoke_Properties_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Properties_get_raw_pointer');
+    >('library_smoke_Properties_get_raw_pointer'));
 class Properties$Impl implements Properties {
   @protected
   Pointer<Void> handle;
@@ -181,7 +181,7 @@ class Properties$Impl implements Properties {
   }
   @override
   int get builtInTypeProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_builtInTypeProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_builtInTypeProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -192,7 +192,7 @@ class Properties$Impl implements Properties {
   }
   @override
   set builtInTypeProperty(int value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_builtInTypeProperty_set__UInt');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_builtInTypeProperty_set__UInt'));
     final _value_handle = (value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -205,7 +205,7 @@ class Properties$Impl implements Properties {
   }
   @override
   double get readonlyProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_Properties_readonlyProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_Properties_readonlyProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -216,7 +216,7 @@ class Properties$Impl implements Properties {
   }
   @override
   Properties_ExampleStruct get structProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_structProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_structProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -227,7 +227,7 @@ class Properties$Impl implements Properties {
   }
   @override
   set structProperty(Properties_ExampleStruct value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_structProperty_set__ExampleStruct');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_structProperty_set__ExampleStruct'));
     final _value_handle = smoke_Properties_ExampleStruct_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -240,7 +240,7 @@ class Properties$Impl implements Properties {
   }
   @override
   List<String> get arrayProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_arrayProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_arrayProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -251,7 +251,7 @@ class Properties$Impl implements Properties {
   }
   @override
   set arrayProperty(List<String> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_arrayProperty_set__ListOf_1String');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_arrayProperty_set__ListOf_1String'));
     final _value_handle = ListOf_String_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -264,7 +264,7 @@ class Properties$Impl implements Properties {
   }
   @override
   Properties_InternalErrorCode get complexTypeProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_complexTypeProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_complexTypeProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -275,7 +275,7 @@ class Properties$Impl implements Properties {
   }
   @override
   set complexTypeProperty(Properties_InternalErrorCode value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_complexTypeProperty_set__InternalErrorCode');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_complexTypeProperty_set__InternalErrorCode'));
     final _value_handle = smoke_Properties_InternalErrorCode_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -288,7 +288,7 @@ class Properties$Impl implements Properties {
   }
   @override
   Uint8List get byteBufferProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_byteBufferProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_byteBufferProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -299,7 +299,7 @@ class Properties$Impl implements Properties {
   }
   @override
   set byteBufferProperty(Uint8List value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_byteBufferProperty_set__Blob');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_byteBufferProperty_set__Blob'));
     final _value_handle = Blob_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -312,7 +312,7 @@ class Properties$Impl implements Properties {
   }
   @override
   PropertiesInterface get instanceProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_instanceProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_instanceProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -323,7 +323,7 @@ class Properties$Impl implements Properties {
   }
   @override
   set instanceProperty(PropertiesInterface value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_instanceProperty_set__PropertiesInterface');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_instanceProperty_set__PropertiesInterface'));
     final _value_handle = smoke_PropertiesInterface_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -336,7 +336,7 @@ class Properties$Impl implements Properties {
   }
   @override
   bool get isBooleanProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_isBooleanProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_isBooleanProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -347,7 +347,7 @@ class Properties$Impl implements Properties {
   }
   @override
   set isBooleanProperty(bool value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_isBooleanProperty_set__Boolean');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_isBooleanProperty_set__Boolean'));
     final _value_handle = Boolean_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -359,7 +359,7 @@ class Properties$Impl implements Properties {
     }
   }
   static String get staticProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticProperty_get'));
     final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
     try {
       return String_fromFfi(__result_handle);
@@ -368,7 +368,7 @@ class Properties$Impl implements Properties {
     }
   }
   static set staticProperty(String value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_Properties_staticProperty_set__String');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_Properties_staticProperty_set__String'));
     final _value_handle = String_toFfi(value);
     final __result_handle = _set_ffi(__lib.LibraryContext.isolateId, _value_handle);
     String_releaseFfiHandle(_value_handle);
@@ -379,7 +379,7 @@ class Properties$Impl implements Properties {
     }
   }
   static Properties_ExampleStruct get staticReadonlyProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticReadonlyProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticReadonlyProperty_get'));
     final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
     try {
       return smoke_Properties_ExampleStruct_fromFfi(__result_handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -27,18 +27,18 @@ class PropertiesInterface_ExampleStruct {
   PropertiesInterface_ExampleStruct(this.value);
 }
 // PropertiesInterface_ExampleStruct "private" section, not exported.
-final _smoke_PropertiesInterface_ExampleStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PropertiesInterface_ExampleStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
-  >('library_smoke_PropertiesInterface_ExampleStruct_create_handle');
-final _smoke_PropertiesInterface_ExampleStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PropertiesInterface_ExampleStruct_create_handle'));
+final _smoke_PropertiesInterface_ExampleStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PropertiesInterface_ExampleStruct_release_handle');
-final _smoke_PropertiesInterface_ExampleStruct_get_field_value = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PropertiesInterface_ExampleStruct_release_handle'));
+final _smoke_PropertiesInterface_ExampleStruct_get_field_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_PropertiesInterface_ExampleStruct_get_field_value');
+  >('library_smoke_PropertiesInterface_ExampleStruct_get_field_value'));
 Pointer<Void> smoke_PropertiesInterface_ExampleStruct_toFfi(PropertiesInterface_ExampleStruct value) {
   final _value_handle = (value.value);
   final _result = _smoke_PropertiesInterface_ExampleStruct_create_handle(_value_handle);
@@ -57,18 +57,18 @@ PropertiesInterface_ExampleStruct smoke_PropertiesInterface_ExampleStruct_fromFf
 }
 void smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PropertiesInterface_ExampleStruct_release_handle(handle);
 // Nullable PropertiesInterface_ExampleStruct
-final _smoke_PropertiesInterface_ExampleStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_PropertiesInterface_ExampleStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PropertiesInterface_ExampleStruct_create_handle_nullable');
-final _smoke_PropertiesInterface_ExampleStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PropertiesInterface_ExampleStruct_create_handle_nullable'));
+final _smoke_PropertiesInterface_ExampleStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PropertiesInterface_ExampleStruct_release_handle_nullable');
-final _smoke_PropertiesInterface_ExampleStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PropertiesInterface_ExampleStruct_release_handle_nullable'));
+final _smoke_PropertiesInterface_ExampleStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PropertiesInterface_ExampleStruct_get_value_nullable');
+  >('library_smoke_PropertiesInterface_ExampleStruct_get_value_nullable'));
 Pointer<Void> smoke_PropertiesInterface_ExampleStruct_toFfi_nullable(PropertiesInterface_ExampleStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PropertiesInterface_ExampleStruct_toFfi(value);
@@ -87,26 +87,26 @@ void smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle_nullable(Pointer<V
   _smoke_PropertiesInterface_ExampleStruct_release_handle_nullable(handle);
 // End of PropertiesInterface_ExampleStruct "private" section.
 // PropertiesInterface "private" section, not exported.
-final _smoke_PropertiesInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PropertiesInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PropertiesInterface_copy_handle');
-final _smoke_PropertiesInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PropertiesInterface_copy_handle'));
+final _smoke_PropertiesInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PropertiesInterface_release_handle');
-final _smoke_PropertiesInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PropertiesInterface_release_handle'));
+final _smoke_PropertiesInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer)
-  >('library_smoke_PropertiesInterface_create_proxy');
-final _smoke_PropertiesInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PropertiesInterface_create_proxy'));
+final _smoke_PropertiesInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_PropertiesInterface_get_raw_pointer');
-final _smoke_PropertiesInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_PropertiesInterface_get_raw_pointer'));
+final _smoke_PropertiesInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PropertiesInterface_get_type_id');
+  >('library_smoke_PropertiesInterface_get_type_id'));
 class PropertiesInterface$Lambdas implements PropertiesInterface {
   PropertiesInterface_ExampleStruct Function() lambda_structProperty_get;
   void Function(PropertiesInterface_ExampleStruct) lambda_structProperty_set;
@@ -136,7 +136,7 @@ class PropertiesInterface$Impl implements PropertiesInterface {
     handle = null;
   }
   PropertiesInterface_ExampleStruct get structProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PropertiesInterface_structProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PropertiesInterface_structProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -146,7 +146,7 @@ class PropertiesInterface$Impl implements PropertiesInterface {
     }
   }
   set structProperty(PropertiesInterface_ExampleStruct value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PropertiesInterface_structProperty_set__ExampleStruct');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PropertiesInterface_structProperty_set__ExampleStruct'));
     final _value_handle = smoke_PropertiesInterface_ExampleStruct_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -14,18 +14,18 @@ abstract class SkipFunctions {
   static bool notInSwift(bool input) => SkipFunctions$Impl.notInSwift(input);
 }
 // SkipFunctions "private" section, not exported.
-final _smoke_SkipFunctions_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipFunctions_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SkipFunctions_copy_handle');
-final _smoke_SkipFunctions_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SkipFunctions_copy_handle'));
+final _smoke_SkipFunctions_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_SkipFunctions_release_handle');
-final _smoke_SkipFunctions_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SkipFunctions_release_handle'));
+final _smoke_SkipFunctions_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_SkipFunctions_get_raw_pointer');
+    >('library_smoke_SkipFunctions_get_raw_pointer'));
 class SkipFunctions$Impl implements SkipFunctions {
   @protected
   Pointer<Void> handle;
@@ -38,7 +38,7 @@ class SkipFunctions$Impl implements SkipFunctions {
     handle = null;
   }
   static String notInJava(String input) {
-    final _notInJava_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_SkipFunctions_notInJava__String');
+    final _notInJava_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_SkipFunctions_notInJava__String'));
     final _input_handle = String_toFfi(input);
     final __result_handle = _notInJava_ffi(__lib.LibraryContext.isolateId, _input_handle);
     String_releaseFfiHandle(_input_handle);
@@ -49,7 +49,7 @@ class SkipFunctions$Impl implements SkipFunctions {
     }
   }
   static bool notInSwift(bool input) {
-    final _notInSwift_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_SkipFunctions_notInSwift__Boolean');
+    final _notInSwift_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_SkipFunctions_notInSwift__Boolean'));
     final _input_handle = Boolean_toFfi(input);
     final __result_handle = _notInSwift_ffi(__lib.LibraryContext.isolateId, _input_handle);
     Boolean_releaseFfiHandle(_input_handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -16,18 +16,18 @@ class SkipTypes_NotInJava {
   SkipTypes_NotInJava(this.fooField);
 }
 // SkipTypes_NotInJava "private" section, not exported.
-final _smoke_SkipTypes_NotInJava_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipTypes_NotInJava_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_NotInJava_create_handle');
-final _smoke_SkipTypes_NotInJava_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SkipTypes_NotInJava_create_handle'));
+final _smoke_SkipTypes_NotInJava_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_NotInJava_release_handle');
-final _smoke_SkipTypes_NotInJava_get_field_fooField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SkipTypes_NotInJava_release_handle'));
+final _smoke_SkipTypes_NotInJava_get_field_fooField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_NotInJava_get_field_fooField');
+  >('library_smoke_SkipTypes_NotInJava_get_field_fooField'));
 Pointer<Void> smoke_SkipTypes_NotInJava_toFfi(SkipTypes_NotInJava value) {
   final _fooField_handle = String_toFfi(value.fooField);
   final _result = _smoke_SkipTypes_NotInJava_create_handle(_fooField_handle);
@@ -46,18 +46,18 @@ SkipTypes_NotInJava smoke_SkipTypes_NotInJava_fromFfi(Pointer<Void> handle) {
 }
 void smoke_SkipTypes_NotInJava_releaseFfiHandle(Pointer<Void> handle) => _smoke_SkipTypes_NotInJava_release_handle(handle);
 // Nullable SkipTypes_NotInJava
-final _smoke_SkipTypes_NotInJava_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipTypes_NotInJava_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_NotInJava_create_handle_nullable');
-final _smoke_SkipTypes_NotInJava_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SkipTypes_NotInJava_create_handle_nullable'));
+final _smoke_SkipTypes_NotInJava_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_NotInJava_release_handle_nullable');
-final _smoke_SkipTypes_NotInJava_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SkipTypes_NotInJava_release_handle_nullable'));
+final _smoke_SkipTypes_NotInJava_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_NotInJava_get_value_nullable');
+  >('library_smoke_SkipTypes_NotInJava_get_value_nullable'));
 Pointer<Void> smoke_SkipTypes_NotInJava_toFfi_nullable(SkipTypes_NotInJava value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SkipTypes_NotInJava_toFfi(value);
@@ -80,18 +80,18 @@ class SkipTypes_NotInSwift {
   SkipTypes_NotInSwift(this.fooField);
 }
 // SkipTypes_NotInSwift "private" section, not exported.
-final _smoke_SkipTypes_NotInSwift_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipTypes_NotInSwift_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_NotInSwift_create_handle');
-final _smoke_SkipTypes_NotInSwift_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SkipTypes_NotInSwift_create_handle'));
+final _smoke_SkipTypes_NotInSwift_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_NotInSwift_release_handle');
-final _smoke_SkipTypes_NotInSwift_get_field_fooField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SkipTypes_NotInSwift_release_handle'));
+final _smoke_SkipTypes_NotInSwift_get_field_fooField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_NotInSwift_get_field_fooField');
+  >('library_smoke_SkipTypes_NotInSwift_get_field_fooField'));
 Pointer<Void> smoke_SkipTypes_NotInSwift_toFfi(SkipTypes_NotInSwift value) {
   final _fooField_handle = String_toFfi(value.fooField);
   final _result = _smoke_SkipTypes_NotInSwift_create_handle(_fooField_handle);
@@ -110,18 +110,18 @@ SkipTypes_NotInSwift smoke_SkipTypes_NotInSwift_fromFfi(Pointer<Void> handle) {
 }
 void smoke_SkipTypes_NotInSwift_releaseFfiHandle(Pointer<Void> handle) => _smoke_SkipTypes_NotInSwift_release_handle(handle);
 // Nullable SkipTypes_NotInSwift
-final _smoke_SkipTypes_NotInSwift_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipTypes_NotInSwift_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_NotInSwift_create_handle_nullable');
-final _smoke_SkipTypes_NotInSwift_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SkipTypes_NotInSwift_create_handle_nullable'));
+final _smoke_SkipTypes_NotInSwift_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_NotInSwift_release_handle_nullable');
-final _smoke_SkipTypes_NotInSwift_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SkipTypes_NotInSwift_release_handle_nullable'));
+final _smoke_SkipTypes_NotInSwift_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_NotInSwift_get_value_nullable');
+  >('library_smoke_SkipTypes_NotInSwift_get_value_nullable'));
 Pointer<Void> smoke_SkipTypes_NotInSwift_toFfi_nullable(SkipTypes_NotInSwift value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SkipTypes_NotInSwift_toFfi(value);
@@ -140,18 +140,18 @@ void smoke_SkipTypes_NotInSwift_releaseFfiHandle_nullable(Pointer<Void> handle) 
   _smoke_SkipTypes_NotInSwift_release_handle_nullable(handle);
 // End of SkipTypes_NotInSwift "private" section.
 // SkipTypes "private" section, not exported.
-final _smoke_SkipTypes_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_copy_handle');
-final _smoke_SkipTypes_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SkipTypes_copy_handle'));
+final _smoke_SkipTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_SkipTypes_release_handle');
-final _smoke_SkipTypes_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_SkipTypes_release_handle'));
+final _smoke_SkipTypes_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_SkipTypes_get_raw_pointer');
+    >('library_smoke_SkipTypes_get_raw_pointer'));
 class SkipTypes$Impl implements SkipTypes {
   @protected
   Pointer<Void> handle;

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -48,18 +48,18 @@ Structs_FooBar smoke_Structs_FooBar_fromFfi(int handle) {
   }
 }
 void smoke_Structs_FooBar_releaseFfiHandle(int handle) {}
-final _smoke_Structs_FooBar_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_FooBar_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_Structs_FooBar_create_handle_nullable');
-final _smoke_Structs_FooBar_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_FooBar_create_handle_nullable'));
+final _smoke_Structs_FooBar_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_FooBar_release_handle_nullable');
-final _smoke_Structs_FooBar_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_FooBar_release_handle_nullable'));
+final _smoke_Structs_FooBar_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Structs_FooBar_get_value_nullable');
+  >('library_smoke_Structs_FooBar_get_value_nullable'));
 Pointer<Void> smoke_Structs_FooBar_toFfi_nullable(Structs_FooBar value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_FooBar_toFfi(value);
@@ -83,22 +83,22 @@ class Structs_Point {
   Structs_Point(this.x, this.y);
 }
 // Structs_Point "private" section, not exported.
-final _smoke_Structs_Point_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_Point_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double, Double),
     Pointer<Void> Function(double, double)
-  >('library_smoke_Structs_Point_create_handle');
-final _smoke_Structs_Point_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_Point_create_handle'));
+final _smoke_Structs_Point_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_Point_release_handle');
-final _smoke_Structs_Point_get_field_x = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_Point_release_handle'));
+final _smoke_Structs_Point_get_field_x = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_Structs_Point_get_field_x');
-final _smoke_Structs_Point_get_field_y = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_Point_get_field_x'));
+final _smoke_Structs_Point_get_field_y = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_Structs_Point_get_field_y');
+  >('library_smoke_Structs_Point_get_field_y'));
 Pointer<Void> smoke_Structs_Point_toFfi(Structs_Point value) {
   final _x_handle = (value.x);
   final _y_handle = (value.y);
@@ -122,18 +122,18 @@ Structs_Point smoke_Structs_Point_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Structs_Point_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_Point_release_handle(handle);
 // Nullable Structs_Point
-final _smoke_Structs_Point_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_Point_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_Point_create_handle_nullable');
-final _smoke_Structs_Point_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_Point_create_handle_nullable'));
+final _smoke_Structs_Point_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_Point_release_handle_nullable');
-final _smoke_Structs_Point_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_Point_release_handle_nullable'));
+final _smoke_Structs_Point_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_Point_get_value_nullable');
+  >('library_smoke_Structs_Point_get_value_nullable'));
 Pointer<Void> smoke_Structs_Point_toFfi_nullable(Structs_Point value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_Point_toFfi(value);
@@ -157,22 +157,22 @@ class Structs_Line {
   Structs_Line(this.a, this.b);
 }
 // Structs_Line "private" section, not exported.
-final _smoke_Structs_Line_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_Line_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>)
-  >('library_smoke_Structs_Line_create_handle');
-final _smoke_Structs_Line_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_Line_create_handle'));
+final _smoke_Structs_Line_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_Line_release_handle');
-final _smoke_Structs_Line_get_field_a = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_Line_release_handle'));
+final _smoke_Structs_Line_get_field_a = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_Line_get_field_a');
-final _smoke_Structs_Line_get_field_b = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_Line_get_field_a'));
+final _smoke_Structs_Line_get_field_b = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_Line_get_field_b');
+  >('library_smoke_Structs_Line_get_field_b'));
 Pointer<Void> smoke_Structs_Line_toFfi(Structs_Line value) {
   final _a_handle = smoke_Structs_Point_toFfi(value.a);
   final _b_handle = smoke_Structs_Point_toFfi(value.b);
@@ -196,18 +196,18 @@ Structs_Line smoke_Structs_Line_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Structs_Line_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_Line_release_handle(handle);
 // Nullable Structs_Line
-final _smoke_Structs_Line_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_Line_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_Line_create_handle_nullable');
-final _smoke_Structs_Line_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_Line_create_handle_nullable'));
+final _smoke_Structs_Line_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_Line_release_handle_nullable');
-final _smoke_Structs_Line_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_Line_release_handle_nullable'));
+final _smoke_Structs_Line_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_Line_get_value_nullable');
+  >('library_smoke_Structs_Line_get_value_nullable'));
 Pointer<Void> smoke_Structs_Line_toFfi_nullable(Structs_Line value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_Line_toFfi(value);
@@ -244,70 +244,70 @@ class Structs_AllTypesStruct {
   const Structs_AllTypesStruct(this.int8Field, this.uint8Field, this.int16Field, this.uint16Field, this.int32Field, this.uint32Field, this.int64Field, this.uint64Field, this.floatField, this.doubleField, this.stringField, this.booleanField, this.bytesField, this.pointField);
 }
 // Structs_AllTypesStruct "private" section, not exported.
-final _smoke_Structs_AllTypesStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_AllTypesStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64, Float, Double, Pointer<Void>, Uint8, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(int, int, int, int, int, int, int, int, double, double, Pointer<Void>, int, Pointer<Void>, Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_create_handle');
-final _smoke_Structs_AllTypesStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_create_handle'));
+final _smoke_Structs_AllTypesStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_release_handle');
-final _smoke_Structs_AllTypesStruct_get_field_int8Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_release_handle'));
+final _smoke_Structs_AllTypesStruct_get_field_int8Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_int8Field');
-final _smoke_Structs_AllTypesStruct_get_field_uint8Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_int8Field'));
+final _smoke_Structs_AllTypesStruct_get_field_uint8Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_uint8Field');
-final _smoke_Structs_AllTypesStruct_get_field_int16Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_uint8Field'));
+final _smoke_Structs_AllTypesStruct_get_field_int16Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int16 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_int16Field');
-final _smoke_Structs_AllTypesStruct_get_field_uint16Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_int16Field'));
+final _smoke_Structs_AllTypesStruct_get_field_uint16Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint16 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_uint16Field');
-final _smoke_Structs_AllTypesStruct_get_field_int32Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_uint16Field'));
+final _smoke_Structs_AllTypesStruct_get_field_int32Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_int32Field');
-final _smoke_Structs_AllTypesStruct_get_field_uint32Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_int32Field'));
+final _smoke_Structs_AllTypesStruct_get_field_uint32Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_uint32Field');
-final _smoke_Structs_AllTypesStruct_get_field_int64Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_uint32Field'));
+final _smoke_Structs_AllTypesStruct_get_field_int64Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_int64Field');
-final _smoke_Structs_AllTypesStruct_get_field_uint64Field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_int64Field'));
+final _smoke_Structs_AllTypesStruct_get_field_uint64Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_uint64Field');
-final _smoke_Structs_AllTypesStruct_get_field_floatField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_uint64Field'));
+final _smoke_Structs_AllTypesStruct_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_floatField');
-final _smoke_Structs_AllTypesStruct_get_field_doubleField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_floatField'));
+final _smoke_Structs_AllTypesStruct_get_field_doubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_doubleField');
-final _smoke_Structs_AllTypesStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_doubleField'));
+final _smoke_Structs_AllTypesStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_stringField');
-final _smoke_Structs_AllTypesStruct_get_field_booleanField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_stringField'));
+final _smoke_Structs_AllTypesStruct_get_field_booleanField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_booleanField');
-final _smoke_Structs_AllTypesStruct_get_field_bytesField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_booleanField'));
+final _smoke_Structs_AllTypesStruct_get_field_bytesField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_bytesField');
-final _smoke_Structs_AllTypesStruct_get_field_pointField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_get_field_bytesField'));
+final _smoke_Structs_AllTypesStruct_get_field_pointField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_field_pointField');
+  >('library_smoke_Structs_AllTypesStruct_get_field_pointField'));
 Pointer<Void> smoke_Structs_AllTypesStruct_toFfi(Structs_AllTypesStruct value) {
   final _int8Field_handle = (value.int8Field);
   final _uint8Field_handle = (value.uint8Field);
@@ -391,18 +391,18 @@ Structs_AllTypesStruct smoke_Structs_AllTypesStruct_fromFfi(Pointer<Void> handle
 }
 void smoke_Structs_AllTypesStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_AllTypesStruct_release_handle(handle);
 // Nullable Structs_AllTypesStruct
-final _smoke_Structs_AllTypesStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_AllTypesStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_create_handle_nullable');
-final _smoke_Structs_AllTypesStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_create_handle_nullable'));
+final _smoke_Structs_AllTypesStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_release_handle_nullable');
-final _smoke_Structs_AllTypesStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_AllTypesStruct_release_handle_nullable'));
+final _smoke_Structs_AllTypesStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_AllTypesStruct_get_value_nullable');
+  >('library_smoke_Structs_AllTypesStruct_get_value_nullable'));
 Pointer<Void> smoke_Structs_AllTypesStruct_toFfi_nullable(Structs_AllTypesStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_AllTypesStruct_toFfi(value);
@@ -425,18 +425,18 @@ class Structs_NestingImmutableStruct {
   Structs_NestingImmutableStruct(this.structField);
 }
 // Structs_NestingImmutableStruct "private" section, not exported.
-final _smoke_Structs_NestingImmutableStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_NestingImmutableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_NestingImmutableStruct_create_handle');
-final _smoke_Structs_NestingImmutableStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_NestingImmutableStruct_create_handle'));
+final _smoke_Structs_NestingImmutableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_NestingImmutableStruct_release_handle');
-final _smoke_Structs_NestingImmutableStruct_get_field_structField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_NestingImmutableStruct_release_handle'));
+final _smoke_Structs_NestingImmutableStruct_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_NestingImmutableStruct_get_field_structField');
+  >('library_smoke_Structs_NestingImmutableStruct_get_field_structField'));
 Pointer<Void> smoke_Structs_NestingImmutableStruct_toFfi(Structs_NestingImmutableStruct value) {
   final _structField_handle = smoke_Structs_AllTypesStruct_toFfi(value.structField);
   final _result = _smoke_Structs_NestingImmutableStruct_create_handle(_structField_handle);
@@ -455,18 +455,18 @@ Structs_NestingImmutableStruct smoke_Structs_NestingImmutableStruct_fromFfi(Poin
 }
 void smoke_Structs_NestingImmutableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_NestingImmutableStruct_release_handle(handle);
 // Nullable Structs_NestingImmutableStruct
-final _smoke_Structs_NestingImmutableStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_NestingImmutableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_NestingImmutableStruct_create_handle_nullable');
-final _smoke_Structs_NestingImmutableStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_NestingImmutableStruct_create_handle_nullable'));
+final _smoke_Structs_NestingImmutableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_NestingImmutableStruct_release_handle_nullable');
-final _smoke_Structs_NestingImmutableStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_NestingImmutableStruct_release_handle_nullable'));
+final _smoke_Structs_NestingImmutableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_NestingImmutableStruct_get_value_nullable');
+  >('library_smoke_Structs_NestingImmutableStruct_get_value_nullable'));
 Pointer<Void> smoke_Structs_NestingImmutableStruct_toFfi_nullable(Structs_NestingImmutableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_NestingImmutableStruct_toFfi(value);
@@ -489,18 +489,18 @@ class Structs_DoubleNestingImmutableStruct {
   Structs_DoubleNestingImmutableStruct(this.nestingStructField);
 }
 // Structs_DoubleNestingImmutableStruct "private" section, not exported.
-final _smoke_Structs_DoubleNestingImmutableStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_DoubleNestingImmutableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_DoubleNestingImmutableStruct_create_handle');
-final _smoke_Structs_DoubleNestingImmutableStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_DoubleNestingImmutableStruct_create_handle'));
+final _smoke_Structs_DoubleNestingImmutableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_DoubleNestingImmutableStruct_release_handle');
-final _smoke_Structs_DoubleNestingImmutableStruct_get_field_nestingStructField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_DoubleNestingImmutableStruct_release_handle'));
+final _smoke_Structs_DoubleNestingImmutableStruct_get_field_nestingStructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_DoubleNestingImmutableStruct_get_field_nestingStructField');
+  >('library_smoke_Structs_DoubleNestingImmutableStruct_get_field_nestingStructField'));
 Pointer<Void> smoke_Structs_DoubleNestingImmutableStruct_toFfi(Structs_DoubleNestingImmutableStruct value) {
   final _nestingStructField_handle = smoke_Structs_NestingImmutableStruct_toFfi(value.nestingStructField);
   final _result = _smoke_Structs_DoubleNestingImmutableStruct_create_handle(_nestingStructField_handle);
@@ -519,18 +519,18 @@ Structs_DoubleNestingImmutableStruct smoke_Structs_DoubleNestingImmutableStruct_
 }
 void smoke_Structs_DoubleNestingImmutableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_DoubleNestingImmutableStruct_release_handle(handle);
 // Nullable Structs_DoubleNestingImmutableStruct
-final _smoke_Structs_DoubleNestingImmutableStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_DoubleNestingImmutableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_DoubleNestingImmutableStruct_create_handle_nullable');
-final _smoke_Structs_DoubleNestingImmutableStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_DoubleNestingImmutableStruct_create_handle_nullable'));
+final _smoke_Structs_DoubleNestingImmutableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_DoubleNestingImmutableStruct_release_handle_nullable');
-final _smoke_Structs_DoubleNestingImmutableStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_DoubleNestingImmutableStruct_release_handle_nullable'));
+final _smoke_Structs_DoubleNestingImmutableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_DoubleNestingImmutableStruct_get_value_nullable');
+  >('library_smoke_Structs_DoubleNestingImmutableStruct_get_value_nullable'));
 Pointer<Void> smoke_Structs_DoubleNestingImmutableStruct_toFfi_nullable(Structs_DoubleNestingImmutableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_DoubleNestingImmutableStruct_toFfi(value);
@@ -553,18 +553,18 @@ class Structs_StructWithArrayOfImmutable {
   Structs_StructWithArrayOfImmutable(this.arrayField);
 }
 // Structs_StructWithArrayOfImmutable "private" section, not exported.
-final _smoke_Structs_StructWithArrayOfImmutable_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_StructWithArrayOfImmutable_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_StructWithArrayOfImmutable_create_handle');
-final _smoke_Structs_StructWithArrayOfImmutable_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_StructWithArrayOfImmutable_create_handle'));
+final _smoke_Structs_StructWithArrayOfImmutable_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_StructWithArrayOfImmutable_release_handle');
-final _smoke_Structs_StructWithArrayOfImmutable_get_field_arrayField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_StructWithArrayOfImmutable_release_handle'));
+final _smoke_Structs_StructWithArrayOfImmutable_get_field_arrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_StructWithArrayOfImmutable_get_field_arrayField');
+  >('library_smoke_Structs_StructWithArrayOfImmutable_get_field_arrayField'));
 Pointer<Void> smoke_Structs_StructWithArrayOfImmutable_toFfi(Structs_StructWithArrayOfImmutable value) {
   final _arrayField_handle = ListOf_smoke_Structs_AllTypesStruct_toFfi(value.arrayField);
   final _result = _smoke_Structs_StructWithArrayOfImmutable_create_handle(_arrayField_handle);
@@ -583,18 +583,18 @@ Structs_StructWithArrayOfImmutable smoke_Structs_StructWithArrayOfImmutable_from
 }
 void smoke_Structs_StructWithArrayOfImmutable_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_StructWithArrayOfImmutable_release_handle(handle);
 // Nullable Structs_StructWithArrayOfImmutable
-final _smoke_Structs_StructWithArrayOfImmutable_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_StructWithArrayOfImmutable_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_StructWithArrayOfImmutable_create_handle_nullable');
-final _smoke_Structs_StructWithArrayOfImmutable_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_StructWithArrayOfImmutable_create_handle_nullable'));
+final _smoke_Structs_StructWithArrayOfImmutable_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_StructWithArrayOfImmutable_release_handle_nullable');
-final _smoke_Structs_StructWithArrayOfImmutable_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_StructWithArrayOfImmutable_release_handle_nullable'));
+final _smoke_Structs_StructWithArrayOfImmutable_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_StructWithArrayOfImmutable_get_value_nullable');
+  >('library_smoke_Structs_StructWithArrayOfImmutable_get_value_nullable'));
 Pointer<Void> smoke_Structs_StructWithArrayOfImmutable_toFfi_nullable(Structs_StructWithArrayOfImmutable value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_StructWithArrayOfImmutable_toFfi(value);
@@ -618,18 +618,18 @@ class Structs_ImmutableStructWithCppAccessors {
   const Structs_ImmutableStructWithCppAccessors(this.stringField);
 }
 // Structs_ImmutableStructWithCppAccessors "private" section, not exported.
-final _smoke_Structs_ImmutableStructWithCppAccessors_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_ImmutableStructWithCppAccessors_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_ImmutableStructWithCppAccessors_create_handle');
-final _smoke_Structs_ImmutableStructWithCppAccessors_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_ImmutableStructWithCppAccessors_create_handle'));
+final _smoke_Structs_ImmutableStructWithCppAccessors_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_ImmutableStructWithCppAccessors_release_handle');
-final _smoke_Structs_ImmutableStructWithCppAccessors_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_ImmutableStructWithCppAccessors_release_handle'));
+final _smoke_Structs_ImmutableStructWithCppAccessors_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_ImmutableStructWithCppAccessors_get_field_stringField');
+  >('library_smoke_Structs_ImmutableStructWithCppAccessors_get_field_stringField'));
 Pointer<Void> smoke_Structs_ImmutableStructWithCppAccessors_toFfi(Structs_ImmutableStructWithCppAccessors value) {
   final _stringField_handle = String_toFfi(value.stringField);
   final _result = _smoke_Structs_ImmutableStructWithCppAccessors_create_handle(_stringField_handle);
@@ -648,18 +648,18 @@ Structs_ImmutableStructWithCppAccessors smoke_Structs_ImmutableStructWithCppAcce
 }
 void smoke_Structs_ImmutableStructWithCppAccessors_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_ImmutableStructWithCppAccessors_release_handle(handle);
 // Nullable Structs_ImmutableStructWithCppAccessors
-final _smoke_Structs_ImmutableStructWithCppAccessors_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_ImmutableStructWithCppAccessors_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_ImmutableStructWithCppAccessors_create_handle_nullable');
-final _smoke_Structs_ImmutableStructWithCppAccessors_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_ImmutableStructWithCppAccessors_create_handle_nullable'));
+final _smoke_Structs_ImmutableStructWithCppAccessors_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_ImmutableStructWithCppAccessors_release_handle_nullable');
-final _smoke_Structs_ImmutableStructWithCppAccessors_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_ImmutableStructWithCppAccessors_release_handle_nullable'));
+final _smoke_Structs_ImmutableStructWithCppAccessors_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_ImmutableStructWithCppAccessors_get_value_nullable');
+  >('library_smoke_Structs_ImmutableStructWithCppAccessors_get_value_nullable'));
 Pointer<Void> smoke_Structs_ImmutableStructWithCppAccessors_toFfi_nullable(Structs_ImmutableStructWithCppAccessors value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_ImmutableStructWithCppAccessors_toFfi(value);
@@ -682,18 +682,18 @@ class Structs_MutableStructWithCppAccessors {
   Structs_MutableStructWithCppAccessors(this.stringField);
 }
 // Structs_MutableStructWithCppAccessors "private" section, not exported.
-final _smoke_Structs_MutableStructWithCppAccessors_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_MutableStructWithCppAccessors_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_MutableStructWithCppAccessors_create_handle');
-final _smoke_Structs_MutableStructWithCppAccessors_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_MutableStructWithCppAccessors_create_handle'));
+final _smoke_Structs_MutableStructWithCppAccessors_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_MutableStructWithCppAccessors_release_handle');
-final _smoke_Structs_MutableStructWithCppAccessors_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_MutableStructWithCppAccessors_release_handle'));
+final _smoke_Structs_MutableStructWithCppAccessors_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_MutableStructWithCppAccessors_get_field_stringField');
+  >('library_smoke_Structs_MutableStructWithCppAccessors_get_field_stringField'));
 Pointer<Void> smoke_Structs_MutableStructWithCppAccessors_toFfi(Structs_MutableStructWithCppAccessors value) {
   final _stringField_handle = String_toFfi(value.stringField);
   final _result = _smoke_Structs_MutableStructWithCppAccessors_create_handle(_stringField_handle);
@@ -712,18 +712,18 @@ Structs_MutableStructWithCppAccessors smoke_Structs_MutableStructWithCppAccessor
 }
 void smoke_Structs_MutableStructWithCppAccessors_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_MutableStructWithCppAccessors_release_handle(handle);
 // Nullable Structs_MutableStructWithCppAccessors
-final _smoke_Structs_MutableStructWithCppAccessors_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_MutableStructWithCppAccessors_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_MutableStructWithCppAccessors_create_handle_nullable');
-final _smoke_Structs_MutableStructWithCppAccessors_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_MutableStructWithCppAccessors_create_handle_nullable'));
+final _smoke_Structs_MutableStructWithCppAccessors_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_MutableStructWithCppAccessors_release_handle_nullable');
-final _smoke_Structs_MutableStructWithCppAccessors_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_MutableStructWithCppAccessors_release_handle_nullable'));
+final _smoke_Structs_MutableStructWithCppAccessors_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_MutableStructWithCppAccessors_get_value_nullable');
+  >('library_smoke_Structs_MutableStructWithCppAccessors_get_value_nullable'));
 Pointer<Void> smoke_Structs_MutableStructWithCppAccessors_toFfi_nullable(Structs_MutableStructWithCppAccessors value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_MutableStructWithCppAccessors_toFfi(value);
@@ -742,18 +742,18 @@ void smoke_Structs_MutableStructWithCppAccessors_releaseFfiHandle_nullable(Point
   _smoke_Structs_MutableStructWithCppAccessors_release_handle_nullable(handle);
 // End of Structs_MutableStructWithCppAccessors "private" section.
 // Structs "private" section, not exported.
-final _smoke_Structs_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_Structs_copy_handle');
-final _smoke_Structs_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_copy_handle'));
+final _smoke_Structs_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_Structs_release_handle');
-final _smoke_Structs_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_Structs_release_handle'));
+final _smoke_Structs_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_Structs_get_raw_pointer');
+    >('library_smoke_Structs_get_raw_pointer'));
 class Structs$Impl implements Structs {
   @protected
   Pointer<Void> handle;
@@ -766,7 +766,7 @@ class Structs$Impl implements Structs {
     handle = null;
   }
   static Structs_Point swapPointCoordinates(Structs_Point input) {
-    final _swapPointCoordinates_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_swapPointCoordinates__Point');
+    final _swapPointCoordinates_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_swapPointCoordinates__Point'));
     final _input_handle = smoke_Structs_Point_toFfi(input);
     final __result_handle = _swapPointCoordinates_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Structs_Point_releaseFfiHandle(_input_handle);
@@ -777,7 +777,7 @@ class Structs$Impl implements Structs {
     }
   }
   static Structs_AllTypesStruct returnAllTypesStruct(Structs_AllTypesStruct input) {
-    final _returnAllTypesStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_returnAllTypesStruct__AllTypesStruct');
+    final _returnAllTypesStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_returnAllTypesStruct__AllTypesStruct'));
     final _input_handle = smoke_Structs_AllTypesStruct_toFfi(input);
     final __result_handle = _returnAllTypesStruct_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_Structs_AllTypesStruct_releaseFfiHandle(_input_handle);
@@ -788,7 +788,7 @@ class Structs$Impl implements Structs {
     }
   }
   static Point createPoint(double x, double y) {
-    final _createPoint_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Double, Double), Pointer<Void> Function(int, double, double)>('library_smoke_Structs_createPoint__Double_Double');
+    final _createPoint_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Double, Double), Pointer<Void> Function(int, double, double)>('library_smoke_Structs_createPoint__Double_Double'));
     final _x_handle = (x);
     final _y_handle = (y);
     final __result_handle = _createPoint_ffi(__lib.LibraryContext.isolateId, _x_handle, _y_handle);
@@ -801,7 +801,7 @@ class Structs$Impl implements Structs {
     }
   }
   static AllTypesStruct modifyAllTypesStruct(AllTypesStruct input) {
-    final _modifyAllTypesStruct_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_modifyAllTypesStruct__AllTypesStruct');
+    final _modifyAllTypesStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_modifyAllTypesStruct__AllTypesStruct'));
     final _input_handle = smoke_TypeCollection_AllTypesStruct_toFfi(input);
     final __result_handle = _modifyAllTypesStruct_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(_input_handle);

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_constants.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_constants.dart
@@ -12,22 +12,22 @@ class Route {
   static final RouteType defaultType = RouteType.equestrian;
 }
 // Route "private" section, not exported.
-final _smoke_StructsWithConstants_Route_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructsWithConstants_Route_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Uint32),
     Pointer<Void> Function(Pointer<Void>, int)
-  >('library_smoke_StructsWithConstants_Route_create_handle');
-final _smoke_StructsWithConstants_Route_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithConstants_Route_create_handle'));
+final _smoke_StructsWithConstants_Route_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructsWithConstants_Route_release_handle');
-final _smoke_StructsWithConstants_Route_get_field_description = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithConstants_Route_release_handle'));
+final _smoke_StructsWithConstants_Route_get_field_description = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructsWithConstants_Route_get_field_description');
-final _smoke_StructsWithConstants_Route_get_field_type = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithConstants_Route_get_field_description'));
+final _smoke_StructsWithConstants_Route_get_field_type = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_StructsWithConstants_Route_get_field_type');
+  >('library_smoke_StructsWithConstants_Route_get_field_type'));
 Pointer<Void> smoke_StructsWithConstants_Route_toFfi(Route value) {
   final _description_handle = String_toFfi(value.description);
   final _type_handle = smoke_RouteUtils_RouteType_toFfi(value.type);
@@ -51,18 +51,18 @@ Route smoke_StructsWithConstants_Route_fromFfi(Pointer<Void> handle) {
 }
 void smoke_StructsWithConstants_Route_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructsWithConstants_Route_release_handle(handle);
 // Nullable Route
-final _smoke_StructsWithConstants_Route_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructsWithConstants_Route_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructsWithConstants_Route_create_handle_nullable');
-final _smoke_StructsWithConstants_Route_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithConstants_Route_create_handle_nullable'));
+final _smoke_StructsWithConstants_Route_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructsWithConstants_Route_release_handle_nullable');
-final _smoke_StructsWithConstants_Route_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithConstants_Route_release_handle_nullable'));
+final _smoke_StructsWithConstants_Route_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructsWithConstants_Route_get_value_nullable');
+  >('library_smoke_StructsWithConstants_Route_get_value_nullable'));
 Pointer<Void> smoke_StructsWithConstants_Route_toFfi_nullable(Route value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructsWithConstants_Route_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
@@ -4,22 +4,22 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-final _copy_return_release_handle = __lib.nativeLibrary.lookupFunction<
+final _copy_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructsWithMethods_Vector_create__Vector_return_release_handle');
-final _copy_return_get_result = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithMethods_Vector_create__Vector_return_release_handle'));
+final _copy_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructsWithMethods_Vector_create__Vector_return_get_result');
-final _copy_return_get_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithMethods_Vector_create__Vector_return_get_result'));
+final _copy_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_StructsWithMethods_Vector_create__Vector_return_get_error');
-final _copy_return_has_error = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithMethods_Vector_create__Vector_return_get_error'));
+final _copy_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_StructsWithMethods_Vector_create__Vector_return_has_error');
+  >('library_smoke_StructsWithMethods_Vector_create__Vector_return_has_error'));
 class Vector {
   double x;
   double y;
@@ -29,7 +29,7 @@ class Vector {
   Vector.copy(Vector other) : this._copy(_copy(other));
   Vector.create(int input) : this._copy(_create(input));
   double distanceTo(Vector other) {
-    final _distanceTo_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>), double Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_distanceTo__Vector');
+    final _distanceTo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>), double Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_distanceTo__Vector'));
     final _other_handle = smoke_StructsWithMethods_Vector_toFfi(other);
     final _handle = smoke_StructsWithMethods_Vector_toFfi(this);
     final __result_handle = _distanceTo_ffi(_handle, __lib.LibraryContext.isolateId, _other_handle);
@@ -42,7 +42,7 @@ class Vector {
     }
   }
   Vector add(Vector other) {
-    final _add_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_add__Vector');
+    final _add_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_add__Vector'));
     final _other_handle = smoke_StructsWithMethods_Vector_toFfi(other);
     final _handle = smoke_StructsWithMethods_Vector_toFfi(this);
     final __result_handle = _add_ffi(_handle, __lib.LibraryContext.isolateId, _other_handle);
@@ -55,7 +55,7 @@ class Vector {
     }
   }
   static bool validate(double x, double y) {
-    final _validate_ffi = __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Double, Double), int Function(int, double, double)>('library_smoke_StructsWithMethods_Vector_validate__Double_Double');
+    final _validate_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Double, Double), int Function(int, double, double)>('library_smoke_StructsWithMethods_Vector_validate__Double_Double'));
     final _x_handle = (x);
     final _y_handle = (y);
     final __result_handle = _validate_ffi(__lib.LibraryContext.isolateId, _x_handle, _y_handle);
@@ -68,7 +68,7 @@ class Vector {
     }
   }
   static Vector _$init(double x, double y) {
-    final _$init_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Double, Double), Pointer<Void> Function(int, double, double)>('library_smoke_StructsWithMethods_Vector_create__Double_Double');
+    final _$init_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Double, Double), Pointer<Void> Function(int, double, double)>('library_smoke_StructsWithMethods_Vector_create__Double_Double'));
     final _x_handle = (x);
     final _y_handle = (y);
     final __result_handle = _$init_ffi(__lib.LibraryContext.isolateId, _x_handle, _y_handle);
@@ -81,7 +81,7 @@ class Vector {
     }
   }
   static Vector _copy(Vector other) {
-    final _copy_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_create__Vector');
+    final _copy_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_create__Vector'));
     final _other_handle = smoke_StructsWithMethods_Vector_toFfi(other);
     final __call_result_handle = _copy_ffi(__lib.LibraryContext.isolateId, _other_handle);
     smoke_StructsWithMethods_Vector_releaseFfiHandle(_other_handle);
@@ -103,7 +103,7 @@ class Vector {
     }
   }
   static Vector _create(int input) {
-    final _create_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_StructsWithMethods_Vector_create__ULong');
+    final _create_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_StructsWithMethods_Vector_create__ULong'));
     final _input_handle = (input);
     final __result_handle = _create_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
@@ -115,22 +115,22 @@ class Vector {
   }
 }
 // Vector "private" section, not exported.
-final _smoke_StructsWithMethods_Vector_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructsWithMethods_Vector_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double, Double),
     Pointer<Void> Function(double, double)
-  >('library_smoke_StructsWithMethods_Vector_create_handle');
-final _smoke_StructsWithMethods_Vector_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithMethods_Vector_create_handle'));
+final _smoke_StructsWithMethods_Vector_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructsWithMethods_Vector_release_handle');
-final _smoke_StructsWithMethods_Vector_get_field_x = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithMethods_Vector_release_handle'));
+final _smoke_StructsWithMethods_Vector_get_field_x = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_StructsWithMethods_Vector_get_field_x');
-final _smoke_StructsWithMethods_Vector_get_field_y = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithMethods_Vector_get_field_x'));
+final _smoke_StructsWithMethods_Vector_get_field_y = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_StructsWithMethods_Vector_get_field_y');
+  >('library_smoke_StructsWithMethods_Vector_get_field_y'));
 Pointer<Void> smoke_StructsWithMethods_Vector_toFfi(Vector value) {
   final _x_handle = (value.x);
   final _y_handle = (value.y);
@@ -154,18 +154,18 @@ Vector smoke_StructsWithMethods_Vector_fromFfi(Pointer<Void> handle) {
 }
 void smoke_StructsWithMethods_Vector_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructsWithMethods_Vector_release_handle(handle);
 // Nullable Vector
-final _smoke_StructsWithMethods_Vector_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_StructsWithMethods_Vector_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructsWithMethods_Vector_create_handle_nullable');
-final _smoke_StructsWithMethods_Vector_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithMethods_Vector_create_handle_nullable'));
+final _smoke_StructsWithMethods_Vector_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_StructsWithMethods_Vector_release_handle_nullable');
-final _smoke_StructsWithMethods_Vector_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_StructsWithMethods_Vector_release_handle_nullable'));
+final _smoke_StructsWithMethods_Vector_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_StructsWithMethods_Vector_get_value_nullable');
+  >('library_smoke_StructsWithMethods_Vector_get_value_nullable'));
 Pointer<Void> smoke_StructsWithMethods_Vector_toFfi_nullable(Vector value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructsWithMethods_Vector_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -26,18 +26,18 @@ class TypeDefs_StructHavingAliasFieldDefinedBelow {
   TypeDefs_StructHavingAliasFieldDefinedBelow(this.field);
 }
 // TypeDefs_StructHavingAliasFieldDefinedBelow "private" section, not exported.
-final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
-  >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle');
-final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle'));
+final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle');
-final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_field_field = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle'));
+final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_field_field');
+  >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_field_field'));
 Pointer<Void> smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_toFfi(TypeDefs_StructHavingAliasFieldDefinedBelow value) {
   final _field_handle = (value.field);
   final _result = _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle(_field_handle);
@@ -56,18 +56,18 @@ TypeDefs_StructHavingAliasFieldDefinedBelow smoke_TypeDefs_StructHavingAliasFiel
 }
 void smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle(handle);
 // Nullable TypeDefs_StructHavingAliasFieldDefinedBelow
-final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle_nullable');
-final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle_nullable'));
+final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle_nullable');
-final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle_nullable'));
+final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_value_nullable');
+  >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_value_nullable'));
 Pointer<Void> smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_toFfi_nullable(TypeDefs_StructHavingAliasFieldDefinedBelow value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_toFfi(value);
@@ -90,18 +90,18 @@ class TypeDefs_TestStruct {
   TypeDefs_TestStruct(this.something);
 }
 // TypeDefs_TestStruct "private" section, not exported.
-final _smoke_TypeDefs_TestStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_TypeDefs_TestStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_TestStruct_create_handle');
-final _smoke_TypeDefs_TestStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypeDefs_TestStruct_create_handle'));
+final _smoke_TypeDefs_TestStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_TestStruct_release_handle');
-final _smoke_TypeDefs_TestStruct_get_field_something = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypeDefs_TestStruct_release_handle'));
+final _smoke_TypeDefs_TestStruct_get_field_something = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_TestStruct_get_field_something');
+  >('library_smoke_TypeDefs_TestStruct_get_field_something'));
 Pointer<Void> smoke_TypeDefs_TestStruct_toFfi(TypeDefs_TestStruct value) {
   final _something_handle = String_toFfi(value.something);
   final _result = _smoke_TypeDefs_TestStruct_create_handle(_something_handle);
@@ -120,18 +120,18 @@ TypeDefs_TestStruct smoke_TypeDefs_TestStruct_fromFfi(Pointer<Void> handle) {
 }
 void smoke_TypeDefs_TestStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypeDefs_TestStruct_release_handle(handle);
 // Nullable TypeDefs_TestStruct
-final _smoke_TypeDefs_TestStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_TypeDefs_TestStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_TestStruct_create_handle_nullable');
-final _smoke_TypeDefs_TestStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypeDefs_TestStruct_create_handle_nullable'));
+final _smoke_TypeDefs_TestStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_TestStruct_release_handle_nullable');
-final _smoke_TypeDefs_TestStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypeDefs_TestStruct_release_handle_nullable'));
+final _smoke_TypeDefs_TestStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_TestStruct_get_value_nullable');
+  >('library_smoke_TypeDefs_TestStruct_get_value_nullable'));
 Pointer<Void> smoke_TypeDefs_TestStruct_toFfi_nullable(TypeDefs_TestStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypeDefs_TestStruct_toFfi(value);
@@ -150,18 +150,18 @@ void smoke_TypeDefs_TestStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =
   _smoke_TypeDefs_TestStruct_release_handle_nullable(handle);
 // End of TypeDefs_TestStruct "private" section.
 // TypeDefs "private" section, not exported.
-final _smoke_TypeDefs_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_TypeDefs_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_copy_handle');
-final _smoke_TypeDefs_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypeDefs_copy_handle'));
+final _smoke_TypeDefs_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_TypeDefs_release_handle');
-final _smoke_TypeDefs_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_TypeDefs_release_handle'));
+final _smoke_TypeDefs_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_TypeDefs_get_raw_pointer');
+    >('library_smoke_TypeDefs_get_raw_pointer'));
 class TypeDefs$Impl implements TypeDefs {
   @protected
   Pointer<Void> handle;
@@ -174,7 +174,7 @@ class TypeDefs$Impl implements TypeDefs {
     handle = null;
   }
   static double methodWithPrimitiveTypeDef(double input) {
-    final _methodWithPrimitiveTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_methodWithPrimitiveTypeDef__Double');
+    final _methodWithPrimitiveTypeDef_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_methodWithPrimitiveTypeDef__Double'));
     final _input_handle = (input);
     final __result_handle = _methodWithPrimitiveTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
@@ -185,7 +185,7 @@ class TypeDefs$Impl implements TypeDefs {
     }
   }
   static List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) {
-    final _methodWithComplexTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_methodWithComplexTypeDef__ListOf_1smoke_1TypeDefs_1TestStruct');
+    final _methodWithComplexTypeDef_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_methodWithComplexTypeDef__ListOf_1smoke_1TypeDefs_1TestStruct'));
     final _input_handle = ListOf_smoke_TypeDefs_TestStruct_toFfi(input);
     final __result_handle = _methodWithComplexTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
     ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
@@ -196,7 +196,7 @@ class TypeDefs$Impl implements TypeDefs {
     }
   }
   static double returnNestedIntTypeDef(double input) {
-    final _returnNestedIntTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_returnNestedIntTypeDef__Double');
+    final _returnNestedIntTypeDef_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_returnNestedIntTypeDef__Double'));
     final _input_handle = (input);
     final __result_handle = _returnNestedIntTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
     (_input_handle);
@@ -207,7 +207,7 @@ class TypeDefs$Impl implements TypeDefs {
     }
   }
   static TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) {
-    final _returnTestStructTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTestStructTypeDef__TestStruct');
+    final _returnTestStructTypeDef_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTestStructTypeDef__TestStruct'));
     final _input_handle = smoke_TypeDefs_TestStruct_toFfi(input);
     final __result_handle = _returnTestStructTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
@@ -218,7 +218,7 @@ class TypeDefs$Impl implements TypeDefs {
     }
   }
   static TypeDefs_TestStruct returnNestedStructTypeDef(TypeDefs_TestStruct input) {
-    final _returnNestedStructTypeDef_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnNestedStructTypeDef__TestStruct');
+    final _returnNestedStructTypeDef_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnNestedStructTypeDef__TestStruct'));
     final _input_handle = smoke_TypeDefs_TestStruct_toFfi(input);
     final __result_handle = _returnNestedStructTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
@@ -229,7 +229,7 @@ class TypeDefs$Impl implements TypeDefs {
     }
   }
   static Point returnTypeDefPointFromTypeCollection(Point input) {
-    final _returnTypeDefPointFromTypeCollection_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTypeDefPointFromTypeCollection__Point');
+    final _returnTypeDefPointFromTypeCollection_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTypeDefPointFromTypeCollection__Point'));
     final _input_handle = smoke_TypeCollection_Point_toFfi(input);
     final __result_handle = _returnTypeDefPointFromTypeCollection_ffi(__lib.LibraryContext.isolateId, _input_handle);
     smoke_TypeCollection_Point_releaseFfiHandle(_input_handle);
@@ -241,7 +241,7 @@ class TypeDefs$Impl implements TypeDefs {
   }
   @override
   List<double> get primitiveTypeProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_TypeDefs_primitiveTypeProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_TypeDefs_primitiveTypeProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -252,7 +252,7 @@ class TypeDefs$Impl implements TypeDefs {
   }
   @override
   set primitiveTypeProperty(List<double> value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_TypeDefs_primitiveTypeProperty_set__ListOf_1Double');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_TypeDefs_primitiveTypeProperty_set__ListOf_1Double'));
     final _value_handle = ListOf_Double_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -12,18 +12,18 @@ abstract class InternalClass {
   void release();
 }
 // InternalClass "private" section, not exported.
-final _smoke_InternalClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_InternalClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_InternalClass_copy_handle');
-final _smoke_InternalClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_InternalClass_copy_handle'));
+final _smoke_InternalClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_InternalClass_release_handle');
-final _smoke_InternalClass_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_InternalClass_release_handle'));
+final _smoke_InternalClass_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_InternalClass_get_raw_pointer');
+    >('library_smoke_InternalClass_get_raw_pointer'));
 class InternalClass$Impl implements InternalClass {
   @protected
   Pointer<Void> handle;

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -19,18 +19,18 @@ abstract class InternalClassWithFunctions {
   internal_fooBar();
 }
 // InternalClassWithFunctions "private" section, not exported.
-final _smoke_InternalClassWithFunctions_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_InternalClassWithFunctions_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_InternalClassWithFunctions_copy_handle');
-final _smoke_InternalClassWithFunctions_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_InternalClassWithFunctions_copy_handle'));
+final _smoke_InternalClassWithFunctions_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_InternalClassWithFunctions_release_handle');
-final _smoke_InternalClassWithFunctions_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_InternalClassWithFunctions_release_handle'));
+final _smoke_InternalClassWithFunctions_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_InternalClassWithFunctions_get_raw_pointer');
+    >('library_smoke_InternalClassWithFunctions_get_raw_pointer'));
 class InternalClassWithFunctions$Impl implements InternalClassWithFunctions {
   @protected
   Pointer<Void> handle;
@@ -50,7 +50,7 @@ class InternalClassWithFunctions$Impl implements InternalClassWithFunctions {
   }
   @override
   internal_fooBar() {
-    final _fooBar_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithFunctions_fooBar');
+    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithFunctions_fooBar'));
     final _handle = this.handle;
     final __result_handle = _fooBar_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -60,12 +60,12 @@ class InternalClassWithFunctions$Impl implements InternalClassWithFunctions {
     }
   }
   static Pointer<Void> _make() {
-    final _make_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithFunctions_make');
+    final _make_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithFunctions_make'));
     final __result_handle = _make_ffi(__lib.LibraryContext.isolateId);
     return __result_handle;
   }
   static Pointer<Void> _remake(String foo) {
-    final _remake_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_InternalClassWithFunctions_make__String');
+    final _remake_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_InternalClassWithFunctions_make__String'));
     final _foo_handle = String_toFfi(foo);
     final __result_handle = _remake_ffi(__lib.LibraryContext.isolateId, _foo_handle);
     String_releaseFfiHandle(_foo_handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -17,18 +17,18 @@ abstract class InternalClassWithStaticProperty {
   static set internal_fooBar(String value) { InternalClassWithStaticProperty$Impl.internal_fooBar = value; }
 }
 // InternalClassWithStaticProperty "private" section, not exported.
-final _smoke_InternalClassWithStaticProperty_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_InternalClassWithStaticProperty_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_InternalClassWithStaticProperty_copy_handle');
-final _smoke_InternalClassWithStaticProperty_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_InternalClassWithStaticProperty_copy_handle'));
+final _smoke_InternalClassWithStaticProperty_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_InternalClassWithStaticProperty_release_handle');
-final _smoke_InternalClassWithStaticProperty_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_InternalClassWithStaticProperty_release_handle'));
+final _smoke_InternalClassWithStaticProperty_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_InternalClassWithStaticProperty_get_raw_pointer');
+    >('library_smoke_InternalClassWithStaticProperty_get_raw_pointer'));
 class InternalClassWithStaticProperty$Impl implements InternalClassWithStaticProperty {
   @protected
   Pointer<Void> handle;
@@ -41,7 +41,7 @@ class InternalClassWithStaticProperty$Impl implements InternalClassWithStaticPro
     handle = null;
   }
   static String get internal_fooBar {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithStaticProperty_fooBar_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithStaticProperty_fooBar_get'));
     final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
     try {
       return String_fromFfi(__result_handle);
@@ -50,7 +50,7 @@ class InternalClassWithStaticProperty$Impl implements InternalClassWithStaticPro
     }
   }
   static set internal_fooBar(String value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InternalClassWithStaticProperty_fooBar_set__String');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InternalClassWithStaticProperty_fooBar_set__String'));
     final _value_handle = String_toFfi(value);
     final __result_handle = _set_ffi(__lib.LibraryContext.isolateId, _value_handle);
     String_releaseFfiHandle(_value_handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -14,26 +14,26 @@ abstract class InternalInterface {
   void release() {}
 }
 // InternalInterface "private" section, not exported.
-final _smoke_InternalInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_InternalInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_InternalInterface_copy_handle');
-final _smoke_InternalInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_InternalInterface_copy_handle'));
+final _smoke_InternalInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_InternalInterface_release_handle');
-final _smoke_InternalInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_InternalInterface_release_handle'));
+final _smoke_InternalInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer),
     Pointer<Void> Function(int, int, Pointer)
-  >('library_smoke_InternalInterface_create_proxy');
-final _smoke_InternalInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_InternalInterface_create_proxy'));
+final _smoke_InternalInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_InternalInterface_get_raw_pointer');
-final _smoke_InternalInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_InternalInterface_get_raw_pointer'));
+final _smoke_InternalInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_InternalInterface_get_type_id');
+  >('library_smoke_InternalInterface_get_type_id'));
 class InternalInterface$Impl implements InternalInterface {
   @protected
   Pointer<Void> handle;

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -51,18 +51,18 @@ PublicClass_InternalEnum smoke_PublicClass_InternalEnum_fromFfi(int handle) {
   }
 }
 void smoke_PublicClass_InternalEnum_releaseFfiHandle(int handle) {}
-final _smoke_PublicClass_InternalEnum_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_InternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
-  >('library_smoke_PublicClass_InternalEnum_create_handle_nullable');
-final _smoke_PublicClass_InternalEnum_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_InternalEnum_create_handle_nullable'));
+final _smoke_PublicClass_InternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicClass_InternalEnum_release_handle_nullable');
-final _smoke_PublicClass_InternalEnum_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_InternalEnum_release_handle_nullable'));
+final _smoke_PublicClass_InternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_PublicClass_InternalEnum_get_value_nullable');
+  >('library_smoke_PublicClass_InternalEnum_get_value_nullable'));
 Pointer<Void> smoke_PublicClass_InternalEnum_toFfi_nullable(PublicClass_InternalEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicClass_InternalEnum_toFfi(value);
@@ -87,18 +87,18 @@ class PublicClass_InternalStruct {
   PublicClass_InternalStruct(this.internal_stringField);
 }
 // PublicClass_InternalStruct "private" section, not exported.
-final _smoke_PublicClass_InternalStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_InternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_InternalStruct_create_handle');
-final _smoke_PublicClass_InternalStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_InternalStruct_create_handle'));
+final _smoke_PublicClass_InternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicClass_InternalStruct_release_handle');
-final _smoke_PublicClass_InternalStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_InternalStruct_release_handle'));
+final _smoke_PublicClass_InternalStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_InternalStruct_get_field_stringField');
+  >('library_smoke_PublicClass_InternalStruct_get_field_stringField'));
 Pointer<Void> smoke_PublicClass_InternalStruct_toFfi(PublicClass_InternalStruct value) {
   final _stringField_handle = String_toFfi(value.internal_stringField);
   final _result = _smoke_PublicClass_InternalStruct_create_handle(_stringField_handle);
@@ -117,18 +117,18 @@ PublicClass_InternalStruct smoke_PublicClass_InternalStruct_fromFfi(Pointer<Void
 }
 void smoke_PublicClass_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicClass_InternalStruct_release_handle(handle);
 // Nullable PublicClass_InternalStruct
-final _smoke_PublicClass_InternalStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_InternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_InternalStruct_create_handle_nullable');
-final _smoke_PublicClass_InternalStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_InternalStruct_create_handle_nullable'));
+final _smoke_PublicClass_InternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicClass_InternalStruct_release_handle_nullable');
-final _smoke_PublicClass_InternalStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_InternalStruct_release_handle_nullable'));
+final _smoke_PublicClass_InternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_InternalStruct_get_value_nullable');
+  >('library_smoke_PublicClass_InternalStruct_get_value_nullable'));
 Pointer<Void> smoke_PublicClass_InternalStruct_toFfi_nullable(PublicClass_InternalStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicClass_InternalStruct_toFfi(value);
@@ -152,18 +152,18 @@ class PublicClass_PublicStruct {
   PublicClass_PublicStruct(this.internal_internalField);
 }
 // PublicClass_PublicStruct "private" section, not exported.
-final _smoke_PublicClass_PublicStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_PublicStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_PublicStruct_create_handle');
-final _smoke_PublicClass_PublicStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_PublicStruct_create_handle'));
+final _smoke_PublicClass_PublicStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicClass_PublicStruct_release_handle');
-final _smoke_PublicClass_PublicStruct_get_field_internalField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_PublicStruct_release_handle'));
+final _smoke_PublicClass_PublicStruct_get_field_internalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_PublicStruct_get_field_internalField');
+  >('library_smoke_PublicClass_PublicStruct_get_field_internalField'));
 Pointer<Void> smoke_PublicClass_PublicStruct_toFfi(PublicClass_PublicStruct value) {
   final _internalField_handle = smoke_PublicClass_InternalStruct_toFfi(value.internal_internalField);
   final _result = _smoke_PublicClass_PublicStruct_create_handle(_internalField_handle);
@@ -182,18 +182,18 @@ PublicClass_PublicStruct smoke_PublicClass_PublicStruct_fromFfi(Pointer<Void> ha
 }
 void smoke_PublicClass_PublicStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicClass_PublicStruct_release_handle(handle);
 // Nullable PublicClass_PublicStruct
-final _smoke_PublicClass_PublicStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_PublicStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_PublicStruct_create_handle_nullable');
-final _smoke_PublicClass_PublicStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_PublicStruct_create_handle_nullable'));
+final _smoke_PublicClass_PublicStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicClass_PublicStruct_release_handle_nullable');
-final _smoke_PublicClass_PublicStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_PublicStruct_release_handle_nullable'));
+final _smoke_PublicClass_PublicStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_PublicStruct_get_value_nullable');
+  >('library_smoke_PublicClass_PublicStruct_get_value_nullable'));
 Pointer<Void> smoke_PublicClass_PublicStruct_toFfi_nullable(PublicClass_PublicStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicClass_PublicStruct_toFfi(value);
@@ -220,22 +220,22 @@ class PublicClass_PublicStructWithInternalDefaults {
     : internal_internalField = "foo", publicField = publicField;
 }
 // PublicClass_PublicStructWithInternalDefaults "private" section, not exported.
-final _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Float),
     Pointer<Void> Function(Pointer<Void>, double)
-  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_create_handle');
-final _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_create_handle'));
+final _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_release_handle');
-final _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_internalField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_release_handle'));
+final _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_internalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_field_internalField');
-final _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_field_internalField'));
+final _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
-  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField');
+  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField'));
 Pointer<Void> smoke_PublicClass_PublicStructWithInternalDefaults_toFfi(PublicClass_PublicStructWithInternalDefaults value) {
   final _internalField_handle = String_toFfi(value.internal_internalField);
   final _publicField_handle = (value.publicField);
@@ -259,18 +259,18 @@ PublicClass_PublicStructWithInternalDefaults smoke_PublicClass_PublicStructWithI
 }
 void smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle(handle);
 // Nullable PublicClass_PublicStructWithInternalDefaults
-final _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_create_handle_nullable');
-final _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_create_handle_nullable'));
+final _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_release_handle_nullable');
-final _smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_release_handle_nullable'));
+final _smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable');
+  >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable'));
 Pointer<Void> smoke_PublicClass_PublicStructWithInternalDefaults_toFfi_nullable(PublicClass_PublicStructWithInternalDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicClass_PublicStructWithInternalDefaults_toFfi(value);
@@ -289,18 +289,18 @@ void smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle_nullabl
   _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle_nullable(handle);
 // End of PublicClass_PublicStructWithInternalDefaults "private" section.
 // PublicClass "private" section, not exported.
-final _smoke_PublicClass_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicClass_copy_handle');
-final _smoke_PublicClass_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_copy_handle'));
+final _smoke_PublicClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicClass_release_handle');
-final _smoke_PublicClass_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicClass_release_handle'));
+final _smoke_PublicClass_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_PublicClass_get_raw_pointer');
+    >('library_smoke_PublicClass_get_raw_pointer'));
 class PublicClass$Impl implements PublicClass {
   @protected
   Pointer<Void> handle;
@@ -314,7 +314,7 @@ class PublicClass$Impl implements PublicClass {
   }
   @override
   PublicClass_InternalStruct internal_internalMethod(PublicClass_InternalStruct input) {
-    final _internalMethod_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalMethod__InternalStruct');
+    final _internalMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalMethod__InternalStruct'));
     final _input_handle = smoke_PublicClass_InternalStruct_toFfi(input);
     final _handle = this.handle;
     final __result_handle = _internalMethod_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
@@ -327,7 +327,7 @@ class PublicClass$Impl implements PublicClass {
   }
   @override
   PublicClass_InternalStruct get internal_internalStructProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PublicClass_internalStructProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PublicClass_internalStructProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -338,7 +338,7 @@ class PublicClass$Impl implements PublicClass {
   }
   @override
   set internal_internalStructProperty(PublicClass_InternalStruct value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalStructProperty_set__InternalStruct');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalStructProperty_set__InternalStruct'));
     final _value_handle = smoke_PublicClass_InternalStruct_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
@@ -351,7 +351,7 @@ class PublicClass$Impl implements PublicClass {
   }
   @override
   String get internalSetterProperty {
-    final _get_ffi = __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PublicClass_internalSetterProperty_get');
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PublicClass_internalSetterProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -362,7 +362,7 @@ class PublicClass$Impl implements PublicClass {
   }
   @override
   set internal_internalSetterProperty(String value) {
-    final _set_ffi = __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalSetterProperty_set__String');
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalSetterProperty_set__String'));
     final _value_handle = String_toFfi(value);
     final _handle = this.handle;
     final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
@@ -20,18 +20,18 @@ class PublicInterface_InternalStruct {
   PublicInterface_InternalStruct(this.internal_fieldOfInternalType);
 }
 // PublicInterface_InternalStruct "private" section, not exported.
-final _smoke_PublicInterface_InternalStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicInterface_InternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicInterface_InternalStruct_create_handle');
-final _smoke_PublicInterface_InternalStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicInterface_InternalStruct_create_handle'));
+final _smoke_PublicInterface_InternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicInterface_InternalStruct_release_handle');
-final _smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicInterface_InternalStruct_release_handle'));
+final _smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType');
+  >('library_smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType'));
 Pointer<Void> smoke_PublicInterface_InternalStruct_toFfi(PublicInterface_InternalStruct value) {
   final _fieldOfInternalType_handle = smoke_PublicClass_InternalStruct_toFfi(value.internal_fieldOfInternalType);
   final _result = _smoke_PublicInterface_InternalStruct_create_handle(_fieldOfInternalType_handle);
@@ -50,18 +50,18 @@ PublicInterface_InternalStruct smoke_PublicInterface_InternalStruct_fromFfi(Poin
 }
 void smoke_PublicInterface_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicInterface_InternalStruct_release_handle(handle);
 // Nullable PublicInterface_InternalStruct
-final _smoke_PublicInterface_InternalStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicInterface_InternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicInterface_InternalStruct_create_handle_nullable');
-final _smoke_PublicInterface_InternalStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicInterface_InternalStruct_create_handle_nullable'));
+final _smoke_PublicInterface_InternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicInterface_InternalStruct_release_handle_nullable');
-final _smoke_PublicInterface_InternalStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicInterface_InternalStruct_release_handle_nullable'));
+final _smoke_PublicInterface_InternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicInterface_InternalStruct_get_value_nullable');
+  >('library_smoke_PublicInterface_InternalStruct_get_value_nullable'));
 Pointer<Void> smoke_PublicInterface_InternalStruct_toFfi_nullable(PublicInterface_InternalStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicInterface_InternalStruct_toFfi(value);
@@ -80,26 +80,26 @@ void smoke_PublicInterface_InternalStruct_releaseFfiHandle_nullable(Pointer<Void
   _smoke_PublicInterface_InternalStruct_release_handle_nullable(handle);
 // End of PublicInterface_InternalStruct "private" section.
 // PublicInterface "private" section, not exported.
-final _smoke_PublicInterface_copy_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicInterface_copy_handle');
-final _smoke_PublicInterface_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicInterface_copy_handle'));
+final _smoke_PublicInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicInterface_release_handle');
-final _smoke_PublicInterface_create_proxy = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicInterface_release_handle'));
+final _smoke_PublicInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer),
     Pointer<Void> Function(int, int, Pointer)
-  >('library_smoke_PublicInterface_create_proxy');
-final _smoke_PublicInterface_get_raw_pointer = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicInterface_create_proxy'));
+final _smoke_PublicInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
       Pointer<Void> Function(Pointer<Void>)
-    >('library_smoke_PublicInterface_get_raw_pointer');
-final _smoke_PublicInterface_get_type_id = __lib.nativeLibrary.lookupFunction<
+    >('library_smoke_PublicInterface_get_raw_pointer'));
+final _smoke_PublicInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicInterface_get_type_id');
+  >('library_smoke_PublicInterface_get_type_id'));
 class PublicInterface$Impl implements PublicInterface {
   @protected
   Pointer<Void> handle;

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
@@ -13,26 +13,26 @@ class PublicStructWithNonDefaultInternalField {
     : defaultedField = 42, internal_internalField = internalField, publicField = publicField;
 }
 // PublicStructWithNonDefaultInternalField "private" section, not exported.
-final _smoke_PublicStructWithNonDefaultInternalField_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicStructWithNonDefaultInternalField_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Pointer<Void>, Uint8),
     Pointer<Void> Function(int, Pointer<Void>, int)
-  >('library_smoke_PublicStructWithNonDefaultInternalField_create_handle');
-final _smoke_PublicStructWithNonDefaultInternalField_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicStructWithNonDefaultInternalField_create_handle'));
+final _smoke_PublicStructWithNonDefaultInternalField_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicStructWithNonDefaultInternalField_release_handle');
-final _smoke_PublicStructWithNonDefaultInternalField_get_field_defaultedField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicStructWithNonDefaultInternalField_release_handle'));
+final _smoke_PublicStructWithNonDefaultInternalField_get_field_defaultedField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_PublicStructWithNonDefaultInternalField_get_field_defaultedField');
-final _smoke_PublicStructWithNonDefaultInternalField_get_field_internalField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicStructWithNonDefaultInternalField_get_field_defaultedField'));
+final _smoke_PublicStructWithNonDefaultInternalField_get_field_internalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicStructWithNonDefaultInternalField_get_field_internalField');
-final _smoke_PublicStructWithNonDefaultInternalField_get_field_publicField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicStructWithNonDefaultInternalField_get_field_internalField'));
+final _smoke_PublicStructWithNonDefaultInternalField_get_field_publicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('library_smoke_PublicStructWithNonDefaultInternalField_get_field_publicField');
+  >('library_smoke_PublicStructWithNonDefaultInternalField_get_field_publicField'));
 Pointer<Void> smoke_PublicStructWithNonDefaultInternalField_toFfi(PublicStructWithNonDefaultInternalField value) {
   final _defaultedField_handle = (value.defaultedField);
   final _internalField_handle = String_toFfi(value.internal_internalField);
@@ -61,18 +61,18 @@ PublicStructWithNonDefaultInternalField smoke_PublicStructWithNonDefaultInternal
 }
 void smoke_PublicStructWithNonDefaultInternalField_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicStructWithNonDefaultInternalField_release_handle(handle);
 // Nullable PublicStructWithNonDefaultInternalField
-final _smoke_PublicStructWithNonDefaultInternalField_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicStructWithNonDefaultInternalField_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicStructWithNonDefaultInternalField_create_handle_nullable');
-final _smoke_PublicStructWithNonDefaultInternalField_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicStructWithNonDefaultInternalField_create_handle_nullable'));
+final _smoke_PublicStructWithNonDefaultInternalField_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicStructWithNonDefaultInternalField_release_handle_nullable');
-final _smoke_PublicStructWithNonDefaultInternalField_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicStructWithNonDefaultInternalField_release_handle_nullable'));
+final _smoke_PublicStructWithNonDefaultInternalField_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicStructWithNonDefaultInternalField_get_value_nullable');
+  >('library_smoke_PublicStructWithNonDefaultInternalField_get_value_nullable'));
 Pointer<Void> smoke_PublicStructWithNonDefaultInternalField_toFfi_nullable(PublicStructWithNonDefaultInternalField value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicStructWithNonDefaultInternalField_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
@@ -10,18 +10,18 @@ class InternalStruct {
   InternalStruct(this.internal_stringField);
 }
 // InternalStruct "private" section, not exported.
-final _smoke_PublicTypeCollection_InternalStruct_create_handle = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicTypeCollection_InternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicTypeCollection_InternalStruct_create_handle');
-final _smoke_PublicTypeCollection_InternalStruct_release_handle = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicTypeCollection_InternalStruct_create_handle'));
+final _smoke_PublicTypeCollection_InternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicTypeCollection_InternalStruct_release_handle');
-final _smoke_PublicTypeCollection_InternalStruct_get_field_stringField = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicTypeCollection_InternalStruct_release_handle'));
+final _smoke_PublicTypeCollection_InternalStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicTypeCollection_InternalStruct_get_field_stringField');
+  >('library_smoke_PublicTypeCollection_InternalStruct_get_field_stringField'));
 Pointer<Void> smoke_PublicTypeCollection_InternalStruct_toFfi(InternalStruct value) {
   final _stringField_handle = String_toFfi(value.internal_stringField);
   final _result = _smoke_PublicTypeCollection_InternalStruct_create_handle(_stringField_handle);
@@ -40,18 +40,18 @@ InternalStruct smoke_PublicTypeCollection_InternalStruct_fromFfi(Pointer<Void> h
 }
 void smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicTypeCollection_InternalStruct_release_handle(handle);
 // Nullable InternalStruct
-final _smoke_PublicTypeCollection_InternalStruct_create_handle_nullable = __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicTypeCollection_InternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicTypeCollection_InternalStruct_create_handle_nullable');
-final _smoke_PublicTypeCollection_InternalStruct_release_handle_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicTypeCollection_InternalStruct_create_handle_nullable'));
+final _smoke_PublicTypeCollection_InternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_smoke_PublicTypeCollection_InternalStruct_release_handle_nullable');
-final _smoke_PublicTypeCollection_InternalStruct_get_value_nullable = __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_PublicTypeCollection_InternalStruct_release_handle_nullable'));
+final _smoke_PublicTypeCollection_InternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_PublicTypeCollection_InternalStruct_get_value_nullable');
+  >('library_smoke_PublicTypeCollection_InternalStruct_get_value_nullable'));
 Pointer<Void> smoke_PublicTypeCollection_InternalStruct_toFfi_nullable(InternalStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicTypeCollection_InternalStruct_toFfi(value);


### PR DESCRIPTION
Updated Dart templates to wrap calls to lookupFunction() with a try-catch. This allows for a better/additional error
message. The default additional error message refers to LibraryContext.init(). The message can be overridden through a
new command line parameter to be fully custom.

The original FFI error message is appended after the custom one.

Updated smoke tests.

Resolves: #479
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>