### PR TITLE
Fix generation for @Deprecated attribute without a message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Features
   * Added customizable additional error message in Dart for when FFI function lookup fails.
+### Bug fixes:
+  * Fixed generator failures for `@Deprecated` attribute without a message (C++, Dart).
 
 ## 8.2.1
 Release date: 2020-08-26

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/NameResolverHelper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/NameResolverHelper.kt
@@ -57,7 +57,7 @@ internal class NameResolverHelper : BasicHelper() {
                     element = options.peek()
                     key = parameter
                 } else {
-                    element = parameter
+                    element = parameter ?: return
                     key = ""
                 }
             }

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/NameResolverHelperTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/common/templates/NameResolverHelperTest.kt
@@ -32,7 +32,7 @@ import org.trimou.handlebars.Options
 
 @RunWith(JUnit4::class)
 class NameResolverHelperTest {
-    private val parameters = mutableListOf<Any>()
+    private val parameters = mutableListOf<Any?>()
     private val options = spyk<Options>()
     private val genericElement = object : Any() {}
 
@@ -65,6 +65,16 @@ class NameResolverHelperTest {
         helper.execute(options)
 
         verify(exactly = 1) { options.append("foo") }
+    }
+
+    @Test
+    fun executeNullParameter() {
+        every { options.peek() } returns genericElement
+        parameters.add(null)
+
+        helper.execute(options)
+
+        verify(exactly = 0) { options.append(any()) }
     }
 
     @Test

--- a/gluecodium/src/test/resources/smoke/comments/input/DeprecationComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/DeprecationComments.lime
@@ -89,3 +89,8 @@ interface DeprecationCommentsOnly {
         set
     }
 }
+
+@Deprecated
+struct DeprecatedWithNoMessage {
+    field: String
+}


### PR DESCRIPTION
Updated NameResolverHelper to skip silently if "element" resolves to `null`. This fixes a template engine failure for
`@Deprecated` attribute without a message.

Added smoke and unit tests.

Resolves: #484
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>