### PR TITLE
Generate proxy stubs for skipped interface methods in Java

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -431,6 +431,11 @@ feature(SkipAttribute android swift dart SOURCES
     src/test/Skip.cpp
 )
 
+# TODO: #489: merge with use case above when done
+feature(SkipAttributeProxies android SOURCES
+    lime/test/SkipProxy.lime
+)
+
 # This feature is intended for Swift only.
 feature(Extensions swift SOURCES
     lime/test/Extensions.lime

--- a/examples/libhello/lime/test/SkipProxy.lime
+++ b/examples/libhello/lime/test/SkipProxy.lime
@@ -15,31 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-package smoke
-
-class SkipFunctions {
-    @Java(Skip)
-    static fun notInJava(input: String): String
-    @Swift(Skip)
-    static fun notInSwift(input: Boolean): Boolean
-    @Dart(Skip)
-    static fun notInDart(input: Float): Float
-}
-
-class SkipTypes {
-    @Java(Skip)
-    struct NotInJava {
-        fooField: String
-    }
-    @Swift(Skip)
-    struct NotInSwift {
-        fooField: String
-    }
-    @Dart(Skip)
-    struct NotInDart {
-        fooField: String
-    }
-}
+package test
 
 interface SkipProxy {
     @Java(Skip)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaModelBuilder.kt
@@ -45,6 +45,7 @@ import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeAttributeValueType.BUILDER
 import com.here.gluecodium.model.lime.LimeAttributeValueType.FUNCTION_NAME
 import com.here.gluecodium.model.lime.LimeAttributeValueType.MESSAGE
+import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeComment
 import com.here.gluecodium.model.lime.LimeConstant
@@ -129,7 +130,8 @@ class JavaModelBuilder(
             throwsComment = limeMethod.thrownType?.comment?.getFor(PLATFORM_TAG),
             parameters = getPreviousResults(JavaParameter::class.java),
             isConstructor = limeMethod.isConstructor,
-            isStatic = limeMethod.isStatic
+            isStatic = limeMethod.isStatic,
+            isSkipped = limeMethod.attributes.have(JAVA, SKIP)
         )
         addDeprecatedAnnotationIfNeeded(javaMethod)
 
@@ -310,7 +312,8 @@ class JavaModelBuilder(
             returnComment = propertyComment,
             isStatic = limeProperty.isStatic,
             isGetter = true,
-            isCached = limeProperty.attributes.have(LimeAttributeType.CACHED)
+            isCached = limeProperty.attributes.have(LimeAttributeType.CACHED),
+            isSkipped = limeProperty.attributes.have(JAVA, SKIP)
         )
         addDeprecatedAnnotationIfNeeded(getterMethod)
 
@@ -330,7 +333,8 @@ class JavaModelBuilder(
                 visibility = getVisibility(limeSetter),
                 returnType = JavaPrimitiveTypeRef.VOID,
                 parameters = listOf(setterParameter),
-                isStatic = limeProperty.isStatic
+                isStatic = limeProperty.isStatic,
+                isSkipped = limeProperty.attributes.have(JAVA, SKIP)
             )
             addDeprecatedAnnotationIfNeeded(setterMethod)
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniModelBuilder.kt
@@ -61,6 +61,8 @@ import com.here.gluecodium.model.jni.JniStruct
 import com.here.gluecodium.model.jni.JniTopLevelElement
 import com.here.gluecodium.model.jni.JniType
 import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
+import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeEnumeration
@@ -208,7 +210,8 @@ class JniModelBuilder(
             isConst = cppMethod.qualifiers.contains(CppMethod.Qualifier.CONST),
             isOverloaded = javaSignatureResolver.isOverloaded(limeMethod),
             returnsOpaqueHandle = javaMethod.isConstructor && javaMethod.returnType == JavaPrimitiveTypeRef.LONG,
-            exception = jniException
+            exception = jniException,
+            isSkipped = limeMethod.attributes.have(JAVA, SKIP)
         )
         jniMethod.parameters.addAll(getPreviousResults(JniParameter::class.java))
 
@@ -323,7 +326,8 @@ class JniModelBuilder(
                     JniIncludeResolver.getConversionIncludes(getterTypeRef, javaGetter.returnType)
                 ),
                 isConst = true,
-                isStatic = limeProperty.isStatic
+                isStatic = limeProperty.isStatic,
+                isSkipped = limeProperty.attributes.have(JAVA, SKIP)
             )
         )
         val limeSetter = limeProperty.setter
@@ -334,7 +338,8 @@ class JniModelBuilder(
                 javaMethodName = getMangledName(javaSetter.name),
                 cppMethodName = cppSetter.name,
                 returnType = JniType.VOID,
-                isStatic = limeProperty.isStatic
+                isStatic = limeProperty.isStatic,
+                isSkipped = limeProperty.attributes.have(JAVA, SKIP)
             )
 
             val javaParameter = javaSetter.parameters.first()

--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaMethod.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaMethod.kt
@@ -35,6 +35,7 @@ class JavaMethod(
     var isNative: Boolean = false,
     val isGetter: Boolean = false,
     val isCached: Boolean = false,
+    val isSkipped: Boolean = false,
     annotations: Set<JavaTypeRef> = emptySet()
 ) : JavaElement(name) {
 
@@ -71,6 +72,7 @@ class JavaMethod(
         isNative = isNative,
         isGetter = isGetter,
         isCached = isCached,
+        isSkipped = isSkipped,
         annotations = annotations
     )
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaTopLevelElement.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/java/JavaTopLevelElement.kt
@@ -45,7 +45,7 @@ abstract class JavaTopLevelElement(
                 .flatMap { it.imports }
                 .toMutableList()
             imports += parentInterfaces.flatMap { it.imports }
-            imports += methods.mapNotNull { it.exception }.flatMap { it.imports }
+            imports += methods.filterNot { it.isSkipped }.mapNotNull { it.exception }.flatMap { it.imports }
             imports += innerClasses.flatMap { it.imports }
             imports += innerInterfaces.flatMap { it.imports }
 
@@ -56,6 +56,6 @@ abstract class JavaTopLevelElement(
         }
 
     override val childElements
-        get() = super.childElements + methods + constants + parentInterfaces + enums +
+        get() = super.childElements + methods.filterNot { it.isSkipped } + constants + parentInterfaces + enums +
                 innerClasses + exceptions
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniMethod.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/jni/JniMethod.kt
@@ -26,6 +26,7 @@ class JniMethod(
     val isStatic: Boolean = false,
     val isConst: Boolean = false,
     val isOverloaded: Boolean = false,
+    val isSkipped: Boolean = false,
     val returnsOpaqueHandle: Boolean = false,
     val exception: JniException? = null,
     val parameters: MutableList<JniParameter> = mutableListOf()

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
@@ -41,7 +41,9 @@ import com.here.gluecodium.model.java.JavaPackage
 import com.here.gluecodium.model.java.JavaTopLevelElement
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
+import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.platform.common.GeneratorSuite
 import java.util.logging.Logger
 
@@ -90,7 +92,8 @@ open class JavaGeneratorSuite protected constructor(
         )
 
         val filteredElements =
-            LimeModelFilter { !it.attributes.have(JAVA, SKIP) }.filter(limeModel.topElements)
+            LimeModelFilter { it is LimeFunction || it is LimeProperty || !it.attributes.have(JAVA, SKIP) }
+                .filter(limeModel.topElements)
         val combinedModel =
             filteredElements.fold(JavaModel()) { model, rootElement ->
                 model.merge(jniGenerator.generateModel(rootElement))

--- a/gluecodium/src/main/resources/templates/java/Class.mustache
+++ b/gluecodium/src/main/resources/templates/java/Class.mustache
@@ -39,7 +39,7 @@
 {{/innerClasses}}
 {{#innerInterfaces}}{{prefixPartial "java/Interface" "    "}}
 {{/innerInterfaces}}
-{{#set className=name}}{{#constructors}}
+{{#set className=name}}{{#constructors}}{{#unless isSkipped}}
 {{prefixPartial "java/MethodComment" "    "}}
     {{visibility}} {{className}}({{joinPartial parameters "java/Parameter" ", "}}){{#exception}} throws {{name}}{{/exception}} {
 {{#unless stubs}}{{#if isImplClass}}
@@ -51,7 +51,7 @@
 {{/fields}}
 {{/unless}}{{/unless}}
     }
-{{/constructors}}{{/set}}
+{{/unless}}{{/constructors}}{{/set}}
 {{#unless stubs}}{{#if isImplClass}}
 {{prefixPartial "java/NativeConstructor" "    "}}
 {{#if constructors}}
@@ -104,7 +104,7 @@
 {{#if needsBuilder}}{{#unless constructors}}{{prefixPartial "java/FieldsBuilder" "    "}}
 
 {{/unless}}{{/if}}
-{{#methods}}{{#if stubs}}{{#unless isConstructor}}
+{{#methods}}{{#unless isSkipped}}{{#if stubs}}{{#unless isConstructor}}
 {{prefixPartial "java/MethodSignature" "    "}} {
         throw RuntimeException("This method is a stub and has to be mocked.");
     }
@@ -129,5 +129,5 @@
 }}({{joinPartial parameters "java/Parameter" ", "}});
 {{/if}}{{!!
 }}{{#unless isCached}}{{prefixPartial "java/MethodSignature" "    "}};{{/unless}}{{/unless}}
-{{/methods}}
+{{/unless}}{{/methods}}
 }

--- a/gluecodium/src/main/resources/templates/java/Interface.mustache
+++ b/gluecodium/src/main/resources/templates/java/Interface.mustache
@@ -33,6 +33,6 @@
 {{/innerClasses}}
 {{#innerInterfaces}}{{prefixPartial "java/Interface" "    "}}
 {{/innerInterfaces}}
-{{#set isInterface=true}}{{#methods}}{{prefixPartial "java/MethodSignature" "    "}};
-{{/methods}}{{/set}}
+{{#set isInterface=true}}{{#methods}}{{#unless isSkipped}}{{prefixPartial "java/MethodSignature" "    "}};
+{{/unless}}{{/methods}}{{/set}}
 }

--- a/gluecodium/src/main/resources/templates/jni/CppProxyImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/CppProxyImplementation.mustache
@@ -54,6 +54,9 @@ namespace jni
 }}{{+proxyMethod}}
 {{returnType.cppName}}
 {{mangledName}}_CppProxy::{{cppMethodName}}( {{joinPartial parameters "jni/CppProxyMethodParameter" ", "}} ){{#if isConst}} const{{/if}} {
+{{#if isSkipped}}
+    {{#unless returnType.isJavaVoid}}return {};{{/unless}}
+{{/if}}{{#unless isSkipped}}
     JNIEnv* jniEnv = getJniEnvironment( );{{!!
 }}{{#parameters}}{{!!
 }}{{#if type.isComplex}}
@@ -110,5 +113,6 @@ namespace jni
 {{/unless}}{{/if}}
     }
 {{/exception}}
+{{/unless}}
 }
 {{/proxyMethod}}

--- a/gluecodium/src/main/resources/templates/jni/Header.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Header.mustache
@@ -28,16 +28,16 @@
 extern "C" {
 #endif
 
-{{#container}}{{#methods}}
+{{#container}}{{#methods}}{{#unless isSkipped}}
 JNIEXPORT {{returnType.name}} JNICALL
 {{>jni/FunctionSignature}};
 
-{{/methods}}
-{{#if hasInterfaceParent}}{{#parentMethods}}
+{{/unless}}{{/methods}}
+{{#if hasInterfaceParent}}{{#parentMethods}}{{#unless isSkipped}}
 JNIEXPORT {{returnType.name}} JNICALL
 {{>jni/FunctionSignature}};
 
-{{/parentMethods}}{{/if}}
+{{/unless}}{{/parentMethods}}{{/if}}
 {{#hasNativeEquatable}}
 JNIEXPORT jboolean JNICALL
 {{#set javaMethodName="equals"}}{{>jni/FunctionSignaturePrefix}}{{/set}}, jobject jrhs);

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -30,14 +30,14 @@
 
 extern "C" {
 
-{{#container}}{{#methods}}
+{{#container}}{{#methods}}{{#unless isSkipped}}
 {{>jniMethod}}
 
-{{/methods}}
-{{#if hasInterfaceParent}}{{#parentMethods}}
+{{/unless}}{{/methods}}
+{{#if hasInterfaceParent}}{{#parentMethods}}{{#unless isSkipped}}
 {{>jniMethod}}
 
-{{/parentMethods}}{{/if}}
+{{/unless}}{{/parentMethods}}{{/if}}
 {{#instanceOf container "JniContainer"}}
 JNIEXPORT void JNICALL
 Java_{{mangledName}}_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipProxy.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipProxy.java
@@ -1,0 +1,12 @@
+/*
+ *
+ */
+package com.example.smoke;
+public interface SkipProxy {
+    boolean notInSwift(final boolean input);
+    float notInDart(final float input);
+    boolean isSkippedInSwift();
+    void setSkippedInSwift(final boolean value);
+    float getSkippedInDart();
+    void setSkippedInDart(final float value);
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImplCppProxy.cpp
@@ -1,0 +1,107 @@
+/*
+ *
+ */
+#include "com_example_smoke_SkipProxyImplCppProxy.h"
+#include "com_example_smoke_SkipProxy__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+namespace gluecodium
+{
+namespace jni
+{
+com_example_smoke_SkipProxyImpl_CppProxy::com_example_smoke_SkipProxyImpl_CppProxy( JNIEnv* _jenv, JniReference<jobject> globalRef, jint _jHashCode )
+    : CppProxyBase( _jenv, std::move( globalRef ), _jHashCode, "com_example_smoke_SkipProxyImpl" ) {
+}
+::std::string
+com_example_smoke_SkipProxyImpl_CppProxy::not_in_java( const ::std::string& ninput ) {
+    return {};
+}
+bool
+com_example_smoke_SkipProxyImpl_CppProxy::not_in_swift( const bool ninput ) {
+    JNIEnv* jniEnv = getJniEnvironment( );
+    jboolean jinput = ninput;
+    auto result = callJavaMethod<jboolean>( "notInSwift", "(Z)Z", jniEnv , jinput);
+    if ( jniEnv->ExceptionCheck( ) )
+    {
+        jniEnv->ExceptionDescribe( );
+        jniEnv->ExceptionClear( );
+        jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
+            "See the log for more information about the exception (including Java stack trace)." );
+    }
+    return result;
+}
+float
+com_example_smoke_SkipProxyImpl_CppProxy::not_in_dart( const float ninput ) {
+    JNIEnv* jniEnv = getJniEnvironment( );
+    jfloat jinput = ninput;
+    auto result = callJavaMethod<jfloat>( "notInDart", "(F)F", jniEnv , jinput);
+    if ( jniEnv->ExceptionCheck( ) )
+    {
+        jniEnv->ExceptionDescribe( );
+        jniEnv->ExceptionClear( );
+        jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
+            "See the log for more information about the exception (including Java stack trace)." );
+    }
+    return result;
+}
+::std::string
+com_example_smoke_SkipProxyImpl_CppProxy::get_skipped_in_java(  ) const {
+    return {};
+}
+void
+com_example_smoke_SkipProxyImpl_CppProxy::set_skipped_in_java( const ::std::string& nvalue ) {
+}
+bool
+com_example_smoke_SkipProxyImpl_CppProxy::is_skipped_in_swift(  ) const {
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto result = callJavaMethod<jboolean>( "isSkippedInSwift", "()Z", jniEnv  );
+    if ( jniEnv->ExceptionCheck( ) )
+    {
+        jniEnv->ExceptionDescribe( );
+        jniEnv->ExceptionClear( );
+        jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
+            "See the log for more information about the exception (including Java stack trace)." );
+    }
+    return result;
+}
+void
+com_example_smoke_SkipProxyImpl_CppProxy::set_skipped_in_swift( const bool nvalue ) {
+    JNIEnv* jniEnv = getJniEnvironment( );
+    jboolean jvalue = nvalue;
+    callJavaMethod<void>( "setSkippedInSwift", "(Z)V", jniEnv , jvalue);
+    if ( jniEnv->ExceptionCheck( ) )
+    {
+        jniEnv->ExceptionDescribe( );
+        jniEnv->ExceptionClear( );
+        jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
+            "See the log for more information about the exception (including Java stack trace)." );
+    }
+}
+float
+com_example_smoke_SkipProxyImpl_CppProxy::get_skipped_in_dart(  ) const {
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto result = callJavaMethod<jfloat>( "getSkippedInDart", "()F", jniEnv  );
+    if ( jniEnv->ExceptionCheck( ) )
+    {
+        jniEnv->ExceptionDescribe( );
+        jniEnv->ExceptionClear( );
+        jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
+            "See the log for more information about the exception (including Java stack trace)." );
+    }
+    return result;
+}
+void
+com_example_smoke_SkipProxyImpl_CppProxy::set_skipped_in_dart( const float nvalue ) {
+    JNIEnv* jniEnv = getJniEnvironment( );
+    jfloat jvalue = nvalue;
+    callJavaMethod<void>( "setSkippedInDart", "(F)V", jniEnv , jvalue);
+    if ( jniEnv->ExceptionCheck( ) )
+    {
+        jniEnv->ExceptionDescribe( );
+        jniEnv->ExceptionClear( );
+        jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
+            "See the log for more information about the exception (including Java stack trace)." );
+    }
+}
+}
+}


### PR DESCRIPTION
Updated Java generator and templates to generate method stubs for skipped methods in the proxy. Without these stubs code
generated for interfaces fails to compile because proxy classes become abstract due to unimplemented methods.

Added smoke and functional tests.

See: #489
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>