### PR TITLE
Generate proxy stubs for skipped interface methods in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Added customizable additional error message in Dart for when FFI function lookup fails.
 ### Bug fixes:
   * Fixed generator failures for `@Deprecated` attribute without a message (C++, Dart).
+  * Fixed compilation issues for `@Java(Skip)` and `@Swift(Skip)` on functions and properties in an interface.
 
 ## 8.2.1
 Release date: 2020-08-26

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -432,7 +432,7 @@ feature(SkipAttribute android swift dart SOURCES
 )
 
 # TODO: #489: merge with use case above when done
-feature(SkipAttributeProxies android SOURCES
+feature(SkipAttributeProxies android swift SOURCES
     lime/test/SkipProxy.lime
 )
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeComponents.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeComponents.kt
@@ -32,9 +32,6 @@ object CBridgeComponents {
     val WRAPPER_CACHE_HEADER = Paths.get(
         CBridgeNameRules.CBRIDGE_INTERNAL, CBridgeNameRules.INCLUDE_DIR, "WrapperCache.h"
     ).toString()
-    val WRAPPER_CACHE_IMPL = Paths.get(
-        CBridgeNameRules.CBRIDGE_INTERNAL, CBridgeNameRules.SRC_DIR, "WrapperCache.cpp"
-    ).toString()
 
     fun collectImplementationIncludes(cInterface: CInterface): List<Include> {
         val includes = mutableListOf<Include>()
@@ -42,7 +39,7 @@ object CBridgeComponents {
         val functions = mutableListOf<CFunction>()
         functions.addAll(cInterface.functions)
         functions.addAll(cInterface.inheritedFunctions)
-        for (function in functions) {
+        for (function in functions.filter { !it.isSkipped }) {
             includes.addAll(collectFunctionBodyIncludes(function))
         }
         for (struct in cInterface.structs) {
@@ -83,7 +80,7 @@ object CBridgeComponents {
     fun collectHeaderIncludes(cInterface: CInterface): List<Include> {
         val includes = mutableListOf<Include>()
 
-        for (function in cInterface.functions) {
+        for (function in cInterface.functions.filter { !it.isSkipped }) {
             includes.addAll(collectFunctionSignatureIncludes(function))
         }
         for (struct in cInterface.structs) {
@@ -98,7 +95,7 @@ object CBridgeComponents {
         for (enumType in cInterface.enums) {
             includes.addAll(enumType.includes)
         }
-        if (cInterface.hasEquatableType || cInterface.functions.any { it.error != null }) {
+        if (cInterface.hasEquatableType || cInterface.functions.filter { !it.isSkipped }.any { it.error != null }) {
             includes.add(CType.BOOL_INCLUDE)
         }
         includes += cInterface.interfaces.flatMap { collectHeaderIncludes(it) }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeModelBuilder.kt
@@ -42,7 +42,9 @@ import com.here.gluecodium.model.cpp.CppTypeRef
 import com.here.gluecodium.model.cpp.CppUsing
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeType.CPP
+import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
 import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
@@ -171,7 +173,8 @@ class CBridgeModelBuilder(
             cppReturnTypeName = cppMethod.returnType.fullyQualifiedName,
             isConst = limeMethod.attributes.have(CPP, LimeAttributeValueType.CONST),
             error = errorType,
-            errorTypeIsEnum = errorTypeIsEnum
+            errorTypeIsEnum = errorTypeIsEnum,
+            isSkipped = limeMethod.attributes.have(SWIFT, SKIP)
         )
 
         storeResult(result)
@@ -258,16 +261,17 @@ class CBridgeModelBuilder(
 
         val getterSwiftMethod = swiftProperty.getter
         val getterFunction = CFunction(
-            getterSwiftMethod.cShortName,
-            getterSwiftMethod.cNestedSpecifier,
-            attributeTypeInfo,
-            emptyList(),
-            selfParameter,
-            cppGetterMethod.fullyQualifiedName,
-            cppIncludeResolver.resolveIncludes(limeProperty).toSet(),
-            cppGetterMethod.name,
-            cppGetterMethod.returnType.fullyQualifiedName,
-            true
+            shortName = getterSwiftMethod.cShortName,
+            nestedSpecifier = getterSwiftMethod.cNestedSpecifier,
+            returnType = attributeTypeInfo,
+            parameters = emptyList(),
+            selfParameter = selfParameter,
+            delegateCall = cppGetterMethod.fullyQualifiedName,
+            delegateCallIncludes = cppIncludeResolver.resolveIncludes(limeProperty).toSet(),
+            functionName = cppGetterMethod.name,
+            cppReturnTypeName = cppGetterMethod.returnType.fullyQualifiedName,
+            isConst = true,
+            isSkipped = limeProperty.attributes.have(SWIFT, SKIP)
         )
         storeResult(getterFunction)
 
@@ -275,15 +279,16 @@ class CBridgeModelBuilder(
             val setterSwiftMethod = swiftProperty.setter
             val cppSetterMethod = cppMethods[1]
             val setterFunction = CFunction(
-                setterSwiftMethod?.cShortName,
-                setterSwiftMethod?.cNestedSpecifier,
-                CppTypeInfo(CType.VOID),
-                listOf(CParameter("newValue", attributeTypeInfo)),
-                selfParameter,
-                cppSetterMethod.fullyQualifiedName,
-                cppIncludeResolver.resolveIncludes(limeProperty).toSet(),
-                cppSetterMethod.name,
-                cppSetterMethod.returnType.fullyQualifiedName
+                shortName = setterSwiftMethod?.cShortName,
+                nestedSpecifier = setterSwiftMethod?.cNestedSpecifier,
+                returnType = CppTypeInfo(CType.VOID),
+                parameters = listOf(CParameter("newValue", attributeTypeInfo)),
+                selfParameter = selfParameter,
+                delegateCall = cppSetterMethod.fullyQualifiedName,
+                delegateCallIncludes = cppIncludeResolver.resolveIncludes(limeProperty).toSet(),
+                functionName = cppSetterMethod.name,
+                cppReturnTypeName = cppSetterMethod.returnType.fullyQualifiedName,
+                isSkipped = limeProperty.attributes.have(SWIFT, SKIP)
             )
             storeResult(setterFunction)
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
@@ -28,6 +28,7 @@ import com.here.gluecodium.model.lime.LimeAttributeType.EQUATABLE
 import com.here.gluecodium.model.lime.LimeAttributeType.POINTER_EQUATABLE
 import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
 import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
 import com.here.gluecodium.model.lime.LimeAttributeValueType.WEAK
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeClass
@@ -236,9 +237,8 @@ class SwiftModelBuilder(
             error = error,
             isStatic = limeMethod.isStatic,
             isConstructor = limeMethod.isConstructor,
-            isOverriding = limeMethod.isConstructor && signatureResolver.hasSignatureClash(
-                limeMethod
-            ),
+            isOverriding = limeMethod.isConstructor && signatureResolver.hasSignatureClash(limeMethod),
+            isSkipped = limeMethod.attributes.have(SWIFT, SKIP),
             parameters = getPreviousResults(SwiftParameter::class.java)
         )
 
@@ -398,7 +398,8 @@ class SwiftModelBuilder(
             setter = swiftSetter,
             isStatic = limeProperty.isStatic,
             isCached = limeProperty.attributes.have(CACHED),
-            isWeak = limeProperty.attributes.have(SWIFT, WEAK)
+            isWeak = limeProperty.attributes.have(SWIFT, WEAK),
+            isSkipped = limeProperty.attributes.have(SWIFT, SKIP)
         )
         property.comment = createComments(limeProperty)
 

--- a/gluecodium/src/main/java/com/here/gluecodium/model/cbridge/CFunction.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/cbridge/CFunction.kt
@@ -36,7 +36,8 @@ class CFunction(
     val cppReturnTypeName: String? = null,
     @Suppress("unused") val isConst: Boolean = false,
     val error: CppTypeInfo? = null,
-    @Suppress("unused") val errorTypeIsEnum: Boolean = false
+    @Suppress("unused") val errorTypeIsEnum: Boolean = false,
+    val isSkipped: Boolean = false
 ) : CElement(
     NameHelper.joinNames(
         nestedSpecifier,

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftMethod.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftMethod.kt
@@ -35,6 +35,7 @@ class SwiftMethod(
     val isStatic: Boolean = false,
     val isConstructor: Boolean = false,
     val isOverriding: Boolean = false,
+    val isSkipped: Boolean = false,
     val parameters: List<SwiftParameter> = emptyList()
 ) : SwiftModelElement(name, visibility) {
 

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftProperty.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftProperty.kt
@@ -27,7 +27,8 @@ class SwiftProperty(
     val setter: SwiftMethod?,
     val isStatic: Boolean,
     val isCached: Boolean = false,
-    val isWeak: Boolean = false
+    val isWeak: Boolean = false,
+    val isSkipped: Boolean = false
 ) : SwiftTypedModelElement(propertyName, visibility, type) {
 
     override val childElements

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuite.kt
@@ -38,7 +38,9 @@ import com.here.gluecodium.model.cbridge.CBridgeIncludeResolver
 import com.here.gluecodium.model.common.Comments
 import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
 import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
+import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.swift.SwiftFile
 import com.here.gluecodium.model.swift.SwiftMethod
 import com.here.gluecodium.model.swift.SwiftModelElement
@@ -77,7 +79,8 @@ class SwiftGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
         )
 
         val filteredElements =
-            LimeModelFilter { !it.attributes.have(SWIFT, SKIP) }.filter(limeModel.topElements)
+            LimeModelFilter { it is LimeFunction || it is LimeProperty || !it.attributes.have(SWIFT, SKIP) }
+                .filter(limeModel.topElements)
         val validationResult =
             SwiftWeakPropertiesValidator(LimeLogger(logger, limeModel.fileNameMap))
                 .validate(filteredElements)

--- a/gluecodium/src/main/resources/templates/cbridge/CppProxy.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CppProxy.mustache
@@ -36,7 +36,9 @@ public:
     {{#if selfParameter}}
     {{cppReturnTypeName}} {{functionName}}({{joinPartial parameters "baseApiParameter" ", "}}){{!!
     }}{{#if isConst}} const{{/if}}{{#unless isFunctionalInterface}} override{{/unless}} {
-        {{#if error}}
+{{#if isSkipped}}
+        {{#if isReturningVoid error}}return {};{{/if}}{{#unless isReturningVoid}}return {};{{/unless}}
+{{/if}}{{#unless isSkipped}}{{#if error}}
         auto _result_with_error = {{>swiftDelegateCall}};
         if (!_result_with_error.has_value)
         {
@@ -47,7 +49,7 @@ public:
         {{/if}}{{#unless error}}
         {{#unless isReturningVoid}}auto _call_result = {{/unless}}{{>swiftDelegateCall}};
         {{/unless}}
-        {{#unless isReturningVoid}}{{>returnConversion}}{{/unless}}
+        {{#unless isReturningVoid}}{{>returnConversion}}{{/unless}}{{/unless}}
     }
     {{/if}}
     {{/each}}

--- a/gluecodium/src/main/resources/templates/cbridge/InterfaceHeader.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/InterfaceHeader.mustache
@@ -20,8 +20,8 @@
   !}}
 {{#enums}}{{>cbridge/Enumeration}}{{/enums}}
 
-{{#functions}}{{#if error}}{{>cbridge/ThrowingFunctionReturnType}}
-{{/if}}{{/functions}}
+{{#functions}}{{#unless isSkipped}}{{#if error}}{{>cbridge/ThrowingFunctionReturnType}}
+{{/if}}{{/unless}}{{/functions}}
 
 {{#structs}}
 {{>cbridge/StructFunctionDeclarations}}
@@ -30,9 +30,9 @@
 {{#methods}}{{#if error}}{{>cbridge/ThrowingFunctionReturnType}}
 {{/if}}{{/methods}}
 
-{{#methods}}
+{{#methods}}{{#unless isSkipped}}
 _GLUECODIUM_C_EXPORT {{>cbridge/FunctionSignature}};
-{{/methods}}
+{{/unless}}{{/methods}}
 {{/if}}{{/structs}}
 
 {{#if selfType}}
@@ -57,9 +57,9 @@ _GLUECODIUM_C_EXPORT _baseRef {{name}}_create_optional_proxy({{functionTableName
 {{/if}}
 _GLUECODIUM_C_EXPORT const void* {{name}}_get_swift_object_from_cache(_baseRef handle);
 {{/isInterface}}
-{{#functions}}
+{{#functions}}{{#unless isSkipped}}
 _GLUECODIUM_C_EXPORT {{>cbridge/FunctionSignature}};
-{{/functions}}
+{{/unless}}{{/functions}}
 
 {{#interfaces}}
 {{>cbridge/InterfaceHeader}}

--- a/gluecodium/src/main/resources/templates/cbridge/InterfaceImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/InterfaceImpl.mustache
@@ -90,14 +90,14 @@ uint64_t {{name}}_hash(_baseRef handle) {
 {{#structs}}
 {{>cbridge/StructImplementation}}
 
-{{#set selfIsStruct=true}}{{#methods}}
+{{#set selfIsStruct=true}}{{#methods}}{{#unless isSkipped}}
 {{>cbridge/FunctionDefinition}}
-{{/methods}}{{/set}}
+{{/unless}}{{/methods}}{{/set}}
 {{/structs}}
 
-{{#functions}}
+{{#functions}}{{#unless isSkipped}}
 {{>cbridge/FunctionDefinition}}
-{{/functions}}
+{{/unless}}{{/functions}}
 
 {{#isInterface}}
 {{>cbridge/CppProxy}}

--- a/gluecodium/src/main/resources/templates/swift/ClassDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ClassDefinition.mustache
@@ -32,7 +32,7 @@
 {{/typedefs}}{{!!
 }}{{#closures}}
 {{prefixPartial "swift/Closure" "    "}}
-{{/closures}}{{#set className=simpleName}}{{#constructors}}
+{{/closures}}{{#set className=simpleName}}{{#constructors}}{{#unless isSkipped}}
 {{prefixPartial "swift/MethodComment" "    "}}
     {{visibility}} {{#if overriding}}override {{/if}}init({{>swift/MethodParameterDeclaration}}){{#if error}} throws{{/if}} {
         let _result = {{#if error}}try {{/if}}{{className}}.{{name}}({{#parameters}}{{!!
@@ -46,7 +46,7 @@
         {{cInstance}}_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
 
-{{/constructors}}{{/set}}{{!!
+{{/unless}}{{/constructors}}{{/set}}{{!!
 
 }}{{>CommonClassParts}}
 }
@@ -61,12 +61,12 @@
 }}{{#closures}}
 {{prefixPartial "swift/Closure" "    "}}
 {{/closures}}
-{{#properties}}
+{{#properties}}{{#unless isSkipped}}
 {{prefixPartial "swift/Comment" "    "}}
     {{#if isStatic}}static {{/if}}var {{name}}: {{type.publicName}}{{#if type.optional}}?{{/if}} { get {{#setter}}set {{/setter}}}
-{{/properties}}
-{{#methods}}{{prefixPartial 'swift/MethodSignature' '    '}}
-{{/methods}}
+{{/unless}}{{/properties}}
+{{#methods}}{{#unless isSkipped}}{{prefixPartial 'swift/MethodSignature' '    '}}
+{{/unless}}{{/methods}}
 }
 
 internal class _{{simpleName}}: {{simpleName}} {
@@ -79,9 +79,9 @@ internal class _{{simpleName}}: {{simpleName}} {
 }}{{#constants}}
 {{prefixPartial "swift/Constant" "    "}}
 {{/constants}}{{!!
-}}{{#properties}}
+}}{{#properties}}{{#unless isSkipped}}
 {{prefixPartial 'swift/Property' '    '}}
-{{/properties}}{{!!
+{{/unless}}{{/properties}}{{!!
 
 }}{{prefixPartial 'swift/Constructor' '    '}}{{!!
 
@@ -97,7 +97,7 @@ internal class _{{simpleName}}: {{simpleName}} {
 {{prefixPartial 'swift/Struct' '    '}}
 {{/structs}}{{!!
 
-}}{{#methods}}
+}}{{#methods}}{{#unless isSkipped}}
 {{prefixPartial 'swift/Method' '    '}}
-{{/methods}}{{!!
+{{/unless}}{{/methods}}{{!!
 }}{{/CommonClassParts}}

--- a/gluecodium/src/main/resources/templates/swift/GetReference.mustache
+++ b/gluecodium/src/main/resources/templates/swift/GetReference.mustache
@@ -55,13 +55,13 @@ internal func getRef(_ ref: {{name}}?, owning: Bool = true{{#if hasWeakSupport}}
     }
 
 {{#set className=name}}
-{{#methods}}
+{{#methods}}{{#unless isSkipped}}
 {{#set delegateToCall="delegateCall2"}}{{>functionTableEntry}}{{/set}}
-{{/methods}}
-{{#properties}}
+{{/unless}}{{/methods}}
+{{#properties}}{{#unless isSkipped}}
 {{#set propertyName=name}}{{#getter}}{{#set delegateToCall="callPropertyGetter"}}{{>functionTableEntry}}{{/set}}{{/getter}}
 {{#setter}}{{#set delegateToCall="callPropertySetter"}}{{>functionTableEntry}}{{/set}}{{/setter}}{{/set}}
-{{/properties}}
+{{/unless}}{{/properties}}
     let proxy = {{cInstance}}_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: {{cInstance}}_release_handle) : RefHolder(proxy)
 }

--- a/gluecodium/src/main/resources/templates/swift/Struct.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Struct.mustache
@@ -74,7 +74,7 @@
 {{/fields}}
     }
 {{/if}}{{!!
-}}{{#set className=name}}{{#constructors}}
+}}{{#set className=name}}{{#constructors}}{{#unless isSkipped}}
 {{prefixPartial "swift/MethodComment" "    "}}
     {{visibility}} {{#if overriding}}override {{/if}}init({{>swift/MethodParameterDeclaration}}){{#if error}} throws{{/if}} {
         let _result_handle = {{#if error}}try {{/if}}{{className}}.{{name}}({{#parameters}}{{!!
@@ -89,7 +89,7 @@
 {{/fields}}
     }
 
-{{/constructors}}{{/set}}{{!!
+{{/unless}}{{/constructors}}{{/set}}{{!!
 }}{{#if needsExplicitHashable}}
     public static func == (lhs: {{simpleName}}, rhs: {{simpleName}}) -> Bool {
         return
@@ -110,9 +110,9 @@
 {{/if}}{{!!
 }}{{#if methods}}
 
-{{#set selfIsStruct=true}}{{#methods}}
+{{#set selfIsStruct=true}}{{#methods}}{{#unless isSkipped}}
 {{prefixPartial 'swift/Method' '    '}}
-{{/methods}}{{/set}}{{/if}}
+{{/unless}}{{/methods}}{{/set}}{{/if}}
 }
 {{/unless}}{{!!
 

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipProxy.cpp
@@ -1,0 +1,118 @@
+//
+//
+#include "cbridge\include\smoke\cbridge_SkipProxy.h"
+#include "cbridge_internal\include\BaseHandleImpl.h"
+#include "cbridge_internal\include\CachedProxyBase.h"
+#include "cbridge_internal\include\TypeInitRepository.h"
+#include "cbridge_internal\include\WrapperCache.h"
+#include "gluecodium\Optional.h"
+#include "gluecodium\TypeRepository.h"
+#include "smoke\SkipProxy.h"
+#include <memory>
+#include <new>
+#include <string>
+void smoke_SkipProxy_release_handle(_baseRef handle) {
+    delete get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle);
+}
+_baseRef smoke_SkipProxy_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle)))
+        : 0;
+}
+const void* smoke_SkipProxy_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle)->get())
+        : nullptr;
+}
+void smoke_SkipProxy_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle)->get(), swift_pointer);
+}
+void smoke_SkipProxy_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle)->get());
+}
+extern "C" {
+extern void* _CBridgeInitsmoke_SkipProxy(_baseRef handle);
+}
+namespace {
+struct smoke_SkipProxyRegisterInit {
+    smoke_SkipProxyRegisterInit() {
+        get_init_repository().add_init("smoke_SkipProxy", &_CBridgeInitsmoke_SkipProxy);
+    }
+} s_smoke_SkipProxy_register_init;
+}
+void* smoke_SkipProxy_get_typed(_baseRef handle) {
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::SkipProxy>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle)->get());
+    auto init_function = get_init_repository().get_init(real_type_id);
+    return init_function ? init_function(handle) : _CBridgeInitsmoke_SkipProxy(handle);
+}
+_baseRef smoke_SkipProxy_notInJava(_baseRef _instance, _baseRef input) {
+    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->not_in_java(Conversion<std::string>::toCpp(input)));
+}
+float smoke_SkipProxy_notInDart(_baseRef _instance, float input) {
+    return get_pointer<std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->not_in_dart(input);
+}
+_baseRef smoke_SkipProxy_skippedInJava_get(_baseRef _instance) {
+    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->get_skipped_in_java());
+}
+void smoke_SkipProxy_skippedInJava_set(_baseRef _instance, _baseRef newValue) {
+    return get_pointer<std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->set_skipped_in_java(Conversion<std::string>::toCpp(newValue));
+}
+float smoke_SkipProxy_skippedInDart_get(_baseRef _instance) {
+    return get_pointer<std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->get_skipped_in_dart();
+}
+void smoke_SkipProxy_skippedInDart_set(_baseRef _instance, float newValue) {
+    return get_pointer<std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->set_skipped_in_dart(newValue);
+}
+class smoke_SkipProxyProxy : public std::shared_ptr<::smoke::SkipProxy>::element_type, public CachedProxyBase<smoke_SkipProxyProxy> {
+public:
+    smoke_SkipProxyProxy(smoke_SkipProxy_FunctionTable&& functions)
+     : mFunctions(std::move(functions))
+    {
+    }
+    virtual ~smoke_SkipProxyProxy() {
+        mFunctions.release(mFunctions.swift_pointer);
+    }
+    smoke_SkipProxyProxy(const smoke_SkipProxyProxy&) = delete;
+    smoke_SkipProxyProxy& operator=(const smoke_SkipProxyProxy&) = delete;
+    ::std::string not_in_java(const std::string& input) override {
+        auto _call_result = mFunctions.smoke_SkipProxy_notInJava(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(input));
+        return Conversion<std::string>::toCppReturn(_call_result);
+    }
+    bool not_in_swift(bool input) override {
+        return {};
+    }
+    float not_in_dart(float input) override {
+        auto _call_result = mFunctions.smoke_SkipProxy_notInDart(mFunctions.swift_pointer, input);
+        return _call_result;
+    }
+    ::std::string get_skipped_in_java() const override {
+        auto _call_result = mFunctions.smoke_SkipProxy_skippedInJava_get(mFunctions.swift_pointer);
+        return Conversion<std::string>::toCppReturn(_call_result);
+    }
+    void set_skipped_in_java(const std::string& newValue) override {
+        mFunctions.smoke_SkipProxy_skippedInJava_set(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(newValue));
+    }
+    bool is_skipped_in_swift() const override {
+        return {};
+    }
+    void set_skipped_in_swift(bool newValue) override {
+    }
+    float get_skipped_in_dart() const override {
+        auto _call_result = mFunctions.smoke_SkipProxy_skippedInDart_get(mFunctions.swift_pointer);
+        return _call_result;
+    }
+    void set_skipped_in_dart(float newValue) override {
+        mFunctions.smoke_SkipProxy_skippedInDart_set(mFunctions.swift_pointer, newValue);
+    }
+private:
+    smoke_SkipProxy_FunctionTable mFunctions;
+};
+_baseRef smoke_SkipProxy_create_proxy(smoke_SkipProxy_FunctionTable functionTable) {
+    auto proxy = smoke_SkipProxyProxy::get_proxy(std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::SkipProxy>(proxy)) : 0;
+}
+const void* smoke_SkipProxy_get_swift_object_from_cache(_baseRef handle) {
+    return handle ? smoke_SkipProxyProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle)->get()) : nullptr;
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipProxy.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipProxy.swift
@@ -1,0 +1,158 @@
+//
+//
+import Foundation
+public protocol SkipProxy : AnyObject {
+    var skippedInJava: String { get set }
+    var skippedInDart: Float { get set }
+    func notInJava(input: String) -> String
+    func notInDart(input: Float) -> Float
+}
+internal class _SkipProxy: SkipProxy {
+    var skippedInJava: String {
+        get {
+            return moveFromCType(smoke_SkipProxy_skippedInJava_get(self.c_instance))
+        }
+        set {
+            let c_newValue = moveToCType(newValue)
+            return moveFromCType(smoke_SkipProxy_skippedInJava_set(self.c_instance, c_newValue.ref))
+        }
+    }
+    var skippedInDart: Float {
+        get {
+            return moveFromCType(smoke_SkipProxy_skippedInDart_get(self.c_instance))
+        }
+        set {
+            let c_newValue = moveToCType(newValue)
+            return moveFromCType(smoke_SkipProxy_skippedInDart_set(self.c_instance, c_newValue.ref))
+        }
+    }
+    let c_instance : _baseRef
+    init(cSkipProxy: _baseRef) {
+        guard cSkipProxy != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cSkipProxy
+    }
+    deinit {
+        smoke_SkipProxy_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_SkipProxy_release_handle(c_instance)
+    }
+    public func notInJava(input: String) -> String {
+        let c_input = moveToCType(input)
+        return moveFromCType(smoke_SkipProxy_notInJava(self.c_instance, c_input.ref))
+    }
+    public func notInDart(input: Float) -> Float {
+        let c_input = moveToCType(input)
+        return moveFromCType(smoke_SkipProxy_notInDart(self.c_instance, c_input.ref))
+    }
+}
+@_cdecl("_CBridgeInitsmoke_SkipProxy")
+internal func _CBridgeInitsmoke_SkipProxy(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _SkipProxy(cSkipProxy: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: SkipProxy?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_SkipProxy_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_SkipProxy_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_SkipProxy_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    functions.smoke_SkipProxy_notInJava = {(swift_class_pointer, input) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+        return copyToCType(swift_class.notInJava(input: moveFromCType(input))).ref
+    }
+    functions.smoke_SkipProxy_notInDart = {(swift_class_pointer, input) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+        return copyToCType(swift_class.notInDart(input: moveFromCType(input))).ref
+    }
+    functions.smoke_SkipProxy_skippedInJava_get = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+        return copyToCType(swift_class.skippedInJava).ref
+    }
+    functions.smoke_SkipProxy_skippedInJava_set = {(swift_class_pointer, newValue) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+        swift_class.skippedInJava = moveFromCType(newValue)
+    }
+    functions.smoke_SkipProxy_skippedInDart_get = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+        return copyToCType(swift_class.skippedInDart).ref
+    }
+    functions.smoke_SkipProxy_skippedInDart_set = {(swift_class_pointer, newValue) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+        swift_class.skippedInDart = moveFromCType(newValue)
+    }
+    let proxy = smoke_SkipProxy_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_SkipProxy_release_handle) : RefHolder(proxy)
+}
+extension _SkipProxy: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func SkipProxy_copyFromCType(_ handle: _baseRef) -> SkipProxy {
+    if let swift_pointer = smoke_SkipProxy_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipProxy {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_SkipProxy_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipProxy {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_SkipProxy_get_typed(smoke_SkipProxy_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? SkipProxy {
+        smoke_SkipProxy_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func SkipProxy_moveFromCType(_ handle: _baseRef) -> SkipProxy {
+    if let swift_pointer = smoke_SkipProxy_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipProxy {
+        smoke_SkipProxy_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_SkipProxy_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipProxy {
+        smoke_SkipProxy_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_SkipProxy_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? SkipProxy {
+        smoke_SkipProxy_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func SkipProxy_copyFromCType(_ handle: _baseRef) -> SkipProxy? {
+    guard handle != 0 else {
+        return nil
+    }
+    return SkipProxy_moveFromCType(handle) as SkipProxy
+}
+internal func SkipProxy_moveFromCType(_ handle: _baseRef) -> SkipProxy? {
+    guard handle != 0 else {
+        return nil
+    }
+    return SkipProxy_moveFromCType(handle) as SkipProxy
+}
+internal func copyToCType(_ swiftClass: SkipProxy) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: SkipProxy) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: SkipProxy?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: SkipProxy?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}


### PR DESCRIPTION
Updated Swift generator and templates to generate method stubs for skipped methods in the proxy. Without these stubs
code generated for interfaces fails to compile because proxy classes become abstract due to unimplemented methods.

Added smoke and functional tests.

See: #489
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>