### PR TITLE
Fix includes for @Java(Skip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed Java compilation issue with extraneous includes for `@Java(Skip)` on functions and properties in an interface.
+
 ## 8.2.2
 Release date: 2020-09-09
 ### Features

--- a/examples/libhello/lime/test/Skip.lime
+++ b/examples/libhello/lime/test/Skip.lime
@@ -55,4 +55,12 @@ interface SkipProxy {
     property skippedInSwift: Boolean
     @Dart(Skip)
     property skippedInDart: Float
+
+    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    property skippedEverywhere: SkippedEverywhere
+}
+
+@Java(Skip) @Swift(Skip) @Dart(Skip)
+struct SkippedEverywhere {
+    nothingToSeeHere: String
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniIncludeResolver.kt
@@ -95,12 +95,12 @@ internal object JniIncludeResolver {
         val methods = jniContainer.methods + jniContainer.parentMethods +
                 jniContainer.structs.flatMap { it.methods }
         val types = jniContainer.structs.flatMap { it.fields }.map { it.type } +
-                methods.flatMap { collectMethodTypes(it) }
+                methods.filterNot { it.isSkipped }.flatMap { collectMethodTypes(it) }
         return types.flatMap { it.conversionIncludes } + createConversionSelfInclude(jniContainer)
     }
 
     fun collectMethodImplementationIncludes(jniStruct: JniStruct): List<Include> {
-        val types = jniStruct.methods.flatMap { collectMethodTypes(it) }
+        val types = jniStruct.methods.filterNot { it.isSkipped }.flatMap { collectMethodTypes(it) }
         return types.flatMap { it.conversionIncludes } + createConversionSelfInclude(jniStruct)
     }
 

--- a/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
@@ -28,6 +28,7 @@ import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
 
 @RunWith(Parameterized::class)
+
 class SmokeTest(
     private val featureDirectory: File,
     generatorName: String,

--- a/gluecodium/src/test/resources/smoke/skip/input/Skip.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/Skip.lime
@@ -55,4 +55,12 @@ interface SkipProxy {
     property skippedInSwift: Boolean
     @Dart(Skip)
     property skippedInDart: Float
+
+    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    property skippedEverywhere: SkippedEverywhere
+}
+
+@Java(Skip) @Swift(Skip) @Dart(Skip)
+struct SkippedEverywhere {
+    nothingToSeeHere: String
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImpl.cpp
@@ -1,0 +1,92 @@
+/*
+ *
+ */
+#include "com_example_smoke_SkipProxyImpl.h"
+#include "com_example_smoke_SkipProxy__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+#include "JniWrapperCache.h"
+extern "C" {
+jboolean
+Java_com_example_smoke_SkipProxyImpl_notInSwift(JNIEnv* _jenv, jobject _jinstance, jboolean jinput)
+{
+    bool input = jinput;
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SkipProxy>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->not_in_swift(input);
+    return result;
+}
+jfloat
+Java_com_example_smoke_SkipProxyImpl_notInDart(JNIEnv* _jenv, jobject _jinstance, jfloat jinput)
+{
+    float input = jinput;
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SkipProxy>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->not_in_dart(input);
+    return result;
+}
+jboolean
+Java_com_example_smoke_SkipProxyImpl_isSkippedInSwift(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SkipProxy>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->is_skipped_in_swift();
+    return result;
+}
+void
+Java_com_example_smoke_SkipProxyImpl_setSkippedInSwift(JNIEnv* _jenv, jobject _jinstance, jboolean jvalue)
+{
+    bool value = jvalue;
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SkipProxy>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->set_skipped_in_swift(value);
+}
+jfloat
+Java_com_example_smoke_SkipProxyImpl_getSkippedInDart(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SkipProxy>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->get_skipped_in_dart();
+    return result;
+}
+void
+Java_com_example_smoke_SkipProxyImpl_setSkippedInDart(JNIEnv* _jenv, jobject _jinstance, jfloat jvalue)
+{
+    float value = jvalue;
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SkipProxy>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->set_skipped_in_dart(value);
+}
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SkipProxyImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::SkipProxy>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImplCppProxy.cpp
@@ -103,5 +103,12 @@ com_example_smoke_SkipProxyImpl_CppProxy::set_skipped_in_dart( const float nvalu
             "See the log for more information about the exception (including Java stack trace)." );
     }
 }
+::smoke::SkippedEverywhere
+com_example_smoke_SkipProxyImpl_CppProxy::get_skipped_everywhere(  ) const {
+    return {};
+}
+void
+com_example_smoke_SkipProxyImpl_CppProxy::set_skipped_everywhere( const ::smoke::SkippedEverywhere& nvalue ) {
+}
 }
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipProxy.cpp
@@ -106,6 +106,11 @@ public:
     void set_skipped_in_dart(float newValue) override {
         mFunctions.smoke_SkipProxy_skippedInDart_set(mFunctions.swift_pointer, newValue);
     }
+    ::smoke::SkippedEverywhere get_skipped_everywhere() const override {
+        return {};
+    }
+    void set_skipped_everywhere(const ::smoke::SkippedEverywhere& newValue) override {
+    }
 private:
     smoke_SkipProxy_FunctionTable mFunctions;
 };

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipProxy.cpp
@@ -4,6 +4,7 @@
 #include "IsolateContext.h"
 #include "ProxyCache.h"
 #include "smoke\SkipProxy.h"
+#include "smoke\SkippedEverywhere.h"
 #include <memory>
 #include <string>
 #include <memory>
@@ -82,6 +83,13 @@ public:
     }
     void
     set_skipped_in_dart(const float value) override {
+    }
+    ::smoke::SkippedEverywhere
+    get_skipped_everywhere() const override {
+        return {};
+    }
+    void
+    set_skipped_everywhere(const ::smoke::SkippedEverywhere& value) override {
     }
 private:
     const uint64_t token;


### PR DESCRIPTION
Fixed Java compilation issue with extraneous includes for `@Java(Skip)` on functions and properties in an interface.
Added smoke and functional tests as regression tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>