### PR TITLE
Support more elements inside structs in LimeIDL

### DIFF
--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -126,7 +126,7 @@ attribute name that follows.
 
 There are three kinds of file-level declarations: package, import or element declaration. The
 following element types can be placed at the top level: `class`, `interface`, `types`, `struct`,
-`enum`, `exception`, `typealias`. All other declarations can only be placed as child elements to
+`enum`, `exception`, `typealias`, `lambda`. All other declarations can only be placed as child elements to
 some other element.
 
 #### Package declaration
@@ -157,7 +157,7 @@ immediately after the package declaration.
   * **types** declares a loose collection of elements, most of which become free-standing elements
   in the output languages.
 * Classes and interfaces can be free-standing elements at file level or can be placed in another
-class or interface. `types` declaration can be only placed at file level.
+class, interface, or struct. `types` declaration can be only placed at file level.
 
 #### Inheritance
 
@@ -236,7 +236,7 @@ struct Options {
     additionalOptions: List<String> = {}
 }
 ```
-* Can be a free-standing element at file level or can be placed in: class, interface, types
+* Can be a free-standing element at file level or can be placed in: class, interface, types, struct
 * Description: declares a struct type (data type) in the parent type:
   * a struct can have any number of fields, but at least one field is required.
   * a struct field can have a default value associated with it (optionally). For more details on

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/comments.lime
@@ -23,9 +23,6 @@ class comments {
         someField: Usefulness
         // Can be `null`
         nullableField: String?
-        // This is some very useful lambda that does it.
-        @Java(FunctionName = "doIt")
-        lambda SomeLambda = (String, @Java("index") Int) -> Double
     }
     // This is some very useful constant.
     const VeryUseful: Usefulness = true

--- a/lime-loader/src/main/antlr/LimeParser.g4
+++ b/lime-loader/src/main/antlr/LimeParser.g4
@@ -88,7 +88,8 @@ setter
 
 struct
     : docComment* annotation* visibility? 'struct' NewLine* simpleId NewLine*
-      '{' NewLine* externalDescriptor? ((field | function | constructor | constant) NewLine*)+ '}' NewLine+
+      '{' NewLine* externalDescriptor?
+      ((field | function | constructor | constant | container | struct) NewLine*)+ '}' NewLine+
     ;
 
 field

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -374,7 +374,10 @@ internal class AntlrLimeModelBuilder(
             fields = getPreviousResults(LimeField::class.java),
             functions = getPreviousResults(LimeFunction::class.java),
             constants = getPreviousResults(LimeConstant::class.java),
-            constructorComment = structuredCommentsStack.peek().getTagBlock("constructor")
+            constructorComment = structuredCommentsStack.peek().getTagBlock("constructor"),
+            structs = getPreviousResults(LimeStruct::class.java),
+            classes = getPreviousResults(LimeClass::class.java),
+            interfaces = getPreviousResults(LimeInterface::class.java)
         )
 
         storeResultAndPopStacks(limeElement)

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeContainer.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeContainer.kt
@@ -34,7 +34,10 @@ abstract class LimeContainer(
     val typeAliases: List<LimeTypeAlias> = emptyList(),
     val functions: List<LimeFunction> = emptyList(),
     val properties: List<LimeProperty> = emptyList(),
-    val exceptions: List<LimeException> = emptyList()
+    val exceptions: List<LimeException> = emptyList(),
+    val classes: List<LimeClass> = emptyList(),
+    val interfaces: List<LimeInterface> = emptyList(),
+    val lambdas: List<LimeLambda> = emptyList()
 ) : LimeType(path, visibility, comment, attributes, external) {
 
     val constructors

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeContainerWithInheritance.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeContainerWithInheritance.kt
@@ -32,9 +32,9 @@ abstract class LimeContainerWithInheritance(
     functions: List<LimeFunction> = emptyList(),
     properties: List<LimeProperty> = emptyList(),
     exceptions: List<LimeException> = emptyList(),
-    val classes: List<LimeClass> = emptyList(),
-    val interfaces: List<LimeInterface> = emptyList(),
-    val lambdas: List<LimeLambda> = emptyList(),
+    classes: List<LimeClass> = emptyList(),
+    interfaces: List<LimeInterface> = emptyList(),
+    lambdas: List<LimeLambda> = emptyList(),
     val parent: LimeTypeRef? = null
 ) : LimeContainer(
     path = path,
@@ -48,7 +48,10 @@ abstract class LimeContainerWithInheritance(
     typeAliases = typeAliases,
     functions = functions,
     properties = properties,
-    exceptions = exceptions
+    exceptions = exceptions,
+    classes = classes,
+    interfaces = interfaces,
+    lambdas = lambdas
 ) {
     @Suppress("unused")
     val inheritedFunctions: List<LimeFunction>

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
@@ -27,6 +27,9 @@ class LimeStruct(
     external: LimeExternalDescriptor? = null,
     functions: List<LimeFunction> = emptyList(),
     constants: List<LimeConstant> = emptyList(),
+    structs: List<LimeStruct> = emptyList(),
+    classes: List<LimeClass> = emptyList(),
+    interfaces: List<LimeInterface> = emptyList(),
     val fields: List<LimeField> = emptyList(),
     val constructorComment: LimeComment = LimeComment()
 ) : LimeContainer(
@@ -36,7 +39,10 @@ class LimeStruct(
     attributes = attributes,
     external = external,
     functions = functions,
-    constants = constants
+    constants = constants,
+    structs = structs,
+    classes = classes,
+    interfaces = interfaces
 ) {
     override val childTypes
         get() = fields.map { it.typeRef }


### PR DESCRIPTION
Updated LimeIDL grammar, model, and model builder to support nesting of classes, interfaces, and structs inside structs.

See: #487
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>