### PR TITLE
Support more elements inside structs in C++

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -413,6 +413,13 @@ feature(Nesting cpp android swift dart SOURCES
     lime/test/NestedClassWithProperty.lime
 )
 
+# TODO: #487: merge with Nesting above when done
+feature(NestingInStruct cpp SOURCES
+    lime/test/NestingInStruct.lime
+
+    src/test/NestingInStruct.cpp
+)
+
 feature(Lambdas cpp android swift dart SOURCES
     lime/test/Lambdas.lime
 

--- a/examples/libhello/lime/test/NestingInStruct.lime
+++ b/examples/libhello/lime/test/NestingInStruct.lime
@@ -1,0 +1,34 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+struct OuterStruct {
+    field: String
+
+    struct InnerStruct {
+        otherField: String
+    }
+
+    class InnerClass {
+        static fun fooBar()
+    }
+
+    interface InnerInterface {
+        fun barBaz()
+    }
+}

--- a/examples/libhello/src/test/NestingInStruct.cpp
+++ b/examples/libhello/src/test/NestingInStruct.cpp
@@ -1,0 +1,28 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/OuterStruct.h"
+
+namespace test
+{
+void
+OuterStruct::InnerClass::foo_bar() { }
+
+}

--- a/gluecodium/src/main/resources/templates/cpp/CppClassImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppClassImpl.mustache
@@ -35,8 +35,9 @@ bool
 {{resolveName}}::operator!=( const {{resolveName}}& rhs ) {
     return !( *this == rhs );
 }
-{{/if}}{{/unless}}
-{{#unless external.cpp}}{{#resolveName}}{{#setJoin "parentName" parentName this delimiter="::"}}
+
+{{/if}}
+{{#resolveName}}{{#setJoin "parentName" parentName this delimiter="::"}}
 {{#enumerations}}
 {{>cpp/CppEnumerationImpl}}
 {{/enumerations}}
@@ -49,7 +50,8 @@ const {{resolveName typeRef}} {{parentName}}::{{resolveName}} = {{resolveName va
 {{#each classes interfaces}}
 {{>cpp/CppClassImpl}}
 {{/each}}
-{{/setJoin}}{{/resolveName}}{{/unless}}
-{{#if external.cpp}}{{#resolveName "FQN"}}{{#set className=this}}{{#functions}}
+{{/setJoin}}{{/resolveName}}{{/unless}}{{!!
+
+}}{{#if external.cpp}}{{#resolveName "FQN"}}{{#set className=this}}{{#functions}}
 {{>cpp/CppFunctionStaticCheck}}
 {{/functions}}{{/set}}{{/resolveName}}{{/if}}

--- a/gluecodium/src/main/resources/templates/cpp/CppStruct.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppStruct.mustache
@@ -83,16 +83,18 @@ public:
 {{/fields}}{{/set}}
 
 {{/if}}{{!!
-}}{{#if functions}}
+}}{{#sort structs constants}}
+{{#instanceOf this "LimeStruct"}}{{prefixPartial "cpp/CppStruct" "    "}}{{/instanceOf}}{{!!
+}}{{#instanceOf this "LimeConstant"}}{{#set constant=this storageQualifier="static"}}{{#constant}}{{!!
+}}{{prefixPartial "cpp/CppConstant" "    "}}{{/constant}}{{/set}}{{/instanceOf}}
+{{/sort}}
+{{#each classes interfaces}}
+{{prefixPartial "cpp/CppClass" "    "}}
+{{/each}}
+{{#if functions}}
 {{#set isConst=true}}{{#functions}}
 {{prefixPartial "cpp/CppFunctionSignature" "    "}};
 {{/functions}}{{/set}}
-
-{{/if}}{{!!
-}}{{#if constants}}
-{{#set storageQualifier="static"}}{{#constants}}
-{{prefixPartial "cpp/CppConstant" "    "}}
-{{/constants}}{{/set}}
 
 {{/if}}{{!!
 }}{{#if attributes.equatable}}

--- a/gluecodium/src/main/resources/templates/cpp/CppStructImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppStructImpl.mustache
@@ -18,26 +18,33 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless external.cpp}}{{!!
-}}{{#set structElement=this}}{{#constants}}
-const {{resolveName typeRef}} {{#parentName}}{{.}}::{{/parentName}}{{resolveName structElement}}::{{resolveName}} = {{resolveName value}};
-{{/constants}}{{/set}}{{!!
-}}{{#if fields}}
-{{#ifPredicate "hasDefaultConstructor"}}{{#parentName}}{{.}}::{{/parentName}}{{resolveName}}::{{resolveName}}( ){{!!
+{{#set structElement=this}}{{#unless external.cpp}}{{!!
+}}{{#resolveName structElement}}{{#setJoin "parentName" parentName this delimiter="::"}}{{#structElement}}
+{{#structs}}
+{{>cpp/CppStructImpl}}
+{{/structs}}
+{{#constants}}
+const {{resolveName typeRef}} {{parentName}}::{{resolveName}} = {{resolveName value}};
+{{/constants}}
+{{#each classes interfaces}}
+{{>cpp/CppClassImpl}}
+{{/each}}
+{{#if fields}}
+{{#ifPredicate "hasDefaultConstructor"}}{{parentName}}::{{resolveName}}( ){{!!
 }}{{#if uninitializedFields}}
     : {{#uninitializedFields}}{{resolveName}}{ }{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}}{{/if}}
 {
 }{{/ifPredicate}}
 {{#ifPredicate "hasPartialDefaults"}}
 
-{{#parentName}}{{.}}::{{/parentName}}{{resolveName}}::{{resolveName}}( {{!!
+{{parentName}}::{{resolveName}}( {{!!
 }}{{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}} )
     : {{#uninitializedFields}}{{resolveName}}{{#initializer}}( std::move( {{resolveName}} ) ){{/initializer}}{{!!
 }}{{^initializer}}( std::move( {{resolveName}} ) ){{/initializer}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}}
 {
 }{{/ifPredicate}}
 
-{{#parentName}}{{.}}::{{/parentName}}{{resolveName}}::{{resolveName}}( {{!!
+{{parentName}}::{{resolveName}}( {{!!
 }}{{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}} )
     : {{#fields}}{{resolveName}}( std::move( {{resolveName}} ) ){{#if iter.hasNext}}, {{/if}}{{/fields}}
 {
@@ -45,21 +52,22 @@ const {{resolveName typeRef}} {{#parentName}}{{.}}::{{/parentName}}{{resolveName
 
 {{/if}}{{!!
 }}{{#if attributes.equatable}}
-bool {{#parentName}}{{.}}::{{/parentName}}{{resolveName}}::operator==( const {{resolveName}}& rhs ) const
+bool {{parentName}}::operator==( const {{resolveName}}& rhs ) const
 {
     return {{joinPartial fields "fieldEq" " &&
         " }};
 }
 
-bool {{#parentName}}{{.}}::{{/parentName}}{{resolveName}}::operator!=( const {{resolveName}}& rhs ) const
+bool {{parentName}}::operator!=( const {{resolveName}}& rhs ) const
 {
     return !( *this == rhs );
 }
 
-{{/if}}{{/unless}}{{!!
+{{/if}}{{!!
+}}{{/structElement}}{{/setJoin}}{{/resolveName}}{{/unless}}{{!!
 
 }}{{#if external.cpp}}
-{{#set structElement=this}}{{#resolveName structElement "FQN"}}{{#set structName=this}}{{#fields}}
+{{#resolveName structElement "FQN"}}{{#set structName=this}}{{#fields}}
 {{#resolveName this "" "getter"}}
 static_assert(
     std::is_same<
@@ -89,7 +97,7 @@ static_assert(
 {{#set className=structName}}{{#functions}}
 {{>cpp/CppFunctionStaticCheck}}
 {{/functions}}{{/set}}{{!!
-}}{{/set}}{{/resolveName}}{{/set}}{{/if}}{{!!
+}}{{/set}}{{/resolveName}}{{/if}}{{/set}}{{!!
 
 }}{{+fieldEq}}{{#ifPredicate "needsPointerValueEqual"}}( ( {{resolveName}} && rhs.{{resolveName}} )
             ? {{#ifPredicate "needsRawPointerEqual"}}( &*{{resolveName}} == &*rhs.{{resolveName}} ){{/ifPredicate}}{{!!

--- a/gluecodium/src/test/resources/smoke/nesting/input/NestingInStruct.lime
+++ b/gluecodium/src/test/resources/smoke/nesting/input/NestingInStruct.lime
@@ -1,0 +1,34 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct OuterStruct {
+    field: String
+
+    struct InnerStruct {
+        otherField: String
+    }
+
+    class InnerClass {
+        fun fooBar()
+    }
+
+    interface InnerInterface {
+        fun barBaz()
+    }
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/FreePoint.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/FreePoint.h
@@ -3,15 +3,15 @@
 //
 // -------------------------------------------------------------------------------------------------
 #pragma once
-#include "gluecodium/Export.h"
-#include "smoke/FreeEnum.h"
+#include "gluecodium\Export.h"
+#include "smoke\FreeEnum.h"
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT FreePoint {
     double x;
     double y;
     FreePoint( );
     FreePoint( double x, double y );
-    ::smoke::FreePoint flip(  ) const;
     _GLUECODIUM_CPP_EXPORT static const ::smoke::FreeEnum A_BAR;
+    ::smoke::FreePoint flip(  ) const;
 };
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/LevelOne.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/LevelOne.h
@@ -3,9 +3,9 @@
 //
 // -------------------------------------------------------------------------------------------------
 #pragma once
-#include "gluecodium/Export.h"
-#include "smoke/OuterClass.h"
-#include "smoke/OuterInterface.h"
+#include "gluecodium\Export.h"
+#include "smoke\OuterClass.h"
+#include "smoke\OuterInterface.h"
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -32,8 +32,8 @@ public:
                 ::std::string string_field;
                 LevelFour( );
                 LevelFour( ::std::string string_field );
-                static ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour foo_factory(  );
                 _GLUECODIUM_CPP_EXPORT static const bool FOO;
+                static ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour foo_factory(  );
             };
         public:
             /**

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterStruct.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterStruct.h
@@ -1,0 +1,33 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include <string>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT OuterStruct {
+    ::std::string field;
+    OuterStruct( );
+    OuterStruct( ::std::string field );
+    struct _GLUECODIUM_CPP_EXPORT InnerStruct {
+        ::std::string other_field;
+        InnerStruct( );
+        InnerStruct( ::std::string other_field );
+    };
+    class _GLUECODIUM_CPP_EXPORT InnerClass {
+    public:
+        InnerClass();
+        virtual ~InnerClass() = 0;
+    public:
+        virtual void foo_bar(  ) = 0;
+    };
+    class _GLUECODIUM_CPP_EXPORT InnerInterface {
+    public:
+        InnerInterface();
+        virtual ~InnerInterface() = 0;
+    public:
+        virtual void bar_baz(  ) = 0;
+    };
+};
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/src/smoke/OuterStruct.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/src/smoke/OuterStruct.cpp
@@ -1,0 +1,32 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#include "smoke/OuterStruct.h"
+#include <utility>
+namespace smoke {
+OuterStruct::InnerStruct::InnerStruct( )
+    : other_field{ }
+{
+}
+OuterStruct::InnerStruct::InnerStruct( ::std::string other_field )
+    : other_field( std::move( other_field ) )
+{
+}
+OuterStruct::InnerClass::InnerClass() {
+}
+OuterStruct::InnerClass::~InnerClass() {
+}
+OuterStruct::InnerInterface::InnerInterface() {
+}
+OuterStruct::InnerInterface::~InnerInterface() {
+}
+OuterStruct::OuterStruct( )
+    : field{ }
+{
+}
+OuterStruct::OuterStruct( ::std::string field )
+    : field( std::move( field ) )
+{
+}
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/lime/smoke/OuterStruct.lime
+++ b/gluecodium/src/test/resources/smoke/nesting/output/lime/smoke/OuterStruct.lime
@@ -1,0 +1,13 @@
+package smoke
+struct OuterStruct {
+    field: String
+    class InnerClass {
+        fun fooBar()
+    }
+    interface InnerInterface {
+        fun barBaz()
+    }
+    struct InnerStruct {
+        otherField: String
+    }
+}


### PR DESCRIPTION
Updated C++ templates to add support for structs, classes, and
interfaces declared inside structs.

Added smoke and functional tests.

See: #487
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>