### PR TITLE
Support more elements inside structs in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed Swift compilation issue for collections of `Locale` type elements.
+  * Fixed Swift compilation issue for interface declarations nested inside classes.
+
 ## 8.2.3
 Release date: 2020-09-09
 ### Bug fixes:

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -414,7 +414,7 @@ feature(Nesting cpp android swift dart SOURCES
 )
 
 # TODO: #487: merge with Nesting above when done
-feature(NestingInStruct cpp android SOURCES
+feature(NestingInStruct cpp android swift SOURCES
     lime/test/NestingInStruct.lime
 
     src/test/NestingInStruct.cpp

--- a/examples/libhello/lime/test/NestedContainers.lime
+++ b/examples/libhello/lime/test/NestedContainers.lime
@@ -28,6 +28,17 @@ interface OuterInterface {
     fun foo(input: String): String
 }
 
+class OuterClass {
+    class InnerClass {
+        fun foo(input: String): String
+    }
+    interface InnerInterfaceInClass {
+        fun foo(input: String): String
+    }
+
+    fun foo(input: String): String
+}
+
 class LevelOne {
     class LevelTwo {
         class LevelThree {

--- a/examples/libhello/lime/test/NestingInStruct.lime
+++ b/examples/libhello/lime/test/NestingInStruct.lime
@@ -30,7 +30,7 @@ struct OuterStruct {
         static fun fooBar(): Set<Int>
     }
 
-    interface InnerInterface {
+    interface InnerInterfaceInStruct {
         fun barBaz(): Map<String, Locale>
     }
 

--- a/examples/platforms/ios/Tests/main.swift
+++ b/examples/platforms/ios/Tests/main.swift
@@ -51,6 +51,7 @@ let allTests = [
     testCase(MapsTests.allTests),
     testCase(MethodOverloadsTests.allTests),
     testCase(MultiListenerTests.allTests),
+    testCase(NestingTests.allTests),
     testCase(NullableAttributesTests.allTests),
     testCase(NullableInstancesTests.allTests),
     testCase(NullableListenersTests.allTests),

--- a/examples/platforms/ios/Tests/testTests/NestingTests.swift
+++ b/examples/platforms/ios/Tests/testTests/NestingTests.swift
@@ -18,42 +18,18 @@
 //
 // -------------------------------------------------------------------------------------------------
 
-#include "test/OuterStruct.h"
+import XCTest
+import hello
 
-namespace test
-{
-namespace
-{
-class OuterStructBuilderImpl: public OuterStruct::Builder,
-                              public std::enable_shared_from_this<OuterStructBuilderImpl> {
-public:
-    OuterStructBuilderImpl() {}
-    virtual ~OuterStructBuilderImpl() = default;
+class NestingTests: XCTestCase {
 
-    std::shared_ptr<OuterStruct::Builder>
-    field(const std::string& value) override {
-        m_field = value;
-        return shared_from_this();
+    func testNestedClassMethod() {
+        let result = OuterStruct.InnerClass.fooBar()
+
+        XCTAssertEqual(result.first, 42)
     }
 
-    OuterStruct
-    build() override { return OuterStruct(m_field); }
-
-private:
-    std::string m_field;
-};
-}
-
-void
-OuterStruct::do_nothing() { }
-
-void
-OuterStruct::InnerStruct::do_something() { }
-
-std::unordered_set<int32_t>
-OuterStruct::InnerClass::foo_bar() { return {42}; }
-
-std::shared_ptr<OuterStruct::Builder>
-OuterStruct::Builder::create() { return std::make_shared<OuterStructBuilderImpl>(); }
-
+    static var allTests = [
+        ("testNestedClassMethod", testNestedClassMethod)
+    ]
 }

--- a/examples/scripts/valgrind_suppressions
+++ b/examples/scripts/valgrind_suppressions
@@ -31,6 +31,15 @@
    fun:*
 }
 {
+   allocateMetadata
+
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:_ZN5swift16allocateMetadataEmm
+   fun:*
+}
+{
    getTupleTypeMetadata
 
    Memcheck:Leak

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeModelBuilder.kt
@@ -197,12 +197,14 @@ class CBridgeModelBuilder(
     override fun finishBuilding(limeStruct: LimeStruct) {
         val cppStruct = cppBuilder.getFinalResult(CppStruct::class.java)
         val cStruct = CStruct(
-            CBridgeNameRules.getTypeName(limeStruct),
-            cppStruct.fullyQualifiedName,
-            currentContext.currentResults.filterIsInstance<CppTypeInfo>().first(),
-            cppStruct.hasImmutableFields,
-            getPreviousResults(CField::class.java),
-            getPreviousResults(CFunction::class.java)
+            name = CBridgeNameRules.getTypeName(limeStruct),
+            baseApiName = cppStruct.fullyQualifiedName,
+            mappedType = currentContext.currentResults.filterIsInstance<CppTypeInfo>().first(),
+            hasImmutableFields = cppStruct.hasImmutableFields,
+            fields = getPreviousResults(CField::class.java),
+            methods = getPreviousResults(CFunction::class.java),
+            structs = getPreviousResults(CStruct::class.java),
+            interfaces = getPreviousResults(CInterface::class.java)
         )
 
         storeResult(cStruct)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeTypeMapper.kt
@@ -47,6 +47,7 @@ import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeRef
+import java.io.File
 
 class CBridgeTypeMapper(
     private val cppIncludeResolver: CppIncludeResolver,
@@ -68,7 +69,7 @@ class CBridgeTypeMapper(
         "${internalNamespace.joinToString("::")}::Locale",
         CType(BASE_REF_NAME),
         CType(BASE_REF_NAME),
-        listOf(BASE_HANDLE_IMPL_INCLUDE)
+        listOf(BASE_HANDLE_IMPL_INCLUDE, createInternalNamespaceInclude("Locale.h"))
     )
 
     fun mapType(limeTypeRef: LimeTypeRef, cppTypeRef: CppTypeRef): CppTypeInfo {
@@ -82,8 +83,7 @@ class CBridgeTypeMapper(
     private fun mapType(limeType: LimeType, cppTypeRef: CppTypeRef): CppTypeInfo =
         when (limeType) {
             is LimeBasicType -> mapBasicType(limeType)
-            is LimeTypeAlias ->
-                mapType(limeType.actualType, cppTypeRef.actualType)
+            is LimeTypeAlias -> mapType(limeType.actualType, cppTypeRef.actualType)
             is LimeContainerWithInheritance -> createCustomTypeInfo(limeType, isClass = true)
             is LimeStruct -> createCustomTypeInfo(limeType)
             is LimeEnumeration -> createEnumTypeInfo(limeType)
@@ -244,6 +244,9 @@ class CBridgeTypeMapper(
         CType(BASE_REF_NAME),
         baseTypeInfo.includes + cppTypeRef.includes + cppIncludeResolver.optionalInclude
     )
+
+    private fun createInternalNamespaceInclude(fileName: String) =
+        Include.createInternalInclude((internalNamespace + fileName).joinToString(File.separator))
 
     companion object {
         val BASE_HANDLE_IMPL_INCLUDE = Include.createInternalInclude(BASE_HANDLE_IMPL_FILE)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/LimeModelFilter.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/LimeModelFilter.kt
@@ -104,9 +104,9 @@ class LimeModelFilter(private val predicate: (LimeNamedElement) -> Boolean) {
             constants = constants.filter(predicate),
             fields = fields.filter(predicate),
             constructorComment = constructorComment,
-            structs = structs,
-            classes = classes,
-            interfaces = interfaces
+            structs = structs.filter(predicate),
+            classes = classes.filter(predicate),
+            interfaces = interfaces.filter(predicate)
         ) }
 
     private fun filterEnum(limeEnum: LimeEnumeration) =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
@@ -152,7 +152,10 @@ class SwiftModelBuilder(
         addMembersAndParent(swiftFile, swiftClass, parentClass)
         swiftClass.structs.addAll(getPreviousResults(SwiftStruct::class.java))
         swiftClass.enums.addAll(getPreviousResults(SwiftEnum::class.java))
-        swiftClass.classes.addAll(getPreviousResults(SwiftClass::class.java))
+
+        val nestedClasses = getPreviousResults(SwiftClass::class.java)
+        swiftClass.classes.addAll(nestedClasses.filterNot { it.isInterface })
+        swiftFile.classes.addAll(nestedClasses.filter { it.isInterface })
 
         storeNamedResult(limeClass, swiftClass)
         storeResult(swiftFile)
@@ -271,7 +274,9 @@ class SwiftModelBuilder(
             methods = getPreviousResults(SwiftMethod::class.java),
             generatedConstructorComment = limeStruct.constructorComment.getFor(PLATFORM_TAG),
             externalFramework = limeStruct.external?.swift?.get(FRAMEWORK_NAME),
-            externalConverter = limeStruct.external?.swift?.get(CONVERTER_NAME)
+            externalConverter = limeStruct.external?.swift?.get(CONVERTER_NAME),
+            structs = getPreviousResults(SwiftStruct::class.java),
+            classes = getPreviousResults(SwiftClass::class.java)
         )
         swiftStruct.comment = createComments(limeStruct)
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
@@ -26,6 +26,7 @@ import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeAlias
 
@@ -39,10 +40,10 @@ class SwiftNameResolver(
 
         val name = nameRules.getName(limeType)
         return when {
-            parentContainer?.attributes?.have(SWIFT, EXTENSION) == true ||
-                    parentContainer is LimeClass -> getNestedNames(parentContainer) + name
-            parentContainer is LimeInterface &&
-                    (limeType is LimeTypeAlias || limeType is LimeLambda) ->
+            limeType is LimeInterface -> listOf(name)
+            parentContainer?.attributes?.have(SWIFT, EXTENSION) == true -> getNestedNames(parentContainer) + name
+            parentContainer is LimeClass || parentContainer is LimeStruct -> getNestedNames(parentContainer) + name
+            parentContainer is LimeInterface && (limeType is LimeTypeAlias || limeType is LimeLambda) ->
                 getNestedNames(parentContainer) + name
             else -> listOf(name)
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/model/cbridge/CStruct.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/cbridge/CStruct.kt
@@ -27,7 +27,9 @@ class CStruct(
     val mappedType: CppTypeInfo,
     val hasImmutableFields: Boolean = false,
     val fields: List<CField> = emptyList(),
-    val methods: List<CFunction> = emptyList()
+    val methods: List<CFunction> = emptyList(),
+    val structs: List<CStruct> = emptyList(),
+    val interfaces: List<CInterface> = emptyList()
 ) : CType(name) {
 
     val type = mappedType.functionReturnType.toString()

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftStruct.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftStruct.kt
@@ -35,7 +35,9 @@ class SwiftStruct(
     val methods: List<SwiftMethod> = emptyList(),
     var generatedConstructorComment: String? = null,
     externalFramework: String? = null,
-    externalConverter: String? = null
+    externalConverter: String? = null,
+    val structs: List<SwiftStruct> = emptyList(),
+    val classes: List<SwiftClass> = emptyList()
 ) : SwiftType(
     name,
     cPrefix,

--- a/gluecodium/src/main/resources/templates/cbridge/InterfaceHeader.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/InterfaceHeader.mustache
@@ -24,7 +24,7 @@
 {{/if}}{{/unless}}{{/functions}}
 
 {{#structs}}
-{{>cbridge/StructFunctionDeclarations}}
+{{>cbridge/StructHeader}}
 {{#if methods}}
 
 {{#methods}}{{#if error}}{{>cbridge/ThrowingFunctionReturnType}}

--- a/gluecodium/src/main/resources/templates/cbridge/StructHeader.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/StructHeader.mustache
@@ -29,4 +29,20 @@ _GLUECODIUM_C_EXPORT void {{name}}_release_optional_handle(_baseRef handle);
 {{#fields}}
 _GLUECODIUM_C_EXPORT {{type.functionReturnType}} {{structname}}_{{name}}_get(_baseRef handle);
 {{/fields}}
+
+{{#structs}}
+{{>cbridge/StructHeader}}
+{{#if methods}}
+
+{{#methods}}{{#if error}}{{>cbridge/ThrowingFunctionReturnType}}
+{{/if}}{{/methods}}
+
+{{#methods}}{{#unless isSkipped}}
+_GLUECODIUM_C_EXPORT {{>cbridge/FunctionSignature}};
+{{/unless}}{{/methods}}
+{{/if}}{{/structs}}
+
+{{#interfaces}}
+{{>cbridge/InterfaceHeader}}
+{{/interfaces}}
 {{/set}}

--- a/gluecodium/src/main/resources/templates/cbridge/StructImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/StructImplementation.mustache
@@ -83,7 +83,21 @@ void {{name}}_release_optional_handle(_baseRef handle) {
 }
 {{/fields}}
 {{/set}}
-{{/if}}{{!!
+
+{{/if}}
+{{#structs}}
+{{>cbridge/StructImplementation}}
+
+{{#set selfIsStruct=true}}{{#methods}}{{#unless isSkipped}}
+{{>cbridge/FunctionDefinition}}
+{{/unless}}{{/methods}}{{/set}}
+
+{{/structs}}
+
+{{#interfaces}}
+{{>cbridge/InterfaceImpl}}
+
+{{/interfaces}}{{!!
 
 }}{{+getBaseLayerFieldValue}}struct_pointer->{{#if baseLayerGetterName}}{{baseLayerGetterName}}(){{/if}}{{!!
 }}{{#unless baseLayerGetterName}}{{baseLayerName}}{{/unless}}{{/getBaseLayerFieldValue}}

--- a/gluecodium/src/main/resources/templates/swift/Struct.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Struct.mustache
@@ -89,8 +89,14 @@
 {{/fields}}
     }
 
-{{/unless}}{{/constructors}}{{/set}}{{!!
-}}{{#if needsExplicitHashable}}
+{{/unless}}{{/constructors}}{{/set}}
+{{#structs}}
+{{prefixPartial "swift/Struct" "    "}}
+{{/structs}}
+{{#classes}}{{#unless isInterface}}
+{{prefixPartial "swift/ClassDefinition" "    "}}
+{{/unless}}{{/classes}}
+{{#if needsExplicitHashable}}
     public static func == (lhs: {{simpleName}}, rhs: {{simpleName}}) -> Bool {
         return
 {{#fields}}
@@ -114,6 +120,10 @@
 {{prefixPartial 'swift/Method' '    '}}
 {{/unless}}{{/methods}}{{/set}}{{/if}}
 }
+
+{{#classes}}{{#if isInterface}}
+{{>swift/ClassDefinition}}
+{{/if}}{{/classes}}
 {{/unless}}{{!!
 
 }}{{#if skipDeclaration}}

--- a/gluecodium/src/main/resources/templates/swift/StructConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/StructConversion.mustache
@@ -83,3 +83,9 @@ internal func moveToCType(_ swiftType: {{name}}?) -> RefHolder {
 }
 
 {{/if}}
+{{#classes}}
+{{>swift/ClassConversion}}{{!!
+}}{{/classes}}
+{{#structs}}
+{{>swift/StructConversion}}{{!!
+}}{{/structs}}

--- a/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/GenericCollections.cpp
+++ b/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/GenericCollections.cpp
@@ -1,0 +1,75 @@
+//
+//
+#include "cbridge/include/GenericCollections.h"
+#include "cbridge/include/StringHandle.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "gluecodium/Locale.h"
+#include <new>
+#include <string>
+#include <unordered_map>
+#include <vector>
+_baseRef ArrayOf__Locale_create_handle() {
+    return reinterpret_cast<_baseRef>( new std::vector<gluecodium::Locale>( ) );
+}
+_baseRef ArrayOf__Locale_copy_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( new std::vector<gluecodium::Locale>( *reinterpret_cast<std::vector<gluecodium::Locale>*>( handle ) ) );
+}
+void ArrayOf__Locale_release_handle(_baseRef handle) {
+    delete reinterpret_cast<std::vector<gluecodium::Locale>*>( handle );
+}
+uint64_t ArrayOf__Locale_count(_baseRef handle) {
+    return Conversion<std::vector<gluecodium::Locale>>::toCpp( handle ).size( );
+}
+_baseRef ArrayOf__Locale_get( _baseRef handle, uint64_t index ) { return Conversion<gluecodium::Locale>::referenceBaseRef(Conversion<std::vector<gluecodium::Locale>>::toCpp( handle )[index]);
+}
+void ArrayOf__Locale_append( _baseRef handle, _baseRef item )
+{
+Conversion<std::vector<gluecodium::Locale>>::toCpp(handle).push_back(Conversion<gluecodium::Locale>::toCpp(item));
+}
+_baseRef ArrayOf__Locale_create_optional_handle() {
+    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<gluecodium::Locale>>( std::vector<gluecodium::Locale>( ) ) );
+}
+void ArrayOf__Locale_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<std::vector<gluecodium::Locale>>*>( handle );
+}
+_baseRef ArrayOf__Locale_unwrap_optional_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<gluecodium::Locale>>*>( handle ) );
+}
+_baseRef MapOf__String_To__Locale_create_handle() {
+    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::string, gluecodium::Locale >() );
+}
+void MapOf__String_To__Locale_release_handle(_baseRef handle) {
+    delete get_pointer<std::unordered_map<std::string, gluecodium::Locale >>(handle);
+}
+_baseRef MapOf__String_To__Locale_iterator(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::string, gluecodium::Locale >::iterator( get_pointer<std::unordered_map<std::string, gluecodium::Locale >>(handle)->begin() ) );
+}
+void MapOf__String_To__Locale_iterator_release_handle(_baseRef iterator_handle) {
+    delete reinterpret_cast<std::unordered_map<std::string, gluecodium::Locale >::iterator*>( iterator_handle );
+}
+void MapOf__String_To__Locale_put(_baseRef handle, _baseRef key, _baseRef value) {
+    (*get_pointer<std::unordered_map<std::string, gluecodium::Locale >>(handle)).emplace(Conversion<std::string>::toCpp(key), Conversion<gluecodium::Locale>::toCpp(value));
+}
+bool MapOf__String_To__Locale_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
+    return *reinterpret_cast<std::unordered_map<std::string, gluecodium::Locale >::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<std::string, gluecodium::Locale >>(handle)->end();
+}
+void MapOf__String_To__Locale_iterator_increment(_baseRef iterator_handle) {
+    ++*reinterpret_cast<std::unordered_map<std::string, gluecodium::Locale >::iterator*>( iterator_handle );
+}
+_baseRef MapOf__String_To__Locale_iterator_key(_baseRef iterator_handle) {
+    auto& key = (*reinterpret_cast<std::unordered_map<std::string, gluecodium::Locale >::iterator*>( iterator_handle ))->first;
+    return Conversion<std::string>::toBaseRef(key);
+}
+_baseRef MapOf__String_To__Locale_iterator_value(_baseRef iterator_handle) {
+    auto& value = (*reinterpret_cast<std::unordered_map<std::string, gluecodium::Locale >::iterator*>( iterator_handle ))->second;
+    return Conversion<gluecodium::Locale>::toBaseRef(value);
+}
+_baseRef MapOf__String_To__Locale_create_optional_handle() {
+    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<std::string, gluecodium::Locale >>( std::unordered_map<std::string, gluecodium::Locale >( ) ) );
+}
+void MapOf__String_To__Locale_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<std::string, gluecodium::Locale >>*>( handle );
+}
+_baseRef MapOf__String_To__Locale_unwrap_optional_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<std::string, gluecodium::Locale >>*>( handle ) );
+}

--- a/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/smoke/cbridge_Locales.cpp
+++ b/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/smoke/cbridge_Locales.cpp
@@ -4,6 +4,7 @@
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
 #include "cbridge_internal/include/WrapperCache.h"
+#include "gluecodium/Locale.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/Locales.h"

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterStruct.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterStruct.cpp
@@ -1,0 +1,168 @@
+//
+//
+#include "cbridge\include\smoke\cbridge_OuterStruct.h"
+#include "cbridge_internal\include\BaseHandleImpl.h"
+#include "gluecodium\Optional.h"
+#include "smoke\OuterStruct.h"
+#include <memory>
+#include <new>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+_baseRef
+smoke_OuterStruct_create_handle( _baseRef field )
+{
+    ::smoke::OuterStruct* _struct = new ( std::nothrow ) ::smoke::OuterStruct();
+    _struct->field = Conversion<std::string>::toCpp( field );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+void
+smoke_OuterStruct_release_handle( _baseRef handle )
+{
+    delete get_pointer<::smoke::OuterStruct>( handle );
+}
+_baseRef
+smoke_OuterStruct_create_optional_handle(_baseRef field)
+{
+    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::OuterStruct>( ::smoke::OuterStruct( ) );
+    (*_struct)->field = Conversion<std::string>::toCpp( field );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+_baseRef
+smoke_OuterStruct_unwrap_optional_handle( _baseRef handle )
+{
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::smoke::OuterStruct>*>( handle ) );
+}
+void smoke_OuterStruct_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::smoke::OuterStruct>*>( handle );
+}
+_baseRef smoke_OuterStruct_field_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const ::smoke::OuterStruct>(handle);
+return Conversion<std::string>::toBaseRef(struct_pointer->field);
+}
+_baseRef
+smoke_OuterStruct_InnerStruct_create_handle( _baseRef otherField )
+{
+    ::smoke::OuterStruct::InnerStruct* _struct = new ( std::nothrow ) ::smoke::OuterStruct::InnerStruct();
+    _struct->other_field = Conversion<std::vector<std::chrono::system_clock::time_point>>::toCpp( otherField );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+void
+smoke_OuterStruct_InnerStruct_release_handle( _baseRef handle )
+{
+    delete get_pointer<::smoke::OuterStruct::InnerStruct>( handle );
+}
+_baseRef
+smoke_OuterStruct_InnerStruct_create_optional_handle(_baseRef otherField)
+{
+    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::OuterStruct::InnerStruct>( ::smoke::OuterStruct::InnerStruct( ) );
+    (*_struct)->other_field = Conversion<std::vector<std::chrono::system_clock::time_point>>::toCpp( otherField );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+_baseRef
+smoke_OuterStruct_InnerStruct_unwrap_optional_handle( _baseRef handle )
+{
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::smoke::OuterStruct::InnerStruct>*>( handle ) );
+}
+void smoke_OuterStruct_InnerStruct_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::smoke::OuterStruct::InnerStruct>*>( handle );
+}
+_baseRef smoke_OuterStruct_InnerStruct_otherField_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const ::smoke::OuterStruct::InnerStruct>(handle);
+return Conversion<std::vector<std::chrono::system_clock::time_point>>::toBaseRef(struct_pointer->other_field);
+}
+void smoke_OuterStruct_InnerStruct_doSomething(_baseRef _instance) {
+    return get_pointer<::smoke::OuterStruct::InnerStruct>(_instance)->do_something();
+}
+void smoke_OuterStruct_InnerClass_release_handle(_baseRef handle) {
+    delete get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle);
+}
+_baseRef smoke_OuterStruct_InnerClass_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle)))
+        : 0;
+}
+const void* smoke_OuterStruct_InnerClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle)->get())
+        : nullptr;
+}
+void smoke_OuterStruct_InnerClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle)->get(), swift_pointer);
+}
+void smoke_OuterStruct_InnerClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle)->get());
+}
+_baseRef smoke_OuterStruct_InnerClass_fooBar(_baseRef _instance) {
+    return Conversion<std::unordered_set<gluecodium::Locale>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerClass>>(_instance)->get()->foo_bar());
+}
+void smoke_OuterStruct_InnerInterface_release_handle(_baseRef handle) {
+    delete get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle);
+}
+_baseRef smoke_OuterStruct_InnerInterface_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)))
+        : 0;
+}
+const void* smoke_OuterStruct_InnerInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get())
+        : nullptr;
+}
+void smoke_OuterStruct_InnerInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get(), swift_pointer);
+}
+void smoke_OuterStruct_InnerInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get());
+}
+extern "C" {
+extern void* _CBridgeInitsmoke_OuterStruct_InnerInterface(_baseRef handle);
+}
+namespace {
+struct smoke_OuterStruct_InnerInterfaceRegisterInit {
+    smoke_OuterStruct_InnerInterfaceRegisterInit() {
+        get_init_repository().add_init("smoke_OuterStruct_InnerInterface", &_CBridgeInitsmoke_OuterStruct_InnerInterface);
+    }
+} s_smoke_OuterStruct_InnerInterface_register_init;
+}
+void* smoke_OuterStruct_InnerInterface_get_typed(_baseRef handle) {
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::OuterStruct::InnerInterface>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get());
+    auto init_function = get_init_repository().get_init(real_type_id);
+    return init_function ? init_function(handle) : _CBridgeInitsmoke_OuterStruct_InnerInterface(handle);
+}
+_baseRef smoke_OuterStruct_InnerInterface_barBaz(_baseRef _instance) {
+    return Conversion<std::unordered_map<std::string, ::std::shared_ptr< ::std::vector< uint8_t > >>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(_instance)->get()->bar_baz());
+}
+class smoke_OuterStruct_InnerInterfaceProxy : public std::shared_ptr<::smoke::OuterStruct::InnerInterface>::element_type, public CachedProxyBase<smoke_OuterStruct_InnerInterfaceProxy> {
+public:
+    smoke_OuterStruct_InnerInterfaceProxy(smoke_OuterStruct_InnerInterface_FunctionTable&& functions)
+     : mFunctions(std::move(functions))
+    {
+    }
+    virtual ~smoke_OuterStruct_InnerInterfaceProxy() {
+        mFunctions.release(mFunctions.swift_pointer);
+    }
+    smoke_OuterStruct_InnerInterfaceProxy(const smoke_OuterStruct_InnerInterfaceProxy&) = delete;
+    smoke_OuterStruct_InnerInterfaceProxy& operator=(const smoke_OuterStruct_InnerInterfaceProxy&) = delete;
+    ::std::unordered_map< ::std::string, ::std::shared_ptr< ::std::vector< uint8_t > > > bar_baz() override {
+        auto _call_result = mFunctions.smoke_OuterStruct_InnerInterface_barBaz(mFunctions.swift_pointer);
+        return Conversion<std::unordered_map<std::string, ::std::shared_ptr< ::std::vector< uint8_t > >>>::toCppReturn(_call_result);
+    }
+private:
+    smoke_OuterStruct_InnerInterface_FunctionTable mFunctions;
+};
+_baseRef smoke_OuterStruct_InnerInterface_create_proxy(smoke_OuterStruct_InnerInterface_FunctionTable functionTable) {
+    auto proxy = smoke_OuterStruct_InnerInterfaceProxy::get_proxy(std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::OuterStruct::InnerInterface>(proxy)) : 0;
+}
+const void* smoke_OuterStruct_InnerInterface_get_swift_object_from_cache(_baseRef handle) {
+    return handle ? smoke_OuterStruct_InnerInterfaceProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get()) : nullptr;
+}
+void smoke_OuterStruct_doNothing(_baseRef _instance) {
+    return get_pointer<::smoke::OuterStruct>(_instance)->do_nothing();
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/LevelOne.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/LevelOne.swift
@@ -53,7 +53,7 @@ public class LevelOne {
                     return moveFromCType(smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fooFactory())
                 }
             }
-            public func foo(input: OuterClass.InnerInterface) -> InnerClass {
+            public func foo(input: InnerInterface) -> InnerClass {
                 let c_input = moveToCType(input)
                 return InnerClass_moveFromCType(smoke_LevelOne_LevelTwo_LevelThree_foo(self.c_instance, c_input.ref))
             }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClass.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClass.swift
@@ -30,26 +30,6 @@ public class OuterClass {
             return moveFromCType(smoke_OuterClass_InnerClass_foo(self.c_instance, c_input.ref))
         }
     }
-    public protocol InnerInterface : AnyObject {
-        func foo(input: String) -> String
-    }
-    internal class _InnerInterface: InnerInterface {
-        let c_instance : _baseRef
-        init(cInnerInterface: _baseRef) {
-            guard cInnerInterface != 0 else {
-                fatalError("Nullptr value is not supported for initializers")
-            }
-            c_instance = cInnerInterface
-        }
-        deinit {
-            smoke_OuterClass_InnerInterface_remove_swift_object_from_wrapper_cache(c_instance)
-            smoke_OuterClass_InnerInterface_release_handle(c_instance)
-        }
-        public func foo(input: String) -> String {
-            let c_input = moveToCType(input)
-            return moveFromCType(smoke_OuterClass_InnerInterface_foo(self.c_instance, c_input.ref))
-        }
-    }
     public func foo(input: String) -> String {
         let c_input = moveToCType(input)
         return moveFromCType(smoke_OuterClass_foo(self.c_instance, c_input.ref))
@@ -165,12 +145,32 @@ internal func copyToCType(_ swiftClass: OuterClass.InnerClass?) -> RefHolder {
 internal func moveToCType(_ swiftClass: OuterClass.InnerClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+public protocol InnerInterface : AnyObject {
+    func foo(input: String) -> String
+}
+internal class _InnerInterface: InnerInterface {
+    let c_instance : _baseRef
+    init(cInnerInterface: _baseRef) {
+        guard cInnerInterface != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cInnerInterface
+    }
+    deinit {
+        smoke_OuterClass_InnerInterface_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_OuterClass_InnerInterface_release_handle(c_instance)
+    }
+    public func foo(input: String) -> String {
+        let c_input = moveToCType(input)
+        return moveFromCType(smoke_OuterClass_InnerInterface_foo(self.c_instance, c_input.ref))
+    }
+}
 @_cdecl("_CBridgeInitsmoke_OuterClass_InnerInterface")
 internal func _CBridgeInitsmoke_OuterClass_InnerInterface(handle: _baseRef) -> UnsafeMutableRawPointer {
-    let reference = OuterClass._InnerInterface(cInnerInterface: handle)
+    let reference = _InnerInterface(cInnerInterface: handle)
     return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
 }
-internal func getRef(_ ref: OuterClass.InnerInterface?, owning: Bool = true) -> RefHolder {
+internal func getRef(_ ref: InnerInterface?, owning: Bool = true) -> RefHolder {
     guard let reference = ref else {
         return RefHolder(0)
     }
@@ -188,70 +188,70 @@ internal func getRef(_ ref: OuterClass.InnerInterface?, owning: Bool = true) -> 
         }
     }
     functions.smoke_OuterClass_InnerInterface_foo = {(swift_class_pointer, input) in
-        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! OuterClass.InnerInterface
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! InnerInterface
         return copyToCType(swift_class.foo(input: moveFromCType(input))).ref
     }
     let proxy = smoke_OuterClass_InnerInterface_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_OuterClass_InnerInterface_release_handle) : RefHolder(proxy)
 }
-extension OuterClass._InnerInterface: NativeBase {
+extension _InnerInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func OuterClass_InnerInterface_copyFromCType(_ handle: _baseRef) -> OuterClass.InnerInterface {
+internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface {
     if let swift_pointer = smoke_OuterClass_InnerInterface_get_swift_object_from_cache(handle),
-        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerInterface {
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
         return re_constructed
     }
     if let swift_pointer = smoke_OuterClass_InnerInterface_get_swift_object_from_wrapper_cache(handle),
-        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerInterface {
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
         return re_constructed
     }
     if let swift_pointer = smoke_OuterClass_InnerInterface_get_typed(smoke_OuterClass_InnerInterface_copy_handle(handle)),
-        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? OuterClass.InnerInterface {
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InnerInterface {
         smoke_OuterClass_InnerInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func OuterClass_InnerInterface_moveFromCType(_ handle: _baseRef) -> OuterClass.InnerInterface {
+internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface {
     if let swift_pointer = smoke_OuterClass_InnerInterface_get_swift_object_from_cache(handle),
-        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerInterface {
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
         smoke_OuterClass_InnerInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_OuterClass_InnerInterface_get_swift_object_from_wrapper_cache(handle),
-        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerInterface {
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
         smoke_OuterClass_InnerInterface_release_handle(handle)
         return re_constructed
     }
     if let swift_pointer = smoke_OuterClass_InnerInterface_get_typed(handle),
-        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? OuterClass.InnerInterface {
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InnerInterface {
         smoke_OuterClass_InnerInterface_cache_swift_object_wrapper(handle, swift_pointer)
         return typed
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func OuterClass_InnerInterface_copyFromCType(_ handle: _baseRef) -> OuterClass.InnerInterface? {
+internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface? {
     guard handle != 0 else {
         return nil
     }
-    return OuterClass_InnerInterface_moveFromCType(handle) as OuterClass.InnerInterface
+    return InnerInterface_moveFromCType(handle) as InnerInterface
 }
-internal func OuterClass_InnerInterface_moveFromCType(_ handle: _baseRef) -> OuterClass.InnerInterface? {
+internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface? {
     guard handle != 0 else {
         return nil
     }
-    return OuterClass_InnerInterface_moveFromCType(handle) as OuterClass.InnerInterface
+    return InnerInterface_moveFromCType(handle) as InnerInterface
 }
-internal func copyToCType(_ swiftClass: OuterClass.InnerInterface) -> RefHolder {
+internal func copyToCType(_ swiftClass: InnerInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: OuterClass.InnerInterface) -> RefHolder {
+internal func moveToCType(_ swiftClass: InnerInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: OuterClass.InnerInterface?) -> RefHolder {
+internal func copyToCType(_ swiftClass: InnerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: OuterClass.InnerInterface?) -> RefHolder {
+internal func moveToCType(_ swiftClass: InnerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterStruct.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterStruct.swift
@@ -1,0 +1,287 @@
+//
+//
+import Foundation
+public struct OuterStruct {
+    public var field: String
+    public init(field: String) {
+        self.field = field
+    }
+    internal init(cHandle: _baseRef) {
+        field = moveFromCType(smoke_OuterStruct_field_get(cHandle))
+    }
+    public struct InnerStruct {
+        public var otherField: [Date]
+        public init(otherField: [Date]) {
+            self.otherField = otherField
+        }
+        internal init(cHandle: _baseRef) {
+            otherField = moveFromCType(smoke_OuterStruct_InnerStruct_otherField_get(cHandle))
+        }
+        public func doSomething() -> Void {
+            let c_self_handle = moveToCType(self)
+            return moveFromCType(smoke_OuterStruct_InnerStruct_doSomething(c_self_handle.ref))
+        }
+    }
+    public class InnerClass {
+        let c_instance : _baseRef
+        init(cInnerClass: _baseRef) {
+            guard cInnerClass != 0 else {
+                fatalError("Nullptr value is not supported for initializers")
+            }
+            c_instance = cInnerClass
+        }
+        deinit {
+            smoke_OuterStruct_InnerClass_remove_swift_object_from_wrapper_cache(c_instance)
+            smoke_OuterStruct_InnerClass_release_handle(c_instance)
+        }
+        public func fooBar() -> Set<Locale> {
+            return moveFromCType(smoke_OuterStruct_InnerClass_fooBar(self.c_instance))
+        }
+    }
+    public func doNothing() -> Void {
+        let c_self_handle = moveToCType(self)
+        return moveFromCType(smoke_OuterStruct_doNothing(c_self_handle.ref))
+    }
+}
+public protocol InnerInterface : AnyObject {
+    func barBaz() -> [String: Data]
+}
+internal class _InnerInterface: InnerInterface {
+    let c_instance : _baseRef
+    init(cInnerInterface: _baseRef) {
+        guard cInnerInterface != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cInnerInterface
+    }
+    deinit {
+        smoke_OuterStruct_InnerInterface_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_OuterStruct_InnerInterface_release_handle(c_instance)
+    }
+    public func barBaz() -> [String: Data] {
+        return moveFromCType(smoke_OuterStruct_InnerInterface_barBaz(self.c_instance))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> OuterStruct {
+    return OuterStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> OuterStruct {
+    defer {
+        smoke_OuterStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: OuterStruct) -> RefHolder {
+    let c_field = moveToCType(swiftType.field)
+    return RefHolder(smoke_OuterStruct_create_handle(c_field.ref))
+}
+internal func moveToCType(_ swiftType: OuterStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> OuterStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_OuterStruct_unwrap_optional_handle(handle)
+    return OuterStruct(cHandle: unwrappedHandle) as OuterStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> OuterStruct? {
+    defer {
+        smoke_OuterStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: OuterStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_field = moveToCType(swiftType.field)
+    return RefHolder(smoke_OuterStruct_create_optional_handle(c_field.ref))
+}
+internal func moveToCType(_ swiftType: OuterStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStruct_release_optional_handle)
+}
+internal func getRef(_ ref: OuterStruct.InnerClass?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_OuterStruct_InnerClass_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_OuterStruct_InnerClass_release_handle)
+        : RefHolder(handle_copy)
+}
+extension OuterStruct.InnerClass: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func OuterStruct_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass {
+    if let swift_pointer = smoke_OuterStruct_InnerClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterStruct.InnerClass {
+        return re_constructed
+    }
+    let result = OuterStruct.InnerClass(cInnerClass: smoke_OuterStruct_InnerClass_copy_handle(handle))
+    smoke_OuterStruct_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func OuterStruct_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass {
+    if let swift_pointer = smoke_OuterStruct_InnerClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterStruct.InnerClass {
+        smoke_OuterStruct_InnerClass_release_handle(handle)
+        return re_constructed
+    }
+    let result = OuterStruct.InnerClass(cInnerClass: handle)
+    smoke_OuterStruct_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func OuterStruct_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return OuterStruct_InnerClass_moveFromCType(handle) as OuterStruct.InnerClass
+}
+internal func OuterStruct_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return OuterStruct_InnerClass_moveFromCType(handle) as OuterStruct.InnerClass
+}
+internal func copyToCType(_ swiftClass: OuterStruct.InnerClass) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: OuterStruct.InnerClass) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: OuterStruct.InnerClass?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: OuterStruct.InnerClass?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+@_cdecl("_CBridgeInitsmoke_OuterStruct_InnerInterface")
+internal func _CBridgeInitsmoke_OuterStruct_InnerInterface(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _InnerInterface(cInnerInterface: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: InnerInterface?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_OuterStruct_InnerInterface_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_OuterStruct_InnerInterface_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_OuterStruct_InnerInterface_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    functions.smoke_OuterStruct_InnerInterface_barBaz = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! InnerInterface
+        return copyToCType(swift_class.barBaz()).ref
+    }
+    let proxy = smoke_OuterStruct_InnerInterface_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_OuterStruct_InnerInterface_release_handle) : RefHolder(proxy)
+}
+extension _InnerInterface: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface {
+    if let swift_pointer = smoke_OuterStruct_InnerInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_OuterStruct_InnerInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_OuterStruct_InnerInterface_get_typed(smoke_OuterStruct_InnerInterface_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InnerInterface {
+        smoke_OuterStruct_InnerInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface {
+    if let swift_pointer = smoke_OuterStruct_InnerInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
+        smoke_OuterStruct_InnerInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_OuterStruct_InnerInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
+        smoke_OuterStruct_InnerInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_OuterStruct_InnerInterface_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InnerInterface {
+        smoke_OuterStruct_InnerInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return InnerInterface_moveFromCType(handle) as InnerInterface
+}
+internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return InnerInterface_moveFromCType(handle) as InnerInterface
+}
+internal func copyToCType(_ swiftClass: InnerInterface) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: InnerInterface) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: InnerInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: InnerInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct {
+    return OuterStruct.InnerStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct {
+    defer {
+        smoke_OuterStruct_InnerStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: OuterStruct.InnerStruct) -> RefHolder {
+    let c_otherField = moveToCType(swiftType.otherField)
+    return RefHolder(smoke_OuterStruct_InnerStruct_create_handle(c_otherField.ref))
+}
+internal func moveToCType(_ swiftType: OuterStruct.InnerStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStruct_InnerStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_OuterStruct_InnerStruct_unwrap_optional_handle(handle)
+    return OuterStruct.InnerStruct(cHandle: unwrappedHandle) as OuterStruct.InnerStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct? {
+    defer {
+        smoke_OuterStruct_InnerStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: OuterStruct.InnerStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_otherField = moveToCType(swiftType.otherField)
+    return RefHolder(smoke_OuterStruct_InnerStruct_create_optional_handle(c_otherField.ref))
+}
+internal func moveToCType(_ swiftType: OuterStruct.InnerStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStruct_InnerStruct_release_optional_handle)
+}


### PR DESCRIPTION
Updated Swift model builder and templates to add support for structs,
classes, and interfaces declared inside structs.

Added smoke and functional tests.

See: #487
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>