### PR TITLE
Add @exclude LimeDoc tag support for C++

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorPredicates.kt
@@ -44,15 +44,13 @@ internal object CppGeneratorPredicates {
         "hasAnyComment" to { limeElement: Any ->
             when (limeElement) {
                 is LimeFunction -> limeElement.run {
-                    !comment.isEmpty() || !returnType.comment.isEmpty() ||
+                    !comment.isEmpty() || comment.isExcluded || !returnType.comment.isEmpty() ||
                     needsNotNullComment(returnType.typeRef) ||
-                    (thrownType?.comment?.isEmpty() == false) || attributes.have(
-                        LimeAttributeType.DEPRECATED
-                    ) ||
+                    (thrownType?.comment?.isEmpty() == false) || attributes.have(LimeAttributeType.DEPRECATED) ||
                     parameters.any { !it.comment.isEmpty() || needsNotNullComment(it.typeRef) }
                 }
                 is LimeNamedElement -> limeElement.run {
-                    !comment.isEmpty() || attributes.have(LimeAttributeType.DEPRECATED)
+                    !comment.isEmpty() || comment.isExcluded || attributes.have(LimeAttributeType.DEPRECATED)
                 }
                 else -> false
             }

--- a/gluecodium/src/main/resources/templates/cpp/CppDocComment.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppDocComment.mustache
@@ -19,9 +19,12 @@
   !
   !}}
 {{#ifPredicate "hasAnyComment"}}
-/**{{#unless comment.isEmpty}}{{#resolveName comment}}
-{{prefix this " * "}}{{/resolveName}}{{/unless}}{{!!
-}}{{#if attributes.deprecated}}
+/**
+{{#unless comment.isEmpty}}{{!!
+}}{{#resolveName comment}}{{prefix this " * "}}{{/resolveName}}
+{{/unless}}{{#if comment.isExcluded}}
+ * \private
+{{/if}}{{#if attributes.deprecated}}
  * \deprecated {{#resolveName attributes.deprecated.message}}{{!!
 }}{{prefix this " * " skipFirstLine=true}}{{/resolveName}}{{/if}}
  */

--- a/gluecodium/src/main/resources/templates/cpp/CppFieldDoc.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppFieldDoc.mustache
@@ -19,9 +19,11 @@
   !
   !}}
 {{#ifPredicate "hasAnyComment"}}
-/**{{#unless comment.isEmpty}}{{#resolveName comment}}
-{{prefix this " * "}}{{/resolveName}}{{/unless}}{{!!
-}}{{#if attributes.deprecated}}
+/**
+{{#unless comment.isEmpty}}{{#resolveName comment}}{{prefix this " * "}}{{/resolveName}}
+{{/unless}}{{#if comment.isExcluded}}
+ * \private
+{{/if}}{{#if attributes.deprecated}}
  * \deprecated {{#resolveName attributes.deprecated.message}}{{!!
 }}{{prefix this " * " skipFirstLine=true}}{{/resolveName}}{{/if}}
 {{#ifPredicate typeRef "needsNotNullComment"}}

--- a/gluecodium/src/main/resources/templates/cpp/CppFunctionDoc.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppFunctionDoc.mustache
@@ -24,7 +24,9 @@
  */
 {{/ifPredicate}}{{!!
 
-}}{{+combinedComment}}{{resolveName comment}}{{#if attributes.deprecated}}
+}}{{+combinedComment}}{{resolveName comment}}{{#if comment.isExcluded}}
+\private{{/if}}{{!!
+}}{{#if attributes.deprecated}}
 \deprecated {{resolveName attributes.deprecated.message}}{{/if}}{{!!
 }}{{#parameters}}
 \param[in] {{resolveName}} {{#ifPredicate typeRef "needsNotNullComment"}}@NotNull {{/ifPredicate}}{{!!

--- a/gluecodium/src/test/resources/smoke/comments/input/ExcludedComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/ExcludedComments.lime
@@ -1,0 +1,117 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+// This is some very useful class.
+// @exclude
+class ExcludedComments {
+    // This is some very useful struct.
+    // @constructor This is how easy it is to construct.
+    // @exclude
+    struct SomeStruct {
+        // How useful this struct is
+        // remains to be seen
+        // @exclude
+        someField: Usefulness
+    }
+
+    // This is some very useful enum.
+    // @exclude
+    enum SomeEnum {
+        // Not quite useful
+        // @exclude
+        Useless
+    }
+
+    // This is some very useful typealias.
+    // @exclude
+    typealias Usefulness = Boolean
+
+    // This is some very useful constant.
+    // @exclude
+    const VeryUseful: Usefulness = true
+
+    // This is some very useful method that measures the usefulness of its input.
+    // @param[input_parameter] Very useful input parameter
+    // @return Usefulness of the input
+    // @throws Sometimes it happens.
+    // @exclude
+    fun someMethodWithAllComments(input_parameter: String): Usefulness throws SomethingWrong
+    // This is some very useful method that does nothing.
+    // @exclude
+    fun someMethodWithoutReturnTypeOrInputParameters()
+
+    // Some very useful property.
+    // @get Gets some very useful property.
+    // @set Sets some very useful property.
+    // @exclude
+    property SomeProperty: Usefulness
+
+    // This is some very useful exception.
+    // @exclude
+    exception SomethingWrong(SomeEnum)
+
+    // This is some very useful lambda that does it.
+    // @param[p0] Very useful input parameter
+    // @param[p1] Slightly less useful input parameter
+    // @return Usefulness of the input
+    // @exclude
+    @Java(FunctionName = "doIt")
+    lambda SomeLambda = (String, @Java("index") Int) -> Double
+}
+
+// @exclude
+class ExcludedCommentsOnly {
+    // @exclude
+    struct SomeStruct {
+        // @exclude
+        someField: Usefulness
+    }
+
+    // @exclude
+    enum SomeEnum {
+        // @exclude
+        Useless
+    }
+
+    // @exclude
+    typealias Usefulness = Boolean
+
+    // @exclude
+    const VeryUseful: Usefulness = true
+
+    // @exclude
+    fun someMethodWithAllComments(input_parameter: String): Usefulness throws SomethingWrong
+    // @exclude
+    fun someMethodWithoutReturnTypeOrInputParameters()
+
+    // @exclude
+    property SomeProperty: Usefulness
+
+    // @exclude
+    exception SomethingWrong(SomeEnum)
+
+    // @exclude
+    @Java(FunctionName = "doIt")
+    lambda SomeLambda = (String, @Java("index") Int) -> Double
+}
+
+// This is some very useful interface.
+// @exclude
+interface ExcludedCommentsInterface {
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedComments.h
@@ -1,0 +1,103 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include "gluecodium/Return.h"
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <system_error>
+namespace smoke {
+/**
+ * This is some very useful class.
+ * \private
+ */
+class _GLUECODIUM_CPP_EXPORT ExcludedComments {
+public:
+    ExcludedComments();
+    virtual ~ExcludedComments() = 0;
+public:
+    /**
+     * This is some very useful enum.
+     * \private
+     */
+    enum class SomeEnum {
+        /**
+         * Not quite useful
+         * \private
+         */
+        USELESS
+    };
+    /**
+     * This is some very useful lambda that does it.
+     * \private
+     */
+    using SomeLambda = ::std::function<double(const ::std::string&, const int32_t)>;
+    /**
+     * This is some very useful typealias.
+     * \private
+     */
+    using Usefulness = bool;
+    /**
+     * This is some very useful struct.
+     * \private
+     */
+    struct _GLUECODIUM_CPP_EXPORT SomeStruct {
+        /**
+         * How useful this struct is
+         * remains to be seen
+         * \private
+         */
+        ::smoke::ExcludedComments::Usefulness some_field;
+        /**
+         * This is how easy it is to construct.
+         */
+        SomeStruct( );
+        /**
+         * This is how easy it is to construct.
+         * @param some_field How useful this struct is
+         * remains to be seen
+         */
+        SomeStruct( ::smoke::ExcludedComments::Usefulness some_field );
+    };
+    /**
+     * This is some very useful constant.
+     * \private
+     */
+    _GLUECODIUM_CPP_EXPORT static const ::smoke::ExcludedComments::Usefulness VERY_USEFUL;
+public:
+    /**
+     * This is some very useful method that measures the usefulness of its input.
+     * \private
+     * \param[in] input_parameter Very useful input parameter
+     * \return Usefulness of the input
+     * \retval ::smoke::ExcludedComments::SomeEnum Sometimes it happens.
+     */
+    virtual ::gluecodium::Return< ::smoke::ExcludedComments::Usefulness, ::std::error_code > some_method_with_all_comments( const ::std::string& input_parameter ) = 0;
+    /**
+     * This is some very useful method that does nothing.
+     * \private
+     */
+    virtual void some_method_without_return_type_or_input_parameters(  ) = 0;
+    /**
+     * Gets some very useful property.
+     * \private
+     * \return Some very useful property.
+     */
+    virtual ::smoke::ExcludedComments::Usefulness is_some_property(  ) const = 0;
+    /**
+     * Sets some very useful property.
+     * \private
+     * \param[in] value Some very useful property.
+     */
+    virtual void set_some_property( const ::smoke::ExcludedComments::Usefulness value ) = 0;
+};
+_GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::ExcludedComments::SomeEnum value ) noexcept;
+}
+namespace std
+{
+template <>
+struct is_error_code_enum< ::smoke::ExcludedComments::SomeEnum > : public std::true_type { };
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsInterface.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsInterface.h
@@ -1,0 +1,21 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include "gluecodium/TypeRepository.h"
+namespace smoke {
+/**
+ * This is some very useful interface.
+ * \private
+ */
+class _GLUECODIUM_CPP_EXPORT ExcludedCommentsInterface {
+public:
+    ExcludedCommentsInterface();
+    virtual ~ExcludedCommentsInterface() = 0;
+};
+}
+namespace gluecodium {
+_GLUECODIUM_CPP_EXPORT TypeRepository& get_type_repository(const ::smoke::ExcludedCommentsInterface*);
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsOnly.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsOnly.h
@@ -1,0 +1,86 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include "gluecodium/Return.h"
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <system_error>
+namespace smoke {
+/**
+ * \private
+ */
+class _GLUECODIUM_CPP_EXPORT ExcludedCommentsOnly {
+public:
+    ExcludedCommentsOnly();
+    virtual ~ExcludedCommentsOnly() = 0;
+public:
+    /**
+     * \private
+     */
+    enum class SomeEnum {
+        /**
+         * \private
+         */
+        USELESS
+    };
+    /**
+     * \private
+     */
+    using SomeLambda = ::std::function<double(const ::std::string&, const int32_t)>;
+    /**
+     * \private
+     */
+    using Usefulness = bool;
+    /**
+     * \private
+     */
+    struct _GLUECODIUM_CPP_EXPORT SomeStruct {
+        /**
+         * \private
+         */
+        ::smoke::ExcludedCommentsOnly::Usefulness some_field;
+        SomeStruct( );
+        SomeStruct( ::smoke::ExcludedCommentsOnly::Usefulness some_field );
+    };
+    /**
+     * \private
+     */
+    _GLUECODIUM_CPP_EXPORT static const ::smoke::ExcludedCommentsOnly::Usefulness VERY_USEFUL;
+public:
+    /**
+     *
+     * \private
+     * \param[in] input_parameter
+     * \return
+     * \retval ::smoke::ExcludedCommentsOnly::SomeEnum
+     */
+    virtual ::gluecodium::Return< ::smoke::ExcludedCommentsOnly::Usefulness, ::std::error_code > some_method_with_all_comments( const ::std::string& input_parameter ) = 0;
+    /**
+     *
+     * \private
+     */
+    virtual void some_method_without_return_type_or_input_parameters(  ) = 0;
+    /**
+     *
+     * \private
+     * \return
+     */
+    virtual ::smoke::ExcludedCommentsOnly::Usefulness is_some_property(  ) const = 0;
+    /**
+     *
+     * \private
+     * \param[in] value
+     */
+    virtual void set_some_property( const ::smoke::ExcludedCommentsOnly::Usefulness value ) = 0;
+};
+_GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::ExcludedCommentsOnly::SomeEnum value ) noexcept;
+}
+namespace std
+{
+template <>
+struct is_error_code_enum< ::smoke::ExcludedCommentsOnly::SomeEnum > : public std::true_type { };
+}

--- a/lime-loader/src/main/antlr/LimedocParser.g4
+++ b/lime-loader/src/main/antlr/LimedocParser.g4
@@ -60,7 +60,7 @@ tagSection
     ;
 
 blockTag
-    : WhiteSpace* '@' tagName ('[' blockTagParameter ']')? WhiteSpace blockTagContent*
+    : WhiteSpace* '@' tagName ('[' blockTagParameter ']')? (WhiteSpace blockTagContent*)?
     ;
 
 tagName

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -292,14 +292,14 @@ internal class AntlrLimeModelBuilder(
         if (getterContext == null) {
             getter = LimeFunction(
                 path = getterPath,
-                comment = getComment("get", emptyList(), ctx),
+                comment = getComment("get", emptyList(), ctx).withExcluded(propertyComment.isExcluded),
                 visibility = propertyVisibility,
                 returnType = LimeReturnType(propertyType, propertyComment),
                 isStatic = propertyIsStatic
             )
             setter = LimeFunction(
                 path = currentPath.child("set"),
-                comment = getComment("set", emptyList(), ctx),
+                comment = getComment("set", emptyList(), ctx).withExcluded(propertyComment.isExcluded),
                 visibility = propertyVisibility,
                 parameters = listOf(LimeParameter(
                     getterPath.child("value"),
@@ -313,10 +313,11 @@ internal class AntlrLimeModelBuilder(
                 AntlrLimeConverter.convertAnnotations(currentPath, getterContext.annotation())
             val getterExternalDescriptor =
                 parseExternalDescriptor(getterContext.externalDescriptor(), getterContext.annotation())
+            val getterComment = getComment("get", getterContext.docComment(), getterContext)
             getter = LimeFunction(
                 path = getterPath,
                 visibility = convertVisibility(getterContext.visibility(), propertyVisibility),
-                comment = getComment("get", getterContext.docComment(), getterContext),
+                comment = getterComment.withExcluded(propertyComment.isExcluded),
                 attributes = getterAttributes,
                 external = getterExternalDescriptor,
                 returnType = LimeReturnType(propertyType, propertyComment),
@@ -327,10 +328,11 @@ internal class AntlrLimeModelBuilder(
                     AntlrLimeConverter.convertAnnotations(currentPath, it.annotation())
                 val setterExternalDescriptor =
                     parseExternalDescriptor(it.externalDescriptor(), it.annotation())
+                val setterComment = getComment("set", it.docComment(), it)
                 LimeFunction(
                     path = currentPath.child("set"),
                     visibility = convertVisibility(it.visibility(), propertyVisibility),
-                    comment = getComment("set", it.docComment(), it),
+                    comment = setterComment.withExcluded(propertyComment.isExcluded),
                     attributes = setterAttributes,
                     external = setterExternalDescriptor,
                     parameters = listOf(LimeParameter(

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimedocBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimedocBuilder.kt
@@ -29,11 +29,12 @@ internal class AntlrLimedocBuilder(private val currentPath: LimePath) : LimedocP
     private val commentsCollector = mutableMapOf<Pair<String, String>, LimeComment>()
     private val contentCollector = mutableListOf<Pair<String, String>>()
 
-    val result
-        get() = LimeStructuredComment(
-            commentsCollector[Pair("", "")] ?: LimeComment(currentPath),
-            commentsCollector
-        )
+    val result: LimeStructuredComment
+        get() {
+            val description = commentsCollector[Pair("", "")] ?: LimeComment(currentPath)
+            val isExcluded = commentsCollector.containsKey(excludeKey)
+            return LimeStructuredComment(description.withExcluded(isExcluded), commentsCollector)
+        }
 
     // Overrides
 
@@ -86,6 +87,9 @@ internal class AntlrLimedocBuilder(private val currentPath: LimePath) : LimedocP
         return inlineTag.tagName().map { it.text to tagContent }
     }
 
-    private fun unescapeText(text: String) =
-        text.replace("""\\(@|\{|\}|\\)""".toRegex()) { it.groupValues[1] }
+    private fun unescapeText(text: String) = text.replace("""\\([@{}\\])""".toRegex()) { it.groupValues[1] }
+
+    companion object {
+        private val excludeKey = Pair("exclude", "")
+    }
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeComment.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeComment.kt
@@ -27,11 +27,10 @@ package com.here.gluecodium.model.lime
  */
 class LimeComment(
     val path: LimePath = LimePath.EMPTY_PATH,
-    private val taggedSections: List<Pair<String, String>> = emptyList()
+    private val taggedSections: List<Pair<String, String>> = emptyList(),
+    val isExcluded: Boolean = false
 ) {
-
-    constructor(comment: String, path: LimePath = LimePath.EMPTY_PATH) :
-            this(path, listOf("" to comment))
+    constructor(comment: String, path: LimePath = LimePath.EMPTY_PATH) : this(path, listOf("" to comment))
 
     fun isEmpty() = taggedSections.all { it.second.isEmpty() }
 
@@ -41,7 +40,10 @@ class LimeComment(
             .joinToString("") { it.second }
             .trim()
 
-    fun withPath(newPath: LimePath) = LimeComment(newPath, taggedSections)
+    fun withPath(newPath: LimePath) = LimeComment(newPath, taggedSections, isExcluded)
+
+    fun withExcluded(newExcluded: Boolean) =
+        if (newExcluded != isExcluded) LimeComment(path, taggedSections, newExcluded) else this
 
     override fun toString() = taggedSections.joinToString("") {
         when (it.first) {
@@ -50,6 +52,5 @@ class LimeComment(
         }
     }.trim()
 
-    private fun escapeText(text: String) =
-        text.replace("""@|\{|\}|\\""".toRegex()) { "\\${it.value}" }
+    private fun escapeText(text: String) = text.replace("""[@{}\\]""".toRegex()) { "\\${it.value}" }
 }


### PR DESCRIPTION
Added `isExcluded` property to LimeComment class in LIME model. Updated LIME loader to fill in this property based on
the presence of the new `@exclude` LimeDoc tag.

Updated C++ templates to generate `\private` DoxyGen tag if `isExcluded` flag is true.

Added dedicated use cases in "comments" smoke test.

See: #514
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
