### PR TITLE
Add @exclude LimeDoc tag support for Java

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/modelbuilder/AbstractLimeBasedModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/modelbuilder/AbstractLimeBasedModelBuilder.kt
@@ -76,6 +76,7 @@ abstract class AbstractLimeBasedModelBuilder<E>(
     protected fun createComments(limeElement: LimeNamedElement, platform: String) =
         Comments(
             limeElement.comment.getFor(platform),
-            limeElement.attributes.get(DEPRECATED, MESSAGE, LimeComment::class.java)?.getFor(platform)
+            limeElement.attributes.get(DEPRECATED, MESSAGE, LimeComment::class.java)?.getFor(platform),
+            limeElement.comment.isExcluded
         )
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/model/common/Comments.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/common/Comments.kt
@@ -21,7 +21,8 @@ package com.here.gluecodium.model.common
 
 class Comments(
     @Suppress("unused") val documentation: String? = null,
-    @Suppress("unused") val deprecated: String? = null
+    @Suppress("unused") val deprecated: String? = null,
+    @Suppress("unused") val isExcluded: Boolean = false
 ) {
-    val isEmpty = documentation.isNullOrEmpty() && deprecated.isNullOrEmpty()
+    val isEmpty = documentation.isNullOrEmpty() && deprecated.isNullOrEmpty() && !isExcluded
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/android/JavaGeneratorSuite.kt
@@ -211,7 +211,7 @@ open class JavaGeneratorSuite protected constructor(
         val deprecationMessage = element.comment.deprecated?.let {
             commentsProcessor.process(limeName, it, limeToJavaName, limeLogger)
         }
-        element.comment = Comments(documentation, deprecationMessage)
+        element.comment = Comments(documentation, deprecationMessage, element.comment.isExcluded)
 
         if (element is JavaMethod) {
             element.returnComment = element.returnComment?.let {

--- a/gluecodium/src/main/resources/templates/java/DocComment.mustache
+++ b/gluecodium/src/main/resources/templates/java/DocComment.mustache
@@ -20,7 +20,8 @@
   !}}
 {{#unless comment.isEmpty}}
 /**
-{{#if comment.documentation}}{{prefix comment.documentation " * "}}{{/if}}{{#if comment.deprecated}}
+{{#if comment.documentation}}{{prefix comment.documentation " * "}}{{/if}}{{#if comment.isExcluded}}
+ * @exclude{{/if}}{{#if comment.deprecated}}
  * @deprecated {{prefix comment.deprecated " * " skipFirstLine=true}}{{/if}}
  */
 {{/unless}}

--- a/gluecodium/src/main/resources/templates/java/Field.mustache
+++ b/gluecodium/src/main/resources/templates/java/Field.mustache
@@ -20,7 +20,8 @@
   !}}
 {{#unless comment.isEmpty}}
 /**
-{{#if comment.documentation}}{{prefix comment.documentation " * "}}{{/if}}{{#if comment.deprecated}}
+{{#if comment.documentation}}{{prefix comment.documentation " * "}}{{/if}}{{#if comment.isExcluded}}
+ * @exclude{{/if}}{{#if comment.deprecated}}
  * @deprecated {{prefix comment.deprecated " * " skipFirstLine=true}}{{/if}}
  */
 {{/unless}}

--- a/gluecodium/src/main/resources/templates/java/MethodComment.mustache
+++ b/gluecodium/src/main/resources/templates/java/MethodComment.mustache
@@ -24,7 +24,8 @@
  */
 {{/if}}{{!!
 
-}}{{+combinedComment}}{{comment.documentation}}{{#if comment.deprecated}}
+}}{{+combinedComment}}{{comment.documentation}}{{#if comment.isExcluded}}
+@exclude{{/if}}{{#if comment.deprecated}}
 @deprecated {{comment.deprecated}}{{/if}}{{!!
 }}{{#parameters}}
 @param {{name}} {{prefix this.comment.documentation "    " skipFirstLine=true}}{{/parameters}}{{!!

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/ExcludedComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/ExcludedComments.java
@@ -1,0 +1,137 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import com.example.NativeBase;
+/**
+ * <p>This is some very useful class.</p>
+ * @exclude
+ */
+public final class ExcludedComments extends NativeBase {
+    /**
+     * <p>This is some very useful constant.</p>
+     * @exclude
+     */
+    public static final boolean VERY_USEFUL = true;
+    /**
+     * <p>This is some very useful enum.</p>
+     * @exclude
+     */
+    public enum SomeEnum {
+        /**
+         * <p>Not quite useful</p>
+         * @exclude
+         */
+        USELESS(0);
+        public final int value;
+        SomeEnum(final int value) {
+            this.value = value;
+        }
+    }
+    /**
+     * <p>This is some very useful exception.</p>
+     * @exclude
+     */
+    public static final class SomethingWrongException extends Exception {
+        public SomethingWrongException(final ExcludedComments.SomeEnum error) {
+            super(error.toString());
+            this.error = error;
+        }
+        public final ExcludedComments.SomeEnum error;
+    }
+    /**
+     * @exclude
+     */
+    static class SomeLambdaImpl extends NativeBase implements SomeLambda {
+        protected SomeLambdaImpl(final long nativeHandle, final Object dummy) {
+            super(nativeHandle, new Disposer() {
+                @Override
+                public void disposeNative(long handle) {
+                    disposeNativeHandle(handle);
+                }
+            });
+        }
+        private static native void disposeNativeHandle(long nativeHandle);
+        /**
+         * This is some very useful lambda that does it.
+         * @exclude
+         * @param p0 Very useful input parameter
+         * @param index Slightly less useful input parameter
+         * @return Usefulness of the input
+         */
+        public native double doIt(@NonNull final String p0, final int index);
+    }
+    /**
+     * <p>This is some very useful struct.</p>
+     * @exclude
+     */
+    public static final class SomeStruct {
+        /**
+         * <p>How useful this struct is
+         * remains to be seen</p>
+         * @exclude
+         */
+        public boolean someField;
+        /**
+         * <p>This is how easy it is to construct.</p>
+         * @param someField <p>How useful this struct is
+         * remains to be seen</p>
+         */
+        public SomeStruct(final boolean someField) {
+            this.someField = someField;
+        }
+    }
+    /**
+     * This is some very useful lambda that does it.
+     * @exclude
+     */
+    @FunctionalInterface
+    public interface SomeLambda {
+        /**
+         * This is some very useful lambda that does it.
+         * @exclude
+         * @param p0 Very useful input parameter
+         * @param index Slightly less useful input parameter
+         * @return Usefulness of the input
+         */
+        double doIt(@NonNull final String p0, final int index);
+    }
+    /**
+     * For internal use only.
+     * @exclude
+     */
+    protected ExcludedComments(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+    private static native void disposeNativeHandle(long nativeHandle);
+    /**
+     * <p>This is some very useful method that measures the usefulness of its input.</p>
+     * @exclude
+     * @param inputParameter <p>Very useful input parameter</p>
+     * @return <p>Usefulness of the input</p>
+     * @throws ExcludedComments.SomethingWrongException <p>Sometimes it happens.</p>
+     */
+    public native boolean someMethodWithAllComments(@NonNull final String inputParameter) throws ExcludedComments.SomethingWrongException;
+    /**
+     * <p>This is some very useful method that does nothing.</p>
+     * @exclude
+     */
+    public native void someMethodWithoutReturnTypeOrInputParameters();
+    /**
+     * <p>Gets some very useful property.</p>
+     * @exclude
+     */
+    public native boolean isSomeProperty();
+    /**
+     * <p>Sets some very useful property.</p>
+     * @exclude
+     * @param value Some very useful property.
+     */
+    public native void setSomeProperty(final boolean value);
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/ExcludedCommentsInterface.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/ExcludedCommentsInterface.java
@@ -1,0 +1,10 @@
+/*
+ *
+ */
+package com.example.smoke;
+/**
+ * <p>This is some very useful interface.</p>
+ * @exclude
+ */
+public interface ExcludedCommentsInterface {
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/ExcludedCommentsOnly.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/ExcludedCommentsOnly.java
@@ -1,0 +1,123 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import com.example.NativeBase;
+/**
+ * @exclude
+ */
+public final class ExcludedCommentsOnly extends NativeBase {
+    /**
+     * @exclude
+     */
+    public static final boolean VERY_USEFUL = true;
+    /**
+     * @exclude
+     */
+    public enum SomeEnum {
+        /**
+         * @exclude
+         */
+        USELESS(0);
+        public final int value;
+        SomeEnum(final int value) {
+            this.value = value;
+        }
+    }
+    /**
+     * @exclude
+     */
+    public static final class SomethingWrongException extends Exception {
+        public SomethingWrongException(final ExcludedCommentsOnly.SomeEnum error) {
+            super(error.toString());
+            this.error = error;
+        }
+        public final ExcludedCommentsOnly.SomeEnum error;
+    }
+    /**
+     * @exclude
+     */
+    static class SomeLambdaImpl extends NativeBase implements SomeLambda {
+        protected SomeLambdaImpl(final long nativeHandle, final Object dummy) {
+            super(nativeHandle, new Disposer() {
+                @Override
+                public void disposeNative(long handle) {
+                    disposeNativeHandle(handle);
+                }
+            });
+        }
+        private static native void disposeNativeHandle(long nativeHandle);
+        /**
+         *
+         * @exclude
+         * @param p0
+         * @param index
+         * @return
+         */
+        public native double doIt(@NonNull final String p0, final int index);
+    }
+    /**
+     * @exclude
+     */
+    public static final class SomeStruct {
+        /**
+         * @exclude
+         */
+        public boolean someField;
+        public SomeStruct(final boolean someField) {
+            this.someField = someField;
+        }
+    }
+    /**
+     * @exclude
+     */
+    @FunctionalInterface
+    public interface SomeLambda {
+        /**
+         *
+         * @exclude
+         * @param p0
+         * @param index
+         * @return
+         */
+        double doIt(@NonNull final String p0, final int index);
+    }
+    /**
+     * For internal use only.
+     * @exclude
+     */
+    protected ExcludedCommentsOnly(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+    private static native void disposeNativeHandle(long nativeHandle);
+    /**
+     *
+     * @exclude
+     * @param inputParameter
+     * @return
+     * @throws ExcludedCommentsOnly.SomethingWrongException
+     */
+    public native boolean someMethodWithAllComments(@NonNull final String inputParameter) throws ExcludedCommentsOnly.SomethingWrongException;
+    /**
+     *
+     * @exclude
+     */
+    public native void someMethodWithoutReturnTypeOrInputParameters();
+    /**
+     *
+     * @exclude
+     */
+    public native boolean isSomeProperty();
+    /**
+     *
+     * @exclude
+     * @param value
+     */
+    public native void setSomeProperty(final boolean value);
+}


### PR DESCRIPTION
Updated Java templates to generate `@exclude` JavaDoc tag if isExcluded flag is true.

Added smoke test.

See: #514
Signed-off-by: Daniel Kamkha daniel.kamkha@here.com