### PR TITLE
Add @exclude LimeDoc tag support for Swift

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftGeneratorSuite.kt
@@ -176,7 +176,7 @@ class SwiftGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
         val deprecationMessage = element.comment.deprecated?.let {
             commentsProcessor.process(limeName, it, limeToSwiftName, limeLogger)
         }
-        element.comment = Comments(documentation, deprecationMessage)
+        element.comment = Comments(documentation, deprecationMessage, element.comment.isExcluded)
 
         if (element is SwiftMethod) {
             element.returnComment = element.returnComment?.let {

--- a/gluecodium/src/main/resources/templates/swift/Comment.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Comment.mustache
@@ -19,6 +19,7 @@
   !
   !}}
 {{#unless this.comment.isEmpty}}
-{{#if this.comment.documentation}}{{prefix this.comment.documentation '/// '}}{{/if}}{{#if comment.deprecated}}
-@available(*, deprecated, message: "{{comment.deprecated}}"){{/if}}
+{{#if this.comment.documentation}}{{prefix this.comment.documentation '/// '}}{{/if}}{{#if this.comment.isExcluded}}
+/// :nodoc:{{/if}}{{#if this.comment.deprecated}}
+@available(*, deprecated, message: "{{this.comment.deprecated}}"){{/if}}
 {{/unless}}

--- a/gluecodium/src/main/resources/templates/swift/MethodComment.mustache
+++ b/gluecodium/src/main/resources/templates/swift/MethodComment.mustache
@@ -19,7 +19,8 @@
   !
   !}}
 {{#if hasComment}}
-{{prefixPartial "combinedComment" "/// "}}{{#if comment.deprecated}}
+{{prefixPartial "combinedComment" "/// "}}{{#if comment.isExcluded}}
+/// :nodoc:{{/if}}{{#if comment.deprecated}}
 @available(*, deprecated, message: "{{comment.deprecated}}"){{/if}}
 {{/if}}{{!!
 

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
@@ -1,0 +1,274 @@
+//
+//
+import Foundation
+/// This is some very useful class.
+/// :nodoc:
+public class ExcludedComments {
+    /// This is some very useful typealias.
+    /// :nodoc:
+    public typealias Usefulness = Bool
+    /// This is some very useful exception.
+    /// :nodoc:
+    public typealias SomethingWrongError = ExcludedComments.SomeEnum
+    /// This is some very useful lambda that does it.
+    /// :nodoc:
+    public typealias SomeLambda = (String, Int32) -> Double
+    /// This is some very useful constant.
+    /// :nodoc:
+    public static let veryUseful: ExcludedComments.Usefulness = true
+    /// Some very useful property.
+    /// :nodoc:
+    public var isSomeProperty: ExcludedComments.Usefulness {
+        get {
+            return moveFromCType(smoke_ExcludedComments_someProperty_get(self.c_instance))
+        }
+        set {
+            let c_newValue = moveToCType(newValue)
+            return moveFromCType(smoke_ExcludedComments_someProperty_set(self.c_instance, c_newValue.ref))
+        }
+    }
+    let c_instance : _baseRef
+    init(cExcludedComments: _baseRef) {
+        guard cExcludedComments != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cExcludedComments
+    }
+    deinit {
+        smoke_ExcludedComments_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_ExcludedComments_release_handle(c_instance)
+    }
+    /// This is some very useful enum.
+    /// :nodoc:
+    public enum SomeEnum : UInt32, CaseIterable, Codable {
+        /// Not quite useful
+        /// :nodoc:
+        case useless
+    }
+    /// This is some very useful struct.
+    /// :nodoc:
+    public struct SomeStruct {
+        /// How useful this struct is
+        /// remains to be seen
+        /// :nodoc:
+        public var someField: ExcludedComments.Usefulness
+        /// This is how easy it is to construct.
+        /// - Parameters
+        ///   - someField: How useful this struct is
+        ///       remains to be seen
+        public init(someField: ExcludedComments.Usefulness) {
+            self.someField = someField
+        }
+        internal init(cHandle: _baseRef) {
+            someField = moveFromCType(smoke_ExcludedComments_SomeStruct_someField_get(cHandle))
+        }
+    }
+    /// This is some very useful method that measures the usefulness of its input.
+    /// - Parameter inputParameter: Very useful input parameter
+    /// - Returns: Usefulness of the input
+    /// - Throws: `ExcludedComments.SomethingWrongError` Sometimes it happens.
+    /// :nodoc:
+    public func someMethodWithAllComments(inputParameter: String) throws -> ExcludedComments.Usefulness {
+        let c_inputParameter = moveToCType(inputParameter)
+        let RESULT = smoke_ExcludedComments_someMethodWithAllComments(self.c_instance, c_inputParameter.ref)
+        if (!RESULT.has_value) {
+            throw moveFromCType(RESULT.error_value) as ExcludedComments.SomethingWrongError
+        } else {
+            return moveFromCType(RESULT.returned_value)
+        }
+    }
+    /// This is some very useful method that does nothing.
+    /// :nodoc:
+    public func someMethodWithoutReturnTypeOrInputParameters() -> Void {
+        return moveFromCType(smoke_ExcludedComments_someMethodWithoutReturnTypeOrInputParameters(self.c_instance))
+    }
+}
+internal func getRef(_ ref: ExcludedComments?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_ExcludedComments_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_ExcludedComments_release_handle)
+        : RefHolder(handle_copy)
+}
+extension ExcludedComments: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func ExcludedComments_copyFromCType(_ handle: _baseRef) -> ExcludedComments {
+    if let swift_pointer = smoke_ExcludedComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedComments {
+        return re_constructed
+    }
+    let result = ExcludedComments(cExcludedComments: smoke_ExcludedComments_copy_handle(handle))
+    smoke_ExcludedComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func ExcludedComments_moveFromCType(_ handle: _baseRef) -> ExcludedComments {
+    if let swift_pointer = smoke_ExcludedComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedComments {
+        smoke_ExcludedComments_release_handle(handle)
+        return re_constructed
+    }
+    let result = ExcludedComments(cExcludedComments: handle)
+    smoke_ExcludedComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func ExcludedComments_copyFromCType(_ handle: _baseRef) -> ExcludedComments? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ExcludedComments_moveFromCType(handle) as ExcludedComments
+}
+internal func ExcludedComments_moveFromCType(_ handle: _baseRef) -> ExcludedComments? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ExcludedComments_moveFromCType(handle) as ExcludedComments
+}
+internal func copyToCType(_ swiftClass: ExcludedComments) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ExcludedComments) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: ExcludedComments?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ExcludedComments?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda {
+    return moveFromCType(smoke_ExcludedComments_SomeLambda_copy_handle(handle))
+}
+internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda {
+    let refHolder = RefHolder(ref: handle, release: smoke_ExcludedComments_SomeLambda_release_handle)
+    return { (p0: String, p1: Int32) -> Double in
+        return moveFromCType(smoke_ExcludedComments_SomeLambda_call(refHolder.ref, moveToCType(p0).ref, moveToCType(p1).ref))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda? {
+    guard handle != 0 else {
+        return nil
+    }
+    return copyFromCType(handle) as ExcludedComments.SomeLambda
+}
+internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda? {
+    guard handle != 0 else {
+        return nil
+    }
+    return moveFromCType(handle) as ExcludedComments.SomeLambda
+}
+internal func createFunctionalTable(_ swiftType: @escaping ExcludedComments.SomeLambda) -> smoke_ExcludedComments_SomeLambda_FunctionTable {
+    class smoke_ExcludedComments_SomeLambda_Holder {
+        let closure: ExcludedComments.SomeLambda
+        init(_ closure: @escaping ExcludedComments.SomeLambda) {
+            self.closure = closure
+        }
+    }
+    var functions = smoke_ExcludedComments_SomeLambda_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(smoke_ExcludedComments_SomeLambda_Holder(swiftType)).toOpaque()
+    functions.release = { swift_closure_pointer in
+        if let swift_closure = swift_closure_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_closure).release()
+        }
+    }
+    functions.smoke_ExcludedComments_SomeLambda_call = { swift_closure_pointer, p0, p1 in
+        let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_ExcludedComments_SomeLambda_Holder
+        return copyToCType(closure_holder.closure(moveFromCType(p0), moveFromCType(p1))).ref
+    }
+    return functions
+}
+internal func copyToCType(_ swiftType: @escaping ExcludedComments.SomeLambda) -> RefHolder {
+    let handle = smoke_ExcludedComments_SomeLambda_create_proxy(createFunctionalTable(swiftType))
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftType: @escaping ExcludedComments.SomeLambda) -> RefHolder {
+    let handle = smoke_ExcludedComments_SomeLambda_create_proxy(createFunctionalTable(swiftType))
+    return RefHolder(ref: handle, release: smoke_ExcludedComments_SomeLambda_release_handle)
+}
+internal func copyToCType(_ swiftType: ExcludedComments.SomeLambda?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let handle = smoke_ExcludedComments_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftType: ExcludedComments.SomeLambda?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let handle = smoke_ExcludedComments_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    return RefHolder(ref: handle, release: smoke_ExcludedComments_SomeLambda_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct {
+    return ExcludedComments.SomeStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct {
+    defer {
+        smoke_ExcludedComments_SomeStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: ExcludedComments.SomeStruct) -> RefHolder {
+    let c_someField = moveToCType(swiftType.someField)
+    return RefHolder(smoke_ExcludedComments_SomeStruct_create_handle(c_someField.ref))
+}
+internal func moveToCType(_ swiftType: ExcludedComments.SomeStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ExcludedComments_SomeStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_ExcludedComments_SomeStruct_unwrap_optional_handle(handle)
+    return ExcludedComments.SomeStruct(cHandle: unwrappedHandle) as ExcludedComments.SomeStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct? {
+    defer {
+        smoke_ExcludedComments_SomeStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: ExcludedComments.SomeStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_someField = moveToCType(swiftType.someField)
+    return RefHolder(smoke_ExcludedComments_SomeStruct_create_optional_handle(c_someField.ref))
+}
+internal func moveToCType(_ swiftType: ExcludedComments.SomeStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ExcludedComments_SomeStruct_release_optional_handle)
+}
+internal func copyToCType(_ swiftEnum: ExcludedComments.SomeEnum) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func moveToCType(_ swiftEnum: ExcludedComments.SomeEnum) -> PrimitiveHolder<UInt32> {
+    return copyToCType(swiftEnum)
+}
+internal func copyToCType(_ swiftEnum: ExcludedComments.SomeEnum?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func moveToCType(_ swiftEnum: ExcludedComments.SomeEnum?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func copyFromCType(_ cValue: UInt32) -> ExcludedComments.SomeEnum {
+    return ExcludedComments.SomeEnum(rawValue: cValue)!
+}
+internal func moveFromCType(_ cValue: UInt32) -> ExcludedComments.SomeEnum {
+    return copyFromCType(cValue)
+}
+internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeEnum? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ExcludedComments.SomeEnum(rawValue: uint32_t_value_get(handle))!
+}
+internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeEnum? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+extension ExcludedComments.SomeEnum : Error {
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsInterface.swift
@@ -1,0 +1,106 @@
+//
+//
+import Foundation
+/// This is some very useful interface.
+/// :nodoc:
+public protocol ExcludedCommentsInterface : AnyObject {
+}
+internal class _ExcludedCommentsInterface: ExcludedCommentsInterface {
+    let c_instance : _baseRef
+    init(cExcludedCommentsInterface: _baseRef) {
+        guard cExcludedCommentsInterface != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cExcludedCommentsInterface
+    }
+    deinit {
+        smoke_ExcludedCommentsInterface_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_ExcludedCommentsInterface_release_handle(c_instance)
+    }
+}
+@_cdecl("_CBridgeInitsmoke_ExcludedCommentsInterface")
+internal func _CBridgeInitsmoke_ExcludedCommentsInterface(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _ExcludedCommentsInterface(cExcludedCommentsInterface: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: ExcludedCommentsInterface?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_ExcludedCommentsInterface_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_ExcludedCommentsInterface_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_ExcludedCommentsInterface_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    let proxy = smoke_ExcludedCommentsInterface_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_ExcludedCommentsInterface_release_handle) : RefHolder(proxy)
+}
+extension _ExcludedCommentsInterface: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func ExcludedCommentsInterface_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsInterface {
+    if let swift_pointer = smoke_ExcludedCommentsInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedCommentsInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ExcludedCommentsInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedCommentsInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ExcludedCommentsInterface_get_typed(smoke_ExcludedCommentsInterface_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ExcludedCommentsInterface {
+        smoke_ExcludedCommentsInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func ExcludedCommentsInterface_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsInterface {
+    if let swift_pointer = smoke_ExcludedCommentsInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedCommentsInterface {
+        smoke_ExcludedCommentsInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ExcludedCommentsInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedCommentsInterface {
+        smoke_ExcludedCommentsInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ExcludedCommentsInterface_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ExcludedCommentsInterface {
+        smoke_ExcludedCommentsInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func ExcludedCommentsInterface_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ExcludedCommentsInterface_moveFromCType(handle) as ExcludedCommentsInterface
+}
+internal func ExcludedCommentsInterface_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ExcludedCommentsInterface_moveFromCType(handle) as ExcludedCommentsInterface
+}
+internal func copyToCType(_ swiftClass: ExcludedCommentsInterface) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ExcludedCommentsInterface) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: ExcludedCommentsInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ExcludedCommentsInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
@@ -1,0 +1,259 @@
+//
+//
+import Foundation
+/// :nodoc:
+public class ExcludedCommentsOnly {
+    /// :nodoc:
+    public typealias Usefulness = Bool
+    /// :nodoc:
+    public typealias SomethingWrongError = ExcludedCommentsOnly.SomeEnum
+    /// :nodoc:
+    public typealias SomeLambda = (String, Int32) -> Double
+    /// :nodoc:
+    public static let veryUseful: ExcludedCommentsOnly.Usefulness = true
+    /// :nodoc:
+    public var isSomeProperty: ExcludedCommentsOnly.Usefulness {
+        get {
+            return moveFromCType(smoke_ExcludedCommentsOnly_someProperty_get(self.c_instance))
+        }
+        set {
+            let c_newValue = moveToCType(newValue)
+            return moveFromCType(smoke_ExcludedCommentsOnly_someProperty_set(self.c_instance, c_newValue.ref))
+        }
+    }
+    let c_instance : _baseRef
+    init(cExcludedCommentsOnly: _baseRef) {
+        guard cExcludedCommentsOnly != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cExcludedCommentsOnly
+    }
+    deinit {
+        smoke_ExcludedCommentsOnly_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_ExcludedCommentsOnly_release_handle(c_instance)
+    }
+    /// :nodoc:
+    public enum SomeEnum : UInt32, CaseIterable, Codable {
+        /// :nodoc:
+        case useless
+    }
+    /// :nodoc:
+    public struct SomeStruct {
+        /// :nodoc:
+        public var someField: ExcludedCommentsOnly.Usefulness
+        public init(someField: ExcludedCommentsOnly.Usefulness) {
+            self.someField = someField
+        }
+        internal init(cHandle: _baseRef) {
+            someField = moveFromCType(smoke_ExcludedCommentsOnly_SomeStruct_someField_get(cHandle))
+        }
+    }
+    ///
+    /// - Parameter inputParameter:
+    /// - Returns:
+    /// - Throws: `ExcludedCommentsOnly.SomethingWrongError`
+    /// :nodoc:
+    public func someMethodWithAllComments(inputParameter: String) throws -> ExcludedCommentsOnly.Usefulness {
+        let c_inputParameter = moveToCType(inputParameter)
+        let RESULT = smoke_ExcludedCommentsOnly_someMethodWithAllComments(self.c_instance, c_inputParameter.ref)
+        if (!RESULT.has_value) {
+            throw moveFromCType(RESULT.error_value) as ExcludedCommentsOnly.SomethingWrongError
+        } else {
+            return moveFromCType(RESULT.returned_value)
+        }
+    }
+    ///
+    /// :nodoc:
+    public func someMethodWithoutReturnTypeOrInputParameters() -> Void {
+        return moveFromCType(smoke_ExcludedCommentsOnly_someMethodWithoutReturnTypeOrInputParameters(self.c_instance))
+    }
+}
+internal func getRef(_ ref: ExcludedCommentsOnly?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_ExcludedCommentsOnly_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_ExcludedCommentsOnly_release_handle)
+        : RefHolder(handle_copy)
+}
+extension ExcludedCommentsOnly: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func ExcludedCommentsOnly_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly {
+    if let swift_pointer = smoke_ExcludedCommentsOnly_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedCommentsOnly {
+        return re_constructed
+    }
+    let result = ExcludedCommentsOnly(cExcludedCommentsOnly: smoke_ExcludedCommentsOnly_copy_handle(handle))
+    smoke_ExcludedCommentsOnly_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func ExcludedCommentsOnly_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly {
+    if let swift_pointer = smoke_ExcludedCommentsOnly_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedCommentsOnly {
+        smoke_ExcludedCommentsOnly_release_handle(handle)
+        return re_constructed
+    }
+    let result = ExcludedCommentsOnly(cExcludedCommentsOnly: handle)
+    smoke_ExcludedCommentsOnly_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func ExcludedCommentsOnly_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ExcludedCommentsOnly_moveFromCType(handle) as ExcludedCommentsOnly
+}
+internal func ExcludedCommentsOnly_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ExcludedCommentsOnly_moveFromCType(handle) as ExcludedCommentsOnly
+}
+internal func copyToCType(_ swiftClass: ExcludedCommentsOnly) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ExcludedCommentsOnly) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: ExcludedCommentsOnly?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ExcludedCommentsOnly?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda {
+    return moveFromCType(smoke_ExcludedCommentsOnly_SomeLambda_copy_handle(handle))
+}
+internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda {
+    let refHolder = RefHolder(ref: handle, release: smoke_ExcludedCommentsOnly_SomeLambda_release_handle)
+    return { (p0: String, p1: Int32) -> Double in
+        return moveFromCType(smoke_ExcludedCommentsOnly_SomeLambda_call(refHolder.ref, moveToCType(p0).ref, moveToCType(p1).ref))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda? {
+    guard handle != 0 else {
+        return nil
+    }
+    return copyFromCType(handle) as ExcludedCommentsOnly.SomeLambda
+}
+internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda? {
+    guard handle != 0 else {
+        return nil
+    }
+    return moveFromCType(handle) as ExcludedCommentsOnly.SomeLambda
+}
+internal func createFunctionalTable(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> smoke_ExcludedCommentsOnly_SomeLambda_FunctionTable {
+    class smoke_ExcludedCommentsOnly_SomeLambda_Holder {
+        let closure: ExcludedCommentsOnly.SomeLambda
+        init(_ closure: @escaping ExcludedCommentsOnly.SomeLambda) {
+            self.closure = closure
+        }
+    }
+    var functions = smoke_ExcludedCommentsOnly_SomeLambda_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(smoke_ExcludedCommentsOnly_SomeLambda_Holder(swiftType)).toOpaque()
+    functions.release = { swift_closure_pointer in
+        if let swift_closure = swift_closure_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_closure).release()
+        }
+    }
+    functions.smoke_ExcludedCommentsOnly_SomeLambda_call = { swift_closure_pointer, p0, p1 in
+        let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_ExcludedCommentsOnly_SomeLambda_Holder
+        return copyToCType(closure_holder.closure(moveFromCType(p0), moveFromCType(p1))).ref
+    }
+    return functions
+}
+internal func copyToCType(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> RefHolder {
+    let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_proxy(createFunctionalTable(swiftType))
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> RefHolder {
+    let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_proxy(createFunctionalTable(swiftType))
+    return RefHolder(ref: handle, release: smoke_ExcludedCommentsOnly_SomeLambda_release_handle)
+}
+internal func copyToCType(_ swiftType: ExcludedCommentsOnly.SomeLambda?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftType: ExcludedCommentsOnly.SomeLambda?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    return RefHolder(ref: handle, release: smoke_ExcludedCommentsOnly_SomeLambda_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct {
+    return ExcludedCommentsOnly.SomeStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct {
+    defer {
+        smoke_ExcludedCommentsOnly_SomeStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: ExcludedCommentsOnly.SomeStruct) -> RefHolder {
+    let c_someField = moveToCType(swiftType.someField)
+    return RefHolder(smoke_ExcludedCommentsOnly_SomeStruct_create_handle(c_someField.ref))
+}
+internal func moveToCType(_ swiftType: ExcludedCommentsOnly.SomeStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ExcludedCommentsOnly_SomeStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_ExcludedCommentsOnly_SomeStruct_unwrap_optional_handle(handle)
+    return ExcludedCommentsOnly.SomeStruct(cHandle: unwrappedHandle) as ExcludedCommentsOnly.SomeStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct? {
+    defer {
+        smoke_ExcludedCommentsOnly_SomeStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: ExcludedCommentsOnly.SomeStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_someField = moveToCType(swiftType.someField)
+    return RefHolder(smoke_ExcludedCommentsOnly_SomeStruct_create_optional_handle(c_someField.ref))
+}
+internal func moveToCType(_ swiftType: ExcludedCommentsOnly.SomeStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ExcludedCommentsOnly_SomeStruct_release_optional_handle)
+}
+internal func copyToCType(_ swiftEnum: ExcludedCommentsOnly.SomeEnum) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func moveToCType(_ swiftEnum: ExcludedCommentsOnly.SomeEnum) -> PrimitiveHolder<UInt32> {
+    return copyToCType(swiftEnum)
+}
+internal func copyToCType(_ swiftEnum: ExcludedCommentsOnly.SomeEnum?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func moveToCType(_ swiftEnum: ExcludedCommentsOnly.SomeEnum?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func copyFromCType(_ cValue: UInt32) -> ExcludedCommentsOnly.SomeEnum {
+    return ExcludedCommentsOnly.SomeEnum(rawValue: cValue)!
+}
+internal func moveFromCType(_ cValue: UInt32) -> ExcludedCommentsOnly.SomeEnum {
+    return copyFromCType(cValue)
+}
+internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeEnum? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ExcludedCommentsOnly.SomeEnum(rawValue: uint32_t_value_get(handle))!
+}
+internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeEnum? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+extension ExcludedCommentsOnly.SomeEnum : Error {
+}


### PR DESCRIPTION
Updated Swift templates to generate `:nodoc` Markup tag if isExcluded flag is true.

Added dedicated use cases in "comments" smoke test.

See: #514
Signed-off-by: Daniel Kamkha daniel.kamkha@here.com
