### PR TITLE
Fix Swift enum protocol conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Features:
   * Added support for `@exclude` tag in documentation comments. This tag is converted into a language-appropriate
     "exclude from the documentation" tag in the generated code.
+### Bug fixes:
+  * Fixed Swift compilation issue for enumerations with one or more enumerators marked as `@Deprecated`.
 
 ## 8.3.1
 Release date: 2020-09-17

--- a/examples/libhello/lime/test/Enums.lime
+++ b/examples/libhello/lime/test/Enums.lime
@@ -54,3 +54,11 @@ enum EnumStartsWithOne {
     FIRST = 1,
     SECOND
 }
+
+@Java(Skip) @Dart(Skip)
+enum EnumWithDeprecatedItems {
+    foo,
+    @Deprecated("Hi there!")
+    bar,
+    baz
+}

--- a/examples/platforms/ios/Tests/testTests/EnumsTests.swift
+++ b/examples/platforms/ios/Tests/testTests/EnumsTests.swift
@@ -59,10 +59,25 @@ class EnumsTests: XCTestCase {
         XCTAssertEqual([.errorNone, .errorFatal], Enums.InternalError.allCases)
     }
 
+    func testCaseIterableWithDeprecated() {
+        XCTAssertEqual([.foo, .bar, .baz], EnumWithDeprecatedItems.allCases)
+    }
+
+    func testCodableWithDeprecated() {
+        let value = EnumWithDeprecatedItems.baz
+
+        let data = try! JSONEncoder().encode(value)
+        let result = try! JSONDecoder().decode(EnumWithDeprecatedItems.self, from: data)
+
+        XCTAssertEqual(result, value)
+    }
+
     static var allTests = [
         ("testFlipEnumValue", testFlipEnumValue),
         ("testExtractEnumFromStruct", testExtractEnumFromStruct),
         ("testCreateStructWithEnumInside", testCreateStructWithEnumInside),
-        ("testCaseIterable", testCaseIterable)
+        ("testCaseIterable", testCaseIterable),
+        ("testCaseIterableWithDeprecated", testCaseIterableWithDeprecated),
+        ("testCodableWithDeprecated", testCodableWithDeprecated)
     ]
 }

--- a/examples/scripts/valgrind_suppressions
+++ b/examples/scripts/valgrind_suppressions
@@ -45,7 +45,6 @@
    Memcheck:Leak
    match-leak-kinds: possible
    fun:_Znam
-   fun:_ZN5swift17MetadataAllocator8AllocateEmm
    ...
    fun:swift_getTupleTypeMetadata
    fun:swift_getTupleTypeMetadata2

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftEnum.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftEnum.kt
@@ -33,6 +33,10 @@ class SwiftEnum(
     externalFramework = externalFramework,
     externalConverter = externalConverter
 ) {
+    @Suppress("unused")
+    val hasDeprecatedItems
+        get() = items.any { !it.comment.deprecated.isNullOrEmpty() }
+
     override val childElements
         get() = items
 }

--- a/gluecodium/src/main/resources/templates/swift/Enum.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Enum.mustache
@@ -21,7 +21,43 @@
 {{#unless skipDeclaration}}{{>swift/Comment}}
 {{visibility}} enum {{simpleName}}{{#if externalConverter}}_internal{{/if}} : UInt32, CaseIterable, Codable {
 {{#items}}{{prefixPartial "enumItem" "    "}}
+{{/items}}{{!!
+}}{{#if hasDeprecatedItems}}
+    {{visibility}} static var allCases: [{{simpleName}}] {
+        return [{{#items}}.{{name}}{{#if iter.hasNext}}, {{/if}}{{/items}}]
+    }
+
+    {{visibility}} enum Key: CodingKey {
+        case rawValue
+    }
+
+    {{visibility}} enum CodingError: Error {
+        case unknownValue
+    }
+
+    {{visibility}} init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Key.self)
+        let rawValue = try container.decode(Int.self, forKey: .rawValue)
+        switch rawValue {
+{{#items}}
+        case {{iter.position}}:
+            self = .{{name}}
 {{/items}}
+        default:
+            throw CodingError.unknownValue
+        }
+    }
+
+    {{visibility}} func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: Key.self)
+        switch self {
+{{#items}}
+        case .{{name}}:
+            try container.encode({{iter.position}}, forKey: .rawValue)
+{{/items}}
+        }
+    }
+{{/if}}
 }
 {{/unless}}{{!!
 }}{{+enumItem}}{{>swift/Comment}}

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationComments.swift
@@ -164,6 +164,32 @@ public enum SomeEnum : UInt32, CaseIterable, Codable {
     @available(*, deprecated, message: "Unfortunately, this item is deprecated.
     Use `Comments.SomeEnum.useless` instead.")
     case useless
+    public static var allCases: [SomeEnum] {
+        return [.useless]
+    }
+    public enum Key: CodingKey {
+        case rawValue
+    }
+    public enum CodingError: Error {
+        case unknownValue
+    }
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Key.self)
+        let rawValue = try container.decode(Int.self, forKey: .rawValue)
+        switch rawValue {
+        case 0:
+            self = .useless
+        default:
+            throw CodingError.unknownValue
+        }
+    }
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: Key.self)
+        switch self {
+        case .useless:
+            try container.encode(0, forKey: .rawValue)
+        }
+    }
 }
 internal func copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationCommentsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationCommentsOnly.swift
@@ -148,6 +148,32 @@ internal func moveToCType(_ swiftClass: DeprecationCommentsOnly?) -> RefHolder {
 public enum SomeEnum : UInt32, CaseIterable, Codable {
     @available(*, deprecated, message: "Unfortunately, this item is deprecated.")
     case useless
+    public static var allCases: [SomeEnum] {
+        return [.useless]
+    }
+    public enum Key: CodingKey {
+        case rawValue
+    }
+    public enum CodingError: Error {
+        case unknownValue
+    }
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Key.self)
+        let rawValue = try container.decode(Int.self, forKey: .rawValue)
+        switch rawValue {
+        case 0:
+            self = .useless
+        default:
+            throw CodingError.unknownValue
+        }
+    }
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: Key.self)
+        switch self {
+        case .useless:
+            try container.encode(0, forKey: .rawValue)
+        }
+    }
 }
 internal func copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)


### PR DESCRIPTION
Swift compiler cannot provide automatic conformance to CaseIterable and Codable protocols for enums with one or more
items marked with `@available` attribute. Gluecodium uses this attribute in generated Swift code to mark elements as
deprecated.

Updated Swift templates to provide explicit conformance to CaseIterable and Codable protocols for enums with one or more
items marked as `@Deprecated` in IDL.

Added smoke and functional tests.

Resolves: #517
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>