### PR TITLE
Add support for @Cpp(Ref) attribute

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -70,10 +70,12 @@ feature(Strings cpp android swift dart SOURCES
     src/hello/HelloWorld.cpp
     src/test/StaticStringMethods.cpp
     src/test/StringsWithCstring.cpp
+    src/test/CppRefReturnType.cpp
 
     lime/hello/HelloWorld.lime
     lime/test/StaticStringMethods.lime
     lime/test/StringsWithCstring.lime
+    lime/test/CppRefReturnType.lime
 )
 
 feature(MethodOverloading cpp android swift dart SOURCES

--- a/examples/libhello/lime/test/CppRefReturnType.lime
+++ b/examples/libhello/lime/test/CppRefReturnType.lime
@@ -1,0 +1,31 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+class CppRefReturnType {
+    @Cpp(Ref)
+    static fun stringRef(): String
+
+    @Cpp(Ref)
+    static property stringProperty: String { get }
+}
+
+struct CppRefReturnTypeStruct {
+    @Cpp(Ref)
+    static fun stringRef(): String
+}

--- a/examples/libhello/src/test/CppRefReturnType.cpp
+++ b/examples/libhello/src/test/CppRefReturnType.cpp
@@ -1,0 +1,40 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/CppRefReturnType.h"
+#include "test/CppRefReturnTypeStruct.h"
+
+namespace test
+{
+namespace
+{
+const std::string s_value = "nonsense";
+}
+
+const std::string&
+CppRefReturnType::string_ref() { return s_value; }
+
+const std::string&
+CppRefReturnType::get_string_property() { return s_value; }
+
+const std::string&
+CppRefReturnTypeStruct::string_ref() { return s_value; }
+
+}

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/StaticStringMethodsTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/StaticStringMethodsTest.java
@@ -77,4 +77,18 @@ public final class StaticStringMethodsTest {
     // Assert
     assertTrue(returnedString.isEmpty());
   }
+
+  @Test
+  public void stringRef() {
+    String result = CppRefReturnType.stringRef();
+
+    assertEquals("nonsense", result);
+  }
+
+  @Test
+  public void stringProperty() {
+    String result = CppRefReturnType.getStringProperty();
+
+    assertEquals("nonsense", result);
+  }
 }

--- a/examples/platforms/dart/test/StaticStringMethods_test.dart
+++ b/examples/platforms/dart/test/StaticStringMethods_test.dart
@@ -50,4 +50,14 @@ void main() {
 
     expect(result, equals(""));
   });
+  _testSuite.test("String ref", () {
+    final result = CppRefReturnType.stringRef();
+
+    expect(result, "nonsense");
+  });
+  _testSuite.test("String property", () {
+    final result = CppRefReturnType.stringProperty;
+
+    expect(result, "nonsense");
+  });
 }

--- a/examples/platforms/ios/Tests/testTests/StaticStringMethodTests.swift
+++ b/examples/platforms/ios/Tests/testTests/StaticStringMethodTests.swift
@@ -48,11 +48,21 @@ class StaticStringMethodsTests: XCTestCase {
         XCTAssertEqual(StaticStringMethods.returnEmpty(), "")
     }
 
+    func testStringRef() {
+        XCTAssertEqual(CppRefReturnType.stringRef(), "nonsense")
+    }
+
+    func testStringProperty() {
+        XCTAssertEqual(CppRefReturnType.stringProperty, "nonsense")
+    }
+
     static var allTests = [
         ("testPassEmptyString", testPassEmptyString),
         ("testTwoStringParameters", testTwoStringParameters),
         ("testTwoStringParametersOneEmpty", testTwoStringParametersOneEmpty),
         ("testStringReturnString", testStringReturnString),
-        ("testEmptyReturnString", testEmptyReturnString)
+        ("testEmptyReturnString", testEmptyReturnString),
+        ("testStringRef", testStringRef),
+        ("testStringProperty", testStringProperty)
     ]
 }

--- a/gluecodium/src/main/resources/templates/cpp/CppProperty.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppProperty.mustache
@@ -18,9 +18,10 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#set propertyElement=this}}{{#getter}}
+{{#set propertyElement=this cppRef=attributes.cpp.ref}}{{#getter}}
 {{>cpp/CppFunctionDoc}}
-{{#if isStatic}}static {{/if}}{{#unless isStatic}}virtual {{/unless}}{{resolveName returnType.typeRef}} {{!!
+{{#if isStatic}}static {{/if}}{{#unless isStatic}}virtual {{/unless}}{{!!
+}}{{#if cppRef}}const {{/if}}{{resolveName returnType.typeRef}}{{#if cppRef}}&{{/if}} {{!!
 }}{{resolveName propertyElement "" "getter"}}(  ){{#unless isStatic}} const = 0{{/unless}};
 {{/getter}}
 {{#setter}}

--- a/gluecodium/src/main/resources/templates/cpp/CppReturnType.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppReturnType.mustache
@@ -21,8 +21,14 @@
 {{#if thrownType}}{{#instanceOf exception.errorType.type.actualType "LimeEnumeration"}}{{!!
 }}{{#if returnType.isVoid}}::std::error_code{{/if}}{{!!
 }}{{#unless returnType.isVoid}}{{#internalNamespace}}::{{.}}{{/internalNamespace}}::Return{{!!
-}}< {{resolveName returnType.typeRef "C++"}}, ::std::error_code >{{/unless}}{{/instanceOf}}{{!!
+}}< {{>returnTypeRef}}, ::std::error_code >{{/unless}}{{/instanceOf}}{{!!
 }}{{#notInstanceOf exception.errorType.type.actualType "LimeEnumeration"}}{{!!
 }}{{#internalNamespace}}::{{.}}{{/internalNamespace}}::Return{{!!
-}}< {{resolveName returnType.typeRef "C++"}}, {{resolveName exception.errorType "C++"}} >{{/notInstanceOf}}{{/if}}{{!!
-}}{{#unless thrownType}}{{resolveName returnType.typeRef "C++"}}{{/unless}}
+}}< {{>returnTypeRef}}, {{resolveName exception.errorType "C++"}} >{{/notInstanceOf}}{{/if}}{{!!
+}}{{#unless thrownType}}{{>returnTypeRef}}{{/unless}}{{!!
+
+}}{{+returnTypeRef}}{{!!
+}}{{#if attributes.cpp.ref}}{{#if returnType.isVoid}}void{{/if}}{{!!
+}}{{#unless returnType.isVoid}}const {{resolveName returnType.typeRef "C++"}}&{{/unless}}{{/if}}{{!!
+}}{{#unless attributes.cpp.ref}}{{resolveName returnType.typeRef "C++"}}{{/unless}}{{!!
+}}{{/returnTypeRef}}

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeFunctionsValidatorRefsTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeFunctionsValidatorRefsTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeAttributes
+import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimePath
+import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
+import com.here.gluecodium.model.lime.LimeStruct
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class LimeFunctionsValidatorRefsTest {
+
+    private val allElements = mutableMapOf<String, LimeElement>()
+    private val barPath = LimePath(emptyList(), listOf("foo", "bar"))
+
+    private val limeModel = LimeModel(allElements, emptyList())
+    private val cppRefAttributes =
+        LimeAttributes.Builder().addAttribute(LimeAttributeType.CPP, LimeAttributeValueType.REF).build()
+    private val limeFunction = LimeFunction(barPath, attributes = cppRefAttributes)
+
+    private val validator = LimeFunctionsValidator(mockk(relaxed = true))
+
+    @Test
+    fun validateRefsAttributeInClass() {
+        allElements[""] = limeFunction
+        allElements["foo"] = LimeClass(EMPTY_PATH)
+
+        assertTrue(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateRefsAttributeInStruct() {
+        allElements[""] = limeFunction
+        allElements["foo"] = LimeStruct(EMPTY_PATH)
+
+        assertTrue(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateRefsAttributeInInterface() {
+        allElements[""] = limeFunction
+        allElements["foo"] = LimeInterface(EMPTY_PATH)
+
+        assertFalse(validator.validate(limeModel))
+    }
+}

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimePropertiesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimePropertiesValidatorTest.kt
@@ -20,12 +20,15 @@
 package com.here.gluecodium.validator
 
 import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeAttributes
 import com.here.gluecodium.model.lime.LimeBasicTypeRef
+import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimePath
 import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
@@ -63,8 +66,15 @@ class LimePropertiesValidatorTest {
         EMPTY_PATH,
         properties = listOf(limePropertyFoo, limePropertyFoo2)
     ) {}
-    private val cachedAttributes =
-        LimeAttributes.Builder().addAttribute(LimeAttributeType.CACHED).build()
+    private val cachedAttributes = LimeAttributes.Builder().addAttribute(LimeAttributeType.CACHED).build()
+    private val cppRefAttributes =
+        LimeAttributes.Builder().addAttribute(LimeAttributeType.CPP, LimeAttributeValueType.REF).build()
+    private val cppRefProperty = LimeProperty(
+        fooPath.child("bar"),
+        typeRef = LimeBasicTypeRef.INT,
+        getter = limeFunction,
+        attributes = cppRefAttributes
+    )
 
     private val validator = LimePropertiesValidator(mockk(relaxed = true))
 
@@ -149,6 +159,20 @@ class LimePropertiesValidatorTest {
         )
         allElements[""] =
             object : LimeContainerWithInheritance(EMPTY_PATH, properties = listOf(limeProperty)) {}
+
+        assertFalse(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateRefsAttributeInClass() {
+        allElements["foo"] = LimeClass(EMPTY_PATH, properties = listOf(cppRefProperty))
+
+        assertTrue(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateRefsAttributeInInterface() {
+        allElements["foo"] = LimeInterface(EMPTY_PATH, properties = listOf(cppRefProperty))
 
         assertFalse(validator.validate(limeModel))
     }

--- a/gluecodium/src/test/resources/smoke/basic_types/input/CppRefReturnType.lime
+++ b/gluecodium/src/test/resources/smoke/basic_types/input/CppRefReturnType.lime
@@ -1,0 +1,62 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+class CppRefReturnType {
+    struct SomeStruct {
+        field: String
+    }
+
+    enum InternalError {
+        foo,
+        bar
+    }
+
+    exception EnumBased(InternalError)
+    exception StructBased(SomeStruct)
+
+    @Cpp(Ref)
+    static fun voidRef(): Void
+    @Cpp(Ref)
+    static fun boolRef(): Boolean
+    @Cpp(Ref)
+    static fun stringRef(): String
+    @Cpp(Ref)
+    static fun structRef(): SomeStruct
+    @Cpp(Ref)
+    static fun classRef(): CppRefReturnType
+    @Cpp(Ref)
+    static fun nullableRef(): String?
+
+    @Cpp(Ref)
+    static fun throwingEnumWithVoid(): Void throws EnumBased
+    @Cpp(Ref)
+    static fun throwingEnumWithString(): String throws EnumBased
+    @Cpp(Ref)
+    static fun throwingStructWithVoid(): Void throws StructBased
+    @Cpp(Ref)
+    static fun throwingStructWithString(): String throws StructBased
+
+    @Cpp(Ref)
+    static property stringProperty: String { get }
+}
+
+struct CppRefReturnTypeStruct {
+    @Cpp(Ref)
+    static fun stringRef(): String
+}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnType.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnType.h
@@ -1,0 +1,54 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include "gluecodium/Optional.h"
+#include "gluecodium/Return.h"
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <system_error>
+namespace smoke {
+    class CppRefReturnType;
+}
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT CppRefReturnType {
+public:
+    CppRefReturnType();
+    virtual ~CppRefReturnType() = 0;
+public:
+    enum class InternalError {
+        FOO,
+        BAR
+    };
+    struct _GLUECODIUM_CPP_EXPORT SomeStruct {
+        ::std::string field;
+        SomeStruct( );
+        SomeStruct( ::std::string field );
+    };
+public:
+    static void void_ref(  );
+    static const bool& bool_ref(  );
+    static const ::std::string& string_ref(  );
+    static const ::smoke::CppRefReturnType::SomeStruct& struct_ref(  );
+    /**
+     *
+     * \return @NotNull
+     */
+    static const ::std::shared_ptr< ::smoke::CppRefReturnType >& class_ref(  );
+    static const ::gluecodium::optional< ::std::string >& nullable_ref(  );
+    static ::std::error_code throwing_enum_with_void(  );
+    static ::gluecodium::Return< const ::std::string&, ::std::error_code > throwing_enum_with_string(  );
+    static ::gluecodium::Return< void, ::smoke::CppRefReturnType::SomeStruct > throwing_struct_with_void(  );
+    static ::gluecodium::Return< const ::std::string&, ::smoke::CppRefReturnType::SomeStruct > throwing_struct_with_string(  );
+    static const ::std::string& get_string_property(  );
+};
+_GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::CppRefReturnType::InternalError value ) noexcept;
+}
+namespace std
+{
+template <>
+struct is_error_code_enum< ::smoke::CppRefReturnType::InternalError > : public std::true_type { };
+}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnTypeStruct.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnTypeStruct.h
@@ -1,0 +1,12 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include <string>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT CppRefReturnTypeStruct {
+    static const ::std::string& string_ref(  );
+};
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -139,6 +139,7 @@ internal object AntlrLimeConverter {
             "Label" -> LimeAttributeValueType.LABEL
             "ObjC" -> LimeAttributeValueType.OBJC
             "Message" -> LimeAttributeValueType.MESSAGE
+            "Ref" -> LimeAttributeValueType.REF
             "Skip" -> LimeAttributeValueType.SKIP
             "Weak" -> LimeAttributeValueType.WEAK
             "ExternalType", "ExternalName", "ExternalGetter", "ExternalSetter" -> null

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
@@ -31,6 +31,7 @@ enum class LimeAttributeValueType(private val tag: String) {
     LABEL("Label"),
     OBJC("ObjC"),
     MESSAGE("Message"),
+    REF("Ref"),
     SKIP("Skip"),
     WEAK("Weak");
 


### PR DESCRIPTION
Added support for `@Cpp(Ref)` attribute. This attribute is available for functions and properties in classes and
structs. This attribute affects return value type of the function or the getter accessor of a property in generated C++
code: the value is returned by const reference (instead of usual "by copy").

Added validation against using the new attribute inside interfaces. Supporting it for interfaces would require a lot of
additional boilerplate. As there is no use case for interface usage yet, the initial implementation just forbids those.

Added smoke and functional tests. Added unit tests for new validation.

Resolves: #515
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>