### PR TITLE
Add more JNI smoke tests for inheritance

### DIFF
--- a/gluecodium/src/test/resources/smoke/inheritance/input/InheritanceIncludes.lime
+++ b/gluecodium/src/test/resources/smoke/inheritance/input/InheritanceIncludes.lime
@@ -1,0 +1,39 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct IncludableStruct {
+    field: String
+}
+
+enum IncludableEnum {
+    foo
+}
+
+class IncludableClass {}
+
+lambda IncludableLambda = () -> Void
+
+@Dart(Skip)
+interface ParentInterfaceWithIncludes {
+    fun rootMethod(input1: IncludableStruct, input2: IncludableEnum): IncludableClass
+    property rootProperty: IncludableLambda
+}
+
+@Dart(Skip)
+class ChildClassWithIncludes: ParentInterfaceWithIncludes {}

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassWithIncludes.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassWithIncludes.cpp
@@ -1,0 +1,66 @@
+/*
+ *
+ */
+#include "com_example_smoke_ChildClassWithIncludes.h"
+#include "com_example_smoke_ChildClassWithIncludes__Conversion.h"
+#include "com_example_smoke_IncludableClass__Conversion.h"
+#include "com_example_smoke_IncludableEnum__Conversion.h"
+#include "com_example_smoke_IncludableLambda__Conversion.h"
+#include "com_example_smoke_IncludableStruct__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+#include "JniWrapperCache.h"
+extern "C" {
+jobject
+Java_com_example_smoke_ChildClassWithIncludes_rootMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput1, jobject jinput2)
+{
+    ::smoke::IncludableStruct input1 = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput1),
+            (::smoke::IncludableStruct*)nullptr);
+    ::smoke::IncludableEnum input2 = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput2),
+            (::smoke::IncludableEnum*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::ChildClassWithIncludes>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->root_method(input1,input2);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+jobject
+Java_com_example_smoke_ChildClassWithIncludes_getRootProperty(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::ChildClassWithIncludes>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->get_root_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+void
+Java_com_example_smoke_ChildClassWithIncludes_setRootProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
+{
+    ::smoke::IncludableLambda value = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jvalue),
+            (::smoke::IncludableLambda*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::ChildClassWithIncludes>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->set_root_property(value);
+}
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildClassWithIncludes_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::ChildClassWithIncludes>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+}


### PR DESCRIPTION
Added a new test case for "inheritance" smoke test. This test case covers the scenario where the JNI impl file for a
child class should have all conversion includes for types used in functions and properties of the parent
class/interface.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>