### PR TITLE
Add JNI smoke test for skipping parent methods

### DIFF
--- a/gluecodium/src/test/resources/smoke/inheritance/input/InheritanceIncludes.lime
+++ b/gluecodium/src/test/resources/smoke/inheritance/input/InheritanceIncludes.lime
@@ -21,6 +21,10 @@ struct IncludableStruct {
     field: String
 }
 
+struct ShouldNotInclude {
+    field: String
+}
+
 enum IncludableEnum {
     foo
 }
@@ -33,6 +37,10 @@ lambda IncludableLambda = () -> Void
 interface ParentInterfaceWithIncludes {
     fun rootMethod(input1: IncludableStruct, input2: IncludableEnum): IncludableClass
     property rootProperty: IncludableLambda
+    @Java(Skip)
+    fun notInJava(): ShouldNotInclude
+    @Java(Skip)
+    property notInJavaProperty: ShouldNotInclude
 }
 
 @Dart(Skip)

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassWithIncludes.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassWithIncludes.h
@@ -1,0 +1,17 @@
+/*
+ *
+ */
+#pragma once
+#include <jni.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+JNIEXPORT jobject JNICALL
+Java_com_example_smoke_ChildClassWithIncludes_rootMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput1, jobject jinput2);
+JNIEXPORT jobject JNICALL
+Java_com_example_smoke_ChildClassWithIncludes_getRootProperty(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildClassWithIncludes_setRootProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue);
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Added a new test case for "inheritance" smoke test. This test case covers the scenario where the JNI impl file for a
child class should _not_ have functions/properties from the parent class/interface due to these being marked with
`@Java(Skip)`.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>