### PR TITLE
Don't generate generics conversions for types skipped in Dart

### DIFF
--- a/examples/libhello/lime/test/Skip.lime
+++ b/examples/libhello/lime/test/Skip.lime
@@ -39,6 +39,9 @@ class SkipTypes {
     struct NotInDart {
         fooField: String
     }
+
+    @Dart(Skip) @Java(Skip) @Swift(Skip)
+    fun useListInDart(): List<NotInDart>
 }
 
 interface SkipProxy {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -120,8 +120,7 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
             dartNameResolver,
             "$libraryName/$SRC_DIR_SUFFIX"
         )
-        val includeResolver =
-            FfiCppIncludeResolver(limeModel.referenceMap, cppNameRules, internalNamespace)
+        val includeResolver = FfiCppIncludeResolver(limeModel.referenceMap, cppNameRules, internalNamespace)
         val exportsCollector = mutableMapOf<List<String>, MutableList<DartExport>>()
         val typeRepositoriesCollector = mutableListOf<LimeContainerWithInheritance>()
 
@@ -474,7 +473,8 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
                 else -> emptyList()
             }
 
-        fun getAllTypeRefs(limeModel: LimeModel) = traverseModel(limeModel).flatten()
+        fun getAllTypeRefs(limeModel: LimeModel) =
+            traverseModel(limeModel.referenceMap.values.filterNot { it.attributes.have(DART, SKIP) }).flatten()
     }
 
     companion object {

--- a/gluecodium/src/test/resources/smoke/skip/input/Skip.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/Skip.lime
@@ -39,6 +39,9 @@ class SkipTypes {
     struct NotInDart {
         fooField: String
     }
+
+    @Dart(Skip) @Java(Skip) @Swift(Skip)
+    fun useListInDart(): List<NotInDart>
 }
 
 interface SkipProxy {

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/generic_types__conversion.dart
@@ -1,0 +1,3 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:library/src/_library_context.dart' as __lib;

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeTypeRefsVisitor.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeTypeRefsVisitor.kt
@@ -20,6 +20,7 @@
 package com.here.gluecodium.common
 
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeException
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeLambda
@@ -30,8 +31,9 @@ import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeTypedElement
 
 abstract class LimeTypeRefsVisitor<T> {
-    protected fun traverseModel(limeModel: LimeModel): List<T> {
-        val allElements = limeModel.referenceMap.values
+    protected fun traverseModel(limeModel: LimeModel) = traverseModel(limeModel.referenceMap.values)
+
+    protected fun traverseModel(allElements: Collection<LimeElement>): List<T> {
         val allLambdasAsFunctions = allElements.filterIsInstance<LimeLambda>().map { it.asFunction() }
         val allFunctions = allElements.filterIsInstance<LimeFunction>() + allLambdasAsFunctions
         val allTypedElements = allElements.filterIsInstance<LimeTypedElement>() +


### PR DESCRIPTION
Updated DartGenerator suite to avoid generating generics conversion functions when the only occurence of the generic
type is in an element skipped with `@Dart(Skip)`.

Added smoke and functional tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>