### PR TITLE
Add support for web links in LimeDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for web links in documentation comments. Reference web links, inline web links, and automatic web
+    links are supported per Markdown specification.
+
 ## 8.4.3
 Release date: 2020-10-05
 ### Bug fixes:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -621,7 +621,7 @@ fun process(mode: Mode, input: String): GenericResult
 ```
 
 There are three ways to specify web links:
-1. reference web link, e.g. `[example]` with `[example]: https://www.example.com/details2` listed at the end of the comment.
+1. reference web link, e.g. `[example]` with `[example]: https://www.example.com/details1` listed at the end of the comment.
 2. inline web link, e.g. `[another example](https://www.example.com/details2)`.
 3. automatic web link, e.g. `<https://www.example.com/details3>`.
 

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -609,6 +609,24 @@ struct Options {
 }
 ```
 
+#### Links in documentation comments
+
+Markdown-style links are supported in documentation comments. Example:
+```
+// Process the input in the given mode, based on [Mode]. For more details, see [example],
+// [another example](https://www.example.com/details2), or <https://www.example.com/details3>.
+//
+// [example]: https://www.example.com/details1
+fun process(mode: Mode, input: String): GenericResult
+```
+
+There are three ways to specify web links:
+1. reference web link, e.g. `[example]` with `[example]: https://www.example.com/details2` listed at the end of the comment.
+2. inline web link, e.g. `[another example](https://www.example.com/details2)`.
+3. automatic web link, e.g. `<https://www.example.com/details3>`.
+
+Any square-brackets link that does not resolve into a web link is treated as a link to some IDL element, e.g. `[Mode]`.
+
 #### Platform-specific comments
 
 Parts of documentation comments can be varied per platform (i.e. per output language). Example:

--- a/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/platform/swift/SwiftCommentsProcessor.kt
@@ -20,6 +20,7 @@
 package com.here.gluecodium.platform.swift
 
 import com.here.gluecodium.platform.common.CommentsProcessor
+import com.vladsch.flexmark.ast.AutoLink
 import com.vladsch.flexmark.ast.LinkRef
 import com.vladsch.flexmark.formatter.Formatter
 import com.vladsch.flexmark.parser.ParserEmulationProfile
@@ -38,6 +39,10 @@ class SwiftCommentsProcessor(werror: Boolean) :
         linkNode.referenceOpeningMarker = BasedSequenceImpl.of("`")
         linkNode.referenceClosingMarker = BasedSequenceImpl.of("`")
         linkNode.firstChild?.unlink()
+    }
+
+    override fun processAutoLink(linkNode: AutoLink) {
+        linkNode.chars = BasedSequenceImpl.of(linkNode.chars.trim('<', '>'))
     }
 
     override val nullReference = "nil"

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -147,9 +147,9 @@ types CommentsTypeCollection {
 // possible to references other interfaces like [smoke.CommentsInterface] or other members
 // [comments.someMethodWithAllComments].
 //
-// Weblinks are not modified like this [example] or [www.example.com].
+// Weblinks are not modified like this [example1], [example2](http://www.example.com/2) or <https://www.example.com/3>.
 //
-// [example]: http://example.com
+// [example1]: http://example.com/1
 class CommentsLinks {
 
     // Link types:

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
@@ -8,7 +8,7 @@ import com.example.NativeBase;
  * <p>The nested types like {@link com.example.smoke.CommentsLinks#randomMethod(String, boolean)} don't need full name prefix, but it's
  * possible to references other interfaces like {@link com.example.smoke.CommentsInterface} or other members
  * {@link com.example.smoke.Comments#someMethodWithAllComments}.</p>
- * <p>Weblinks are not modified like this <a href="http://example.com">example</a> or [www.example.com].</p>
+ * <p>Weblinks are not modified like this <a href="http://example.com/1">example1</a>, <a href="http://www.example.com/2">example2</a> or <a href="https://www.example.com/3">https://www.example.com/3</a>.</p>
  */
 public final class CommentsLinks extends NativeBase {
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
@@ -14,9 +14,9 @@ namespace smoke {
  * possible to references other interfaces like ::smoke::CommentsInterface or other members
  * ::smoke::Comments::some_method_with_all_comments.
  *
- * Weblinks are not modified like this [example] or [www.example.com].
+ * Weblinks are not modified like this [example1], [example2](http://www.example.com/2) or <https://www.example.com/3>.
  *
- * [example]: http://example.com
+ * [example1]: http://example.com/1
  */
 class _GLUECODIUM_CPP_EXPORT CommentsLinks {
 public:

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -9,9 +9,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 /// possible to references other interfaces like [CommentsInterface] or other members
 /// [someMethodWithAllComments].
 ///
-/// Weblinks are not modified like this [example] or [www.example.com].
+/// Weblinks are not modified like this [example1], [example2](http://www.example.com/2) or <https://www.example.com/3>.
 ///
-/// [example]: http://example.com
+/// [example1]: http://example.com/1
 abstract class CommentsLinks {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
@@ -6,9 +6,9 @@ import smoke.comments.SomethingWrong
 // possible to references other interfaces like [smoke.CommentsInterface] or other members
 // [comments.someMethodWithAllComments].
 //
-// Weblinks are not modified like this [example] or [www.example.com].
+// Weblinks are not modified like this [example1], [example2](http://www.example.com/2) or <https://www.example.com/3>.
 //
-// [example]: http://example.com
+// [example1]: http://example.com/1
 class CommentsLinks {
     // Links also work in:
     // @constructor constructor comments [comments.SomeStruct]

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
@@ -5,9 +5,9 @@ import Foundation
 /// possible to references other interfaces like `CommentsInterface` or other members
 /// `Comments.someMethodWithAllComments(...)`.
 ///
-/// Weblinks are not modified like this [example] or [www.example.com].
+/// Weblinks are not modified like this [example1], [example2](http://www.example.com/2) or https://www.example.com/3.
 ///
-/// [example]: http://example.com
+/// [example1]: http://example.com/1
 public class CommentsLinks {
     let c_instance : _baseRef
     init(cCommentsLinks: _baseRef) {


### PR DESCRIPTION
Updated Gluecodium's own documentation to explicitly state that various flavors of Markdown's web links are supported.

Updated Swift comments processor to de-decorate "automatic" Markdown links (i.e. links in angle brackets `<>`), as it is
unclear whether Apple's Markup supports those.

For other output lanugages all flavors of web links are supported without any changes. For JavaDoc they are correctly
converted to HTML by Flexmark HTML rendered that is in use already. For C++ and Dart both DoxyGen and DartDocs fully
support Markdown syntax for web links (according to their respective documentation pages).

Added smoke tests for all flavors of web links.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>