### PR TITLE
Fix "hasAnyComment" predicate for C++ templates

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorPredicates.kt
@@ -44,13 +44,16 @@ internal object CppGeneratorPredicates {
         "hasAnyComment" to { limeElement: Any ->
             when (limeElement) {
                 is LimeFunction -> limeElement.run {
-                    !comment.isEmpty() || comment.isExcluded || !returnType.comment.isEmpty() ||
-                    needsNotNullComment(returnType.typeRef) ||
-                    (thrownType?.comment?.isEmpty() == false) || attributes.have(LimeAttributeType.DEPRECATED) ||
-                    parameters.any { !it.comment.isEmpty() || needsNotNullComment(it.typeRef) }
+                    comment.getFor("Cpp").isNotBlank() || comment.isExcluded ||
+                        returnType.comment.getFor("Cpp").isNotBlank() ||
+                        needsNotNullComment(returnType.typeRef) ||
+                        (thrownType?.comment?.getFor("Cpp")?.isBlank() == false) ||
+                        attributes.have(LimeAttributeType.DEPRECATED) ||
+                        parameters.any { it.comment.getFor("Cpp").isNotBlank() || needsNotNullComment(it.typeRef) }
                 }
                 is LimeNamedElement -> limeElement.run {
-                    !comment.isEmpty() || comment.isExcluded || attributes.have(LimeAttributeType.DEPRECATED)
+                    comment.getFor("Cpp").isNotBlank() || comment.isExcluded ||
+                        attributes.have(LimeAttributeType.DEPRECATED)
                 }
                 else -> false
             }

--- a/gluecodium/src/test/resources/smoke/comments/input/PlatformComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/PlatformComments.lime
@@ -20,6 +20,7 @@ package smoke
 class PlatformComments {
     // {@Cpp An error code when something goes wrong.}
     enum SomeEnum {
+        // {@Java Maybe useful.}
         Useless,
         Useful
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/PlatformComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/PlatformComments.java
@@ -6,6 +6,9 @@ import android.support.annotation.NonNull;
 import com.example.NativeBase;
 public final class PlatformComments extends NativeBase {
     public enum SomeEnum {
+        /**
+         * <p>Maybe useful.</p>
+         */
         USELESS(0),
         USEFUL(1);
         public final int value;

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/PlatformComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/PlatformComments.lime
@@ -2,6 +2,7 @@ package smoke
 class PlatformComments {
     // {@Cpp An error code when something goes wrong.}
     enum SomeEnum {
+        // {@Java Maybe useful.}
         Useless,
         Useful
     }


### PR DESCRIPTION
Updated "hasAnyComment" predicate for C++ templates to check comments for not being empty through the C++-specific text
of these comments instead of through the whole comment (which also includes text for other platforms).

Added a smoke test where the C++ comment is blank while the whole comment is not.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>