### PR TITLE
Add smoke tests for function visibility inside internal types

### DIFF
--- a/gluecodium/src/test/resources/smoke/visibility/input/Visibility.lime
+++ b/gluecodium/src/test/resources/smoke/visibility/input/Visibility.lime
@@ -17,9 +17,15 @@
 
 package smoke
 
-internal interface InternalInterface {}
+internal interface InternalInterface {
+    fun fooBar()
+}
 
-internal class InternalClass {}
+internal class InternalClass {
+    fun fooBar()
+}
+
+internal lambda InternalLambda = () -> Void
 
 interface PublicInterface {
     internal struct InternalStruct {
@@ -62,6 +68,7 @@ class PublicClass {
 types PublicTypeCollection {
     internal struct InternalStruct {
         internal stringField: String
+        fun fooBar()
     }
 }
 

--- a/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalInterface.java
+++ b/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalInterface.java
@@ -1,9 +1,7 @@
 /*
  *
-
  */
-
 package com.example.smoke;
-
 interface InternalInterface {
+    void fooBar();
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalInterfaceImpl.java
+++ b/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalInterfaceImpl.java
@@ -3,8 +3,8 @@
  */
 package com.example.smoke;
 import com.example.NativeBase;
-class InternalClass extends NativeBase {
-    protected InternalClass(final long nativeHandle, final Object dummy) {
+class InternalInterfaceImpl extends NativeBase implements InternalInterface {
+    protected InternalInterfaceImpl(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {
@@ -13,5 +13,5 @@ class InternalClass extends NativeBase {
         });
     }
     private static native void disposeNativeHandle(long nativeHandle);
-    native void fooBar();
+    public native void fooBar();
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalLambda.java
+++ b/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalLambda.java
@@ -1,0 +1,8 @@
+/*
+ *
+ */
+package com.example.smoke;
+@FunctionalInterface
+interface InternalLambda {
+    void apply();
+}

--- a/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalLambdaImpl.java
+++ b/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalLambdaImpl.java
@@ -3,8 +3,11 @@
  */
 package com.example.smoke;
 import com.example.NativeBase;
-class InternalClass extends NativeBase {
-    protected InternalClass(final long nativeHandle, final Object dummy) {
+/**
+ * @exclude
+ */
+class InternalLambdaImpl extends NativeBase implements InternalLambda {
+    protected InternalLambdaImpl(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
             @Override
             public void disposeNative(long handle) {
@@ -13,5 +16,5 @@ class InternalClass extends NativeBase {
         });
     }
     private static native void disposeNativeHandle(long nativeHandle);
-    native void fooBar();
+    public native void apply();
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalStruct.java
+++ b/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalStruct.java
@@ -1,6 +1,5 @@
 /*
  *
-
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
@@ -10,4 +9,5 @@ final class InternalStruct {
     InternalStruct(@NonNull final String stringField) {
         this.stringField = stringField;
     }
+    native void fooBar();
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
@@ -10,6 +11,8 @@ abstract class InternalClass {
   /// Call this to free memory when you no longer need this instance.
   /// Note that setting the instance to null will not destroy the underlying native object.
   void release();
+  /// @nodoc
+  internal_fooBar();
 }
 // InternalClass "private" section, not exported.
 final _smoke_InternalClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -34,6 +37,17 @@ class InternalClass$Impl implements InternalClass {
     __lib.reverseCache.remove(_smoke_InternalClass_get_raw_pointer(handle));
     _smoke_InternalClass_release_handle(handle);
     handle = null;
+  }
+  @override
+  internal_fooBar() {
+    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClass_fooBar'));
+    final _handle = this.handle;
+    final __result_handle = _fooBar_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
   }
 }
 Pointer<Void> smoke_InternalClass_toFfi(InternalClass value) =>

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -7,11 +7,19 @@ import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
 abstract class InternalInterface {
+  InternalInterface() {}
+  factory InternalInterface.fromLambdas({
+    @required void Function() lambda_fooBar
+  }) => InternalInterface$Lambdas(
+    lambda_fooBar
+  );
   /// Destroys the underlying native object.
   ///
   /// Call this to free memory when you no longer need this instance.
   /// Note that setting the instance to null will not destroy the underlying native object.
   void release() {}
+  /// @nodoc
+  internal_fooBar();
 }
 // InternalInterface "private" section, not exported.
 final _smoke_InternalInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -23,8 +31,8 @@ final _smoke_InternalInterface_release_handle = __lib.catchArgumentError(() => _
     void Function(Pointer<Void>)
   >('library_smoke_InternalInterface_release_handle'));
 final _smoke_InternalInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Uint64, Int32, Pointer),
-    Pointer<Void> Function(int, int, Pointer)
+    Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
+    Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_InternalInterface_create_proxy'));
 final _smoke_InternalInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
@@ -34,6 +42,19 @@ final _smoke_InternalInterface_get_type_id = __lib.catchArgumentError(() => __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InternalInterface_get_type_id'));
+class InternalInterface$Lambdas implements InternalInterface {
+  void Function() lambda_fooBar;
+  InternalInterface$Lambdas(
+    void Function() lambda_fooBar
+  ) {
+    this.lambda_fooBar = lambda_fooBar;
+  }
+  @override
+  void release() {}
+  @override
+  internal_fooBar() =>
+    lambda_fooBar();
+}
 class InternalInterface$Impl implements InternalInterface {
   @protected
   Pointer<Void> handle;
@@ -45,13 +66,32 @@ class InternalInterface$Impl implements InternalInterface {
     _smoke_InternalInterface_release_handle(handle);
     handle = null;
   }
+  @override
+  internal_fooBar() {
+    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalInterface_fooBar'));
+    final _handle = this.handle;
+    final __result_handle = _fooBar_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+}
+int _InternalInterface_fooBar_static(int _token) {
+  try {
+    (__lib.instanceCache[_token] as InternalInterface).internal_fooBar();
+  } finally {
+  }
+  return 0;
 }
 Pointer<Void> smoke_InternalInterface_toFfi(InternalInterface value) {
   if (value is InternalInterface$Impl) return _smoke_InternalInterface_copy_handle(value.handle);
   final result = _smoke_InternalInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
-    __lib.uncacheObjectFfi
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Uint8 Function(Uint64)>(_InternalInterface_fooBar_static, __lib.unknownError)
   );
   __lib.reverseCache[_smoke_InternalInterface_get_raw_pointer(result)] = value;
   return result;

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
@@ -8,6 +8,18 @@ class InternalStruct {
   /// @nodoc
   String internal_stringField;
   InternalStruct(this.internal_stringField);
+  /// @nodoc
+  internal_fooBar() {
+    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PublicTypeCollection_InternalStruct_fooBar'));
+    final _handle = smoke_PublicTypeCollection_InternalStruct_toFfi(this);
+    final __result_handle = _fooBar_ffi(_handle, __lib.LibraryContext.isolateId);
+    smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle(_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
 }
 // InternalStruct "private" section, not exported.
 final _smoke_PublicTypeCollection_InternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/visibility/output/lime/smoke/InternalClass.lime
+++ b/gluecodium/src/test/resources/smoke/visibility/output/lime/smoke/InternalClass.lime
@@ -1,4 +1,4 @@
 package smoke
-
 internal class InternalClass {
+    internal fun fooBar()
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/lime/smoke/InternalInterface.lime
+++ b/gluecodium/src/test/resources/smoke/visibility/output/lime/smoke/InternalInterface.lime
@@ -1,4 +1,4 @@
 package smoke
-
 internal interface InternalInterface {
+    internal fun fooBar()
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/lime/smoke/PublicTypeCollection.lime
+++ b/gluecodium/src/test/resources/smoke/visibility/output/lime/smoke/PublicTypeCollection.lime
@@ -1,7 +1,7 @@
 package smoke
-
 types PublicTypeCollection {
     internal struct InternalStruct {
         stringField: String
+        internal fun fooBar()
     }
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalClass.swift
@@ -13,6 +13,9 @@ internal class InternalClass {
         smoke_InternalClass_remove_swift_object_from_wrapper_cache(c_instance)
         smoke_InternalClass_release_handle(c_instance)
     }
+    internal func fooBar() -> Void {
+        return moveFromCType(smoke_InternalClass_fooBar(self.c_instance))
+    }
 }
 internal func getRef(_ ref: InternalClass?, owning: Bool = true) -> RefHolder {
     guard let c_handle = ref?.c_instance else {

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalInterface.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalInterface.swift
@@ -2,6 +2,7 @@
 //
 import Foundation
 internal protocol InternalInterface : AnyObject {
+    func fooBar() -> Void
 }
 internal class _InternalInterface: InternalInterface {
     let c_instance : _baseRef
@@ -14,6 +15,9 @@ internal class _InternalInterface: InternalInterface {
     deinit {
         smoke_InternalInterface_remove_swift_object_from_wrapper_cache(c_instance)
         smoke_InternalInterface_release_handle(c_instance)
+    }
+    internal func fooBar() -> Void {
+        return moveFromCType(smoke_InternalInterface_fooBar(self.c_instance))
     }
 }
 @_cdecl("_CBridgeInitsmoke_InternalInterface")
@@ -37,6 +41,10 @@ internal func getRef(_ ref: InternalInterface?, owning: Bool = true) -> RefHolde
         if let swift_class = swift_class_pointer {
             Unmanaged<AnyObject>.fromOpaque(swift_class).release()
         }
+    }
+    functions.smoke_InternalInterface_fooBar = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! InternalInterface
+        swift_class.fooBar()
     }
     let proxy = smoke_InternalInterface_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_InternalInterface_release_handle) : RefHolder(proxy)

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicTypeCollection.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicTypeCollection.swift
@@ -1,6 +1,5 @@
 //
 //
-
 import Foundation
 internal struct InternalStruct {
     internal var stringField: String
@@ -9,6 +8,10 @@ internal struct InternalStruct {
     }
     internal init(cHandle: _baseRef) {
         stringField = moveFromCType(smoke_PublicTypeCollection_InternalStruct_stringField_get(cHandle))
+    }
+    internal func fooBar() -> Void {
+        let c_self_handle = moveToCType(self)
+        return moveFromCType(smoke_PublicTypeCollection_InternalStruct_fooBar(c_self_handle.ref))
     }
 }
 internal func copyFromCType(_ handle: _baseRef) -> InternalStruct {


### PR DESCRIPTION
Added more use cases to "visibility" smoke test. These use cases cover proper visibility modifiers inside types marked
as `internal` in IDL.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>