### PR TITLE
Fix fields skipping validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Enabled validation against applying `Skip` attributes to struct fields.
+
 ## 8.4.5
 Release date: 2020-10-08
 ### Bug fixes:

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -37,6 +37,7 @@ import com.here.gluecodium.platform.common.GeneratorSuite
 import com.here.gluecodium.validator.LimeDeprecationsValidator
 import com.here.gluecodium.validator.LimeEnumeratorRefsValidator
 import com.here.gluecodium.validator.LimeExternalTypesValidator
+import com.here.gluecodium.validator.LimeFieldsValidator
 import com.here.gluecodium.validator.LimeFunctionsValidator
 import com.here.gluecodium.validator.LimeGenericTypesValidator
 import com.here.gluecodium.validator.LimeInheritanceValidator
@@ -166,7 +167,7 @@ class Gluecodium(
         return saveToDirectory(options.outputDir, mainFiles) && saveToDirectory(options.commonOutputDir, commonFiles)
     }
 
-    private fun validateModel(limeModel: LimeModel): Boolean {
+    internal fun validateModel(limeModel: LimeModel): Boolean {
         val limeLogger = LimeLogger(LOGGER, limeModel.fileNameMap)
         val typeRefsValidationResult = LimeTypeRefsValidator(limeLogger).validate(limeModel)
         val validators = getIndependentValidators(limeLogger) +
@@ -194,7 +195,8 @@ class Gluecodium(
                 limeLogger,
                 options.werror.contains(Options.WARNING_DEPRECATED_ATTRIBUTES)
             ).validate(it.topElements) },
-            { LimeFunctionsValidator(limeLogger).validate(it) }
+            { LimeFunctionsValidator(limeLogger).validate(it) },
+            { LimeFieldsValidator(limeLogger).validate(it) }
         )
 
     data class Options(

--- a/gluecodium/src/test/java/com/here/gluecodium/AcceptanceTestBase.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/AcceptanceTestBase.kt
@@ -75,8 +75,8 @@ abstract class AcceptanceTestBase protected constructor(
 
         assumeFalse("No reference files were found", referenceFiles.isEmpty())
 
-        val limeModel =
-            LOADER.loadModel(listOf(inputDirectory.toString()), listOf(auxDirectory.toString()))
+        val limeModel = LOADER.loadModel(listOf(inputDirectory.toString()), listOf(auxDirectory.toString()))
+        assertTrue(gluecodium.validateModel(limeModel))
         assertTrue(gluecodium.executeGenerator(generatorName, limeModel, HashMap()))
 
         val generatedContents = results.associateBy({ it.targetFile.path }, { it.content })

--- a/gluecodium/src/test/resources/smoke/external_types/input/DartExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/DartExternalTypes.lime
@@ -77,5 +77,5 @@ class UseDartExternalTypes {
 
 @Java(Skip) @Swift(Skip)
 class UseDartExternalGenerics {
-    fun useGenerics(list: List<Rectangle>, `set`: Set<Rectangle>): Map<CompressionState, Rectangle>
+    fun useGenerics(list: List<Rectangle>, `set`: Set<CompressionState>): Map<CompressionState, Rectangle>
 }

--- a/gluecodium/src/test/resources/smoke/external_types/input/SwiftExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/SwiftExternalTypes.lime
@@ -76,6 +76,6 @@ class UseSwiftExternalTypes {
 @Java(Skip) @Dart(Skip)
 typealias ExternalList = List<DateInterval>
 @Java(Skip) @Dart(Skip)
-typealias ExternalSet = Set<DateInterval>
+typealias ExternalSet = Set<Persistence>
 @Java(Skip) @Dart(Skip)
 typealias ExternalMap = Map<Persistence, DateInterval>

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
@@ -356,88 +356,88 @@ Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> MapOf_smoke_Com
 }
 void MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle_nullable(handle);
-final _SetOf_smoke_Rectangle_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _SetOf_smoke_CompressionState_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
-  >('library_SetOf_smoke_Rectangle_create_handle'));
-final _SetOf_smoke_Rectangle_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_CompressionState_create_handle'));
+final _SetOf_smoke_CompressionState_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_SetOf_smoke_Rectangle_release_handle'));
-final _SetOf_smoke_Rectangle_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>, Pointer<Void>),
-    void Function(Pointer<Void>, Pointer<Void>)
-  >('library_SetOf_smoke_Rectangle_insert'));
-final _SetOf_smoke_Rectangle_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_CompressionState_release_handle'));
+final _SetOf_smoke_CompressionState_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Uint32),
+    void Function(Pointer<Void>, int)
+  >('library_SetOf_smoke_CompressionState_insert'));
+final _SetOf_smoke_CompressionState_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
->('library_SetOf_smoke_Rectangle_iterator'));
-final _SetOf_smoke_Rectangle_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+>('library_SetOf_smoke_CompressionState_iterator'));
+final _SetOf_smoke_CompressionState_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_SetOf_smoke_Rectangle_iterator_release_handle'));
-final _SetOf_smoke_Rectangle_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+>('library_SetOf_smoke_CompressionState_iterator_release_handle'));
+final _SetOf_smoke_CompressionState_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
->('library_SetOf_smoke_Rectangle_iterator_is_valid'));
-final _SetOf_smoke_Rectangle_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+>('library_SetOf_smoke_CompressionState_iterator_is_valid'));
+final _SetOf_smoke_CompressionState_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
->('library_SetOf_smoke_Rectangle_iterator_increment'));
-final _SetOf_smoke_Rectangle_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
->('library_SetOf_smoke_Rectangle_iterator_get'));
-Pointer<Void> SetOf_smoke_Rectangle_toFfi(Set<math.Rectangle<int>> value) {
-  final _result = _SetOf_smoke_Rectangle_create_handle();
+>('library_SetOf_smoke_CompressionState_iterator_increment'));
+final _SetOf_smoke_CompressionState_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+>('library_SetOf_smoke_CompressionState_iterator_get'));
+Pointer<Void> SetOf_smoke_CompressionState_toFfi(Set<bar.HttpClientResponseCompressionState> value) {
+  final _result = _SetOf_smoke_CompressionState_create_handle();
   for (final element in value) {
-    final _element_handle = smoke_Rectangle_toFfi(element);
-    _SetOf_smoke_Rectangle_insert(_result, _element_handle);
-    smoke_Rectangle_releaseFfiHandle(_element_handle);
+    final _element_handle = smoke_CompressionState_toFfi(element);
+    _SetOf_smoke_CompressionState_insert(_result, _element_handle);
+    smoke_CompressionState_releaseFfiHandle(_element_handle);
   }
   return _result;
 }
-Set<math.Rectangle<int>> SetOf_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
-  final result = Set<math.Rectangle<int>>();
-  final _iterator_handle = _SetOf_smoke_Rectangle_iterator(handle);
-  while (_SetOf_smoke_Rectangle_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _SetOf_smoke_Rectangle_iterator_get(_iterator_handle);
+Set<bar.HttpClientResponseCompressionState> SetOf_smoke_CompressionState_fromFfi(Pointer<Void> handle) {
+  final result = Set<bar.HttpClientResponseCompressionState>();
+  final _iterator_handle = _SetOf_smoke_CompressionState_iterator(handle);
+  while (_SetOf_smoke_CompressionState_iterator_is_valid(handle, _iterator_handle) != 0) {
+    final _element_handle = _SetOf_smoke_CompressionState_iterator_get(_iterator_handle);
     try {
-      result.add(smoke_Rectangle_fromFfi(_element_handle));
+      result.add(smoke_CompressionState_fromFfi(_element_handle));
     } finally {
-      smoke_Rectangle_releaseFfiHandle(_element_handle);
+      smoke_CompressionState_releaseFfiHandle(_element_handle);
     }
-    _SetOf_smoke_Rectangle_iterator_increment(_iterator_handle);
+    _SetOf_smoke_CompressionState_iterator_increment(_iterator_handle);
   }
-  _SetOf_smoke_Rectangle_iterator_release_handle(_iterator_handle);
+  _SetOf_smoke_CompressionState_iterator_release_handle(_iterator_handle);
   return result;
 }
-void SetOf_smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _SetOf_smoke_Rectangle_release_handle(handle);
-final _SetOf_smoke_Rectangle_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void SetOf_smoke_CompressionState_releaseFfiHandle(Pointer<Void> handle) => _SetOf_smoke_CompressionState_release_handle(handle);
+final _SetOf_smoke_CompressionState_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_SetOf_smoke_Rectangle_create_handle_nullable'));
-final _SetOf_smoke_Rectangle_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_CompressionState_create_handle_nullable'));
+final _SetOf_smoke_CompressionState_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('library_SetOf_smoke_Rectangle_release_handle_nullable'));
-final _SetOf_smoke_Rectangle_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  >('library_SetOf_smoke_CompressionState_release_handle_nullable'));
+final _SetOf_smoke_CompressionState_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
-  >('library_SetOf_smoke_Rectangle_get_value_nullable'));
-Pointer<Void> SetOf_smoke_Rectangle_toFfi_nullable(Set<math.Rectangle<int>> value) {
+  >('library_SetOf_smoke_CompressionState_get_value_nullable'));
+Pointer<Void> SetOf_smoke_CompressionState_toFfi_nullable(Set<bar.HttpClientResponseCompressionState> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
-  final _handle = SetOf_smoke_Rectangle_toFfi(value);
-  final result = _SetOf_smoke_Rectangle_create_handle_nullable(_handle);
-  SetOf_smoke_Rectangle_releaseFfiHandle(_handle);
+  final _handle = SetOf_smoke_CompressionState_toFfi(value);
+  final result = _SetOf_smoke_CompressionState_create_handle_nullable(_handle);
+  SetOf_smoke_CompressionState_releaseFfiHandle(_handle);
   return result;
 }
-Set<math.Rectangle<int>> SetOf_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
+Set<bar.HttpClientResponseCompressionState> SetOf_smoke_CompressionState_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _SetOf_smoke_Rectangle_get_value_nullable(handle);
-  final result = SetOf_smoke_Rectangle_fromFfi(_handle);
-  SetOf_smoke_Rectangle_releaseFfiHandle(_handle);
+  final _handle = _SetOf_smoke_CompressionState_get_value_nullable(handle);
+  final result = SetOf_smoke_CompressionState_fromFfi(_handle);
+  SetOf_smoke_CompressionState_releaseFfiHandle(_handle);
   return result;
 }
-void SetOf_smoke_Rectangle_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _SetOf_smoke_Rectangle_release_handle_nullable(handle);
+void SetOf_smoke_CompressionState_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _SetOf_smoke_CompressionState_release_handle_nullable(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/Sets.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/Sets.swift
@@ -2,56 +2,56 @@
 //
 import Foundation
 import Foundation
-internal func copyFromCType(_ handle: _baseRef) -> Set<DateInterval> {
-    var result: Set<DateInterval> = []
-    let iterator_handle = SetOf_smoke_DateInterval_iterator(handle)
-    while SetOf_smoke_DateInterval_iterator_is_valid(handle, iterator_handle) {
-        result.insert(copyFromCType(SetOf_smoke_DateInterval_iterator_get(iterator_handle)))
-        SetOf_smoke_DateInterval_iterator_increment(iterator_handle)
+internal func copyFromCType(_ handle: _baseRef) -> Set<URLCredential.Persistence> {
+    var result: Set<URLCredential.Persistence> = []
+    let iterator_handle = SetOf_smoke_URLCredential_1Persistence_iterator(handle)
+    while SetOf_smoke_URLCredential_1Persistence_iterator_is_valid(handle, iterator_handle) {
+        result.insert(copyFromCType(SetOf_smoke_URLCredential_1Persistence_iterator_get(iterator_handle)))
+        SetOf_smoke_URLCredential_1Persistence_iterator_increment(iterator_handle)
     }
-    SetOf_smoke_DateInterval_iterator_release_handle(iterator_handle)
+    SetOf_smoke_URLCredential_1Persistence_iterator_release_handle(iterator_handle)
     return result
 }
-internal func moveFromCType(_ handle: _baseRef) -> Set<DateInterval> {
+internal func moveFromCType(_ handle: _baseRef) -> Set<URLCredential.Persistence> {
     defer {
-        SetOf_smoke_DateInterval_release_handle(handle)
+        SetOf_smoke_URLCredential_1Persistence_release_handle(handle)
     }
     return copyFromCType(handle)
 }
-internal func copyToCType(_ swiftSet: Set<DateInterval>) -> RefHolder {
-    let handle = SetOf_smoke_DateInterval_create_handle()
+internal func copyToCType(_ swiftSet: Set<URLCredential.Persistence>) -> RefHolder {
+    let handle = SetOf_smoke_URLCredential_1Persistence_create_handle()
     for item in swiftSet {
-        SetOf_smoke_DateInterval_insert(handle, moveToCType(item).ref)
+        SetOf_smoke_URLCredential_1Persistence_insert(handle, moveToCType(item).ref)
     }
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftSet: Set<DateInterval>) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftSet).ref, release: SetOf_smoke_DateInterval_release_handle)
+internal func moveToCType(_ swiftSet: Set<URLCredential.Persistence>) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftSet).ref, release: SetOf_smoke_URLCredential_1Persistence_release_handle)
 }
-internal func copyToCType(_ swiftSet: Set<DateInterval>?) -> RefHolder {
+internal func copyToCType(_ swiftSet: Set<URLCredential.Persistence>?) -> RefHolder {
     guard let swiftSet = swiftSet else {
         return RefHolder(0)
     }
-    let optionalHandle = SetOf_smoke_DateInterval_create_optional_handle()
-    let handle = SetOf_smoke_DateInterval_unwrap_optional_handle(optionalHandle)
+    let optionalHandle = SetOf_smoke_URLCredential_1Persistence_create_optional_handle()
+    let handle = SetOf_smoke_URLCredential_1Persistence_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        SetOf_smoke_DateInterval_insert(handle, moveToCType(item).ref)
+        SetOf_smoke_URLCredential_1Persistence_insert(handle, moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }
-internal func moveToCType(_ swiftType: Set<DateInterval>?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: SetOf_smoke_DateInterval_release_optional_handle)
+internal func moveToCType(_ swiftType: Set<URLCredential.Persistence>?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: SetOf_smoke_URLCredential_1Persistence_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Set<DateInterval>? {
+internal func copyFromCType(_ handle: _baseRef) -> Set<URLCredential.Persistence>? {
     guard handle != 0 else {
         return nil
     }
-    let unwrappedHandle = SetOf_smoke_DateInterval_unwrap_optional_handle(handle)
-    return copyFromCType(unwrappedHandle) as Set<DateInterval>
+    let unwrappedHandle = SetOf_smoke_URLCredential_1Persistence_unwrap_optional_handle(handle)
+    return copyFromCType(unwrappedHandle) as Set<URLCredential.Persistence>
 }
-internal func moveFromCType(_ handle: _baseRef) -> Set<DateInterval>? {
+internal func moveFromCType(_ handle: _baseRef) -> Set<URLCredential.Persistence>? {
     defer {
-        SetOf_smoke_DateInterval_release_optional_handle(handle)
+        SetOf_smoke_URLCredential_1Persistence_release_optional_handle(handle)
     }
     return copyFromCType(handle)
 }


### PR DESCRIPTION
Added LimeFieldsValidator to Gluecodium.validateMode(). It was accidentially omitted before.

Also added a Gluecodium.validateMode() to AcceptanceTestBase, so that LIME models in smoke tests are always validated.
Fixed issues in smoke tests revealed by this validation.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>