### PR TITLE
Test cross-package usage of Java external types

### DIFF
--- a/gluecodium/src/test/resources/smoke/external_types/input/JavaExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/JavaExternalTypes.lime
@@ -79,17 +79,6 @@ enum Season {
 }
 
 @Swift(Skip) @Dart(Skip)
-class UseJavaExternalTypes {
-    static fun currencyRoundTrip(input: Currency): Currency
-    static fun timeZoneRoundTrip(input: TimeZone): TimeZone
-    static fun monthRoundTrip(input: Month): Month
-    static fun colorRoundTrip(input: SystemColor): SystemColor
-    static fun seasonRoundTrip(input: Season): Season
-
-    static fun structRoundTrip(input: JavaExternalTypesStruct): JavaExternalTypesStruct
-}
-
-@Swift(Skip) @Dart(Skip)
 struct JavaExternalTypesStruct {
     currency: Currency
     timeZone: TimeZone

--- a/gluecodium/src/test/resources/smoke/external_types/input/UseJavaExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/UseJavaExternalTypes.lime
@@ -1,0 +1,36 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package dontsmoke
+
+import smoke.Currency
+import smoke.TimeZone
+import smoke.Month
+import smoke.SystemColor
+import smoke.Season
+import smoke.JavaExternalTypesStruct
+
+@Swift(Skip) @Dart(Skip)
+class UseJavaExternalTypes {
+    static fun currencyRoundTrip(input: Currency): Currency
+    static fun timeZoneRoundTrip(input: TimeZone): TimeZone
+    static fun monthRoundTrip(input: Month): Month
+    static fun colorRoundTrip(input: SystemColor): SystemColor
+    static fun seasonRoundTrip(input: Season): Season
+
+    static fun structRoundTrip(input: JavaExternalTypesStruct): JavaExternalTypesStruct
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/dontsmoke/UseJavaExternalTypes.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/dontsmoke/UseJavaExternalTypes.java
@@ -1,9 +1,10 @@
 /*
  *
  */
-package com.example.smoke;
+package com.example.dontsmoke;
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
+import com.example.smoke.JavaExternalTypesStruct;
 public final class UseJavaExternalTypes extends NativeBase {
     /**
      * For internal use only.


### PR DESCRIPTION
Moved "UseJavaExternalTypes" IDL declaration in "external_types" smoke test to a separate package. This adds testing
cross-package imports for external types. Normally there should not be any cross-package imports there, but incorrect
import resolution logic can erroneously introduce some.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>