### PR TITLE
Fix handling of Locale type in structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Enabled validation against applying `Skip` attributes to struct fields.
   * Fixed an issue when empty documentation comment was generated in C++ instead of no documentation comment.
   * Updated HTML formatting of generated JavaDoc to be more consistent.
+  * Fixed Java and C++ compilation issues for struct fields of `Locale` type.
 
 ## 8.4.5
 Release date: 2020-10-08

--- a/examples/libhello/lime/test/Locales.lime
+++ b/examples/libhello/lime/test/Locales.lime
@@ -28,3 +28,11 @@ class Locales {
     static property localeWithMalformedCountry: Locale { get }
     static property localeWithMalformedScript: Locale { get }
 }
+
+@Equatable
+struct LocalesStruct {
+    primaryLocale: Locale
+    secondaryLocale: Locale?
+
+    static fun localesStructRoundTrip(input: LocalesStruct): LocalesStruct
+}

--- a/examples/libhello/src/test/Locales.cpp
+++ b/examples/libhello/src/test/Locales.cpp
@@ -19,6 +19,7 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "test/Locales.h"
+#include "test/LocalesStruct.h"
 
 namespace test
 {
@@ -71,4 +72,9 @@ Locales::get_locale_with_malformed_script() {
     return lorem_ipsum::test::Locale("foo", "bar", nonsense);
 }
 
-}  // namespace test
+LocalesStruct
+LocalesStruct::locales_struct_round_trip(const LocalesStruct& input) {
+    return input;
+}
+
+}

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/LocalesTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/LocalesTest.java
@@ -113,4 +113,15 @@ public class LocalesTest {
 
     Locales.getLocaleWithMalformedScript();
   }
+
+  @Test
+  public void localesStructRoundTrip() {
+    Locale locale = Locale.getDefault();
+    LocalesStruct localesStruct = new LocalesStruct(locale, locale);
+
+    LocalesStruct result = LocalesStruct.localesStructRoundTrip(localesStruct);
+
+    assertEquals(localesStruct, result);
+    assertEquals(localesStruct.hashCode(), result.hashCode());
+  }
 }

--- a/examples/platforms/dart/test/Locales_test.dart
+++ b/examples/platforms/dart/test/Locales_test.dart
@@ -73,4 +73,13 @@ void main() {
   _testSuite.test("Locale with malformed script", () {
     expect(() => Locales.localeWithMalformedScript, throwsFormatException);
   });
+  _testSuite.test("LocalesStruct method round trip", () {
+    final locale = Locale.parse(Intl.systemLocale);
+    final localesStruct = LocalesStruct(locale, locale);
+
+    final result = LocalesStruct.localesStructRoundTrip(localesStruct);
+
+    expect(result, localesStruct);
+    expect(result.hashCode == localesStruct.hashCode, isTrue);
+  });
 }

--- a/examples/platforms/ios/Tests/testTests/LocalesTests.swift
+++ b/examples/platforms/ios/Tests/testTests/LocalesTests.swift
@@ -86,6 +86,22 @@ class LocalesTests: XCTestCase {
         XCTAssertEqual(result.identifier, "foo_")
     }
 
+    func testLocalesStructRoundTrip() {
+        let locale = Locale.current
+        let localesStruct = LocalesStruct(primaryLocale: locale, secondaryLocale: locale)
+
+        let result = LocalesStruct.localesStructRoundTrip(input: localesStruct)
+
+        XCTAssertEqual(result, localesStruct)
+        XCTAssertEqual(hash(result), hash(localesStruct))
+    }
+
+    func hash<H>(_ value: H) -> Int where H: Hashable {
+        var hasher = Hasher()
+        value.hash(into: &hasher)
+        return hasher.finalize()
+    }
+
     static var allTests = [
         ("testLocaleRoundTrip", testLocaleRoundTrip),
         ("testLocaleRoundTripStripTag", testLocaleRoundTripStripTag),
@@ -95,6 +111,7 @@ class LocalesTests: XCTestCase {
         ("testLocaleWithMalformedTag", testLocaleWithMalformedTag),
         ("testLocaleWithMalformedLanguage", testLocaleWithMalformedLanguage),
         ("testLocaleWithMalformedCountry", testLocaleWithMalformedCountry),
-        ("testLocaleWithMalformedScript", testLocaleWithMalformedScript)
+        ("testLocaleWithMalformedScript", testLocaleWithMalformedScript),
+        ("testLocalesStructRoundTrip", testLocalesStructRoundTrip)
     ]
 }

--- a/gluecodium/src/main/resources/templates/cpp/common/Locale.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/common/Locale.mustache
@@ -40,6 +40,7 @@
 
 #pragma once
 
+#include "Hash.h"
 #include "Optional.h"
 #include <string>
 
@@ -82,6 +83,12 @@ struct Locale {
 
     bool operator==(const Locale& rhs) const;
     bool operator!=(const Locale& rhs) const;
+};
+
+template<>
+struct hash<Locale>
+{
+    size_t operator()(const Locale& t) const noexcept;
 };
 
 {{#internalNamespace}}

--- a/gluecodium/src/main/resources/templates/cpp/common/LocaleImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/common/LocaleImpl.mustache
@@ -115,7 +115,6 @@ Locale::operator!=(const Locale& rhs) const
     return !(*this == rhs);
 }
 
-template<>
 std::size_t
 hash<Locale>::operator()(const Locale& t) const noexcept {
     size_t hash_value = 43;

--- a/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsHeader.mustache
@@ -26,6 +26,7 @@
 
 #include "JniCppConversionUtils.h"
 #include "JniReference.h"
+#include "{{>common/InternalInclude}}Locale.h"
 #include "{{>common/InternalInclude}}Optional.h"
 
 #include <chrono>
@@ -138,6 +139,17 @@ double get_field_value(
     const char* fieldName,
     {{>common/InternalNamespace}}optional< ::std::chrono::system_clock::time_point >* );
 
+{{>common/InternalNamespace}}Locale get_field_value(
+    JNIEnv* env,
+    const JniReference< jobject >& object,
+    const char* fieldName,
+    {{>common/InternalNamespace}}Locale* );
+{{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Locale > get_field_value(
+    JNIEnv* env,
+    const JniReference< jobject >& object,
+    const char* fieldName,
+    {{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Locale* > );
+
 JniReference< jobject > get_object_field_value( JNIEnv* env,
                                        const JniReference<jobject>& object,
                                        const char* fieldName,
@@ -238,6 +250,15 @@ void set_field_value( JNIEnv* env,
                       const JniReference<jobject>& object,
                       const char* fieldName,
                       {{>common/InternalNamespace}}optional< ::std::chrono::system_clock::time_point > fieldValue );
+
+void set_field_value( JNIEnv* env,
+                      const JniReference<jobject>& object,
+                      const char* fieldName,
+                      const {{>common/InternalNamespace}}Locale& fieldValue );
+void set_field_value( JNIEnv* env,
+                      const JniReference<jobject>& object,
+                      const char* fieldName,
+                      {{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Locale > fieldValue );
 
 void set_object_field_value( JNIEnv* env,
                              const JniReference<jobject>& object,

--- a/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsImplementation.mustache
@@ -345,6 +345,30 @@ get_field_value( JNIEnv* env,
         env, fieldValue, ({{>common/InternalNamespace}}optional< std::chrono::system_clock::time_point >*)nullptr );
 }
 
+{{>common/InternalNamespace}}Locale
+get_field_value( JNIEnv* env,
+                 const JniReference<jobject>& object,
+                 const char* fieldName,
+                 {{>common/InternalNamespace}}Locale* )
+{
+    auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/util/Locale;" );
+
+    return {{>common/InternalNamespace}}jni::convert_from_jni(
+        env, fieldValue, ({{>common/InternalNamespace}}Locale*)nullptr );
+}
+
+{{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Locale >
+get_field_value( JNIEnv* env,
+                 const JniReference<jobject>& object,
+                 const char* fieldName,
+                 {{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Locale >* )
+{
+    auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/util/Locale;" );
+
+    return {{>common/InternalNamespace}}jni::convert_from_jni(
+        env, fieldValue, ({{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Locale >*)nullptr );
+}
+
 JniReference<jobject>
 get_object_field_value( JNIEnv* env,
                         const JniReference<jobject>& object,
@@ -652,6 +676,28 @@ set_field_value( JNIEnv* env,
                  {{>common/InternalNamespace}}optional< std::chrono::system_clock::time_point > fieldValue )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "Ljava/util/Date;" );
+    auto jValue = {{>common/InternalNamespace}}jni::convert_to_jni( env, fieldValue );
+    env->SetObjectField( object.get(), fieldId, jValue.get() );
+}
+
+void
+set_field_value( JNIEnv* env,
+                 const JniReference<jobject>& object,
+                 const char* fieldName,
+                 const {{>common/InternalNamespace}}Locale& fieldValue )
+{
+    auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "Ljava/util/Locale;" );
+    auto jValue = {{>common/InternalNamespace}}jni::convert_to_jni( env, fieldValue );
+    env->SetObjectField( object.get(), fieldId, jValue.get() );
+}
+
+void
+set_field_value( JNIEnv* env,
+                 const JniReference<jobject>& object,
+                 const char* fieldName,
+                 {{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Locale > fieldValue )
+{
+    auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "Ljava/util/Locale;" );
     auto jValue = {{>common/InternalNamespace}}jni::convert_to_jni( env, fieldValue );
     env->SetObjectField( object.get(), fieldId, jValue.get() );
 }


### PR DESCRIPTION
Added missing (get/set)_field_value() functions for Locale type
to JNI templates. This fixes a Java compilation issue when
Locale type is used for a struct field.

Also updated C++ Locale templates to correctly expose the hasher 
functor. This is intended to fix a C++ compilation issue for some compilers.

Added functional tests for usage of Locale type in struct fields.

Resolves: #546
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>