### PR TITLE
Adds script to run cmake unit tests.

### DIFF
--- a/cmake/.gitignore
+++ b/cmake/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+_test_build

--- a/cmake/run-cmake-unit-test.cmake
+++ b/cmake/run-cmake-unit-test.cmake
@@ -1,0 +1,67 @@
+#!/usr/bin/env cmake -P
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+# Script is configured with following environment variables:
+#
+#   CTEST_FILTER                    Filter tests. Parameter is passed
+#                                   as regex to ctest like:
+#                                   ctest -R $ENV{CTEST_FILTER}
+#
+#   GLUECODIUM_BUILD_ENVIRONMENT    Build environment to run unit tests.
+#                                   Next environments are supported:
+#                                   android-x86_64, ios-x86_64
+#
+# Example:
+# > GLUECODIUM_BUILD_ENVIRONMENT=ios-x86_64 CTEST_FILTER="example" ./run-cmake-unit-test.cmake
+
+set (TEST_BUILD_DIR "${CMAKE_CURRENT_LIST_DIR}/_test_build")
+set (OUTPUT_FILE cmake_unit_test_output.txt)
+set (DIRECTORY_WRITH_TESTS "${CMAKE_CURRENT_LIST_DIR}/tests")
+
+list (APPEND cmake_module_paths ${CMAKE_MODULE_PATH} "${DIRECTORY_WRITH_TESTS}")
+
+function (heresdk_configure_cmake)
+    file (MAKE_DIRECTORY ${TEST_BUILD_DIR})
+    set (_test_output_file "${TEST_BUILD_DIR}/${OUTPUT_FILE}")
+    file (REMOVE "${_test_output_file}")
+    execute_process (
+        COMMAND
+            ${CMAKE_COMMAND} -Wno-dev ${DIRECTORY_WRITH_TESTS}
+            -DTEST_OUTPUT_FILE=${_test_output_file}
+            "-DCMAKE_MODULE_PATH=${cmake_module_paths}"
+            ${ARGN}
+        WORKING_DIRECTORY ${TEST_BUILD_DIR}
+        RESULT_VARIABLE CMAKE_PROCESS_RESULT)
+    if (CMAKE_PROCESS_RESULT)
+        message (FATAL_ERROR "CMake configuration failed")
+    endif ()
+endfunction ()
+
+function (heresdk_test_cmake)
+    if (DEFINED ENV{CTEST_FILTER})
+        set (_filter -R $ENV{CTEST_FILTER})
+    endif ()
+    execute_process (COMMAND ${CMAKE_CTEST_COMMAND} --verbose -C "Debug" ${_filter}
+                     WORKING_DIRECTORY ${TEST_BUILD_DIR} RESULT_VARIABLE CMAKE_PROCESS_RESULT)
+    if (CMAKE_PROCESS_RESULT)
+        message (FATAL_ERROR "CMake test failed")
+    endif ()
+endfunction ()
+
+heresdk_configure_cmake ()
+heresdk_test_cmake ()

--- a/cmake/tests/CMakeLists.txt
+++ b/cmake/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.5)
+
+project (cmake_test)
+
+include (run_tests.cmake)

--- a/cmake/tests/run_tests.cmake
+++ b/cmake/tests/run_tests.cmake
@@ -1,0 +1,240 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+function (
+    prepare_detailed_information
+    result
+    testname
+    status
+    result_config
+    output_config
+    result_build
+    output_build
+    expectation_msg)
+    set (
+        ${result}
+        "Test ${testname} ... ${status}:
+##############################################################
+
+CONFIGURE STEP (retcode ${result_config}):
+
+${output_config}
+
+BUILD STEP (retcode ${result_build}):
+
+${output_build}
+
+##############################################################
+
+  ${expectation_msg}
+
+"
+        PARENT_SCOPE)
+endfunction ()
+
+function (print_output_information msgtype text)
+    if (TEST_OUTPUT_FILE)
+        file (APPEND "${TEST_OUTPUT_FILE}" ${text} "\n")
+    endif ()
+
+    if ("${msgtype}" STREQUAL "FATAL_ERROR" OR NOT TEST_OUTPUT_FILE)
+        message (${msgtype} "${text}")
+    endif ()
+endfunction ()
+
+function (
+    print_detailed_information
+    msgtype
+    testname
+    status
+    result_config
+    output_config
+    result_build
+    output_build
+    expectation_msg)
+    prepare_detailed_information (
+        detailed_info
+        ${testname}
+        ${status}
+        ${result_config}
+        "${output_config}"
+        ${result_build}
+        "${output_build}"
+        "${expectation_msg}")
+    print_output_information (${msgtype} "${detailed_info}")
+endfunction ()
+
+function (get_parameters_for_build_environment result)
+    if (NOT GLUECODIUM_BUILD_ENVIRONMENT)
+        set (${result} "-GUnix Makefiles" PARENT_SCOPE)
+        return()
+    endif ()
+
+    unset (_params)
+
+    if (GLUECODIUM_BUILD_ENVIRONMENT STREQUAL "ios-x86_64")
+        list (APPEND _params
+            -GXcode
+            -DCMAKE_OSX_ARCHITECTURES=x86_64
+            -DCMAKE_OSX_SYSROOT=iphonesimulator
+            -DCMAKE_SYSTEM_NAME=iOS)
+    elseif (GLUECODIUM_BUILD_ENVIRONMENT STREQUAL "android-x86_64")
+        if (NOT DEFINED ENV{ANDROID_HOME} OR NOT DEFINED ENV{ANDROID_NDK_HOME})
+            message(FATAL_ERROR "Environment variable must be set: ANDROID_HOME")
+        endif ()
+        list (APPEND _params
+            -GNinja
+            -DANDROID_ABI=x86_64
+            -DANDROID_PLATFORM=android-21
+            -DANDROID_HOME=$ENV{ANDROID_HOME}
+            -DANDROID_STL=c++_shared
+            -DCMAKE_TOOLCHAIN_FILE=$ENV{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake)
+    else ()
+        message(FATAL_ERROR "Unknown build environment: ${GLUECODIUM_BUILD_ENVIRONMENT}")
+    endif ()
+
+    set (${result} ${_params} PARENT_SCOPE)
+endfunction ()
+
+# This function will be invoked when run in script mode:
+function (base_devel_run_test test_file builddir)
+    cmake_minimum_required (VERSION 3.5)
+
+    if (NOT _TEST_DIR)
+        print_output_information (FATAL_ERROR "Cannot run without a test directory!")
+    endif ()
+
+    get_filename_component (testname "${test_file}" NAME)
+    file (REMOVE_RECURSE "${builddir}")
+    file (MAKE_DIRECTORY "${builddir}")
+    if ($ENV{ENABLE_TRACING})
+        set (maybe_trace "--trace-expand")
+    endif ()
+
+    get_parameters_for_build_environment (_env_params)
+
+    execute_process (
+        COMMAND
+            ${CMAKE_COMMAND} ${maybe_trace} "-DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}"
+            "-DGLUECODIUM_CMAKE_TESTS_DIR=${CMAKE_CURRENT_LIST_DIR}"
+            "-DGLUECODIUM_CMAKE_DIR=${CMAKE_CURRENT_LIST_DIR}/.."
+            ${_env_params}
+            ${test_file}
+        WORKING_DIRECTORY "${builddir}"
+        OUTPUT_VARIABLE output_config
+        ERROR_VARIABLE output_config
+        RESULT_VARIABLE result_config)
+
+    set (result_build "NOT-RUN") # default value
+    if (result_config EQUAL 0)
+        execute_process (
+            COMMAND ${CMAKE_COMMAND} --build .
+            WORKING_DIRECTORY "${builddir}"
+            OUTPUT_VARIABLE output_build
+            ERROR_VARIABLE output_build
+            RESULT_VARIABLE result_build)
+    endif ()
+
+    set (expectations_matched TRUE)
+    set (expectation_file "${test_file}/successful.regex")
+    if (EXISTS "${expectation_file}" AND NOT output_config MATCHES "skipping this test")
+        print_output_information (STATUS "Checking expectations ...")
+        file (STRINGS "${expectation_file}" expectations)
+        string (REGEX REPLACE "[\n\r]" "" output_to_match "${output_config}" "${output_build}")
+        string (REGEX REPLACE "[ ]+" " " output_to_match "${output_to_match}")
+        set (i 0)
+        foreach (expectation IN LISTS expectations)
+            if (NOT expectation)
+                continue ()
+            endif ()
+
+            math (EXPR i "${i} + 1")
+            string (REGEX MATCH "${expectation}" matched "${output_to_match}")
+            if (NOT matched)
+                set (expectations_matched FALSE)
+                set (failed_expectation "${expectation}")
+                # You can uncomment the following line for debug: file(WRITE ${builddir}/runtest-
+                # remanining-output.txt
+                # "${output_to_match}")
+                break ()
+            else ()
+                string (FIND "${output_to_match}" "${matched}" pos)
+                string (LENGTH "${matched}" len)
+                math (EXPR pos "${pos} + ${len}")
+                string (SUBSTRING "${output_to_match}" ${pos} -1 output_to_match)
+            endif ()
+        endforeach ()
+        print_output_information (STATUS "Checking expectations ... done")
+    endif ()
+
+    # tests ending with the '-XFAIL' suffix are eXpected to FAIL, so we invert the result condition
+    # for them.
+    if (((NOT test_file MATCHES "-XFAIL$" AND result_config EQUAL 0 AND result_build EQUAL 0)
+         OR (test_file MATCHES "-XFAIL$" AND NOT (result_config EQUAL 0 AND result_build EQUAL 0)))
+        AND expectations_matched)
+        set (msgtype STATUS)
+        set (status "passed")
+    else ()
+        set (msgtype FATAL_ERROR)
+        set (status "failed")
+        if (NOT expectations_matched)
+            set (expectation_msg "Failed to match expectation ${i}:\n    * ${failed_expectation}")
+        endif ()
+    endif ()
+
+    print_detailed_information (
+        ${msgtype}
+        ${testname}
+        ${status}
+        ${result_config}
+        "${output_config}"
+        ${result_build}
+        "${output_build}"
+        "${expectation_msg}")
+
+endfunction (base_devel_run_test)
+
+# --- if run in script mode, run the test: -------------------------
+
+if (CMAKE_SCRIPT_MODE_FILE)
+    base_devel_run_test (${_CURRENT_TEST} ${_TEST_DIR})
+    return ()
+endif ()
+
+# --- else, just add all tests to the list -------------------------
+
+file (GLOB tests ${CMAKE_CURRENT_SOURCE_DIR}/unit/*/*)
+list (SORT tests)
+
+enable_testing ()
+
+foreach (test_file IN LISTS tests)
+    file (RELATIVE_PATH relpath "${CMAKE_CURRENT_SOURCE_DIR}/unit" "${test_file}")
+    if (NOT IS_DIRECTORY ${test_file} OR test_file MATCHES "-DISABLED$")
+        continue ()
+    endif ()
+    set (test_name "${PROJECT_NAME}.${relpath}")
+
+    add_test (
+        NAME "${test_name}"
+        COMMAND
+            ${CMAKE_COMMAND}
+            "-DGLUECODIUM_BUILD_ENVIRONMENT=$ENV{GLUECODIUM_BUILD_ENVIRONMENT}"
+            "-DCMAKE_MODULE_PATH=${CMAKE_MODULE_PATH}" "-D_CURRENT_TEST=${test_file}"
+            "-D_TEST_DIR=${CMAKE_CURRENT_BINARY_DIR}/test/${relpath}"
+            "-DTEST_OUTPUT_FILE=${TEST_OUTPUT_FILE}" -P ${CMAKE_CURRENT_LIST_FILE})
+endforeach ()

--- a/cmake/tests/unit/example/example-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/example/example-XFAIL/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.12)
+
+include (${GLUECODIUM_CMAKE_TESTS_DIR}/utils/assert.cmake)
+
+test_assert_true(CONDITION FALSE MESSAGE "Should fail with this message")

--- a/cmake/tests/unit/example/example-XFAIL/successful.regex
+++ b/cmake/tests/unit/example/example-XFAIL/successful.regex
@@ -1,0 +1,1 @@
+Should fail with this message

--- a/cmake/tests/unit/example/example_success/CMakeLists.txt
+++ b/cmake/tests/unit/example/example_success/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.12)
+
+include (${GLUECODIUM_CMAKE_TESTS_DIR}/utils/assert.cmake)
+
+test_assert_true(CONDITION TRUE MESSAGE "Check that condition is true")

--- a/cmake/tests/utils/assert.cmake
+++ b/cmake/tests/utils/assert.cmake
@@ -1,0 +1,604 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+include (${CMAKE_CURRENT_LIST_DIR}/message_colored.cmake)
+
+#[=======================================================================[.rst:
+
+.. command:test_assert_true
+
+If variables are specified checks that theirs values are 1, ON, YES, TRUE, Y, or a non-zero number.
+If condition is specified checks that it's TRUE with if/else clauses.
+Prints error and breaks execution if any of checks didn't pass.
+
+  test_assert_true(
+     [VARIABLE] <variable_name>             # Variable or variable list to check
+     [CONDITION] <condition>                # Condition to check. It's possible to pass any condition which
+                                            # default CMake's if/else clauses may process.
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_expect_true
+
+If variables are specified checks that theirs values are 1, ON, YES, TRUE, Y, or a non-zero number.
+If condition is specified checks that it's TRUE with if/else clauses.
+Prints error but doesn't break execution if any of checks didn't pass.
+
+  test_expect_true(
+     [VARIABLE] <variable_name>             # Variable or variable list to check
+     [CONDITION] <condition>                # Condition to check. It's possible to pass any condition which
+                                            # default CMake's if/else clauses may process.
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_assert_false
+
+Checks that variable's value is 0, OFF, NO, FALSE, N, IGNORE, NOTFOUND, the empty string,
+or ends in the suffix -NOTFOUND. If condition is specified checks that it's FALSE with if/else clauses.
+Prints error and breaks execution if any of checks didn't pass.
+
+  test_assert_false(
+     [VARIABLE] <variable_name>             # Variable or variable list to check
+     [CONDITION] <condition>                # Condition to check. It's possible to pass any condition which
+                                            # default CMake's if/else clauses may process.
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_expect_false
+
+Checks that variable's value is 0, OFF, NO, FALSE, N, IGNORE, NOTFOUND, the empty string,
+or ends in the suffix -NOTFOUND. If condition is specified checks that it's FALSE with if/else clauses.
+Prints error but doesn't break execution if any of checks didn't pass.
+
+  test_expect_false(
+     VARIABLE <variable_name>               # Variable to check
+     [CONDITION] <condition>                # Condition to check. It's possible to pass any condition which
+                                            # default CMake's if/else clauses may process.
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_assert_strequal
+
+Checks that arguments are STREQUAL. Prints error and breaks execution in case if values are mismatched
+  test_assert_strequal(
+     EXPECTED <expected>                    # Expected value
+     ACTUAL <actual>                        # Actual value
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_expect_strequal
+
+Checks that arguments are STREQUAL. Prints error but doesn't break execution in case if values are mismatched
+  test_expect_strequal(
+     EXPECTED <expected>                    # Expected value
+     ACTUAL <actual>                        # Actual value
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_assert_not_strequal
+
+Checks that arguments are NOT STREQUAL. Prints error and breaks execution in case if values are matched
+  test_assert_not_strequal(
+     EXPECTED <expected>                    # Expected value
+     ACTUAL <actual>                        # Actual value
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_expect_not_strequal
+
+Checks that arguments are NOT STREQUAL. Prints error but doesn't break execution in case if values are matched
+  test_expect_not_strequal(
+     EXPECTED <expected>                    # Expected value
+     ACTUAL <actual>                        # Actual value
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_assert_matches_regex
+
+Checks that actual value matches to expected regex. Prints error and breaks execution in case if values are mismatched
+  test_assert_matches_regex(
+     EXPECTED <expected_regex>              # Expected regex
+     ACTUAL <actual>                        # Actual value
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_expect_matches_regex
+
+Checks that actual value matches to expected regex. Prints error but doesn't break execution in case if values are mismatched
+  test_expect_matches_regex(
+     EXPECTED <expected_regex>              # Expected regex
+     ACTUAL <actual>                        # Actual value
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_assert_defined
+
+Checks that variable is defined. Prints error and breaks execution in case if variable is not defined
+  test_assert_defined(
+     VARIABLE <variable_name>               # Variable to check
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_expect_defined
+
+Checks that variable is defined. Prints error but doesn't breakg execution in case if variable is not defined
+  test_expect_defined(
+     VARIABLE <variable_name>               # Variable to check
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_assert_not_defined
+
+Checks that variable is NOT defined. Prints error and breaks execution in case if variable is defined
+  test_assert_not_defined(
+     VARIABLE <variable_name>               # Variable to check
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_expect_not_defined
+
+Checks that variable is NOT defined. Prints error but doesn't break execution in case if variable is defined
+  test_expect_not_defined(
+     VARIABLE <variable_name>               # Variable to check
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_assert_strequal_lists
+
+Checks that lists have same count of items and items at the same positions are STREQUAL.
+Prints error and breaks execution in case if values are mismatched
+  test_assert_strequal_lists(
+     EXPECTED item1 item2 ...               # Expected list
+     ACTUAL item1 item2 ...                 # Actual list
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_expect_strequal_lists
+
+Checks that lists have same count of items and items at the same positions are STREQUAL.
+Prints error but doesn't break execution in case if values are mismatched
+  test_expect_strequal_lists(
+     EXPECTED item1 item2 ...               # Expected list
+     ACTUAL item1 item2 ...                 # Actual list
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_assert_execute_process_succeed
+
+Checks that process was executed and succeed. Prints execution output, error and breaks execution
+if execution failed.
+  test_assert_execute_process_succeed(
+     option1 option2 ...                    # All options will be passed to CMake execute_process function
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_assert_execute_process_failed
+
+Checks that process was executed and failed. Prints execution output and breaks execution
+if execution succeed.
+  test_assert_execute_process_failed(
+     option1 option2 ...                    # All options will be passed to CMake execute_process function
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_expect_execute_process_succeed
+
+Checks that process was executed and succeed. Prints execution output and error
+if execution failed.
+  test_expect_execute_process_succeed(
+     option1 option2 ...                    # All options will be passed to CMake execute_process function
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+
+.. command:test_expect_execute_process_failed
+
+Checks that process was executed and failed. Prints execution output if execution succeed.
+  test_expect_execute_process_failed(
+     option1 option2 ...                    # All options will be passed to CMake execute_process function
+     [MESSAGE] "message1" "message1" ...    # Optional message list to display in case of failed test
+   )
+
+#]=======================================================================]
+
+function (_report_test_error mode additional_message)
+    set (_message "")
+    foreach (arg ${ARGN})
+        set (_message "${_message}
+        ${arg}")
+    endforeach ()
+    if (additional_message)
+        set (_message "${_message}
+        Message: ${additional_message}")
+    endif ()
+
+    message_colored (RED ${mode} "${_message}")
+endfunction ()
+
+macro (_test_parse_variable_message)
+    unset (_test_check_parameters_args_MESSAGE)
+    unset (_test_check_parameters_args_VARIABLE)
+
+    set (_multi_value_args VARIABLE MESSAGE)
+
+    cmake_parse_arguments (_test_check_parameters_args "" "" "${_multi_value_args}" ${ARGN})
+endmacro ()
+
+macro (_test_parse_condition_variable_message)
+    unset (_test_check_parameters_args_MESSAGE)
+    unset (_test_check_parameters_args_VARIABLE)
+    unset (_test_check_parameters_args_CONDITION)
+
+    set (_multi_value_args CONDITION VARIABLE MESSAGE)
+
+    cmake_parse_arguments (_test_check_parameters_args "" "" "${_multi_value_args}" ${ARGN})
+
+    if (NOT DEFINED _test_check_parameters_args_VARIABLE AND NOT DEFINED
+                                                             _test_check_parameters_args_CONDITION)
+        _report_test_error (FATAL_ERROR "Either VARIABLE or CONDITION parameter should be passed")
+    endif ()
+endmacro ()
+
+macro (_test_parse_expected_actual_message)
+    unset (_test_check_parameters_args_EXPECTED)
+    unset (_test_check_parameters_args_ACTUAL)
+    unset (_test_check_parameters_args_MESSAGE)
+
+    set (_single_value_args EXPECTED ACTUAL)
+    set (_multi_value_args MESSAGE)
+
+    cmake_parse_arguments (_test_check_parameters_args "" "${_single_value_args}"
+                           "${_multi_value_args}" ${ARGN})
+
+    if (NOT DEFINED _test_check_parameters_args_EXPECTED)
+        if (EXPECTED IN_LIST ARGN)
+            set (_test_check_parameters_args_EXPECTED "")
+        else ()
+            _report_test_error (FATAL_ERROR "Missed EXPECTED parameter")
+        endif ()
+    endif ()
+
+    if (NOT DEFINED _test_check_parameters_args_ACTUAL)
+        if (ACTUAL IN_LIST ARGN)
+            set (_test_check_parameters_args_ACTUAL "")
+        else ()
+            _report_test_error (FATAL_ERROR "Missed ACTUAL parameter")
+        endif ()
+    endif ()
+endmacro ()
+
+macro (_test_parse_multi_expected_actual_message)
+    unset (_test_check_parameters_args_EXPECTED)
+    unset (_test_check_parameters_args_ACTUAL)
+    unset (_test_check_parameters_args_MESSAGE)
+
+    set (_multi_value_args EXPECTED ACTUAL MESSAGE)
+
+    cmake_parse_arguments (_test_check_parameters_args "" "" "${_multi_value_args}" ${ARGN})
+
+    if (NOT DEFINED _test_check_parameters_args_EXPECTED)
+        if (EXPECTED IN_LIST ARGN)
+            set (_test_check_parameters_args_EXPECTED "")
+        else ()
+            _report_test_error (FATAL_ERROR "Missed EXPECTED parameter")
+        endif ()
+    endif ()
+
+    if (NOT DEFINED _test_check_parameters_args_ACTUAL)
+        if (ACTUAL IN_LIST ARGN)
+            set (_test_check_parameters_args_ACTUAL "")
+        else ()
+            _report_test_error (FATAL_ERROR "Missed ACTUAL parameter")
+        endif ()
+    endif ()
+endmacro ()
+
+function (_test_check_strequal message_mode)
+    _test_parse_expected_actual_message (${ARGN})
+
+    if (NOT _test_check_parameters_args_EXPECTED STREQUAL _test_check_parameters_args_ACTUAL)
+        _report_test_error (
+            ${message_mode} "${_test_check_parameters_args_MESSAGE}"
+            "Comparison failed" "Expected:  ${_test_check_parameters_args_EXPECTED}"
+            "Actual:    ${_test_check_parameters_args_ACTUAL}")
+    endif ()
+endfunction ()
+
+function (test_assert_strequal)
+    _test_check_strequal (FATAL_ERROR ${ARGN})
+endfunction ()
+
+function (test_expect_strequal)
+    _test_check_strequal (SEND_ERROR ${ARGN})
+endfunction ()
+
+function (_test_check_not_strequal message_mode)
+    _test_parse_expected_actual_message (${ARGN})
+
+    if (_test_check_parameters_args_EXPECTED STREQUAL _test_check_parameters_args_ACTUAL)
+        _report_test_error (
+            ${message_mode} "${_test_check_parameters_args_MESSAGE}"
+            "Comparison failed" "Expected:  Not equal to ${_test_check_parameters_args_EXPECTED}"
+            "Actual:    ${_test_check_parameters_args_ACTUAL}")
+    endif ()
+endfunction ()
+
+function (test_assert_not_strequal)
+    _test_check_not_strequal (FATAL_ERROR ${ARGN})
+endfunction ()
+
+function (test_expect_not_strequal)
+    _test_check_not_strequal (SEND_ERROR ${ARGN})
+endfunction ()
+
+function (_test_check_matches_regex message_mode)
+    _test_parse_expected_actual_message (${ARGN})
+
+    if (NOT _test_check_parameters_args_ACTUAL MATCHES ${_test_check_parameters_args_EXPECTED})
+        _report_test_error (
+            ${message_mode} "${_test_check_parameters_args_MESSAGE}"
+            "Regex matching failed"
+            "Expected:  Matches to regex '${_test_check_parameters_args_EXPECTED}'"
+            "Actual:    '${_test_check_parameters_args_ACTUAL}'")
+    endif ()
+endfunction ()
+
+function (test_assert_matches_regex)
+    _test_check_matches_regex (FATAL_ERROR ${ARGN})
+endfunction ()
+
+function (test_expect_matches_regex)
+    _test_check_matches_regex (SEND_ERROR ${ARGN})
+endfunction ()
+
+function (_test_check_defined message_mode)
+    _test_parse_variable_message (${ARGN})
+
+    if (NOT DEFINED ${_test_check_parameters_args_VARIABLE})
+        _report_test_error (
+            ${message_mode} "${_test_check_parameters_args_MESSAGE}"
+            "Variable check definition failed"
+            "Expected:  Variable '${_test_check_parameters_args_VARIABLE}' defined"
+            "Actual:    Not defined")
+    endif ()
+endfunction ()
+
+function (test_assert_defined)
+    _test_check_defined (FATAL_ERROR ${ARGN})
+endfunction ()
+
+function (test_expect_defined)
+    _test_check_defined (SEND_ERROR ${ARGN})
+endfunction ()
+
+function (_test_check_not_defined message_mode)
+    _test_parse_variable_message (${ARGN})
+
+    if (DEFINED ${_test_check_parameters_args_VARIABLE})
+        _report_test_error (
+            ${message_mode} "${_test_check_parameters_args_MESSAGE}"
+            "Variable check definition failed"
+            "Expected:  Variable '${_test_check_parameters_args_VARIABLE}' NOT defined"
+            "Actual:    Defined and contains: ${${_test_check_parameters_args_VARIABLE}}")
+    endif ()
+endfunction ()
+
+function (test_assert_not_defined)
+    _test_check_not_defined (FATAL_ERROR ${ARGN})
+endfunction ()
+
+function (test_expect_not_defined)
+    _test_check_not_defined (SEND_ERROR ${ARGN})
+endfunction ()
+
+function (_test_check_true message_mode)
+    unset (_test_check_parameters_args_CONDITION)
+    _test_parse_condition_variable_message (${ARGN})
+    foreach (_var ${_test_check_parameters_args_VARIABLE})
+        if (NOT ${_var})
+            if (NOT DEFINED ${_var})
+                set (_actual_status "Not defined")
+            else ()
+                set (_actual_status "${${_var}}")
+            endif ()
+            _report_test_error (
+                ${message_mode} "${_test_check_parameters_args_MESSAGE}"
+                "Variable boolean check failed"
+                "Expected:  Variable '${_var}' is 1, ON, YES, TRUE, Y, or a non-zero number"
+                "Actual:    ${_actual_status}")
+        endif ()
+    endforeach ()
+    if (DEFINED _test_check_parameters_args_CONDITION)
+        if (${_test_check_parameters_args_CONDITION})
+
+        else ()
+            string (REPLACE ";" " " _condition "${_test_check_parameters_args_CONDITION}")
+            _report_test_error (${message_mode} "${_test_check_parameters_args_MESSAGE}"
+                                "Condition expectation failed: '${_condition}'")
+        endif ()
+    endif ()
+endfunction ()
+
+function (test_assert_true)
+    _test_check_true (FATAL_ERROR ${ARGN})
+endfunction ()
+
+function (test_expect_true)
+    _test_check_true (SEND_ERROR ${ARGN})
+endfunction ()
+
+function (_test_check_false message_mode)
+    unset (_test_check_parameters_args_CONDITION)
+    _test_parse_condition_variable_message (${ARGN})
+    foreach (_var ${_test_check_parameters_args_VARIABLE})
+        if (${_var})
+            _report_test_error (
+                ${message_mode} "${_test_check_parameters_args_MESSAGE}"
+                "Variable boolean check failed"
+                "Expected:  Variable '${_var}' is 0, OFF, NO, FALSE, N, IGNORE, NOTFOUND, the empty string, or ends in the suffix -NOTFOUND"
+                "Actual:    ${${_var}}")
+        endif ()
+    endforeach ()
+    if (DEFINED _test_check_parameters_args_CONDITION)
+        if (${_test_check_parameters_args_CONDITION})
+            string (REPLACE ";" " " _condition "${_test_check_parameters_args_CONDITION}")
+            _report_test_error (${message_mode} "${_test_check_parameters_args_MESSAGE}"
+                                "Condition expectation failed: NOT (${_condition})")
+        endif ()
+    endif ()
+endfunction ()
+
+function (test_assert_false)
+    _test_check_false (FATAL_ERROR ${ARGN})
+endfunction ()
+
+function (test_expect_false)
+    _test_check_false (SEND_ERROR ${ARGN})
+endfunction ()
+
+function (_test_check_strequal_lists message_mode)
+    _test_parse_multi_expected_actual_message (${ARGN})
+
+    list (LENGTH _test_check_parameters_args_EXPECTED expected_length)
+    list (LENGTH _test_check_parameters_args_ACTUAL actual_length)
+
+    unset (_error_message)
+
+    if (NOT expected_length STREQUAL actual_length)
+        list (
+            APPEND _error_message
+                   "List lengths mismatched"
+                   "Expected list length:  ${expected_length}"
+                   "Actual list length:    ${actual_length}")
+    endif ()
+
+    if (NOT _error_message)
+        if (expected_length EQUAL 0)
+            return ()
+        endif ()
+
+        math (EXPR expected_length "${expected_length} - 1")
+
+        foreach (index RANGE ${expected_length})
+            list (GET _test_check_parameters_args_EXPECTED ${index} expected_item)
+            list (GET _test_check_parameters_args_ACTUAL ${index} actual_item)
+            if (NOT expected_item STREQUAL actual_item)
+                list (APPEND _error_message "Mismatch at position ${index}")
+            endif ()
+        endforeach ()
+    endif ()
+
+    if (_error_message)
+        string (REPLACE ";" ", " _test_check_parameters_args_EXPECTED
+                        "${_test_check_parameters_args_EXPECTED}")
+        string (REPLACE ";" ", " _test_check_parameters_args_ACTUAL
+                        "${_test_check_parameters_args_ACTUAL}")
+        list (APPEND _error_message "Expected list: [${_test_check_parameters_args_EXPECTED}]"
+                     "Actual list: [${_test_check_parameters_args_ACTUAL}]")
+        _report_test_error (${message_mode} "${_test_check_parameters_args_MESSAGE}"
+                            ${_error_message})
+    endif ()
+endfunction ()
+
+function (test_assert_strequal_lists)
+    _test_check_strequal_lists (FATAL_ERROR ${ARGN})
+endfunction ()
+
+function (test_expect_strequal_lists)
+    _test_check_strequal_lists (SEND_ERROR ${ARGN})
+endfunction ()
+
+function (_test_check_execute_process message_mode expect_success)
+    set (_single_args RESULT_VARIABLE RESULTS_VARIABLE OUTPUT_VARIABLE ERROR_VARIABLE MESSAGE)
+    cmake_parse_arguments (_args "" "${_single_args}" "" ${ARGN})
+
+    if (_args_RESULTS_VARIABLE)
+        message (FATAL_ERROR "RESULTS_VARIABLE is not supported")
+    endif ()
+
+    if (_args_OUTPUT_VARIABLE AND _args_ERROR_VARIABLE AND NOT _args_OUTPUT_VARIABLE STREQUAL
+                                                           _args_ERROR_VARIABLE)
+        message (
+            FATAL_ERROR "Case when OUTPUT_VARIABLE is NOT equal to ERROR_VARIABLE not supported")
+    endif ()
+
+    execute_process (
+        ${_args_UNPARSED_ARGUMENTS}
+        RESULT_VARIABLE _utils_asserts_result
+        OUTPUT_VARIABLE _utils_asserts_output
+        ERROR_VARIABLE _utils_asserts_output
+        OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE)
+
+    if (_args_RESULT_VARIABLE)
+        set (${_args_RESULT_VARIABLE} ${_utils_asserts_result} PARENT_SCOPE)
+    endif ()
+    if (_args_OUTPUT_VARIABLE)
+        set (${_args_OUTPUT_VARIABLE} ${_utils_asserts_output} PARENT_SCOPE)
+    endif ()
+
+    if (expect_success)
+        if (_utils_asserts_result)
+            _report_test_error (
+                ${message_mode} "${_args_MESSAGE}"
+                "Execution failed." "Exit code: ${_utils_asserts_result}"
+                "Output:" "============================================"
+                ${_utils_asserts_output} "============================================")
+        endif ()
+    else ()
+        if (NOT _utils_asserts_result)
+            _report_test_error (
+                ${message_mode} "${_args_MESSAGE}"
+                "Execution succeed" "Output:"
+                "============================================" ${_utils_asserts_output}
+                "============================================")
+        endif ()
+    endif ()
+endfunction ()
+
+macro (test_assert_execute_process_succeed)
+    _test_check_execute_process (FATAL_ERROR YES ${ARGN})
+endmacro ()
+
+macro (test_assert_execute_process_failed)
+    _test_check_execute_process (FATAL_ERROR NO ${ARGN})
+endmacro ()
+
+macro (test_expect_execute_process_succeed)
+    _test_check_execute_process (SEND_ERROR YES ${ARGN})
+endmacro ()
+
+macro (test_expect_execute_process_failed)
+    _test_check_execute_process (SEND_ERROR NO ${ARGN})
+endmacro ()

--- a/cmake/tests/utils/message_colored.cmake
+++ b/cmake/tests/utils/message_colored.cmake
@@ -1,0 +1,52 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+#[=======================================================================[.rst:
+
+.. command:message_colored
+
+Function prints text like standart CMake's message but also can apply
+color in terminal.
+  message_colored(
+     <color>              # Color to print text. Acceptable values: RED, GREEN, YELLOW, BLUE, WHITE
+     [<mode>]             # Type of message. The same as <mode> variable for standart 'message' function
+                          # please refer to official documentation for detailed information.
+     "message to display" # Message or list of messages to display
+   )
+#]=======================================================================]
+
+function (message_colored COLOR MODE)
+    string (ASCII 27 Esc)
+    set (COLOR_RESET "${Esc}[m")
+
+    if (${COLOR} STREQUAL "RED")
+        set (COLOR_STRING "${Esc}[31m")
+    elseif (${COLOR} STREQUAL "GREEN")
+        set (COLOR_STRING "${Esc}[32m")
+    elseif (${COLOR} STREQUAL "YELLOW")
+        set (COLOR_STRING "${Esc}[33m")
+    elseif (${COLOR} STREQUAL "BLUE")
+        set (COLOR_STRING "${Esc}[34m")
+    elseif (${COLOR} STREQUAL "WHITE")
+        set (COLOR_STRING "${Esc}[37m")
+    endif ()
+    if (${MODE} MATCHES "^(STATUS|WARNING|AUTHOR_WARNING|SEND_ERROR|FATAL_ERROR|DEPRECATION)$")
+        message (${MODE} ${COLOR_STRING} ${ARGN} ${COLOR_RESET})
+    else ()
+        message (${COLOR_STRING} ${MODE} ${ARGN} ${COLOR_RESET})
+    endif ()
+endfunction ()

--- a/cmake/tests/utils/unset_all.cmake
+++ b/cmake/tests/utils/unset_all.cmake
@@ -1,0 +1,32 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+#[=======================================================================[.rst:
+
+.. command:unset_all
+
+Unsets all passed variables
+  unset_all(
+     [ARGN] <expected> # List of variables
+
+#]=======================================================================]
+
+macro (unset_all)
+    foreach (_variable_name ${ARGN})
+        unset (${_variable_name})
+    endforeach ()
+endmacro ()


### PR DESCRIPTION
Examples of usage:
cmake -P run-cmake-unit-test.cmake
GLUECODIUM_BUILD_ENVIRONMENT=ios-x86_64 CTEST_FILTER="test_to_run" cmake -P run-cmake-unit-test.cmake

See: #556 
Signed-off-by: Yauheni Khnykin <yauheni.khnykin@here.com>