### PR TITLE
Fix support for no-message @Deprecated in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Features:
   * Added support for free-form attributes in C++ and Java.
+### Bug fixes:
+  * Fixed support for no-message `@Deprecated` attribute in Swift.
 
 ## 8.4.6
 Release date: 2020-10-26

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/modelbuilder/AbstractLimeBasedModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/modelbuilder/AbstractLimeBasedModelBuilder.kt
@@ -73,10 +73,14 @@ abstract class AbstractLimeBasedModelBuilder<E>(
         reverseReferenceMap[element] = ambiguousKey
     }
 
-    protected fun createComments(limeElement: LimeNamedElement, platform: String) =
-        Comments(
+    protected fun createComments(limeElement: LimeNamedElement, platform: String): Comments {
+        val hasDeprecated = limeElement.attributes.have(DEPRECATED)
+        val deprecatedMessage =
+            limeElement.attributes.get(DEPRECATED, MESSAGE, LimeComment::class.java)?.getFor(platform) ?: ""
+        return Comments(
             limeElement.comment.getFor(platform),
-            limeElement.attributes.get(DEPRECATED, MESSAGE, LimeComment::class.java)?.getFor(platform),
+            if (hasDeprecated) deprecatedMessage else null,
             limeElement.comment.isExcluded
         )
+    }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/model/common/Comments.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/common/Comments.kt
@@ -24,5 +24,5 @@ class Comments(
     @Suppress("unused") val deprecated: String? = null,
     @Suppress("unused") val isExcluded: Boolean = false
 ) {
-    val isEmpty = documentation.isNullOrEmpty() && deprecated.isNullOrEmpty() && !isExcluded
+    val isEmpty = documentation.isNullOrEmpty() && deprecated == null && !isExcluded
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftEnum.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftEnum.kt
@@ -35,7 +35,7 @@ class SwiftEnum(
 ) {
     @Suppress("unused")
     val hasDeprecatedItems
-        get() = items.any { !it.comment.deprecated.isNullOrEmpty() }
+        get() = items.any { it.comment.deprecated != null }
 
     override val childElements
         get() = items

--- a/gluecodium/src/main/resources/templates/swift/Comment.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Comment.mustache
@@ -20,6 +20,6 @@
   !}}
 {{#unless this.comment.isEmpty}}
 {{#if this.comment.documentation}}{{prefix this.comment.documentation '/// '}}{{/if}}{{#if this.comment.isExcluded}}
-/// :nodoc:{{/if}}{{#if this.comment.deprecated}}
-@available(*, deprecated, message: "{{this.comment.deprecated}}"){{/if}}
+/// :nodoc:{{/if}}{{#this.comment.deprecated}}
+@available(*, deprecated{{#if this}}, message: "{{this}}"{{/if}}){{/this.comment.deprecated}}
 {{/unless}}

--- a/gluecodium/src/main/resources/templates/swift/MethodComment.mustache
+++ b/gluecodium/src/main/resources/templates/swift/MethodComment.mustache
@@ -20,8 +20,8 @@
   !}}
 {{#if hasComment}}
 {{prefixPartial "combinedComment" "/// "}}{{#if comment.isExcluded}}
-/// :nodoc:{{/if}}{{#if comment.deprecated}}
-@available(*, deprecated, message: "{{comment.deprecated}}"){{/if}}
+/// :nodoc:{{/if}}{{#comment.deprecated}}
+@available(*, deprecated{{#if this}}, message: "{{this}}"{{/if}}){{/comment.deprecated}}
 {{/if}}{{!!
 
 }}{{+combinedComment}}{{comment.documentation}}{{!!

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/DeprecatedWithNoMessage.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/DeprecatedWithNoMessage.java
@@ -1,0 +1,16 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+/**
+ * @deprecated
+ */
+@Deprecated
+public final class DeprecatedWithNoMessage {
+    @NonNull
+    public String field;
+    public DeprecatedWithNoMessage(@NonNull final String field) {
+        this.field = field;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecatedWithNoMessage.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecatedWithNoMessage.h
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/Export.h"
+#include <string>
+namespace smoke {
+/**
+ * \deprecated
+ */
+struct _GLUECODIUM_CPP_EXPORT DeprecatedWithNoMessage {
+    ::std::string field;
+    DeprecatedWithNoMessage( );
+    DeprecatedWithNoMessage( ::std::string field );
+};
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
@@ -1,0 +1,70 @@
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+@Deprecated("")
+class DeprecatedWithNoMessage {
+  String field;
+  DeprecatedWithNoMessage(this.field);
+}
+// DeprecatedWithNoMessage "private" section, not exported.
+final _smoke_DeprecatedWithNoMessage_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedWithNoMessage_create_handle'));
+final _smoke_DeprecatedWithNoMessage_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecatedWithNoMessage_release_handle'));
+final _smoke_DeprecatedWithNoMessage_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedWithNoMessage_get_field_field'));
+Pointer<Void> smoke_DeprecatedWithNoMessage_toFfi(DeprecatedWithNoMessage value) {
+  final _field_handle = String_toFfi(value.field);
+  final _result = _smoke_DeprecatedWithNoMessage_create_handle(_field_handle);
+  String_releaseFfiHandle(_field_handle);
+  return _result;
+}
+DeprecatedWithNoMessage smoke_DeprecatedWithNoMessage_fromFfi(Pointer<Void> handle) {
+  final _field_handle = _smoke_DeprecatedWithNoMessage_get_field_field(handle);
+  try {
+    return DeprecatedWithNoMessage(
+      String_fromFfi(_field_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_field_handle);
+  }
+}
+void smoke_DeprecatedWithNoMessage_releaseFfiHandle(Pointer<Void> handle) => _smoke_DeprecatedWithNoMessage_release_handle(handle);
+// Nullable DeprecatedWithNoMessage
+final _smoke_DeprecatedWithNoMessage_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedWithNoMessage_create_handle_nullable'));
+final _smoke_DeprecatedWithNoMessage_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecatedWithNoMessage_release_handle_nullable'));
+final _smoke_DeprecatedWithNoMessage_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedWithNoMessage_get_value_nullable'));
+Pointer<Void> smoke_DeprecatedWithNoMessage_toFfi_nullable(DeprecatedWithNoMessage value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_DeprecatedWithNoMessage_toFfi(value);
+  final result = _smoke_DeprecatedWithNoMessage_create_handle_nullable(_handle);
+  smoke_DeprecatedWithNoMessage_releaseFfiHandle(_handle);
+  return result;
+}
+DeprecatedWithNoMessage smoke_DeprecatedWithNoMessage_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_DeprecatedWithNoMessage_get_value_nullable(handle);
+  final result = smoke_DeprecatedWithNoMessage_fromFfi(_handle);
+  smoke_DeprecatedWithNoMessage_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_DeprecatedWithNoMessage_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_DeprecatedWithNoMessage_release_handle_nullable(handle);
+// End of DeprecatedWithNoMessage "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecatedWithNoMessage.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecatedWithNoMessage.swift
@@ -1,0 +1,52 @@
+//
+//
+import Foundation
+@available(*, deprecated)
+public struct DeprecatedWithNoMessage {
+    public var field: String
+    public init(field: String) {
+        self.field = field
+    }
+    internal init(cHandle: _baseRef) {
+        field = moveFromCType(smoke_DeprecatedWithNoMessage_field_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> DeprecatedWithNoMessage {
+    return DeprecatedWithNoMessage(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> DeprecatedWithNoMessage {
+    defer {
+        smoke_DeprecatedWithNoMessage_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: DeprecatedWithNoMessage) -> RefHolder {
+    let c_field = moveToCType(swiftType.field)
+    return RefHolder(smoke_DeprecatedWithNoMessage_create_handle(c_field.ref))
+}
+internal func moveToCType(_ swiftType: DeprecatedWithNoMessage) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DeprecatedWithNoMessage_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> DeprecatedWithNoMessage? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_DeprecatedWithNoMessage_unwrap_optional_handle(handle)
+    return DeprecatedWithNoMessage(cHandle: unwrappedHandle) as DeprecatedWithNoMessage
+}
+internal func moveFromCType(_ handle: _baseRef) -> DeprecatedWithNoMessage? {
+    defer {
+        smoke_DeprecatedWithNoMessage_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: DeprecatedWithNoMessage?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_field = moveToCType(swiftType.field)
+    return RefHolder(smoke_DeprecatedWithNoMessage_create_optional_handle(c_field.ref))
+}
+internal func moveToCType(_ swiftType: DeprecatedWithNoMessage?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DeprecatedWithNoMessage_release_optional_handle)
+}


### PR DESCRIPTION
Updated Swift model and templates to correctly generate `@available(*, deprecated)` for IDL `@Deprecated` attribute with
no message, instead of generating nothing as before.

Added smoke test reference files for the related use case for all generators.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>