### PR TITLE
Add support for free-form attributes in Swift generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 ### Features:
-  * Added support for free-form attributes in C++ and Java.
+  * Added support for free-form attributes in C++, Java, and Swift.
 ### Bug fixes:
   * Fixed support for no-message `@Deprecated` attribute in Swift.
 

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -512,6 +512,10 @@ access and cached in Java/Swift/Dart afterwards). Currently only supported for r
   * **Weak**: marks a property in an interface as `weak` in Swift. Property should have a nullable type. Please note
   that `weak` properties are still represented with "strong" pointers on C++ side. Due to this limitation, if an
   interface type is used for such property, that interface can only have methods that return nullable values or `void`.
+  * **Attribute** **=** **"**_Attribute_**"**: marks an element to be marked with the given attribute in Swift
+  generated code. _Attribute_ does not need to be prepended with `@`. _Attribute_ can contain parameters, e.g.
+  `@Swift(Attribute="@available(*, deprecated, message: \"It's deprecated.\")")`. If some of the parameters are string
+  literals, their enclosing quotes need to be backslash-escaped, as in the example.
 * **@Dart**: marks an element with Dart-specific behaviors:
   * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in Dart.
   This is the default specification for this attribute.

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftModelElement.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftModelElement.kt
@@ -29,6 +29,7 @@ abstract class SwiftModelElement(
 ) : Hierarchical<SwiftModelElement> {
     val visibility = visibility ?: SwiftVisibility.PUBLIC
     var comment = Comments()
+    var attributes: List<String>? = null
 
     open val simpleName: String
         get() {

--- a/gluecodium/src/main/resources/templates/swift/ClassDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ClassDefinition.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>swift/Comment}}{{!!
+{{>swift/Comment}}{{>swift/SwiftAttributes}}{{!!
 }}{{#isInterface}}{{>ClassWithProtocol}}{{/isInterface}}
 {{^isInterface}}{{>ClassWithoutProtocol}}{{/isInterface}}{{!!
 
@@ -62,7 +62,7 @@
 {{prefixPartial "swift/Closure" "    "}}
 {{/closures}}
 {{#properties}}{{#unless isSkipped}}
-{{prefixPartial "swift/Comment" "    "}}
+{{prefixPartial "swift/Comment" "    "}}{{prefixPartial "swift/SwiftAttributes" "    "}}
     {{#if isStatic}}static {{/if}}var {{name}}: {{type.publicName}}{{#if type.optional}}?{{/if}} { get {{#setter}}set {{/setter}}}
 {{/unless}}{{/properties}}
 {{#methods}}{{#unless isSkipped}}{{prefixPartial 'swift/MethodSignature' '    '}}

--- a/gluecodium/src/main/resources/templates/swift/Closure.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Closure.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>swift/Comment}}
+{{>swift/Comment}}{{>swift/SwiftAttributes}}
 {{^isInterface}}{{visibility}} {{/isInterface}}typealias {{simpleName}} = {{!!
 }}({{#parameters}}{{#isEq category.toString "CLOSURE"}}{{#unless optional}}@escaping {{/unless}}{{/isEq}}{{!!
 }}{{publicName}}{{#if optional}}?{{/if}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) -> {{returnType.publicName}}{{#if returnType.optional}}?{{/if}}

--- a/gluecodium/src/main/resources/templates/swift/Constant.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Constant.mustache
@@ -18,5 +18,5 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>swift/Comment}}
+{{>swift/Comment}}{{>swift/SwiftAttributes}}
 {{visibility}} static let {{name}}: {{type.publicName}}{{#type.optional}}?{{/type.optional}} = {{value}}

--- a/gluecodium/src/main/resources/templates/swift/Enum.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Enum.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless skipDeclaration}}{{>swift/Comment}}
+{{#unless skipDeclaration}}{{>swift/Comment}}{{>swift/SwiftAttributes}}
 {{visibility}} enum {{simpleName}}{{#if externalConverter}}_internal{{/if}} : UInt32, CaseIterable, Codable {
 {{#items}}{{prefixPartial "enumItem" "    "}}
 {{/items}}{{!!
@@ -60,5 +60,5 @@
 {{/if}}
 }
 {{/unless}}{{!!
-}}{{+enumItem}}{{>swift/Comment}}
+}}{{+enumItem}}{{>swift/Comment}}{{>swift/SwiftAttributes}}
 case {{name}}{{#if value}} = {{value}}{{/if}}{{/enumItem}}

--- a/gluecodium/src/main/resources/templates/swift/Method.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Method.mustache
@@ -18,6 +18,6 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#set visibilityPrefix=visibility}}{{>swift/MethodSignature}}{{/set}} {
+{{#set visibilityPrefix=visibility method=this}}{{#method}}{{>swift/MethodSignature}}{{/method}}{{/set}} {
 {{prefixPartial 'swift/ParametersConversion' '    '}}
 }

--- a/gluecodium/src/main/resources/templates/swift/MethodParameterDeclaration.mustache
+++ b/gluecodium/src/main/resources/templates/swift/MethodParameterDeclaration.mustache
@@ -18,6 +18,6 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#parameters}}{{#argumentLabel}}{{.}} {{/argumentLabel}}{{name}}: {{!!
+{{#parameters}}{{>swift/SwiftAttributesInline}}{{#argumentLabel}}{{.}} {{/argumentLabel}}{{name}}: {{!!
 }}{{#isEq type.category.toString "CLOSURE"}}{{#unless type.optional}}@escaping {{/unless}}{{/isEq}}{{type.publicName}}{{!!
 }}{{#if type.optional}}?{{/if}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}

--- a/gluecodium/src/main/resources/templates/swift/Property.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Property.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>swift/Comment}}{{#if isCached}}{{!!
+{{>swift/Comment}}{{>swift/SwiftAttributes}}{{#if isCached}}{{!!
 }}{{visibility}} private(set) {{#if isStatic}}static {{/if}}{{#unless isStatic}}lazy {{/unless}}{{!!
 }}var {{name}}: {{type.publicName}}{{#if type.optional}}?{{/if}} = {
     {{#getter}}{{>swift/ParametersConversion}}{{/getter}}

--- a/gluecodium/src/main/resources/templates/swift/Struct.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Struct.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless skipDeclaration}}{{>swift/Comment}}
+{{#unless skipDeclaration}}{{>swift/Comment}}{{>swift/SwiftAttributes}}
 {{visibility}} struct {{simpleName}}{{#if externalConverter}}_internal{{/if}}{{#unless externalConverter}}{{!!
 }}{{#if isEquatable isCodable logic="or"}}{{!!
 }}:{{#if isEquatable}} Hashable{{/if}}{{#if isEquatable isCodable logic="and"}},{{/if}}{{#if isCodable}} Codable{{/if}}{{!!
@@ -28,13 +28,13 @@
 {{/constants}}{{!!
 }}{{#if fields}}{{#fields}}
 {{#if this.comment}}
-{{prefixPartial "swift/Comment" '    '}}
+{{prefixPartial "swift/Comment" "    "}}{{prefixPartial "swift/SwiftAttributes" "    "}}
 {{/if}}
     {{visibility}} {{#if isImmutable}}let{{/if}}{{#unless isImmutable}}var{{/unless}} {{name}}: {{type.publicName}}{{#type.optional}}?{{/type.optional}}
 {{/fields}}{{#unless constructors}}{{#if needsReducedConstructor}}
 
 {{#if generatedConstructorComment}}
-{{prefix generatedConstructorComment '    /// '}}
+{{prefix generatedConstructorComment "    /// "}}
 {{#if publicFields}}
     /// - Parameters
 {{#publicFields}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftAttributes.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftAttributes.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless isConstructor}}{{>swift/MethodComment}}{{>swift/SwiftAttributes}}{{/unless}}
-{{#if isConstructor}}private {{/if}}{{#unless isConstructor}}{{#visibilityPrefix}}{{.}} {{/visibilityPrefix}}{{/unless}}{{!!
-}}{{#isStatic}}static {{/isStatic}}func {{name}}({{>swift/MethodParameterDeclaration}}){{#if error}} throws{{/if}} -> {{returnType.publicName}}{{#if returnType.optional}}?{{/if}}
+{{#if this.attributes}}
+{{#this.attributes}}
+@{{this}}
+{{/this.attributes}}
+{{/if}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftAttributesInline.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftAttributesInline.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -18,6 +18,4 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless isConstructor}}{{>swift/MethodComment}}{{>swift/SwiftAttributes}}{{/unless}}
-{{#if isConstructor}}private {{/if}}{{#unless isConstructor}}{{#visibilityPrefix}}{{.}} {{/visibilityPrefix}}{{/unless}}{{!!
-}}{{#isStatic}}static {{/isStatic}}func {{name}}({{>swift/MethodParameterDeclaration}}){{#if error}} throws{{/if}} -> {{returnType.publicName}}{{#if returnType.optional}}?{{/if}}
+{{#if this.attributes}}{{#this.attributes}}@{{this}} {{/this.attributes}}{{/if}}

--- a/gluecodium/src/main/resources/templates/swift/Typedefs.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Typedefs.mustache
@@ -19,6 +19,6 @@
   !
   !}}
 {{#isNotEq simpleName type.publicName}}
-{{>swift/Comment}}
+{{>swift/Comment}}{{>swift/SwiftAttributes}}
 {{^isInterface}}{{visibility}} {{/isInterface}}typealias {{simpleName}} = {{type.publicName}}
 {{/isNotEq}}

--- a/gluecodium/src/test/resources/smoke/attributes/input/Attributes.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/Attributes.lime
@@ -19,73 +19,93 @@ package smoke
 
 @Cpp(Attribute = "OnClass")
 @Java(Attribute = "OnClass")
+@Swift(Attribute = "OnClass")
 class AttributesClass {
     @Cpp(Attribute = "OnFunctionInClass")
     @Java(Attribute = "OnFunctionInClass")
+    @Swift(Attribute = "OnFunctionInClass")
     fun veryFun(
         @Cpp(Attribute = "OnParameterInClass")
         @Java(Attribute = "OnParameterInClass")
+        @Swift(Attribute = "OnParameterInClass")
         param: String
     )
     @Cpp(Attribute = "OnPropertyInClass")
     @Java(Attribute = "OnPropertyInClass")
+    @Swift(Attribute = "OnPropertyInClass")
     property prop: String
     @Cpp(Attribute = "OnConstInClass")
     @Java(Attribute = "OnConstInClass")
+    @Swift(Attribute = "OnConstInClass")
     const pi: Boolean = false
 }
 
 @Cpp(Attribute = "OnInterface")
 @Java(Attribute = "OnInterface")
+@Swift(Attribute = "OnInterface")
 interface AttributesInterface {
     @Cpp(Attribute = "OnFunctionInInterface")
     @Java(Attribute = "OnFunctionInInterface")
+    @Swift(Attribute = "OnFunctionInInterface")
     fun veryFun(
         @Cpp(Attribute = "OnParameterInInterface")
         @Java(Attribute = "OnParameterInInterface")
+        @Swift(Attribute = "OnParameterInInterface")
         param: String
     )
     @Cpp(Attribute = "OnPropertyInInterface")
     @Java(Attribute = "OnPropertyInInterface")
+    @Swift(Attribute = "OnPropertyInInterface")
     property prop: String
     @Cpp(Attribute = "OnConstInInterface")
     @Java(Attribute = "OnConstInInterface")
+    @Swift(Attribute = "OnConstInInterface")
     const pi: Boolean = false
 }
 
 @Cpp(Attribute = "OnStruct")
 @Java(Attribute = "OnStruct")
+@Swift(Attribute = "OnStruct")
 struct AttributesStruct {
     @Cpp(Attribute = "OnField")
     @Java(Attribute = "OnField")
+    @Swift(Attribute = "OnField")
     field: String
     @Cpp(Attribute = "OnFunctionInStruct")
     @Java(Attribute = "OnFunctionInStruct")
+    @Swift(Attribute = "OnFunctionInStruct")
     fun veryFun(
         @Cpp(Attribute = "OnParameterInStruct")
         @Java(Attribute = "OnParameterInStruct")
+        @Swift(Attribute = "OnParameterInStruct")
         param: String
     )
     @Cpp(Attribute = "OnConstInStruct")
     @Java(Attribute = "OnConstInStruct")
+    @Swift(Attribute = "OnConstInStruct")
     const pi: Boolean = false
 }
 
 @Cpp(Attribute = "OnEnumeration")
 @Java(Attribute = "OnEnumeration")
+@Swift(Attribute = "OnEnumeration")
 enum AttributesEnum {
     @Cpp(Attribute = "OnEnumerator")
     @Java(Attribute = "OnEnumerator")
+    @Swift(Attribute = "OnEnumerator")
     NOPE
 }
 
 @Cpp(Attribute = "OnLambda")
 @Java(Attribute = "OnLambda")
+@Swift(Attribute = "OnLambda")
 lambda AttributesLambda = () -> Void
 
 @Cpp(Attribute = "OnException")
 @Java(Attribute = "OnException")
+@Swift(Attribute = "OnException")
 exception AttributesCrash(String)
 
 @Cpp(Attribute = "OnTypeAlias")
+@Swift(Attribute = "OnTypeAlias")
 typealias AttributesAlias = String

--- a/gluecodium/src/test/resources/smoke/attributes/input/AttributesWithComments.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/AttributesWithComments.lime
@@ -20,26 +20,31 @@ package smoke
 // Class comment
 @Cpp(Attribute = "OnClass")
 @Java(Attribute = "OnClass")
+@Swift(Attribute = "OnClass")
 class AttributesWithComments {
    // Function comment
    @Cpp(Attribute = "OnFunctionInClass")
    @Java(Attribute = "OnFunctionInClass")
+   @Swift(Attribute = "OnFunctionInClass")
    fun veryFun()
    // Property comment
    // @get Getter comment
    // @set Setter comment
    @Cpp(Attribute = "OnPropertyInClass")
    @Java(Attribute = "OnPropertyInClass")
+   @Swift(Attribute = "OnPropertyInClass")
    property prop: String
    // Const comment
    @Cpp(Attribute = "OnConstInClass")
    @Java(Attribute = "OnConstInClass")
+   @Swift(Attribute = "OnConstInClass")
    const pi: Boolean = false
 
    struct SomeStruct {
       // Field comment
       @Cpp(Attribute = "OnField")
       @Java(Attribute = "OnField")
+      @Swift(Attribute = "OnField")
       field: String
    }
 }
@@ -47,24 +52,29 @@ class AttributesWithComments {
 @Deprecated
 @Cpp(Attribute = "OnClass")
 @Java(Attribute = "OnClass")
+@Swift(Attribute = "OnClass")
 class AttributesWithDeprecated {
    @Deprecated
    @Cpp(Attribute = "OnFunctionInClass")
    @Java(Attribute = "OnFunctionInClass")
+   @Swift(Attribute = "OnFunctionInClass")
    fun veryFun()
    @Deprecated
    @Cpp(Attribute = "OnPropertyInClass")
    @Java(Attribute = "OnPropertyInClass")
+   @Swift(Attribute = "OnPropertyInClass")
    property prop: String
    @Deprecated
    @Cpp(Attribute = "OnConstInClass")
    @Java(Attribute = "OnConstInClass")
+   @Swift(Attribute = "OnConstInClass")
    const pi: Boolean = false
 
    struct SomeStruct {
       @Deprecated
       @Cpp(Attribute = "OnField")
       @Java(Attribute = "OnField")
+      @Swift(Attribute = "OnField")
       field: String
    }
 }

--- a/gluecodium/src/test/resources/smoke/attributes/input/MultipleAttributes.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/MultipleAttributes.lime
@@ -56,3 +56,23 @@ class MultipleAttributesJava {
     @Java(Attribute = ["Baz", "Fizz"])
     fun twoLists()
 }
+
+@Java(Skip) @Dart(Skip)
+class MultipleAttributesSwift {
+    @Swift(Attribute = "Foo")
+    @Swift(Attribute = "Bar")
+    fun noLists2()
+    @Swift(Attribute = "Foo")
+    @Swift(Attribute = "Bar")
+    @Swift(Attribute = "Baz")
+    fun noLists3()
+    @Swift(Attribute = ["Foo", "Bar"])
+    @Swift(Attribute = "Baz")
+    fun listFirst()
+    @Swift(Attribute = "Foo")
+    @Swift(Attribute = ["Bar", "Baz"])
+    fun listSecond()
+    @Swift(Attribute = ["Foo", "Bar"])
+    @Swift(Attribute = ["Baz", "Fizz"])
+    fun twoLists()
+}

--- a/gluecodium/src/test/resources/smoke/attributes/input/SpecialAttributes.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/SpecialAttributes.lime
@@ -20,8 +20,10 @@ package smoke
 class SpecialAttributes {
     @Cpp(Attribute = "Deprecated(\"foo\\nbar\")")
     @Java(Attribute = "Deprecated(\"foo\\nbar\")")
+    @Swift(Attribute = "Deprecated(\"foo\\nbar\")")
     fun withEscaping()
     @Cpp(Attribute = "HackMe\nrm -rf *")
     @Java(Attribute = "HackMe\nrm -rf *")
+    @Swift(Attribute = "HackMe\nrm -rf *")
     fun withLineBreak()
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesAlias.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesAlias.swift
@@ -1,0 +1,5 @@
+//
+//
+import Foundation
+@OnTypeAlias
+public typealias AttributesAlias = String

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesClass.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesClass.swift
@@ -1,0 +1,89 @@
+//
+//
+import Foundation
+@OnClass
+public class AttributesClass {
+    @OnConstInClass
+    public static let pi: Bool = false
+    @OnPropertyInClass
+    public var prop: String {
+        get {
+            return moveFromCType(smoke_AttributesClass_prop_get(self.c_instance))
+        }
+        set {
+            let c_newValue = moveToCType(newValue)
+            return moveFromCType(smoke_AttributesClass_prop_set(self.c_instance, c_newValue.ref))
+        }
+    }
+    let c_instance : _baseRef
+    init(cAttributesClass: _baseRef) {
+        guard cAttributesClass != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cAttributesClass
+    }
+    deinit {
+        smoke_AttributesClass_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_AttributesClass_release_handle(c_instance)
+    }
+    @OnFunctionInClass
+    public func veryFun(@OnParameterInClass param: String) -> Void {
+        let c_param = moveToCType(param)
+        return moveFromCType(smoke_AttributesClass_veryFun(self.c_instance, c_param.ref))
+    }
+}
+internal func getRef(_ ref: AttributesClass?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_AttributesClass_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_AttributesClass_release_handle)
+        : RefHolder(handle_copy)
+}
+extension AttributesClass: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func AttributesClass_copyFromCType(_ handle: _baseRef) -> AttributesClass {
+    if let swift_pointer = smoke_AttributesClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesClass {
+        return re_constructed
+    }
+    let result = AttributesClass(cAttributesClass: smoke_AttributesClass_copy_handle(handle))
+    smoke_AttributesClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func AttributesClass_moveFromCType(_ handle: _baseRef) -> AttributesClass {
+    if let swift_pointer = smoke_AttributesClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesClass {
+        smoke_AttributesClass_release_handle(handle)
+        return re_constructed
+    }
+    let result = AttributesClass(cAttributesClass: handle)
+    smoke_AttributesClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func AttributesClass_copyFromCType(_ handle: _baseRef) -> AttributesClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return AttributesClass_moveFromCType(handle) as AttributesClass
+}
+internal func AttributesClass_moveFromCType(_ handle: _baseRef) -> AttributesClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return AttributesClass_moveFromCType(handle) as AttributesClass
+}
+internal func copyToCType(_ swiftClass: AttributesClass) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: AttributesClass) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: AttributesClass?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: AttributesClass?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesCrashError.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesCrashError.swift
@@ -1,0 +1,7 @@
+//
+//
+import Foundation
+@OnException
+public typealias AttributesCrashError = String
+extension String : Error {
+}

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesEnum.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesEnum.swift
@@ -1,0 +1,38 @@
+//
+//
+import Foundation
+@OnEnumeration
+public enum AttributesEnum : UInt32, CaseIterable, Codable {
+    @OnEnumerator
+    case nope
+}
+internal func copyToCType(_ swiftEnum: AttributesEnum) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func moveToCType(_ swiftEnum: AttributesEnum) -> PrimitiveHolder<UInt32> {
+    return copyToCType(swiftEnum)
+}
+internal func copyToCType(_ swiftEnum: AttributesEnum?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func moveToCType(_ swiftEnum: AttributesEnum?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func copyFromCType(_ cValue: UInt32) -> AttributesEnum {
+    return AttributesEnum(rawValue: cValue)!
+}
+internal func moveFromCType(_ cValue: UInt32) -> AttributesEnum {
+    return copyFromCType(cValue)
+}
+internal func copyFromCType(_ handle: _baseRef) -> AttributesEnum? {
+    guard handle != 0 else {
+        return nil
+    }
+    return AttributesEnum(rawValue: uint32_t_value_get(handle))!
+}
+internal func moveFromCType(_ handle: _baseRef) -> AttributesEnum? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesInterface.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesInterface.swift
@@ -1,0 +1,138 @@
+//
+//
+import Foundation
+@OnInterface
+public protocol AttributesInterface : AnyObject {
+    @OnPropertyInInterface
+    var prop: String { get set }
+    @OnFunctionInInterface
+    func veryFun(@OnParameterInInterface param: String) -> Void
+}
+internal class _AttributesInterface: AttributesInterface {
+    @OnConstInInterface
+    public static let pi: Bool = false
+    @OnPropertyInInterface
+    var prop: String {
+        get {
+            return moveFromCType(smoke_AttributesInterface_prop_get(self.c_instance))
+        }
+        set {
+            let c_newValue = moveToCType(newValue)
+            return moveFromCType(smoke_AttributesInterface_prop_set(self.c_instance, c_newValue.ref))
+        }
+    }
+    let c_instance : _baseRef
+    init(cAttributesInterface: _baseRef) {
+        guard cAttributesInterface != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cAttributesInterface
+    }
+    deinit {
+        smoke_AttributesInterface_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_AttributesInterface_release_handle(c_instance)
+    }
+    @OnFunctionInInterface
+    public func veryFun(@OnParameterInInterface param: String) -> Void {
+        let c_param = moveToCType(param)
+        return moveFromCType(smoke_AttributesInterface_veryFun(self.c_instance, c_param.ref))
+    }
+}
+@_cdecl("_CBridgeInitsmoke_AttributesInterface")
+internal func _CBridgeInitsmoke_AttributesInterface(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _AttributesInterface(cAttributesInterface: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: AttributesInterface?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_AttributesInterface_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_AttributesInterface_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_AttributesInterface_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    functions.smoke_AttributesInterface_veryFun = {(swift_class_pointer, param) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! AttributesInterface
+        swift_class.veryFun(param: moveFromCType(param))
+    }
+    functions.smoke_AttributesInterface_prop_get = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! AttributesInterface
+        return copyToCType(swift_class.prop).ref
+    }
+    functions.smoke_AttributesInterface_prop_set = {(swift_class_pointer, newValue) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! AttributesInterface
+        swift_class.prop = moveFromCType(newValue)
+    }
+    let proxy = smoke_AttributesInterface_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_AttributesInterface_release_handle) : RefHolder(proxy)
+}
+extension _AttributesInterface: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func AttributesInterface_copyFromCType(_ handle: _baseRef) -> AttributesInterface {
+    if let swift_pointer = smoke_AttributesInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AttributesInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AttributesInterface_get_typed(smoke_AttributesInterface_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? AttributesInterface {
+        smoke_AttributesInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func AttributesInterface_moveFromCType(_ handle: _baseRef) -> AttributesInterface {
+    if let swift_pointer = smoke_AttributesInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesInterface {
+        smoke_AttributesInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AttributesInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesInterface {
+        smoke_AttributesInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AttributesInterface_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? AttributesInterface {
+        smoke_AttributesInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func AttributesInterface_copyFromCType(_ handle: _baseRef) -> AttributesInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return AttributesInterface_moveFromCType(handle) as AttributesInterface
+}
+internal func AttributesInterface_moveFromCType(_ handle: _baseRef) -> AttributesInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return AttributesInterface_moveFromCType(handle) as AttributesInterface
+}
+internal func copyToCType(_ swiftClass: AttributesInterface) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: AttributesInterface) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: AttributesInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: AttributesInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesLambda.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesLambda.swift
@@ -1,0 +1,68 @@
+//
+//
+import Foundation
+@OnLambda
+public typealias AttributesLambda = () -> Void
+internal func copyFromCType(_ handle: _baseRef) -> AttributesLambda {
+    return moveFromCType(smoke_AttributesLambda_copy_handle(handle))
+}
+internal func moveFromCType(_ handle: _baseRef) -> AttributesLambda {
+    let refHolder = RefHolder(ref: handle, release: smoke_AttributesLambda_release_handle)
+    return { () -> Void in
+        return moveFromCType(smoke_AttributesLambda_call(refHolder.ref))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> AttributesLambda? {
+    guard handle != 0 else {
+        return nil
+    }
+    return copyFromCType(handle) as AttributesLambda
+}
+internal func moveFromCType(_ handle: _baseRef) -> AttributesLambda? {
+    guard handle != 0 else {
+        return nil
+    }
+    return moveFromCType(handle) as AttributesLambda
+}
+internal func createFunctionalTable(_ swiftType: @escaping AttributesLambda) -> smoke_AttributesLambda_FunctionTable {
+    class smoke_AttributesLambda_Holder {
+        let closure: AttributesLambda
+        init(_ closure: @escaping AttributesLambda) {
+            self.closure = closure
+        }
+    }
+    var functions = smoke_AttributesLambda_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(smoke_AttributesLambda_Holder(swiftType)).toOpaque()
+    functions.release = { swift_closure_pointer in
+        if let swift_closure = swift_closure_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_closure).release()
+        }
+    }
+    functions.smoke_AttributesLambda_call = { swift_closure_pointer in
+        let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_AttributesLambda_Holder
+        return copyToCType(closure_holder.closure()).ref
+    }
+    return functions
+}
+internal func copyToCType(_ swiftType: @escaping AttributesLambda) -> RefHolder {
+    let handle = smoke_AttributesLambda_create_proxy(createFunctionalTable(swiftType))
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftType: @escaping AttributesLambda) -> RefHolder {
+    let handle = smoke_AttributesLambda_create_proxy(createFunctionalTable(swiftType))
+    return RefHolder(ref: handle, release: smoke_AttributesLambda_release_handle)
+}
+internal func copyToCType(_ swiftType: AttributesLambda?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let handle = smoke_AttributesLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftType: AttributesLambda?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let handle = smoke_AttributesLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    return RefHolder(ref: handle, release: smoke_AttributesLambda_release_handle)
+}

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesStruct.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesStruct.swift
@@ -1,0 +1,62 @@
+//
+//
+import Foundation
+@OnStruct
+public struct AttributesStruct {
+    @OnConstInStruct
+    public static let pi: Bool = false
+    @OnField
+    public var field: String
+    public init(field: String) {
+        self.field = field
+    }
+    internal init(cHandle: _baseRef) {
+        field = moveFromCType(smoke_AttributesStruct_field_get(cHandle))
+    }
+    @OnFunctionInStruct
+    public func veryFun(@OnParameterInStruct param: String) -> Void {
+        let c_self_handle = moveToCType(self)
+        let c_param = moveToCType(param)
+        return moveFromCType(smoke_AttributesStruct_veryFun(c_self_handle.ref, c_param.ref))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> AttributesStruct {
+    return AttributesStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> AttributesStruct {
+    defer {
+        smoke_AttributesStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: AttributesStruct) -> RefHolder {
+    let c_field = moveToCType(swiftType.field)
+    return RefHolder(smoke_AttributesStruct_create_handle(c_field.ref))
+}
+internal func moveToCType(_ swiftType: AttributesStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_AttributesStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> AttributesStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_AttributesStruct_unwrap_optional_handle(handle)
+    return AttributesStruct(cHandle: unwrappedHandle) as AttributesStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> AttributesStruct? {
+    defer {
+        smoke_AttributesStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: AttributesStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_field = moveToCType(swiftType.field)
+    return RefHolder(smoke_AttributesStruct_create_optional_handle(c_field.ref))
+}
+internal func moveToCType(_ swiftType: AttributesStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_AttributesStruct_release_optional_handle)
+}
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithComments.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithComments.swift
@@ -1,0 +1,142 @@
+//
+//
+import Foundation
+/// Class comment
+@OnClass
+public class AttributesWithComments {
+    /// Const comment
+    @OnConstInClass
+    public static let pi: Bool = false
+    /// Property comment
+    @OnPropertyInClass
+    public var prop: String {
+        get {
+            return moveFromCType(smoke_AttributesWithComments_prop_get(self.c_instance))
+        }
+        set {
+            let c_newValue = moveToCType(newValue)
+            return moveFromCType(smoke_AttributesWithComments_prop_set(self.c_instance, c_newValue.ref))
+        }
+    }
+    let c_instance : _baseRef
+    init(cAttributesWithComments: _baseRef) {
+        guard cAttributesWithComments != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cAttributesWithComments
+    }
+    deinit {
+        smoke_AttributesWithComments_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_AttributesWithComments_release_handle(c_instance)
+    }
+    public struct SomeStruct {
+        /// Field comment
+        @OnField
+        public var field: String
+        public init(field: String) {
+            self.field = field
+        }
+        internal init(cHandle: _baseRef) {
+            field = moveFromCType(smoke_AttributesWithComments_SomeStruct_field_get(cHandle))
+        }
+    }
+    /// Function comment
+    @OnFunctionInClass
+    public func veryFun() -> Void {
+        return moveFromCType(smoke_AttributesWithComments_veryFun(self.c_instance))
+    }
+}
+internal func getRef(_ ref: AttributesWithComments?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_AttributesWithComments_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_AttributesWithComments_release_handle)
+        : RefHolder(handle_copy)
+}
+extension AttributesWithComments: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func AttributesWithComments_copyFromCType(_ handle: _baseRef) -> AttributesWithComments {
+    if let swift_pointer = smoke_AttributesWithComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesWithComments {
+        return re_constructed
+    }
+    let result = AttributesWithComments(cAttributesWithComments: smoke_AttributesWithComments_copy_handle(handle))
+    smoke_AttributesWithComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func AttributesWithComments_moveFromCType(_ handle: _baseRef) -> AttributesWithComments {
+    if let swift_pointer = smoke_AttributesWithComments_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesWithComments {
+        smoke_AttributesWithComments_release_handle(handle)
+        return re_constructed
+    }
+    let result = AttributesWithComments(cAttributesWithComments: handle)
+    smoke_AttributesWithComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func AttributesWithComments_copyFromCType(_ handle: _baseRef) -> AttributesWithComments? {
+    guard handle != 0 else {
+        return nil
+    }
+    return AttributesWithComments_moveFromCType(handle) as AttributesWithComments
+}
+internal func AttributesWithComments_moveFromCType(_ handle: _baseRef) -> AttributesWithComments? {
+    guard handle != 0 else {
+        return nil
+    }
+    return AttributesWithComments_moveFromCType(handle) as AttributesWithComments
+}
+internal func copyToCType(_ swiftClass: AttributesWithComments) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: AttributesWithComments) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: AttributesWithComments?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: AttributesWithComments?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyFromCType(_ handle: _baseRef) -> AttributesWithComments.SomeStruct {
+    return AttributesWithComments.SomeStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> AttributesWithComments.SomeStruct {
+    defer {
+        smoke_AttributesWithComments_SomeStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: AttributesWithComments.SomeStruct) -> RefHolder {
+    let c_field = moveToCType(swiftType.field)
+    return RefHolder(smoke_AttributesWithComments_SomeStruct_create_handle(c_field.ref))
+}
+internal func moveToCType(_ swiftType: AttributesWithComments.SomeStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_AttributesWithComments_SomeStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> AttributesWithComments.SomeStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_AttributesWithComments_SomeStruct_unwrap_optional_handle(handle)
+    return AttributesWithComments.SomeStruct(cHandle: unwrappedHandle) as AttributesWithComments.SomeStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> AttributesWithComments.SomeStruct? {
+    defer {
+        smoke_AttributesWithComments_SomeStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: AttributesWithComments.SomeStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_field = moveToCType(swiftType.field)
+    return RefHolder(smoke_AttributesWithComments_SomeStruct_create_optional_handle(c_field.ref))
+}
+internal func moveToCType(_ swiftType: AttributesWithComments.SomeStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_AttributesWithComments_SomeStruct_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithDeprecated.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithDeprecated.swift
@@ -1,0 +1,143 @@
+//
+//
+import Foundation
+@available(*, deprecated)
+@OnClass
+public class AttributesWithDeprecated {
+    @available(*, deprecated)
+    @OnConstInClass
+    public static let pi: Bool = false
+    @available(*, deprecated)
+    @OnPropertyInClass
+    public var prop: String {
+        get {
+            return moveFromCType(smoke_AttributesWithDeprecated_prop_get(self.c_instance))
+        }
+        set {
+            let c_newValue = moveToCType(newValue)
+            return moveFromCType(smoke_AttributesWithDeprecated_prop_set(self.c_instance, c_newValue.ref))
+        }
+    }
+    let c_instance : _baseRef
+    init(cAttributesWithDeprecated: _baseRef) {
+        guard cAttributesWithDeprecated != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cAttributesWithDeprecated
+    }
+    deinit {
+        smoke_AttributesWithDeprecated_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_AttributesWithDeprecated_release_handle(c_instance)
+    }
+    public struct SomeStruct {
+        @available(*, deprecated)
+        @OnField
+        public var field: String
+        public init(field: String) {
+            self.field = field
+        }
+        internal init(cHandle: _baseRef) {
+            field = moveFromCType(smoke_AttributesWithDeprecated_SomeStruct_field_get(cHandle))
+        }
+    }
+    ///
+    @available(*, deprecated)
+    @OnFunctionInClass
+    public func veryFun() -> Void {
+        return moveFromCType(smoke_AttributesWithDeprecated_veryFun(self.c_instance))
+    }
+}
+internal func getRef(_ ref: AttributesWithDeprecated?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_AttributesWithDeprecated_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_AttributesWithDeprecated_release_handle)
+        : RefHolder(handle_copy)
+}
+extension AttributesWithDeprecated: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func AttributesWithDeprecated_copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated {
+    if let swift_pointer = smoke_AttributesWithDeprecated_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesWithDeprecated {
+        return re_constructed
+    }
+    let result = AttributesWithDeprecated(cAttributesWithDeprecated: smoke_AttributesWithDeprecated_copy_handle(handle))
+    smoke_AttributesWithDeprecated_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func AttributesWithDeprecated_moveFromCType(_ handle: _baseRef) -> AttributesWithDeprecated {
+    if let swift_pointer = smoke_AttributesWithDeprecated_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesWithDeprecated {
+        smoke_AttributesWithDeprecated_release_handle(handle)
+        return re_constructed
+    }
+    let result = AttributesWithDeprecated(cAttributesWithDeprecated: handle)
+    smoke_AttributesWithDeprecated_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func AttributesWithDeprecated_copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated? {
+    guard handle != 0 else {
+        return nil
+    }
+    return AttributesWithDeprecated_moveFromCType(handle) as AttributesWithDeprecated
+}
+internal func AttributesWithDeprecated_moveFromCType(_ handle: _baseRef) -> AttributesWithDeprecated? {
+    guard handle != 0 else {
+        return nil
+    }
+    return AttributesWithDeprecated_moveFromCType(handle) as AttributesWithDeprecated
+}
+internal func copyToCType(_ swiftClass: AttributesWithDeprecated) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: AttributesWithDeprecated) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: AttributesWithDeprecated?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: AttributesWithDeprecated?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated.SomeStruct {
+    return AttributesWithDeprecated.SomeStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> AttributesWithDeprecated.SomeStruct {
+    defer {
+        smoke_AttributesWithDeprecated_SomeStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: AttributesWithDeprecated.SomeStruct) -> RefHolder {
+    let c_field = moveToCType(swiftType.field)
+    return RefHolder(smoke_AttributesWithDeprecated_SomeStruct_create_handle(c_field.ref))
+}
+internal func moveToCType(_ swiftType: AttributesWithDeprecated.SomeStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_AttributesWithDeprecated_SomeStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated.SomeStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_AttributesWithDeprecated_SomeStruct_unwrap_optional_handle(handle)
+    return AttributesWithDeprecated.SomeStruct(cHandle: unwrappedHandle) as AttributesWithDeprecated.SomeStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> AttributesWithDeprecated.SomeStruct? {
+    defer {
+        smoke_AttributesWithDeprecated_SomeStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: AttributesWithDeprecated.SomeStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_field = moveToCType(swiftType.field)
+    return RefHolder(smoke_AttributesWithDeprecated_SomeStruct_create_optional_handle(c_field.ref))
+}
+internal func moveToCType(_ swiftType: AttributesWithDeprecated.SomeStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_AttributesWithDeprecated_SomeStruct_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/MultipleAttributesSwift.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/MultipleAttributesSwift.swift
@@ -1,0 +1,101 @@
+//
+//
+import Foundation
+public class MultipleAttributesSwift {
+    let c_instance : _baseRef
+    init(cMultipleAttributesSwift: _baseRef) {
+        guard cMultipleAttributesSwift != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cMultipleAttributesSwift
+    }
+    deinit {
+        smoke_MultipleAttributesSwift_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_MultipleAttributesSwift_release_handle(c_instance)
+    }
+    @Foo
+    @Bar
+    public func noLists2() -> Void {
+        return moveFromCType(smoke_MultipleAttributesSwift_noLists2(self.c_instance))
+    }
+    @Foo
+    @Bar
+    @Baz
+    public func noLists3() -> Void {
+        return moveFromCType(smoke_MultipleAttributesSwift_noLists3(self.c_instance))
+    }
+    @Foo
+    @Bar
+    @Baz
+    public func listFirst() -> Void {
+        return moveFromCType(smoke_MultipleAttributesSwift_listFirst(self.c_instance))
+    }
+    @Foo
+    @Bar
+    @Baz
+    public func listSecond() -> Void {
+        return moveFromCType(smoke_MultipleAttributesSwift_listSecond(self.c_instance))
+    }
+    @Foo
+    @Bar
+    @Baz
+    @Fizz
+    public func twoLists() -> Void {
+        return moveFromCType(smoke_MultipleAttributesSwift_twoLists(self.c_instance))
+    }
+}
+internal func getRef(_ ref: MultipleAttributesSwift?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_MultipleAttributesSwift_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_MultipleAttributesSwift_release_handle)
+        : RefHolder(handle_copy)
+}
+extension MultipleAttributesSwift: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func MultipleAttributesSwift_copyFromCType(_ handle: _baseRef) -> MultipleAttributesSwift {
+    if let swift_pointer = smoke_MultipleAttributesSwift_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MultipleAttributesSwift {
+        return re_constructed
+    }
+    let result = MultipleAttributesSwift(cMultipleAttributesSwift: smoke_MultipleAttributesSwift_copy_handle(handle))
+    smoke_MultipleAttributesSwift_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func MultipleAttributesSwift_moveFromCType(_ handle: _baseRef) -> MultipleAttributesSwift {
+    if let swift_pointer = smoke_MultipleAttributesSwift_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MultipleAttributesSwift {
+        smoke_MultipleAttributesSwift_release_handle(handle)
+        return re_constructed
+    }
+    let result = MultipleAttributesSwift(cMultipleAttributesSwift: handle)
+    smoke_MultipleAttributesSwift_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func MultipleAttributesSwift_copyFromCType(_ handle: _baseRef) -> MultipleAttributesSwift? {
+    guard handle != 0 else {
+        return nil
+    }
+    return MultipleAttributesSwift_moveFromCType(handle) as MultipleAttributesSwift
+}
+internal func MultipleAttributesSwift_moveFromCType(_ handle: _baseRef) -> MultipleAttributesSwift? {
+    guard handle != 0 else {
+        return nil
+    }
+    return MultipleAttributesSwift_moveFromCType(handle) as MultipleAttributesSwift
+}
+internal func copyToCType(_ swiftClass: MultipleAttributesSwift) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: MultipleAttributesSwift) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: MultipleAttributesSwift?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: MultipleAttributesSwift?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/SpecialAttributes.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/SpecialAttributes.swift
@@ -1,0 +1,79 @@
+//
+//
+import Foundation
+public class SpecialAttributes {
+    let c_instance : _baseRef
+    init(cSpecialAttributes: _baseRef) {
+        guard cSpecialAttributes != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cSpecialAttributes
+    }
+    deinit {
+        smoke_SpecialAttributes_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_SpecialAttributes_release_handle(c_instance)
+    }
+    @Deprecated("foo\nbar")
+    public func withEscaping() -> Void {
+        return moveFromCType(smoke_SpecialAttributes_withEscaping(self.c_instance))
+    }
+    @HackMerm -rf *
+    public func withLineBreak() -> Void {
+        return moveFromCType(smoke_SpecialAttributes_withLineBreak(self.c_instance))
+    }
+}
+internal func getRef(_ ref: SpecialAttributes?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_SpecialAttributes_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_SpecialAttributes_release_handle)
+        : RefHolder(handle_copy)
+}
+extension SpecialAttributes: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func SpecialAttributes_copyFromCType(_ handle: _baseRef) -> SpecialAttributes {
+    if let swift_pointer = smoke_SpecialAttributes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SpecialAttributes {
+        return re_constructed
+    }
+    let result = SpecialAttributes(cSpecialAttributes: smoke_SpecialAttributes_copy_handle(handle))
+    smoke_SpecialAttributes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func SpecialAttributes_moveFromCType(_ handle: _baseRef) -> SpecialAttributes {
+    if let swift_pointer = smoke_SpecialAttributes_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SpecialAttributes {
+        smoke_SpecialAttributes_release_handle(handle)
+        return re_constructed
+    }
+    let result = SpecialAttributes(cSpecialAttributes: handle)
+    smoke_SpecialAttributes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func SpecialAttributes_copyFromCType(_ handle: _baseRef) -> SpecialAttributes? {
+    guard handle != 0 else {
+        return nil
+    }
+    return SpecialAttributes_moveFromCType(handle) as SpecialAttributes
+}
+internal func SpecialAttributes_moveFromCType(_ handle: _baseRef) -> SpecialAttributes? {
+    guard handle != 0 else {
+        return nil
+    }
+    return SpecialAttributes_moveFromCType(handle) as SpecialAttributes
+}
+internal func copyToCType(_ swiftClass: SpecialAttributes) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: SpecialAttributes) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: SpecialAttributes?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: SpecialAttributes?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}


### PR DESCRIPTION
Updated Swift model and templates to add support for `@Swift(Attribute="foo")` IDL attribute. This syntax should produce
a free-form `@Foo` Swift attribute in the generated Swift code.

Added Swift reference files for the smoke test "attributes".

See: #543
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>