### PR TITLE
[CMake] Extracts common macros to work with arguments

### DIFF
--- a/cmake/modules/gluecodium/gluecodium/CheckArguments.cmake
+++ b/cmake/modules/gluecodium/gluecodium/CheckArguments.cmake
@@ -1,0 +1,96 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+if(DEFINED includeguard_gluecodium_CheckArguments)
+  return()
+endif()
+set(includeguard_gluecodium_CheckArguments ON)
+
+#.rst:
+# Macros to validate argument passed to function
+# ----------------------
+#
+# Next macros are provided:
+#  apigen_require_argument              Checks that argument exists
+#  apigen_check_no_unparsed_arguments   Checks that no unparsed arguments are left
+#  apigen_deprecate_argument            Shows deprecation message if argument exists
+#  apigen_deprecate_argument_renamed    Shows suggestion to use new argument
+
+#.rst:
+# .. macro:: apigen_require_argument
+#
+# The general form of the macro is::
+#
+#   apigen_require_argument(prefix argument_name function_name)
+#
+# This macro checks that variable <prefix>_<argument_name> exists
+# in scope and shows fatal error otherwise.
+macro(apigen_require_argument prefix argument_name function_name)
+  if(NOT DEFINED ${prefix}_${argument_name})
+    message(FATAL_ERROR "Mandatory argument ${argument_name} was not passed "
+                        "to function ${function_name}.")
+  endif()
+endmacro()
+
+#.rst:
+# .. macro:: apigen_check_no_unparsed_arguments
+#
+# The general form of the macro is::
+#
+#   apigen_check_no_unparsed_arguments(prefix function_name)
+#
+# This macro checks that variable <prefix>_UNPARSED_ARGUMENTS DOESN't exists
+# in scope and shows fatal error otherwise.
+macro(apigen_check_no_unparsed_arguments prefix function_name)
+  if(${prefix}_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "Function ${function_name} detected unknown argument(s): ${${prefix}_UNPARSED_ARGUMENTS}.")
+  endif()
+endmacro()
+
+#.rst:
+# .. macro:: apigen_deprecate_argument
+#
+# The general form of the macro is::
+#
+#   apigen_deprecate_argument(prefix argument_name function_name)
+#
+# This macro checks that variable <prefix>_<argument_name> exists
+# in scope and shows deprrecation warning in this case.
+macro(apigen_deprecate_argument prefix argument_name function_name)
+  if(DEFINED ${prefix}_${argument_name})
+    message(WARNING "Argument ${argument_name} which is passed to function ${function_name} "
+                    "is deprecated and might be removed in future versions.")
+  endif()
+endmacro()
+
+#.rst:
+# .. macro:: apigen_deprecate_argument_renamed
+#
+# The general form of the macro is::
+#
+#   apigen_deprecate_argument_renamed(prefix argument_name new_argument_name function_name)
+#
+# This macro checks that variable <prefix>_<argument_name> exists
+# in scope and shows deprrecation warning and suggestion to use variable <new_argument_name>
+# if exists.
+macro(apigen_deprecate_argument_renamed prefix argument_name new_argument_name function_name)
+  if(DEFINED ${prefix}_${argument_name})
+    message(WARNING "Argument ${argument_name} which is passed to function ${function_name} "
+                    "is deprecated and might be removed in future versions. "
+                    "Please use ${new_argument_name} instead.")
+  endif()
+endmacro()

--- a/cmake/modules/gluecodium/gluecodium/Generate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/Generate.cmake
@@ -70,6 +70,7 @@ endif()
 set(APIGEN_GLUECODIUM_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 include(${APIGEN_GLUECODIUM_DIR}/GeneratedSources.cmake)
+include(${APIGEN_GLUECODIUM_DIR}/CheckArguments.cmake)
 
 function(apigen_generate)
   set(options VALIDATE_ONLY VERBOSE STUBS)
@@ -95,8 +96,10 @@ function(apigen_generate)
   set(multiValueArgs LIME_SOURCES FRANCA_SOURCES WERROR)
   cmake_parse_arguments(apigen_generate "${options}" "${oneValueArgs}"
                       "${multiValueArgs}" ${ARGN})
+  apigen_check_no_unparsed_arguments(apigen_generate apigen_generate)
+  apigen_deprecate_argument_renamed(apigen_generate FRANCA_SOURCES LIME_SOURCES apigen_generate)
   list(APPEND apigen_generate_LIME_SOURCES ${apigen_generate_FRANCA_SOURCES})
-  _check_option_is_set(LIME_SOURCES)
+  apigen_require_argument(apigen_generate LIME_SOURCES apigen_generate)
 
   _apigen_set_option(GENERATOR)
   _apigen_set_option(TARGET)
@@ -259,7 +262,7 @@ macro(_apigen_parse_option GLUECODIUM_PROPERTY CMAKE_OPTION)
 endmacro()
 
 macro(_apigen_parse_required_option GLUECODIUM_PROPERTY CMAKE_OPTION)
-  _check_option_is_set(${CMAKE_OPTION})
+  apigen_require_argument(apigen_generate ${CMAKE_OPTION} apigen_generate)
   _apigen_parse_option(${GLUECODIUM_PROPERTY} ${CMAKE_OPTION})
 endmacro()
 
@@ -273,17 +276,11 @@ macro(_apigen_set_option_or_default _option _default)
 endmacro()
 
 macro(_apigen_set_option _option)
-  _check_option_is_set(${_option})
+  apigen_require_argument(apigen_generate ${_option} apigen_generate)
   set(APIGEN_${_option} "${apigen_generate_${_option}}")
 endmacro()
 
 macro(_pass_option _option)
   string(REPLACE ";" "$<SEMICOLON>" _escaped_option "${${_option}}")
   list(APPEND APIGEN_COMMAND_OPTIONS -DAPIGEN_${_option}=${_escaped_option}})
-endmacro()
-
-macro(_check_option_is_set _option)
-  if(NOT apigen_generate_${_option})
-    message(FATAL_ERROR "Mandatory option ${_option} was not set")
-  endif()
 endmacro()

--- a/cmake/tests/unit/apigen_check_arguments/apigen_deprecate_argument-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/apigen_check_arguments/apigen_deprecate_argument-XFAIL/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.12)
+
+project(gluecodium.test)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+
+include(gluecodium/gluecodium/CheckArguments)
+
+set(_test_prefix_TEST_ARGUMENT_NAME ON)
+apigen_deprecate_argument(_test_prefix TEST_ARGUMENT_NAME test_function_name)
+message(FATAL_ERROR "Deprecation succeed")

--- a/cmake/tests/unit/apigen_check_arguments/apigen_deprecate_argument-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_check_arguments/apigen_deprecate_argument-XFAIL/successful.regex
@@ -1,0 +1,3 @@
+Argument TEST_ARGUMENT_NAME which is passed to function test_function_name
+is deprecated and might be removed in future versions\.
+Deprecation succeed

--- a/cmake/tests/unit/apigen_check_arguments/apigen_deprecate_argument_renamed-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/apigen_check_arguments/apigen_deprecate_argument_renamed-XFAIL/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.12)
+
+project(gluecodium.test)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+
+include(gluecodium/gluecodium/CheckArguments)
+
+set(_test_prefix_TEST_ARGUMENT_NAME ON)
+apigen_deprecate_argument_renamed(_test_prefix TEST_ARGUMENT_NAME TEST_NEW_ARGUMENT_NAME test_function_name)
+message(FATAL_ERROR "Deprecation succeed")

--- a/cmake/tests/unit/apigen_check_arguments/apigen_deprecate_argument_renamed-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_check_arguments/apigen_deprecate_argument_renamed-XFAIL/successful.regex
@@ -1,0 +1,4 @@
+Argument TEST_ARGUMENT_NAME which is passed to function test_function_name
+is deprecated and might be removed in future versions. Please use
+TEST_NEW_ARGUMENT_NAME instead\.
+Deprecation succeed

--- a/cmake/tests/unit/apigen_check_arguments/check-required-arguments-exist/CMakeLists.txt
+++ b/cmake/tests/unit/apigen_check_arguments/check-required-arguments-exist/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.12)
+
+project(gluecodium.test)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+
+include(gluecodium/gluecodium/CheckArguments)
+
+set (_test_prefix_TEST_ARGUMENT_NAME ON)
+apigen_require_argument(_test_prefix TEST_ARGUMENT_NAME test_function_name)
+apigen_check_no_unparsed_arguments(_test_prefix test_function_name)
+apigen_deprecate_argument(_test_prefix TEST_ARGUMENT_NAME test_function_name)
+apigen_deprecate_argument_renamed(_test_prefix TEST_ARGUMENT_NAME TEST_NEW_ARGUMENT_NAME test_function_name)

--- a/cmake/tests/unit/apigen_check_arguments/required-argument-not-exist-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/apigen_check_arguments/required-argument-not-exist-XFAIL/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.12)
+
+project(gluecodium.test)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+
+include(gluecodium/gluecodium/CheckArguments)
+
+apigen_require_argument(_test_prefix TEST_ARGUMENT_NAME test_function_name)

--- a/cmake/tests/unit/apigen_check_arguments/required-argument-not-exist-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_check_arguments/required-argument-not-exist-XFAIL/successful.regex
@@ -1,0 +1,2 @@
+Mandatory argument TEST_ARGUMENT_NAME was not passed to function
+test_function_name\.

--- a/cmake/tests/unit/apigen_check_arguments/unparsed-arguments-present-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/apigen_check_arguments/unparsed-arguments-present-XFAIL/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.12)
+
+project(gluecodium.test)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+
+include(gluecodium/gluecodium/CheckArguments)
+
+set (_test_prefix_UNPARSED_ARGUMENTS TEST_ARGUMENT1 TEST_ARGUMENT2)
+apigen_check_no_unparsed_arguments(_test_prefix test_function_name)

--- a/cmake/tests/unit/apigen_check_arguments/unparsed-arguments-present-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_check_arguments/unparsed-arguments-present-XFAIL/successful.regex
@@ -1,0 +1,2 @@
+Function test_function_name detected unknown argument\(s\):
+TEST_ARGUMENT1;TEST_ARGUMENT2\.

--- a/cmake/tests/unit/apigen_generate/missing-CPP_INTERNAL_NAMESPACE-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_generate/missing-CPP_INTERNAL_NAMESPACE-XFAIL/successful.regex
@@ -1,1 +1,1 @@
-Mandatory option CPP_INTERNAL_NAMESPACE was not set
+Mandatory argument CPP_INTERNAL_NAMESPACE was not passed to function apigen_generate

--- a/cmake/tests/unit/apigen_generate/missing-GENERATOR-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_generate/missing-GENERATOR-XFAIL/successful.regex
@@ -1,1 +1,1 @@
-Mandatory option GENERATOR was not set
+Mandatory argument GENERATOR was not passed to function apigen_generate

--- a/cmake/tests/unit/apigen_generate/missing-LIME_SOURCES-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_generate/missing-LIME_SOURCES-XFAIL/successful.regex
@@ -1,1 +1,1 @@
-Mandatory option LIME_SOURCES was not set
+Mandatory argument LIME_SOURCES was not passed to function apigen_generate

--- a/cmake/tests/unit/apigen_generate/missing-TARGET-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_generate/missing-TARGET-XFAIL/successful.regex
@@ -1,1 +1,1 @@
-Mandatory option TARGET was not set
+Mandatory argument TARGET was not passed to function apigen_generate

--- a/cmake/tests/unit/apigen_generate/recognised-UNPARSED_ARGUMENTS-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/apigen_generate/recognised-UNPARSED_ARGUMENTS-XFAIL/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.12)
+
+project(gluecodium.test)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+
+include(gluecodium/Gluecodium)
+
+add_library(single.module.package)
+
+apigen_generate(
+    TARGET test
+    LIME_SOURCES "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime"
+    GENERATOR cpp
+    CPP_INTERNAL_NAMESPACE test
+    TEST_EXTRA_UNRECOGNISED_ARGUMENT)

--- a/cmake/tests/unit/apigen_generate/recognised-UNPARSED_ARGUMENTS-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_generate/recognised-UNPARSED_ARGUMENTS-XFAIL/successful.regex
@@ -1,0 +1,2 @@
+Function apigen_generate detected unknown argument\(s\):
+TEST_EXTRA_UNRECOGNISED_ARGUMENT\.


### PR DESCRIPTION
Those macros are:

apigen_require_argument              Checks that argument exists
apigen_check_no_unparsed_arguments   Checks that no unparsed arguments are left
apigen_deprecate_argument            Shows deprecation message if argument exists
apigen_deprecate_argument_renamed    Shows suggestion to use new argument

Signed-off-by: Yauheni Khnykin <yauheni.khnykin@here.com>
