### PR TITLE
Add support for free-form attributes in Dart generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 ### Features:
-  * Added support for free-form attributes in C++, Java, and Swift.
+  * Added support for free-form attributes in C++, Java, Swift, and Dart.
 ### Bug fixes:
   * Fixed support for no-message `@Deprecated` attribute in Swift.
 

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -514,7 +514,7 @@ access and cached in Java/Swift/Dart afterwards). Currently only supported for r
   interface type is used for such property, that interface can only have methods that return nullable values or `void`.
   * **Attribute** **=** **"**_Attribute_**"**: marks an element to be marked with the given attribute in Swift
   generated code. _Attribute_ does not need to be prepended with `@`. _Attribute_ can contain parameters, e.g.
-  `@Swift(Attribute="@available(*, deprecated, message: \"It's deprecated.\")")`. If some of the parameters are string
+  `@Swift(Attribute="available(*, deprecated, message: \"It's deprecated.\")")`. If some of the parameters are string
   literals, their enclosing quotes need to be backslash-escaped, as in the example.
 * **@Dart**: marks an element with Dart-specific behaviors:
   * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in Dart.
@@ -522,6 +522,10 @@ access and cached in Java/Swift/Dart afterwards). Currently only supported for r
   * **Default**: marks a constructor as a "default" (nameless) in Dart.
   * **Skip**: marks an element to be skipped (not generated) in Dart. Can be applied to any element except for struct
   fields.
+  * **Attribute** **=** **"**_Annotation_**"**: marks an element to be marked with the given annotation in Dart
+  generated code. _Annotation_ does not need to be prepended with `@`. _Annotation_ can contain parameters, e.g.
+  `@Dart(Attribute="Deprecated(\"It's deprecated.\")")`. If some of the parameters are string literals, their enclosing
+  quotes need to be backslash-escaped, as in the example.
 * **@Cpp**: marks an element with C++-specific behaviors:
   * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in C++.
   This is the default specification for this attribute.

--- a/gluecodium/src/main/resources/templates/dart/DartAttributes.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartAttributes.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -18,5 +18,13 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
-{{#if isInClass}}static {{/if}}final {{resolveName typeRef}} {{resolveName visibility}}{{resolveName}} = {{resolveName value}};
+{{#if attributes.dart.attribute}}
+{{#attributes.dart.attribute}}
+@{{this}}
+{{/attributes.dart.attribute}}
+{{/if}}{{!!
+}}{{#if property.attributes.dart.attribute}}
+{{#property.attributes.dart.attribute}}
+@{{this}}
+{{/property.attributes.dart.attribute}}
+{{/if}}

--- a/gluecodium/src/main/resources/templates/dart/DartAttributesInline.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartAttributesInline.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -18,5 +18,4 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
-{{#if isInClass}}static {{/if}}final {{resolveName typeRef}} {{resolveName visibility}}{{resolveName}} = {{resolveName value}};
+{{#if attributes.dart.attribute}}{{#attributes.dart.attribute}}@{{this}} {{/attributes.dart.attribute}}{{/if}}

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>dart/DartDocumentation}}
+{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 {{#unless testableMode}}abstract {{/unless}}class {{resolveName}} {{#if parent}}implements {{resolveName parent}} {{/if}}{
 {{#set parent=this}}{{#constructors}}
 {{>dart/DartRedirectConstructor}}
@@ -188,14 +188,14 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 
 }}{{+dartPropertyRedirect}}
 {{#getter}}
-{{>dart/DartDocumentation}}{{!!
+{{>dart/DartDocumentation}}{{>dart/DartAttributes}}{{!!
 }}{{#if isStatic}}{{#unless testableMode}}static {{/unless}}{{/if}}{{!!
 }}{{resolveName property.typeRef}} get {{resolveName visibility}}{{resolveName property}}{{!!
 }}{{#if isStatic}} => {{#if testableMode}}$class{{/if}}{{#unless testableMode}}{{resolveName parent}}$Impl{{/unless}}.{{!!
 }}{{resolveName visibility}}{{resolveName property}}{{/if}};
 {{/getter}}
 {{#setter}}
-{{>dart/DartDocumentation}}{{!!
+{{>dart/DartDocumentation}}{{>dart/DartAttributes}}{{!!
 }}{{#if isStatic}}{{#unless testableMode}}static {{/unless}}{{!!
 }}{{/if}}set {{resolveName visibility}}{{resolveName property}}({{resolveName property.typeRef}} value){{!!
 }}{{#if isStatic}} { {{#if testableMode}}$class{{/if}}{{#unless testableMode}}{{resolveName parent}}$Impl{{/unless}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{#unlessPredicate "skipDeclaration"}}
-{{>dart/DartDocumentation}}
+{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 enum {{resolveName}}{{#if external.dart.converter}}_internal{{/if}} {
 {{#enumerators}}
 {{prefixPartial "dart/DartEnumerator" "    "}}

--- a/gluecodium/src/main/resources/templates/dart/DartEnumerator.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumerator.mustache
@@ -18,5 +18,5 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>dart/DartDocumentation}}
+{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 {{resolveName}}{{#if iter.hasNext}},{{/if}}

--- a/gluecodium/src/main/resources/templates/dart/DartException.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartException.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>dart/DartDocumentation}}
+{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 class {{resolveName}} implements Exception {
   final {{resolveName errorType}} error;
   {{resolveName}}(this.error);

--- a/gluecodium/src/main/resources/templates/dart/DartField.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartField.mustache
@@ -18,6 +18,6 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>dart/DartDocumentation}}
+{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 {{#if parent.attributes.immutable}}final {{/if}}{{!!
 }}{{resolveName typeRef}} {{resolveName visibility}}{{resolveName}};

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
@@ -29,4 +29,10 @@
 /// @nodoc{{/if}}{{!!
 }}{{#if attributes.deprecated}}
 @Deprecated("{{#resolveName attributes.deprecated.message}}{{escape this}}{{/resolveName}}")
-{{/if}}
+{{/if}}{{!!
+}}{{#if attributes.dart.attribute}}
+
+{{#attributes.dart.attribute}}
+@{{this}}{{#if iter.hasNext}}
+
+{{/if}}{{/attributes.dart.attribute}}{{/if}}

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionSignature.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionSignature.mustache
@@ -23,6 +23,6 @@
 }}{{#unless isStruct}}Pointer<Void> {{/unless}}{{/if}}{{!!
 }}{{#unless isConstructor}}{{>ffiReturnDeclaration}}{{/unless}}{{!!
 }}{{#if isConstructor}}_{{/if}}{{#unless isConstructor}}{{resolveName visibility}}{{/unless}}{{resolveName}}({{!!
-}}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
+}}{{#parameters}}{{>dart/DartAttributesInline}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
 
 }}{{+ffiReturnDeclaration}}{{#returnType}}{{#unless isVoid}}{{resolveName typeRef}} {{/unless}}{{/returnType}}{{/ffiReturnDeclaration}}

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>dart/DartDocumentation}}
+{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 abstract class {{resolveName}} {{#if parent}}implements {{resolveName parent}} {{/if}}{
 {{#if inheritedFunctions functions inheritedProperties properties logic="or"}}
   {{resolveName}}() {}

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>dart/DartDocumentation}}
+{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 typedef {{resolveName}} = {{>dart/DartLambdaType}};
 
 // {{resolveName}} "private" section, not exported.

--- a/gluecodium/src/main/resources/templates/dart/DartProperty.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartProperty.mustache
@@ -21,7 +21,7 @@
 {{#set property=this}}
 {{#getter}}
 {{#unless skipDocs}}{{>dart/DartDocumentation}}
-{{/unless}}
+{{/unless}}{{>dart/DartAttributes}}
 {{#if override}}{{#unless isStatic}}@override
 {{/unless}}{{/if}}
 {{#if isStatic}}static {{/if}}{{resolveName property.typeRef}} get {{resolveName visibility}}{{resolveName property}}{{!!
@@ -29,7 +29,7 @@
 {{/getter}}
 {{#setter}}
 {{#unless skipDocs}}{{>dart/DartDocumentation}}
-{{/unless}}
+{{/unless}}{{>dart/DartAttributes}}
 {{#if override}}{{#unless isStatic}}@override
 {{/unless}}{{/if}}
 {{#if isStatic}}static {{/if}}set {{resolveName visibility}}{{resolveName property}}({{resolveName property.typeRef}} value){{!!

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -24,7 +24,7 @@
 
 {{/functions}}{{!!
 }}{{#if testableMode}}
-{{>dart/DartDocumentation}}
+{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 {{#if attributes.immutable}}
 @immutable{{/if}}
 class {{resolveName}}{{#if external.dart.converter}}_internal{{/if}} {
@@ -41,7 +41,7 @@ class {{resolveName}}{{#if external.dart.converter}}_internal{{/if}} {
 
 {{/if}}{{!!
 
-}}{{>dart/DartDocumentation}}
+}}{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 {{#if attributes.immutable}}
 @immutable{{/if}}
 class {{resolveName}}{{#if external.dart.converter}}_internal{{/if}}{{#if testableMode}}$Impl{{/if}} {

--- a/gluecodium/src/test/resources/smoke/attributes/input/Attributes.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/Attributes.lime
@@ -20,90 +20,109 @@ package smoke
 @Cpp(Attribute = "OnClass")
 @Java(Attribute = "OnClass")
 @Swift(Attribute = "OnClass")
+@Dart(Attribute = "OnClass")
 class AttributesClass {
     @Cpp(Attribute = "OnFunctionInClass")
     @Java(Attribute = "OnFunctionInClass")
     @Swift(Attribute = "OnFunctionInClass")
+    @Dart(Attribute = "OnFunctionInClass")
     fun veryFun(
         @Cpp(Attribute = "OnParameterInClass")
         @Java(Attribute = "OnParameterInClass")
         @Swift(Attribute = "OnParameterInClass")
+        @Dart(Attribute = "OnParameterInClass")
         param: String
     )
     @Cpp(Attribute = "OnPropertyInClass")
     @Java(Attribute = "OnPropertyInClass")
     @Swift(Attribute = "OnPropertyInClass")
+    @Dart(Attribute = "OnPropertyInClass")
     property prop: String
     @Cpp(Attribute = "OnConstInClass")
     @Java(Attribute = "OnConstInClass")
     @Swift(Attribute = "OnConstInClass")
+    @Dart(Attribute = "OnConstInClass")
     const pi: Boolean = false
 }
 
 @Cpp(Attribute = "OnInterface")
 @Java(Attribute = "OnInterface")
 @Swift(Attribute = "OnInterface")
+@Dart(Attribute = "OnInterface")
 interface AttributesInterface {
     @Cpp(Attribute = "OnFunctionInInterface")
     @Java(Attribute = "OnFunctionInInterface")
     @Swift(Attribute = "OnFunctionInInterface")
+    @Dart(Attribute = "OnFunctionInInterface")
     fun veryFun(
         @Cpp(Attribute = "OnParameterInInterface")
         @Java(Attribute = "OnParameterInInterface")
         @Swift(Attribute = "OnParameterInInterface")
+        @Dart(Attribute = "OnParameterInInterface")
         param: String
     )
     @Cpp(Attribute = "OnPropertyInInterface")
     @Java(Attribute = "OnPropertyInInterface")
     @Swift(Attribute = "OnPropertyInInterface")
+    @Dart(Attribute = "OnPropertyInInterface")
     property prop: String
     @Cpp(Attribute = "OnConstInInterface")
     @Java(Attribute = "OnConstInInterface")
     @Swift(Attribute = "OnConstInInterface")
+    @Dart(Attribute = "OnConstInInterface")
     const pi: Boolean = false
 }
 
 @Cpp(Attribute = "OnStruct")
 @Java(Attribute = "OnStruct")
 @Swift(Attribute = "OnStruct")
+@Dart(Attribute = "OnStruct")
 struct AttributesStruct {
     @Cpp(Attribute = "OnField")
     @Java(Attribute = "OnField")
     @Swift(Attribute = "OnField")
+    @Dart(Attribute = "OnField")
     field: String
     @Cpp(Attribute = "OnFunctionInStruct")
     @Java(Attribute = "OnFunctionInStruct")
     @Swift(Attribute = "OnFunctionInStruct")
+    @Dart(Attribute = "OnFunctionInStruct")
     fun veryFun(
         @Cpp(Attribute = "OnParameterInStruct")
         @Java(Attribute = "OnParameterInStruct")
         @Swift(Attribute = "OnParameterInStruct")
+        @Dart(Attribute = "OnParameterInStruct")
         param: String
     )
     @Cpp(Attribute = "OnConstInStruct")
     @Java(Attribute = "OnConstInStruct")
     @Swift(Attribute = "OnConstInStruct")
+    @Dart(Attribute = "OnConstInStruct")
     const pi: Boolean = false
 }
 
 @Cpp(Attribute = "OnEnumeration")
 @Java(Attribute = "OnEnumeration")
 @Swift(Attribute = "OnEnumeration")
+@Dart(Attribute = "OnEnumeration")
 enum AttributesEnum {
     @Cpp(Attribute = "OnEnumerator")
     @Java(Attribute = "OnEnumerator")
     @Swift(Attribute = "OnEnumerator")
+    @Dart(Attribute = "OnEnumerator")
     NOPE
 }
 
 @Cpp(Attribute = "OnLambda")
 @Java(Attribute = "OnLambda")
 @Swift(Attribute = "OnLambda")
+@Dart(Attribute = "OnLambda")
 lambda AttributesLambda = () -> Void
 
 @Cpp(Attribute = "OnException")
 @Java(Attribute = "OnException")
 @Swift(Attribute = "OnException")
+@Dart(Attribute = "OnException")
 exception AttributesCrash(String)
 
 @Cpp(Attribute = "OnTypeAlias")

--- a/gluecodium/src/test/resources/smoke/attributes/input/AttributesWithComments.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/AttributesWithComments.lime
@@ -21,60 +21,70 @@ package smoke
 @Cpp(Attribute = "OnClass")
 @Java(Attribute = "OnClass")
 @Swift(Attribute = "OnClass")
+@Dart(Attribute = "OnClass")
 class AttributesWithComments {
-   // Function comment
-   @Cpp(Attribute = "OnFunctionInClass")
-   @Java(Attribute = "OnFunctionInClass")
-   @Swift(Attribute = "OnFunctionInClass")
-   fun veryFun()
-   // Property comment
-   // @get Getter comment
-   // @set Setter comment
-   @Cpp(Attribute = "OnPropertyInClass")
-   @Java(Attribute = "OnPropertyInClass")
-   @Swift(Attribute = "OnPropertyInClass")
-   property prop: String
-   // Const comment
-   @Cpp(Attribute = "OnConstInClass")
-   @Java(Attribute = "OnConstInClass")
-   @Swift(Attribute = "OnConstInClass")
-   const pi: Boolean = false
+    // Function comment
+    @Cpp(Attribute = "OnFunctionInClass")
+    @Java(Attribute = "OnFunctionInClass")
+    @Swift(Attribute = "OnFunctionInClass")
+    @Dart(Attribute = "OnFunctionInClass")
+    fun veryFun()
+    // Property comment
+    // @get Getter comment
+    // @set Setter comment
+    @Cpp(Attribute = "OnPropertyInClass")
+    @Java(Attribute = "OnPropertyInClass")
+    @Swift(Attribute = "OnPropertyInClass")
+    @Dart(Attribute = "OnPropertyInClass")
+    property prop: String
+    // Const comment
+    @Cpp(Attribute = "OnConstInClass")
+    @Java(Attribute = "OnConstInClass")
+    @Swift(Attribute = "OnConstInClass")
+    @Dart(Attribute = "OnConstInClass")
+    const pi: Boolean = false
 
-   struct SomeStruct {
-      // Field comment
-      @Cpp(Attribute = "OnField")
-      @Java(Attribute = "OnField")
-      @Swift(Attribute = "OnField")
-      field: String
-   }
+    struct SomeStruct {
+        // Field comment
+        @Cpp(Attribute = "OnField")
+        @Java(Attribute = "OnField")
+        @Swift(Attribute = "OnField")
+        @Dart(Attribute = "OnField")
+        field: String
+    }
 }
 
 @Deprecated
 @Cpp(Attribute = "OnClass")
 @Java(Attribute = "OnClass")
 @Swift(Attribute = "OnClass")
+@Dart(Attribute = "OnClass")
 class AttributesWithDeprecated {
-   @Deprecated
-   @Cpp(Attribute = "OnFunctionInClass")
-   @Java(Attribute = "OnFunctionInClass")
-   @Swift(Attribute = "OnFunctionInClass")
-   fun veryFun()
-   @Deprecated
-   @Cpp(Attribute = "OnPropertyInClass")
-   @Java(Attribute = "OnPropertyInClass")
-   @Swift(Attribute = "OnPropertyInClass")
-   property prop: String
-   @Deprecated
-   @Cpp(Attribute = "OnConstInClass")
-   @Java(Attribute = "OnConstInClass")
-   @Swift(Attribute = "OnConstInClass")
-   const pi: Boolean = false
+    @Deprecated
+    @Cpp(Attribute = "OnFunctionInClass")
+    @Java(Attribute = "OnFunctionInClass")
+    @Swift(Attribute = "OnFunctionInClass")
+    @Dart(Attribute = "OnFunctionInClass")
+    fun veryFun()
+    @Deprecated
+    @Cpp(Attribute = "OnPropertyInClass")
+    @Java(Attribute = "OnPropertyInClass")
+    @Swift(Attribute = "OnPropertyInClass")
+    @Dart(Attribute = "OnPropertyInClass")
+    property prop: String { @Deprecated get @Deprecated set }
+    @Deprecated
+    @Cpp(Attribute = "OnConstInClass")
+    @Java(Attribute = "OnConstInClass")
+    @Swift(Attribute = "OnConstInClass")
+    @Dart(Attribute = "OnConstInClass")
+    const pi: Boolean = false
 
-   struct SomeStruct {
-      @Deprecated
-      @Cpp(Attribute = "OnField")
-      @Java(Attribute = "OnField")
-      @Swift(Attribute = "OnField")
-      field: String
-   }
+    struct SomeStruct {
+        @Deprecated
+        @Cpp(Attribute = "OnField")
+        @Java(Attribute = "OnField")
+        @Swift(Attribute = "OnField")
+        @Dart(Attribute = "OnField")
+        field: String
+    }
 }

--- a/gluecodium/src/test/resources/smoke/attributes/input/MultipleAttributes.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/MultipleAttributes.lime
@@ -76,3 +76,23 @@ class MultipleAttributesSwift {
     @Swift(Attribute = ["Baz", "Fizz"])
     fun twoLists()
 }
+
+@Java(Skip) @Swift(Skip)
+class MultipleAttributesDart {
+    @Dart(Attribute = "Foo")
+    @Dart(Attribute = "Bar")
+    fun noLists2()
+    @Dart(Attribute = "Foo")
+    @Dart(Attribute = "Bar")
+    @Dart(Attribute = "Baz")
+    fun noLists3()
+    @Dart(Attribute = ["Foo", "Bar"])
+    @Dart(Attribute = "Baz")
+    fun listFirst()
+    @Dart(Attribute = "Foo")
+    @Dart(Attribute = ["Bar", "Baz"])
+    fun listSecond()
+    @Dart(Attribute = ["Foo", "Bar"])
+    @Dart(Attribute = ["Baz", "Fizz"])
+    fun twoLists()
+}

--- a/gluecodium/src/test/resources/smoke/attributes/input/SpecialAttributes.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/SpecialAttributes.lime
@@ -21,9 +21,11 @@ class SpecialAttributes {
     @Cpp(Attribute = "Deprecated(\"foo\\nbar\")")
     @Java(Attribute = "Deprecated(\"foo\\nbar\")")
     @Swift(Attribute = "Deprecated(\"foo\\nbar\")")
+    @Dart(Attribute = "Deprecated(\"foo\\nbar\")")
     fun withEscaping()
     @Cpp(Attribute = "HackMe\nrm -rf *")
     @Java(Attribute = "HackMe\nrm -rf *")
     @Swift(Attribute = "HackMe\nrm -rf *")
+    @Dart(Attribute = "HackMe\nrm -rf *")
     fun withLineBreak()
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/android/com/example/smoke/AttributesWithDeprecated.java
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android/com/example/smoke/AttributesWithDeprecated.java
@@ -48,9 +48,20 @@ public final class AttributesWithDeprecated extends NativeBase {
     @Deprecated
     @OnFunctionInClass
     public native void veryFun();
+    /**
+     *
+     * @deprecated
+     */
+    @Deprecated
     @OnPropertyInClass
     @NonNull
     public native String getProp();
+    /**
+     *
+     * @deprecated
+     * @param value
+     */
+    @Deprecated
     @OnPropertyInClass
     public native void setProp(@NonNull final String value);
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithDeprecated.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithDeprecated.h
@@ -35,8 +35,18 @@ public:
      */
     [[OnFunctionInClass]]
     virtual void very_fun(  ) = 0;
+    /**
+     *
+     * \deprecated
+     * \return
+     */
     [[OnPropertyInClass]]
     virtual ::std::string get_prop(  ) const = 0;
+    /**
+     *
+     * \deprecated
+     * \param[in] value
+     */
     [[OnPropertyInClass]]
     virtual void set_prop( const ::std::string& value ) = 0;
 };

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -1,0 +1,106 @@
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+@OnClass
+abstract class AttributesClass {
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+  @OnConstInClass
+  static final bool pi = false;
+  @OnFunctionInClass
+  veryFun(@OnParameterInClass String param);
+  @OnPropertyInClass
+  String get prop;
+  @OnPropertyInClass
+  set prop(String value);
+}
+// AttributesClass "private" section, not exported.
+final _smoke_AttributesClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesClass_copy_handle'));
+final _smoke_AttributesClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesClass_release_handle'));
+final _smoke_AttributesClass_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_AttributesClass_get_raw_pointer'));
+class AttributesClass$Impl implements AttributesClass {
+  @protected
+  Pointer<Void> handle;
+  AttributesClass$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.reverseCache.remove(_smoke_AttributesClass_get_raw_pointer(handle));
+    _smoke_AttributesClass_release_handle(handle);
+    handle = null;
+  }
+  @override
+  veryFun(@OnParameterInClass String param) {
+    final _veryFun_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesClass_veryFun__String'));
+    final _param_handle = String_toFfi(param);
+    final _handle = this.handle;
+    final __result_handle = _veryFun_ffi(_handle, __lib.LibraryContext.isolateId, _param_handle);
+    String_releaseFfiHandle(_param_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+  @OnPropertyInClass
+  @override
+  String get prop {
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesClass_prop_get'));
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
+  }
+  @OnPropertyInClass
+  @override
+  set prop(String value) {
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesClass_prop_set__String'));
+    final _value_handle = String_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
+    String_releaseFfiHandle(_value_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+}
+Pointer<Void> smoke_AttributesClass_toFfi(AttributesClass value) =>
+  _smoke_AttributesClass_copy_handle((value as AttributesClass$Impl).handle);
+AttributesClass smoke_AttributesClass_fromFfi(Pointer<Void> handle) {
+  final raw_handle = _smoke_AttributesClass_get_raw_pointer(handle);
+  final instance = __lib.reverseCache[raw_handle] as AttributesClass;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_AttributesClass_copy_handle(handle);
+  final result = AttributesClass$Impl(_copied_handle);
+  __lib.reverseCache[raw_handle] = result;
+  return result;
+}
+void smoke_AttributesClass_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_AttributesClass_release_handle(handle);
+Pointer<Void> smoke_AttributesClass_toFfi_nullable(AttributesClass value) =>
+  value != null ? smoke_AttributesClass_toFfi(value) : Pointer<Void>.fromAddress(0);
+AttributesClass smoke_AttributesClass_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_AttributesClass_fromFfi(handle) : null;
+void smoke_AttributesClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_AttributesClass_release_handle(handle);
+// End of AttributesClass "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_crash_exception.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_crash_exception.dart
@@ -1,0 +1,10 @@
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+@OnException
+class AttributesCrashException implements Exception {
+  final String error;
+  AttributesCrashException(this.error);
+}

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_enum.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_enum.dart
@@ -1,0 +1,58 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+@OnEnumeration
+enum AttributesEnum {
+    @OnEnumerator
+    nope
+}
+// AttributesEnum "private" section, not exported.
+int smoke_AttributesEnum_toFfi(AttributesEnum value) {
+  switch (value) {
+  case AttributesEnum.nope:
+    return 0;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for AttributesEnum enum.");
+  }
+}
+AttributesEnum smoke_AttributesEnum_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return AttributesEnum.nope;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for AttributesEnum enum.");
+  }
+}
+void smoke_AttributesEnum_releaseFfiHandle(int handle) {}
+final _smoke_AttributesEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_AttributesEnum_create_handle_nullable'));
+final _smoke_AttributesEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesEnum_release_handle_nullable'));
+final _smoke_AttributesEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_AttributesEnum_get_value_nullable'));
+Pointer<Void> smoke_AttributesEnum_toFfi_nullable(AttributesEnum value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_AttributesEnum_toFfi(value);
+  final result = _smoke_AttributesEnum_create_handle_nullable(_handle);
+  smoke_AttributesEnum_releaseFfiHandle(_handle);
+  return result;
+}
+AttributesEnum smoke_AttributesEnum_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_AttributesEnum_get_value_nullable(handle);
+  final result = smoke_AttributesEnum_fromFfi(_handle);
+  smoke_AttributesEnum_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_AttributesEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_AttributesEnum_release_handle_nullable(handle);
+// End of AttributesEnum "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -1,0 +1,183 @@
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+@OnInterface
+abstract class AttributesInterface {
+  AttributesInterface() {}
+  factory AttributesInterface.fromLambdas({
+    @required void Function(String) lambda_veryFun,
+    @required String Function() lambda_prop_get,
+    @required void Function(String) lambda_prop_set
+  }) => AttributesInterface$Lambdas(
+    lambda_veryFun,
+    lambda_prop_get,
+    lambda_prop_set
+  );
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release() {}
+  @OnConstInInterface
+  static final bool pi = false;
+  @OnFunctionInInterface
+  veryFun(@OnParameterInInterface String param);
+  @OnPropertyInInterface
+  String get prop;
+  @OnPropertyInInterface
+  set prop(String value);
+}
+// AttributesInterface "private" section, not exported.
+final _smoke_AttributesInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesInterface_copy_handle'));
+final _smoke_AttributesInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesInterface_release_handle'));
+final _smoke_AttributesInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer)
+  >('library_smoke_AttributesInterface_create_proxy'));
+final _smoke_AttributesInterface_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_AttributesInterface_get_raw_pointer'));
+final _smoke_AttributesInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesInterface_get_type_id'));
+class AttributesInterface$Lambdas implements AttributesInterface {
+  void Function(String) lambda_veryFun;
+  String Function() lambda_prop_get;
+  void Function(String) lambda_prop_set;
+  AttributesInterface$Lambdas(
+    void Function(String) lambda_veryFun,
+    String Function() lambda_prop_get,
+    void Function(String) lambda_prop_set
+  ) {
+    this.lambda_veryFun = lambda_veryFun;
+    this.lambda_prop_get = lambda_prop_get;
+    this.lambda_prop_set = lambda_prop_set;
+  }
+  @override
+  void release() {}
+  @override
+  veryFun(@OnParameterInInterface String param) =>
+    lambda_veryFun(param);
+  @override
+  String get prop => lambda_prop_get();
+  @override
+  set prop(String value) => lambda_prop_set(value);
+}
+class AttributesInterface$Impl implements AttributesInterface {
+  @protected
+  Pointer<Void> handle;
+  AttributesInterface$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.reverseCache.remove(_smoke_AttributesInterface_get_raw_pointer(handle));
+    _smoke_AttributesInterface_release_handle(handle);
+    handle = null;
+  }
+  @override
+  veryFun(@OnParameterInInterface String param) {
+    final _veryFun_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesInterface_veryFun__String'));
+    final _param_handle = String_toFfi(param);
+    final _handle = this.handle;
+    final __result_handle = _veryFun_ffi(_handle, __lib.LibraryContext.isolateId, _param_handle);
+    String_releaseFfiHandle(_param_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+  @OnPropertyInInterface
+  String get prop {
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesInterface_prop_get'));
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
+  }
+  @OnPropertyInInterface
+  set prop(String value) {
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesInterface_prop_set__String'));
+    final _value_handle = String_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
+    String_releaseFfiHandle(_value_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+}
+int _AttributesInterface_veryFun_static(int _token, Pointer<Void> param) {
+  try {
+    (__lib.instanceCache[_token] as AttributesInterface).veryFun(String_fromFfi(param));
+  } finally {
+    String_releaseFfiHandle(param);
+  }
+  return 0;
+}
+int _AttributesInterface_prop_get_static(int _token, Pointer<Pointer<Void>> _result) {
+  _result.value = String_toFfi((__lib.instanceCache[_token] as AttributesInterface).prop);
+  return 0;
+}
+int _AttributesInterface_prop_set_static(int _token, Pointer<Void> _value) {
+  try {
+    (__lib.instanceCache[_token] as AttributesInterface).prop =
+      String_fromFfi(_value);
+  } finally {
+    String_releaseFfiHandle(_value);
+  }
+  return 0;
+}
+Pointer<Void> smoke_AttributesInterface_toFfi(AttributesInterface value) {
+  if (value is AttributesInterface$Impl) return _smoke_AttributesInterface_copy_handle(value.handle);
+  final result = _smoke_AttributesInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.LibraryContext.isolateId,
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_AttributesInterface_veryFun_static, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_AttributesInterface_prop_get_static, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_AttributesInterface_prop_set_static, __lib.unknownError)
+  );
+  __lib.reverseCache[_smoke_AttributesInterface_get_raw_pointer(result)] = value;
+  return result;
+}
+AttributesInterface smoke_AttributesInterface_fromFfi(Pointer<Void> handle) {
+  final raw_handle = _smoke_AttributesInterface_get_raw_pointer(handle);
+  final instance = __lib.reverseCache[raw_handle] as AttributesInterface;
+  if (instance != null) return instance;
+  final _type_id_handle = _smoke_AttributesInterface_get_type_id(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
+  String_releaseFfiHandle(_type_id_handle);
+  final _copied_handle = _smoke_AttributesInterface_copy_handle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copied_handle)
+    : AttributesInterface$Impl(_copied_handle);
+  __lib.reverseCache[raw_handle] = result;
+  return result;
+}
+void smoke_AttributesInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_AttributesInterface_release_handle(handle);
+Pointer<Void> smoke_AttributesInterface_toFfi_nullable(AttributesInterface value) =>
+  value != null ? smoke_AttributesInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+AttributesInterface smoke_AttributesInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_AttributesInterface_fromFfi(handle) : null;
+void smoke_AttributesInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_AttributesInterface_release_handle(handle);
+// End of AttributesInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
@@ -1,0 +1,100 @@
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+@OnLambda
+typedef AttributesLambda = void Function();
+// AttributesLambda "private" section, not exported.
+final _smoke_AttributesLambda_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesLambda_copy_handle'));
+final _smoke_AttributesLambda_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesLambda_release_handle'));
+final _smoke_AttributesLambda_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
+    Pointer<Void> Function(int, int, Pointer, Pointer)
+  >('library_smoke_AttributesLambda_create_proxy'));
+final _smoke_AttributesLambda_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_AttributesLambda_get_raw_pointer'));
+class AttributesLambda$Impl {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  AttributesLambda$Impl(this.handle);
+  void release() => _smoke_AttributesLambda_release_handle(handle);
+  call() {
+    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesLambda_call'));
+    final _handle = this.handle;
+    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+}
+int _AttributesLambda_call_static(int _token) {
+  try {
+    (__lib.instanceCache[_token] as AttributesLambda)();
+  } finally {
+  }
+  return 0;
+}
+Pointer<Void> smoke_AttributesLambda_toFfi(AttributesLambda value) {
+  final result = _smoke_AttributesLambda_create_proxy(
+    __lib.cacheObject(value),
+    __lib.LibraryContext.isolateId,
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64)>(_AttributesLambda_call_static, __lib.unknownError)
+  );
+  __lib.reverseCache[_smoke_AttributesLambda_get_raw_pointer(result)] = value;
+  return result;
+}
+AttributesLambda smoke_AttributesLambda_fromFfi(Pointer<Void> handle) {
+  final instance = __lib.reverseCache[_smoke_AttributesLambda_get_raw_pointer(handle)] as AttributesLambda;
+  if (instance != null) return instance;
+  final _impl = AttributesLambda$Impl(_smoke_AttributesLambda_copy_handle(handle));
+  return () {
+    final _result =_impl.call();
+    _impl.release();
+    return _result;
+  };
+}
+void smoke_AttributesLambda_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_AttributesLambda_release_handle(handle);
+// Nullable AttributesLambda
+final _smoke_AttributesLambda_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesLambda_create_handle_nullable'));
+final _smoke_AttributesLambda_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesLambda_release_handle_nullable'));
+final _smoke_AttributesLambda_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesLambda_get_value_nullable'));
+Pointer<Void> smoke_AttributesLambda_toFfi_nullable(AttributesLambda value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_AttributesLambda_toFfi(value);
+  final result = _smoke_AttributesLambda_create_handle_nullable(_handle);
+  smoke_AttributesLambda_releaseFfiHandle(_handle);
+  return result;
+}
+AttributesLambda smoke_AttributesLambda_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_AttributesLambda_get_value_nullable(handle);
+  final result = smoke_AttributesLambda_fromFfi(_handle);
+  smoke_AttributesLambda_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_AttributesLambda_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_AttributesLambda_release_handle_nullable(handle);
+// End of AttributesLambda "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
@@ -1,0 +1,87 @@
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+@OnStruct
+class AttributesStruct {
+  @OnField
+  String field;
+  AttributesStruct(this.field);
+  @OnConstInStruct
+  static final bool pi = false;
+  @OnFunctionInStruct
+  veryFun(@OnParameterInStruct String param) {
+    final _veryFun_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesStruct_veryFun__String'));
+    final _param_handle = String_toFfi(param);
+    final _handle = smoke_AttributesStruct_toFfi(this);
+    final __result_handle = _veryFun_ffi(_handle, __lib.LibraryContext.isolateId, _param_handle);
+    smoke_AttributesStruct_releaseFfiHandle(_handle);
+    String_releaseFfiHandle(_param_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+}
+// AttributesStruct "private" section, not exported.
+final _smoke_AttributesStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesStruct_create_handle'));
+final _smoke_AttributesStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesStruct_release_handle'));
+final _smoke_AttributesStruct_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesStruct_get_field_field'));
+Pointer<Void> smoke_AttributesStruct_toFfi(AttributesStruct value) {
+  final _field_handle = String_toFfi(value.field);
+  final _result = _smoke_AttributesStruct_create_handle(_field_handle);
+  String_releaseFfiHandle(_field_handle);
+  return _result;
+}
+AttributesStruct smoke_AttributesStruct_fromFfi(Pointer<Void> handle) {
+  final _field_handle = _smoke_AttributesStruct_get_field_field(handle);
+  try {
+    return AttributesStruct(
+      String_fromFfi(_field_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_field_handle);
+  }
+}
+void smoke_AttributesStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_AttributesStruct_release_handle(handle);
+// Nullable AttributesStruct
+final _smoke_AttributesStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesStruct_create_handle_nullable'));
+final _smoke_AttributesStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesStruct_release_handle_nullable'));
+final _smoke_AttributesStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesStruct_get_value_nullable'));
+Pointer<Void> smoke_AttributesStruct_toFfi_nullable(AttributesStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_AttributesStruct_toFfi(value);
+  final result = _smoke_AttributesStruct_create_handle_nullable(_handle);
+  smoke_AttributesStruct_releaseFfiHandle(_handle);
+  return result;
+}
+AttributesStruct smoke_AttributesStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_AttributesStruct_get_value_nullable(handle);
+  final result = smoke_AttributesStruct_fromFfi(_handle);
+  smoke_AttributesStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_AttributesStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_AttributesStruct_release_handle_nullable(handle);
+// End of AttributesStruct "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -1,0 +1,175 @@
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+/// Class comment
+@OnClass
+abstract class AttributesWithComments {
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+  /// Const comment
+  @OnConstInClass
+  static final bool pi = false;
+  /// Function comment
+  @OnFunctionInClass
+  veryFun();
+  /// Getter comment
+  @OnPropertyInClass
+  String get prop;
+  /// Setter comment
+  @OnPropertyInClass
+  set prop(String value);
+}
+class AttributesWithComments_SomeStruct {
+  /// Field comment
+  @OnField
+  String field;
+  AttributesWithComments_SomeStruct(this.field);
+}
+// AttributesWithComments_SomeStruct "private" section, not exported.
+final _smoke_AttributesWithComments_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesWithComments_SomeStruct_create_handle'));
+final _smoke_AttributesWithComments_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesWithComments_SomeStruct_release_handle'));
+final _smoke_AttributesWithComments_SomeStruct_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesWithComments_SomeStruct_get_field_field'));
+Pointer<Void> smoke_AttributesWithComments_SomeStruct_toFfi(AttributesWithComments_SomeStruct value) {
+  final _field_handle = String_toFfi(value.field);
+  final _result = _smoke_AttributesWithComments_SomeStruct_create_handle(_field_handle);
+  String_releaseFfiHandle(_field_handle);
+  return _result;
+}
+AttributesWithComments_SomeStruct smoke_AttributesWithComments_SomeStruct_fromFfi(Pointer<Void> handle) {
+  final _field_handle = _smoke_AttributesWithComments_SomeStruct_get_field_field(handle);
+  try {
+    return AttributesWithComments_SomeStruct(
+      String_fromFfi(_field_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_field_handle);
+  }
+}
+void smoke_AttributesWithComments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_AttributesWithComments_SomeStruct_release_handle(handle);
+// Nullable AttributesWithComments_SomeStruct
+final _smoke_AttributesWithComments_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesWithComments_SomeStruct_create_handle_nullable'));
+final _smoke_AttributesWithComments_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesWithComments_SomeStruct_release_handle_nullable'));
+final _smoke_AttributesWithComments_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesWithComments_SomeStruct_get_value_nullable'));
+Pointer<Void> smoke_AttributesWithComments_SomeStruct_toFfi_nullable(AttributesWithComments_SomeStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_AttributesWithComments_SomeStruct_toFfi(value);
+  final result = _smoke_AttributesWithComments_SomeStruct_create_handle_nullable(_handle);
+  smoke_AttributesWithComments_SomeStruct_releaseFfiHandle(_handle);
+  return result;
+}
+AttributesWithComments_SomeStruct smoke_AttributesWithComments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_AttributesWithComments_SomeStruct_get_value_nullable(handle);
+  final result = smoke_AttributesWithComments_SomeStruct_fromFfi(_handle);
+  smoke_AttributesWithComments_SomeStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_AttributesWithComments_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_AttributesWithComments_SomeStruct_release_handle_nullable(handle);
+// End of AttributesWithComments_SomeStruct "private" section.
+// AttributesWithComments "private" section, not exported.
+final _smoke_AttributesWithComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesWithComments_copy_handle'));
+final _smoke_AttributesWithComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesWithComments_release_handle'));
+final _smoke_AttributesWithComments_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_AttributesWithComments_get_raw_pointer'));
+class AttributesWithComments$Impl implements AttributesWithComments {
+  @protected
+  Pointer<Void> handle;
+  AttributesWithComments$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.reverseCache.remove(_smoke_AttributesWithComments_get_raw_pointer(handle));
+    _smoke_AttributesWithComments_release_handle(handle);
+    handle = null;
+  }
+  @override
+  veryFun() {
+    final _veryFun_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithComments_veryFun'));
+    final _handle = this.handle;
+    final __result_handle = _veryFun_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+  @OnPropertyInClass
+  @override
+  String get prop {
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesWithComments_prop_get'));
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
+  }
+  @OnPropertyInClass
+  @override
+  set prop(String value) {
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesWithComments_prop_set__String'));
+    final _value_handle = String_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
+    String_releaseFfiHandle(_value_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+}
+Pointer<Void> smoke_AttributesWithComments_toFfi(AttributesWithComments value) =>
+  _smoke_AttributesWithComments_copy_handle((value as AttributesWithComments$Impl).handle);
+AttributesWithComments smoke_AttributesWithComments_fromFfi(Pointer<Void> handle) {
+  final raw_handle = _smoke_AttributesWithComments_get_raw_pointer(handle);
+  final instance = __lib.reverseCache[raw_handle] as AttributesWithComments;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_AttributesWithComments_copy_handle(handle);
+  final result = AttributesWithComments$Impl(_copied_handle);
+  __lib.reverseCache[raw_handle] = result;
+  return result;
+}
+void smoke_AttributesWithComments_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_AttributesWithComments_release_handle(handle);
+Pointer<Void> smoke_AttributesWithComments_toFfi_nullable(AttributesWithComments value) =>
+  value != null ? smoke_AttributesWithComments_toFfi(value) : Pointer<Void>.fromAddress(0);
+AttributesWithComments smoke_AttributesWithComments_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_AttributesWithComments_fromFfi(handle) : null;
+void smoke_AttributesWithComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_AttributesWithComments_release_handle(handle);
+// End of AttributesWithComments "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -1,0 +1,175 @@
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+@Deprecated("")
+@OnClass
+abstract class AttributesWithDeprecated {
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+  @Deprecated("")
+  @OnConstInClass
+  static final bool pi = false;
+  @Deprecated("")
+  @OnFunctionInClass
+  veryFun();
+  @Deprecated("")
+  @OnPropertyInClass
+  String get prop;
+  @Deprecated("")
+  @OnPropertyInClass
+  set prop(String value);
+}
+class AttributesWithDeprecated_SomeStruct {
+  @Deprecated("")
+  @OnField
+  String field;
+  AttributesWithDeprecated_SomeStruct(this.field);
+}
+// AttributesWithDeprecated_SomeStruct "private" section, not exported.
+final _smoke_AttributesWithDeprecated_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesWithDeprecated_SomeStruct_create_handle'));
+final _smoke_AttributesWithDeprecated_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesWithDeprecated_SomeStruct_release_handle'));
+final _smoke_AttributesWithDeprecated_SomeStruct_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesWithDeprecated_SomeStruct_get_field_field'));
+Pointer<Void> smoke_AttributesWithDeprecated_SomeStruct_toFfi(AttributesWithDeprecated_SomeStruct value) {
+  final _field_handle = String_toFfi(value.field);
+  final _result = _smoke_AttributesWithDeprecated_SomeStruct_create_handle(_field_handle);
+  String_releaseFfiHandle(_field_handle);
+  return _result;
+}
+AttributesWithDeprecated_SomeStruct smoke_AttributesWithDeprecated_SomeStruct_fromFfi(Pointer<Void> handle) {
+  final _field_handle = _smoke_AttributesWithDeprecated_SomeStruct_get_field_field(handle);
+  try {
+    return AttributesWithDeprecated_SomeStruct(
+      String_fromFfi(_field_handle)
+    );
+  } finally {
+    String_releaseFfiHandle(_field_handle);
+  }
+}
+void smoke_AttributesWithDeprecated_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_AttributesWithDeprecated_SomeStruct_release_handle(handle);
+// Nullable AttributesWithDeprecated_SomeStruct
+final _smoke_AttributesWithDeprecated_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesWithDeprecated_SomeStruct_create_handle_nullable'));
+final _smoke_AttributesWithDeprecated_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesWithDeprecated_SomeStruct_release_handle_nullable'));
+final _smoke_AttributesWithDeprecated_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesWithDeprecated_SomeStruct_get_value_nullable'));
+Pointer<Void> smoke_AttributesWithDeprecated_SomeStruct_toFfi_nullable(AttributesWithDeprecated_SomeStruct value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_AttributesWithDeprecated_SomeStruct_toFfi(value);
+  final result = _smoke_AttributesWithDeprecated_SomeStruct_create_handle_nullable(_handle);
+  smoke_AttributesWithDeprecated_SomeStruct_releaseFfiHandle(_handle);
+  return result;
+}
+AttributesWithDeprecated_SomeStruct smoke_AttributesWithDeprecated_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_AttributesWithDeprecated_SomeStruct_get_value_nullable(handle);
+  final result = smoke_AttributesWithDeprecated_SomeStruct_fromFfi(_handle);
+  smoke_AttributesWithDeprecated_SomeStruct_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_AttributesWithDeprecated_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_AttributesWithDeprecated_SomeStruct_release_handle_nullable(handle);
+// End of AttributesWithDeprecated_SomeStruct "private" section.
+// AttributesWithDeprecated "private" section, not exported.
+final _smoke_AttributesWithDeprecated_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AttributesWithDeprecated_copy_handle'));
+final _smoke_AttributesWithDeprecated_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AttributesWithDeprecated_release_handle'));
+final _smoke_AttributesWithDeprecated_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_AttributesWithDeprecated_get_raw_pointer'));
+class AttributesWithDeprecated$Impl implements AttributesWithDeprecated {
+  @protected
+  Pointer<Void> handle;
+  AttributesWithDeprecated$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.reverseCache.remove(_smoke_AttributesWithDeprecated_get_raw_pointer(handle));
+    _smoke_AttributesWithDeprecated_release_handle(handle);
+    handle = null;
+  }
+  @override
+  veryFun() {
+    final _veryFun_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithDeprecated_veryFun'));
+    final _handle = this.handle;
+    final __result_handle = _veryFun_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+  @OnPropertyInClass
+  @override
+  String get prop {
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesWithDeprecated_prop_get'));
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
+  }
+  @OnPropertyInClass
+  @override
+  set prop(String value) {
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesWithDeprecated_prop_set__String'));
+    final _value_handle = String_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
+    String_releaseFfiHandle(_value_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+}
+Pointer<Void> smoke_AttributesWithDeprecated_toFfi(AttributesWithDeprecated value) =>
+  _smoke_AttributesWithDeprecated_copy_handle((value as AttributesWithDeprecated$Impl).handle);
+AttributesWithDeprecated smoke_AttributesWithDeprecated_fromFfi(Pointer<Void> handle) {
+  final raw_handle = _smoke_AttributesWithDeprecated_get_raw_pointer(handle);
+  final instance = __lib.reverseCache[raw_handle] as AttributesWithDeprecated;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_AttributesWithDeprecated_copy_handle(handle);
+  final result = AttributesWithDeprecated$Impl(_copied_handle);
+  __lib.reverseCache[raw_handle] = result;
+  return result;
+}
+void smoke_AttributesWithDeprecated_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_AttributesWithDeprecated_release_handle(handle);
+Pointer<Void> smoke_AttributesWithDeprecated_toFfi_nullable(AttributesWithDeprecated value) =>
+  value != null ? smoke_AttributesWithDeprecated_toFfi(value) : Pointer<Void>.fromAddress(0);
+AttributesWithDeprecated smoke_AttributesWithDeprecated_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_AttributesWithDeprecated_fromFfi(handle) : null;
+void smoke_AttributesWithDeprecated_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_AttributesWithDeprecated_release_handle(handle);
+// End of AttributesWithDeprecated "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -1,0 +1,133 @@
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+abstract class MultipleAttributesDart {
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+  @Foo
+  @Bar
+  noLists2();
+  @Foo
+  @Bar
+  @Baz
+  noLists3();
+  @Foo
+  @Bar
+  @Baz
+  listFirst();
+  @Foo
+  @Bar
+  @Baz
+  listSecond();
+  @Foo
+  @Bar
+  @Baz
+  @Fizz
+  twoLists();
+}
+// MultipleAttributesDart "private" section, not exported.
+final _smoke_MultipleAttributesDart_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MultipleAttributesDart_copy_handle'));
+final _smoke_MultipleAttributesDart_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MultipleAttributesDart_release_handle'));
+final _smoke_MultipleAttributesDart_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_MultipleAttributesDart_get_raw_pointer'));
+class MultipleAttributesDart$Impl implements MultipleAttributesDart {
+  @protected
+  Pointer<Void> handle;
+  MultipleAttributesDart$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.reverseCache.remove(_smoke_MultipleAttributesDart_get_raw_pointer(handle));
+    _smoke_MultipleAttributesDart_release_handle(handle);
+    handle = null;
+  }
+  @override
+  noLists2() {
+    final _noLists2_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists2'));
+    final _handle = this.handle;
+    final __result_handle = _noLists2_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+  @override
+  noLists3() {
+    final _noLists3_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists3'));
+    final _handle = this.handle;
+    final __result_handle = _noLists3_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+  @override
+  listFirst() {
+    final _listFirst_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_listFirst'));
+    final _handle = this.handle;
+    final __result_handle = _listFirst_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+  @override
+  listSecond() {
+    final _listSecond_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_listSecond'));
+    final _handle = this.handle;
+    final __result_handle = _listSecond_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+  @override
+  twoLists() {
+    final _twoLists_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_twoLists'));
+    final _handle = this.handle;
+    final __result_handle = _twoLists_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+}
+Pointer<Void> smoke_MultipleAttributesDart_toFfi(MultipleAttributesDart value) =>
+  _smoke_MultipleAttributesDart_copy_handle((value as MultipleAttributesDart$Impl).handle);
+MultipleAttributesDart smoke_MultipleAttributesDart_fromFfi(Pointer<Void> handle) {
+  final raw_handle = _smoke_MultipleAttributesDart_get_raw_pointer(handle);
+  final instance = __lib.reverseCache[raw_handle] as MultipleAttributesDart;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_MultipleAttributesDart_copy_handle(handle);
+  final result = MultipleAttributesDart$Impl(_copied_handle);
+  __lib.reverseCache[raw_handle] = result;
+  return result;
+}
+void smoke_MultipleAttributesDart_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_MultipleAttributesDart_release_handle(handle);
+Pointer<Void> smoke_MultipleAttributesDart_toFfi_nullable(MultipleAttributesDart value) =>
+  value != null ? smoke_MultipleAttributesDart_toFfi(value) : Pointer<Void>.fromAddress(0);
+MultipleAttributesDart smoke_MultipleAttributesDart_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_MultipleAttributesDart_fromFfi(handle) : null;
+void smoke_MultipleAttributesDart_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_MultipleAttributesDart_release_handle(handle);
+// End of MultipleAttributesDart "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -1,0 +1,84 @@
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+abstract class SpecialAttributes {
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+  @Deprecated("foo\nbar")
+  withEscaping();
+  @HackMerm -rf *
+  withLineBreak();
+}
+// SpecialAttributes "private" section, not exported.
+final _smoke_SpecialAttributes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SpecialAttributes_copy_handle'));
+final _smoke_SpecialAttributes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SpecialAttributes_release_handle'));
+final _smoke_SpecialAttributes_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+      Pointer<Void> Function(Pointer<Void>),
+      Pointer<Void> Function(Pointer<Void>)
+    >('library_smoke_SpecialAttributes_get_raw_pointer'));
+class SpecialAttributes$Impl implements SpecialAttributes {
+  @protected
+  Pointer<Void> handle;
+  SpecialAttributes$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.reverseCache.remove(_smoke_SpecialAttributes_get_raw_pointer(handle));
+    _smoke_SpecialAttributes_release_handle(handle);
+    handle = null;
+  }
+  @override
+  withEscaping() {
+    final _withEscaping_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withEscaping'));
+    final _handle = this.handle;
+    final __result_handle = _withEscaping_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+  @override
+  withLineBreak() {
+    final _withLineBreak_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withLineBreak'));
+    final _handle = this.handle;
+    final __result_handle = _withLineBreak_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+}
+Pointer<Void> smoke_SpecialAttributes_toFfi(SpecialAttributes value) =>
+  _smoke_SpecialAttributes_copy_handle((value as SpecialAttributes$Impl).handle);
+SpecialAttributes smoke_SpecialAttributes_fromFfi(Pointer<Void> handle) {
+  final raw_handle = _smoke_SpecialAttributes_get_raw_pointer(handle);
+  final instance = __lib.reverseCache[raw_handle] as SpecialAttributes;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_SpecialAttributes_copy_handle(handle);
+  final result = SpecialAttributes$Impl(_copied_handle);
+  __lib.reverseCache[raw_handle] = result;
+  return result;
+}
+void smoke_SpecialAttributes_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_SpecialAttributes_release_handle(handle);
+Pointer<Void> smoke_SpecialAttributes_toFfi_nullable(SpecialAttributes value) =>
+  value != null ? smoke_SpecialAttributes_toFfi(value) : Pointer<Void>.fromAddress(0);
+SpecialAttributes smoke_SpecialAttributes_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_SpecialAttributes_fromFfi(handle) : null;
+void smoke_SpecialAttributes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_SpecialAttributes_release_handle(handle);
+// End of SpecialAttributes "private" section.


### PR DESCRIPTION
Updated Dart templates to add support for `@Dart(Attribute="foo")` IDL attribute. This syntax should produce a free-form
`@foo` Dart annotation in the generated Dart code.

Added Dart reference files for smoke test "attributes".

Resolves: #543
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>