### PR TITLE
Adds checks that COMMON_OUTPUT_DIR was specified in apigen_generate

### DIFF
--- a/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
+++ b/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
@@ -22,6 +22,8 @@ set(includeguard_gluecodium_TargetIncludeDirectories ON)
 
 cmake_minimum_required(VERSION 3.5)
 
+include(${CMAKE_CURRENT_LIST_DIR}/CheckArguments.cmake)
+
 #.rst:
 # Generated target_include_directories module
 # -------------------------------------------
@@ -77,12 +79,19 @@ function(apigen_get_target_include_directories target)
   set(single_args PUBLIC_RESULT_VARIABLE PRIVATE_RESULT_VARIABLE)
   cmake_parse_arguments(APIGEN_TARGET_INCLUDE_DIRECTORIES "${options}" "${single_args}" "" ${ARGN})
 
+  apigen_check_no_unparsed_arguments(APIGEN_TARGET_INCLUDE_DIRECTORIES apigen_target_include_directories)
+
   unset (_properties_out_dir)
   if (APIGEN_TARGET_INCLUDE_DIRECTORIES_MAIN)
     list (APPEND _properties_out_dir APIGEN_OUTPUT_DIR)
   endif ()
 
   if (APIGEN_TARGET_INCLUDE_DIRECTORIES_COMMON)
+    get_target_property(COMMON_OUTPUT_DIR ${target} APIGEN_COMMON_OUTPUT_DIR)
+    if(NOT COMMON_OUTPUT_DIR)
+      message(FATAL_ERROR "COMMON include directoriy is necessary, but apigen_target was called "
+                          "without COMMON_OUTPUT_DIR argument. Please specify this argument.")
+    endif()
     list (APPEND _properties_out_dir APIGEN_COMMON_OUTPUT_DIR)
   endif ()
 

--- a/cmake/modules/gluecodium/gluecodium/TargetSources.cmake
+++ b/cmake/modules/gluecodium/gluecodium/TargetSources.cmake
@@ -22,6 +22,8 @@ set(includeguard_gluecodium_TargetSources ON)
 
 cmake_minimum_required(VERSION 3.5)
 
+include(${CMAKE_CURRENT_LIST_DIR}/CheckArguments.cmake)
+
 #.rst:
 # Generated target_sources module
 # -------------------------------
@@ -56,6 +58,8 @@ function(apigen_target_sources target)
   set(options MAIN COMMON SKIP_SWIFT)
   cmake_parse_arguments(apigen_target_sources "${options}" "" "" ${ARGN})
 
+  apigen_check_no_unparsed_arguments(apigen_target_sources apigen_target_sources)
+
   get_target_property(GENERATOR ${target} APIGEN_GENERATOR)
   get_target_property(COMMON_OUTPUT_DIR ${target} APIGEN_COMMON_OUTPUT_DIR)
   get_target_property(BUILD_OUTPUT_DIR ${target} APIGEN_BUILD_OUTPUT_DIR)
@@ -71,6 +75,11 @@ function(apigen_target_sources target)
     list(APPEND _source_sets MAIN)
   endif()
   if(apigen_target_sources_COMMON)
+    if(NOT COMMON_OUTPUT_DIR)
+      message(FATAL_ERROR "COMMON source set is specified, but apigen_target was "
+                          "called without COMMON_OUTPUT_DIR argument. "
+                          "Please specify this argument.")
+    endif()
     list(APPEND _source_sets COMMON)
   endif()
 

--- a/cmake/tests/unit/apigen_target_include_directories/missing-COMMON_OUTPUT_DIR-in-apigen_generate-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/apigen_target_include_directories/missing-COMMON_OUTPUT_DIR-in-apigen_generate-XFAIL/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.12)
+
+project(gluecodium.test)
+
+set (CMAKE_CXX_STANDARD 17)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+
+include(gluecodium/Gluecodium)
+
+add_library(single.module SHARED)
+
+apigen_generate(
+    TARGET single.module
+    LIME_SOURCES "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime"
+    GENERATOR cpp
+    CPP_INTERNAL_NAMESPACE test)
+
+apigen_target_include_directories(single.module MAIN COMMON)

--- a/cmake/tests/unit/apigen_target_include_directories/missing-COMMON_OUTPUT_DIR-in-apigen_generate-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_target_include_directories/missing-COMMON_OUTPUT_DIR-in-apigen_generate-XFAIL/successful.regex
@@ -1,0 +1,2 @@
+COMMON include directoriy is necessary, but apigen_target was called
+without COMMON_OUTPUT_DIR argument\. Please specify this argument\.

--- a/cmake/tests/unit/apigen_target_include_directories/recognised-UNPARSED_ARGUMENTS-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/apigen_target_include_directories/recognised-UNPARSED_ARGUMENTS-XFAIL/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.12)
+
+project(gluecodium.test)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+
+include(gluecodium/Gluecodium)
+
+apigen_target_include_directories (single.module TEST_EXTRA_UNRECOGNISED_ARGUMENT)

--- a/cmake/tests/unit/apigen_target_include_directories/recognised-UNPARSED_ARGUMENTS-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_target_include_directories/recognised-UNPARSED_ARGUMENTS-XFAIL/successful.regex
@@ -1,0 +1,2 @@
+Function apigen_target_include_directories detected unknown argument\(s\):
+TEST_EXTRA_UNRECOGNISED_ARGUMENT\.

--- a/cmake/tests/unit/apigen_target_sources/missing-COMMON_OUTPUT_DIR-in-apigen_generate-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/apigen_target_sources/missing-COMMON_OUTPUT_DIR-in-apigen_generate-XFAIL/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.12)
+
+project(gluecodium.test)
+
+set (CMAKE_CXX_STANDARD 17)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+
+include(gluecodium/Gluecodium)
+
+add_library(single.module SHARED)
+
+apigen_generate(
+    TARGET single.module
+    LIME_SOURCES "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime"
+    GENERATOR cpp
+    CPP_INTERNAL_NAMESPACE test)
+
+apigen_target_sources(single.module MAIN COMMON)

--- a/cmake/tests/unit/apigen_target_sources/missing-COMMON_OUTPUT_DIR-in-apigen_generate-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_target_sources/missing-COMMON_OUTPUT_DIR-in-apigen_generate-XFAIL/successful.regex
@@ -1,0 +1,2 @@
+COMMON source set is specified, but apigen_target was called without
+COMMON_OUTPUT_DIR argument\. Please specify this argument\.

--- a/cmake/tests/unit/apigen_target_sources/recognised-UNPARSED_ARGUMENTS-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/apigen_target_sources/recognised-UNPARSED_ARGUMENTS-XFAIL/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required (VERSION 3.12)
+
+project(gluecodium.test)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+
+include(gluecodium/Gluecodium)
+
+apigen_target_sources (single.module TEST_EXTRA_UNRECOGNISED_ARGUMENT)

--- a/cmake/tests/unit/apigen_target_sources/recognised-UNPARSED_ARGUMENTS-XFAIL/successful.regex
+++ b/cmake/tests/unit/apigen_target_sources/recognised-UNPARSED_ARGUMENTS-XFAIL/successful.regex
@@ -1,0 +1,2 @@
+Function apigen_target_sources detected unknown argument\(s\):
+TEST_EXTRA_UNRECOGNISED_ARGUMENT\.


### PR DESCRIPTION
This check is necessary in apigen_target_sources and
apigen_target_include_directories because otherwise
it leads to very confusing compilation errors of generated code.

Signed-off-by: Yauheni Khnykin <yauheni.khnykin@here.com>

