### PR TITLE
Deprecate @Swift(ObjC) attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Deprecated:
+  * `@Swift(ObjC)` IDL attribute is now deprecated. `@Swift(Attribute="objc")` or `@Swift(Attribute="objcMembers")`
+    should be used instead.
+
 ## 8.5.0
 Release date: 2020-10-29
 ### Features:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -502,7 +502,6 @@ access and cached in Java/Swift/Dart afterwards). Currently only supported for r
   This is the default specification for this attribute.
   * **Label** **=** **"**_LabelName_**"**: marks a function parameter to have a distinct argument
   label in Swift.
-  * **ObjC**: marks a class as Objective-C compatible in Swift.
   * **Extension**: marks a type collection (`types`) to be generated as Swift extension. The primary
   use case for this is adding nested types into a pre-existing Swift type (i.e. non-generated).
   Extending a generated type is also possible, but requires usage of `Name` attribute to avoid name
@@ -516,6 +515,7 @@ access and cached in Java/Swift/Dart afterwards). Currently only supported for r
   generated code. _Attribute_ does not need to be prepended with `@`. _Attribute_ can contain parameters, e.g.
   `@Swift(Attribute="available(*, deprecated, message: \"It's deprecated.\")")`. If some of the parameters are string
   literals, their enclosing quotes need to be backslash-escaped, as in the example.
+  * ~~**ObjC**~~: **deprecated**. Marks a class as Objective-C compatible in Swift.
 * **@Dart**: marks an element with Dart-specific behaviors:
   * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in Dart.
   This is the default specification for this attribute.

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDeprecationsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDeprecationsValidator.kt
@@ -22,7 +22,9 @@ package com.here.gluecodium.validator
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeAttributeType.POINTER_EQUATABLE
+import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
 import com.here.gluecodium.model.lime.LimeAttributeValueType.BUILDER
+import com.here.gluecodium.model.lime.LimeAttributeValueType.OBJC
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeNamedElement
 
@@ -52,6 +54,11 @@ internal class LimeDeprecationsValidator(
             }
             limeContainer.attributes.have(JAVA, BUILDER) -> {
                 logger.logFunction(limeContainer, "@Java(Builder) attribute is deprecated")
+                false
+            }
+            limeContainer.attributes.have(SWIFT, OBJC) -> {
+                logger.logFunction(limeContainer, "@Swift(ObjC) attribute is deprecated. @Swift(Attribute=\"objc\") " +
+                    "or @Swift(Attribute=\"objcMembers\") should be used instead.")
                 false
             }
             else -> true


### PR DESCRIPTION
Added validation warning and updated documentation to mark `@Swift(ObjC)` IDL attribute as deprecated.
`@Swift(Attribute="objc")` or `@Swift(Attribute="objcMembers")` should be used instead.

Resolves: #564