### PR TITLE
Add support for nesting enums inside structs in C++

### DIFF
--- a/gluecodium/src/main/resources/templates/cpp/CppStruct.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppStruct.mustache
@@ -83,10 +83,11 @@ public:
 {{/fields}}{{/set}}
 
 {{/if}}{{!!
-}}{{#sort structs constants}}
+}}{{#sort structs constants enumerations}}
 {{#instanceOf this "LimeStruct"}}{{prefixPartial "cpp/CppStruct" "    "}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeConstant"}}{{#set constant=this storageQualifier="static"}}{{#constant}}{{!!
-}}{{prefixPartial "cpp/CppConstant" "    "}}{{/constant}}{{/set}}{{/instanceOf}}
+}}{{prefixPartial "cpp/CppConstant" "    "}}{{/constant}}{{/set}}{{/instanceOf}}{{!!
+}}{{#instanceOf this "LimeEnumeration"}}{{prefixPartial "cpp/CppEnumeration" "    "}}{{/instanceOf}}
 {{/sort}}
 {{#each classes interfaces}}
 {{prefixPartial "cpp/CppClass" "    "}}

--- a/gluecodium/src/main/resources/templates/cpp/CppStructImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppStructImpl.mustache
@@ -20,6 +20,9 @@
   !}}
 {{#set structElement=this}}{{#unless external.cpp}}{{!!
 }}{{#resolveName structElement}}{{#setJoin "parentName" parentName this delimiter="::"}}{{#structElement}}
+{{#enumerations}}
+{{>cpp/CppEnumerationImpl}}
+{{/enumerations}}
 {{#structs}}
 {{>cpp/CppStructImpl}}
 {{/structs}}

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterStruct.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterStruct.h
@@ -3,13 +3,13 @@
 //
 // -------------------------------------------------------------------------------------------------
 #pragma once
-#include "gluecodium\Export.h"
-#include "gluecodium\Locale.h"
-#include "gluecodium\TimePointHash.h"
-#include "gluecodium\TypeRepository.h"
-#include "gluecodium\UnorderedMapHash.h"
-#include "gluecodium\UnorderedSetHash.h"
-#include "gluecodium\VectorHash.h"
+#include "gluecodium/Export.h"
+#include "gluecodium/Locale.h"
+#include "gluecodium/TimePointHash.h"
+#include "gluecodium/TypeRepository.h"
+#include "gluecodium/UnorderedMapHash.h"
+#include "gluecodium/UnorderedSetHash.h"
+#include "gluecodium/VectorHash.h"
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -27,6 +27,10 @@ struct _GLUECODIUM_CPP_EXPORT OuterStruct {
         InnerStruct( );
         InnerStruct( ::std::vector< ::std::chrono::system_clock::time_point > other_field );
         void do_something(  ) const;
+    };
+    enum class InnerEnum {
+        FOO,
+        BAR
     };
     class _GLUECODIUM_CPP_EXPORT InnerClass {
     public:


### PR DESCRIPTION
Updated C++ templates to support nesting enum declarations inside struct declarations.

Updated smoke tests. Functional tests will be updated in a follow-up commit after all output languages are supported.

See: #579
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>