### PR TITLE
Add support for nesting enums inside structs in Java

### DIFF
--- a/gluecodium/src/test/resources/smoke/nesting/input/NestingInStruct.lime
+++ b/gluecodium/src/test/resources/smoke/nesting/input/NestingInStruct.lime
@@ -35,7 +35,7 @@ struct OuterStruct {
     }
 
     # Skip those until full support is added.
-    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    @Swift(Skip) @Dart(Skip)
     enum InnerEnum {
         FOO,
         BAR

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/OuterStruct.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/OuterStruct.java
@@ -12,6 +12,14 @@ import java.util.Set;
 public final class OuterStruct {
     @NonNull
     public String field;
+    public enum InnerEnum {
+        FOO(0),
+        BAR(1);
+        public final int value;
+        InnerEnum(final int value) {
+            this.value = value;
+        }
+    }
     public static final class InnerStruct {
         @NonNull
         public List<Date> otherField;

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerEnum__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerEnum__Conversion.cpp
@@ -1,0 +1,48 @@
+/*
+ *
+ */
+#include "com_example_smoke_OuterStruct_InnerEnum__Conversion.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+namespace gluecodium
+{
+namespace jni
+{
+::smoke::OuterStruct::InnerEnum
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::OuterStruct::InnerEnum*)
+{
+    return ::smoke::OuterStruct::InnerEnum(
+        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+}
+::gluecodium::optional<::smoke::OuterStruct::InnerEnum>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<::smoke::OuterStruct::InnerEnum>*)
+{
+    return _jinput
+        ? ::gluecodium::optional<::smoke::OuterStruct::InnerEnum>(convert_from_jni(_jenv, _jinput, (::smoke::OuterStruct::InnerEnum*)nullptr))
+        : ::gluecodium::optional<::smoke::OuterStruct::InnerEnum>{};
+}
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/OuterStruct$InnerEnum", com_example_smoke_OuterStruct_00024InnerEnum, ::smoke::OuterStruct::InnerEnum)
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::OuterStruct::InnerEnum _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::OuterStruct::InnerEnum>::java_class;
+    const char* enumeratorName = nullptr;
+    switch(_ninput) {
+        case(::smoke::OuterStruct::InnerEnum::FOO):
+            enumeratorName = "FOO";
+            break;
+        case(::smoke::OuterStruct::InnerEnum::BAR):
+            enumeratorName = "BAR";
+            break;
+    }
+    jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Lcom/example/smoke/OuterStruct$InnerEnum;");
+    return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<::smoke::OuterStruct::InnerEnum> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/lime/smoke/OuterStruct.lime
+++ b/gluecodium/src/test/resources/smoke/nesting/output/lime/smoke/OuterStruct.lime
@@ -1,7 +1,6 @@
 package smoke
 struct OuterStruct {
     field: String
-    @Java(Skip)
     @Swift(Skip)
     @Dart(Skip)
     enum InnerEnum {


### PR DESCRIPTION
Updated Java and JNI templates to support nesting enum declarations inside struct declarations.

Updated smoke tests. Functional tests will be updated in a follow-up commit after all output languages are supported.

See: #579
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>