### PR TITLE
Add support for nesting enums inside structs in Swift

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeModelBuilder.kt
@@ -204,7 +204,8 @@ class CBridgeModelBuilder(
             fields = getPreviousResults(CField::class.java),
             methods = getPreviousResults(CFunction::class.java),
             structs = getPreviousResults(CStruct::class.java),
-            interfaces = getPreviousResults(CInterface::class.java)
+            interfaces = getPreviousResults(CInterface::class.java),
+            enums = getPreviousResults(CEnum::class.java)
         )
 
         storeResult(cStruct)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftModelBuilder.kt
@@ -281,7 +281,8 @@ class SwiftModelBuilder(
             externalFramework = limeStruct.external?.swift?.get(FRAMEWORK_NAME),
             externalConverter = limeStruct.external?.swift?.get(CONVERTER_NAME),
             structs = getPreviousResults(SwiftStruct::class.java),
-            classes = getPreviousResults(SwiftClass::class.java)
+            classes = getPreviousResults(SwiftClass::class.java),
+            enums = getPreviousResults(SwiftEnum::class.java)
         )
         swiftStruct.comment = createComments(limeStruct)
         propagateAttributes(limeStruct, swiftStruct)

--- a/gluecodium/src/main/java/com/here/gluecodium/model/cbridge/CStruct.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/cbridge/CStruct.kt
@@ -29,7 +29,8 @@ class CStruct(
     val fields: List<CField> = emptyList(),
     val methods: List<CFunction> = emptyList(),
     val structs: List<CStruct> = emptyList(),
-    val interfaces: List<CInterface> = emptyList()
+    val interfaces: List<CInterface> = emptyList(),
+    val enums: List<CEnum> = emptyList()
 ) : CType(name) {
 
     val type = mappedType.functionReturnType.toString()

--- a/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftStruct.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/model/swift/SwiftStruct.kt
@@ -37,7 +37,8 @@ class SwiftStruct(
     externalFramework: String? = null,
     externalConverter: String? = null,
     val structs: List<SwiftStruct> = emptyList(),
-    val classes: List<SwiftClass> = emptyList()
+    val classes: List<SwiftClass> = emptyList(),
+    val enums: List<SwiftEnum> = emptyList()
 ) : SwiftType(
     name,
     cPrefix,

--- a/gluecodium/src/main/resources/templates/cbridge/StructHeader.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/StructHeader.mustache
@@ -18,6 +18,8 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{#enums}}{{>cbridge/Enumeration}}{{/enums}}
+
 _GLUECODIUM_C_EXPORT _baseRef {{name}}_create_handle({{#fields}}{{type.cType}} {{name}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 _GLUECODIUM_C_EXPORT void {{name}}_release_handle(_baseRef handle);
 

--- a/gluecodium/src/main/resources/templates/swift/Struct.mustache
+++ b/gluecodium/src/main/resources/templates/swift/Struct.mustache
@@ -90,6 +90,9 @@
     }
 
 {{/unless}}{{/constructors}}{{/set}}
+{{#enums}}
+{{prefixPartial "swift/Enum" "    "}}
+{{/enums}}
 {{#structs}}
 {{prefixPartial "swift/Struct" "    "}}
 {{/structs}}

--- a/gluecodium/src/main/resources/templates/swift/StructConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/StructConversion.mustache
@@ -89,3 +89,6 @@ internal func moveToCType(_ swiftType: {{name}}?) -> RefHolder {
 {{#structs}}
 {{>swift/StructConversion}}{{!!
 }}{{/structs}}
+{{#enums}}
+{{>swift/EnumConversion}}{{!!
+}}{{/enums}}

--- a/gluecodium/src/test/resources/smoke/nesting/input/NestingInStruct.lime
+++ b/gluecodium/src/test/resources/smoke/nesting/input/NestingInStruct.lime
@@ -34,8 +34,6 @@ struct OuterStruct {
         fun barBaz(): Map<String, Blob>
     }
 
-    # Skip those until full support is added.
-    @Swift(Skip)
     enum InnerEnum {
         FOO,
         BAR

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/include/smoke/cbridge_OuterStruct.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/include/smoke/cbridge_OuterStruct.h
@@ -1,0 +1,47 @@
+//
+//
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "cbridge/include/BaseHandle.h"
+#include "cbridge/include/Export.h"
+#include "cbridge/include/StringHandle.h"
+typedef uint32_t smoke_OuterStruct_InnerEnum;
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_create_handle(_baseRef field);
+_GLUECODIUM_C_EXPORT void smoke_OuterStruct_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_create_optional_handle(_baseRef field);
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_unwrap_optional_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_OuterStruct_release_optional_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_field_get(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_InnerStruct_create_handle(_baseRef otherField);
+_GLUECODIUM_C_EXPORT void smoke_OuterStruct_InnerStruct_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_InnerStruct_create_optional_handle(_baseRef otherField);
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_InnerStruct_unwrap_optional_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_OuterStruct_InnerStruct_release_optional_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_InnerStruct_otherField_get(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_OuterStruct_InnerStruct_doSomething(_baseRef _instance);
+_GLUECODIUM_C_EXPORT void smoke_OuterStruct_InnerClass_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_InnerClass_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_OuterStruct_InnerClass_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_OuterStruct_InnerClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
+_GLUECODIUM_C_EXPORT void smoke_OuterStruct_InnerClass_remove_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_InnerClass_fooBar(_baseRef _instance);
+_GLUECODIUM_C_EXPORT void smoke_OuterStruct_InnerInterface_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_InnerInterface_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_OuterStruct_InnerInterface_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_OuterStruct_InnerInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
+_GLUECODIUM_C_EXPORT void smoke_OuterStruct_InnerInterface_remove_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void* smoke_OuterStruct_InnerInterface_get_typed(_baseRef handle);
+typedef struct {
+    void* swift_pointer;
+    void(*release)(void* swift_pointer);
+    _baseRef(*smoke_OuterStruct_InnerInterface_barBaz)(void* swift_pointer);
+} smoke_OuterStruct_InnerInterface_FunctionTable;
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_InnerInterface_create_proxy(smoke_OuterStruct_InnerInterface_FunctionTable functionTable);
+_GLUECODIUM_C_EXPORT const void* smoke_OuterStruct_InnerInterface_get_swift_object_from_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_OuterStruct_InnerInterface_barBaz(_baseRef _instance);
+_GLUECODIUM_C_EXPORT void smoke_OuterStruct_doNothing(_baseRef _instance);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/nesting/output/lime/smoke/OuterStruct.lime
+++ b/gluecodium/src/test/resources/smoke/nesting/output/lime/smoke/OuterStruct.lime
@@ -1,7 +1,6 @@
 package smoke
 struct OuterStruct {
     field: String
-    @Swift(Skip)
     enum InnerEnum {
         FOO,
         BAR

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterStruct.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterStruct.swift
@@ -9,6 +9,10 @@ public struct OuterStruct {
     internal init(cHandle: _baseRef) {
         field = moveFromCType(smoke_OuterStruct_field_get(cHandle))
     }
+    public enum InnerEnum : UInt32, CaseIterable, Codable {
+        case foo
+        case bar
+    }
     public struct InnerStruct {
         public var otherField: [Date]
         public init(otherField: [Date]) {
@@ -284,4 +288,34 @@ internal func copyToCType(_ swiftType: OuterStruct.InnerStruct?) -> RefHolder {
 }
 internal func moveToCType(_ swiftType: OuterStruct.InnerStruct?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStruct_InnerStruct_release_optional_handle)
+}
+internal func copyToCType(_ swiftEnum: OuterStruct.InnerEnum) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func moveToCType(_ swiftEnum: OuterStruct.InnerEnum) -> PrimitiveHolder<UInt32> {
+    return copyToCType(swiftEnum)
+}
+internal func copyToCType(_ swiftEnum: OuterStruct.InnerEnum?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func moveToCType(_ swiftEnum: OuterStruct.InnerEnum?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func copyFromCType(_ cValue: UInt32) -> OuterStruct.InnerEnum {
+    return OuterStruct.InnerEnum(rawValue: cValue)!
+}
+internal func moveFromCType(_ cValue: UInt32) -> OuterStruct.InnerEnum {
+    return copyFromCType(cValue)
+}
+internal func copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerEnum? {
+    guard handle != 0 else {
+        return nil
+    }
+    return OuterStruct.InnerEnum(rawValue: uint32_t_value_get(handle))!
+}
+internal func moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerEnum? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return copyFromCType(handle)
 }


### PR DESCRIPTION
Updated Swift and CBridge templates and models to support nesting enum declarations inside struct declarations.

Updated smoke tests. Functional tests will be updated in a follow-up commit.

See: #579
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>