### PR TITLE
Add functional test for "external" interface

### DIFF
--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -309,10 +309,13 @@ feature(CircularDependencies cpp android swift dart SOURCES
 
 feature(ExternalTypes cpp android swift dart SOURCES
     src/test/include/ExternalTypes.h
+    src/test/include/MyClass.h
     src/test/src/ExternalTypes.cpp
     src/test/UseExternalTypes.cpp
+    src/test/UseMyClass.cpp
 
     lime/test/ExternalTypes.lime
+    lime/test/ExternalClassAsInterface.lime
     lime/test/UseExternalTypes.lime
 )
 

--- a/examples/libhello/lime/test/ExternalClassAsInterface.lime
+++ b/examples/libhello/lime/test/ExternalClassAsInterface.lime
@@ -1,0 +1,36 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+interface MyClass {
+    # Replace generated C++ class with a pre-existing header.
+    external {
+        cpp include "include/MyClass.h"
+        cpp name "my::MyClass"
+    }
+
+    @Cpp(Const)
+    fun foo(): Int
+}
+
+class UseMyClass {
+    constructor make()
+
+    // Calls bar() on MyClass instance on C++ side and returns the result of that call.
+    fun callBar(on: MyClass): Int
+}

--- a/examples/libhello/src/test/UseMyClass.cpp
+++ b/examples/libhello/src/test/UseMyClass.cpp
@@ -1,0 +1,41 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/UseMyClass.h"
+
+namespace test
+{
+namespace
+{
+class UseMyClassImpl: public UseMyClass {
+public:
+    int32_t
+    call_bar(const std::shared_ptr<my::MyClass>& on) override {
+        return on->bar();
+    }
+};
+}
+
+std::shared_ptr<UseMyClass>
+UseMyClass::make() {
+    return std::make_shared<UseMyClassImpl>();
+}
+
+}

--- a/examples/libhello/src/test/include/MyClass.h
+++ b/examples/libhello/src/test/include/MyClass.h
@@ -1,0 +1,30 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#pragma once
+
+namespace my
+{
+class MyClass {
+public:
+    int bar() { return foo(); }
+    virtual int foo() const { return 42; };
+};
+}

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/ExternalTypesTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/ExternalTypesTest.java
@@ -42,6 +42,13 @@ import org.robolectric.annotation.Config;
     constants = BuildConfig.class)
 public final class ExternalTypesTest {
 
+  public static class MyJavaClass implements MyClass {
+    @Override
+    public int foo() {
+      return 77;
+    }
+  }
+
   @Test
   public void useExternalTypes() {
     ExternalStruct externalStruct =
@@ -141,5 +148,12 @@ public final class ExternalTypesTest {
     assertEquals(struct.month, result.month);
     assertEquals(struct.color, result.color);
     assertEquals(struct.season, result.season);
+  }
+
+  @Test
+  public void useMyClass() {
+    int result = (new UseMyClass()).callBar(new MyJavaClass());
+
+    assertEquals(77, result);
   }
 }

--- a/examples/platforms/dart/test/ExternalTypes_test.dart
+++ b/examples/platforms/dart/test/ExternalTypes_test.dart
@@ -27,6 +27,11 @@ import "../test_suite.dart";
 
 final _testSuite = TestSuite("ExternalTypes");
 
+class MyDartClass extends MyClass {
+  @override
+  int foo() => 77;
+}
+
 void main() {
   _testSuite.test("Use external struct", () {
     final externalStruct =
@@ -93,5 +98,14 @@ void main() {
     expect(result.compressionState, struct.compressionState);
     expect(result.color, struct.color);
     expect(result.season, struct.season);
+  });
+  _testSuite.test("Use MyClass", () {
+    final useMyClass = UseMyClass();
+
+    final result = useMyClass.callBar(MyDartClass());
+
+    expect(result, 77);
+
+    useMyClass.release(); // No automatic finalizers in Dart's own FFI API yet.
   });
 }

--- a/examples/platforms/ios/Tests/testTests/ExternalTypesTests.swift
+++ b/examples/platforms/ios/Tests/testTests/ExternalTypesTests.swift
@@ -24,6 +24,12 @@ import FoundationNetworking
 
 class ExternalTypesTests: XCTestCase {
 
+    class MySwiftClass: MyClass {
+        public func foo() -> Int32 {
+            return 77
+        }
+    }
+
     let externalStruct = ExternalStruct(stringField: "foo",
                                         externalStringField: "bar",
                                         externalArrayField: [7, 11],
@@ -107,6 +113,12 @@ class ExternalTypesTests: XCTestCase {
         XCTAssertEqual(typesStruct.season.value, result.season.value)
     }
 
+    func testMyClass() {
+        let result = UseMyClass().callBar(on: MySwiftClass())
+
+        XCTAssertEqual(result, 77)
+    }
+
     static var allTests = [
         ("testUseExternalTypesExternalStruct", testUseExternalTypesExternalStruct),
         ("testUseExternalTypesExternalEnum", testUseExternalTypesExternalEnum),
@@ -114,6 +126,7 @@ class ExternalTypesTests: XCTestCase {
         ("testSwiftExternalTypePersistence", testSwiftExternalTypePersistence),
         ("testSwiftExternalTypeColor", testSwiftExternalTypeColor),
         ("testSwiftExternalTypeSeason", testSwiftExternalTypeSeason),
-        ("testSwiftExternalTypesInStruct", testSwiftExternalTypesInStruct)
+        ("testSwiftExternalTypesInStruct", testSwiftExternalTypesInStruct),
+        ("testMyClass", testMyClass)
     ]
 }


### PR DESCRIPTION
Added functional tests for using a pre-existing non-abstract C++
class as an "external" interface in IDL.

See: #582
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>