### PR TITLE
Fix indentation in CBridge struct field getter

### DIFF
--- a/gluecodium/src/main/resources/templates/cbridge/StructImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/StructImplementation.mustache
@@ -75,7 +75,7 @@ void {{name}}_release_optional_handle(_baseRef handle) {
 {{#fields}}
 {{type.functionReturnType}} {{structname}}_{{name}}_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const {{mappedType.name}}>(handle);
-{{#switch type.typeCategory.toString}}{{!!
+    {{#switch type.typeCategory.toString}}{{!!
     }}{{#case "BUILTIN_SIMPLE"}}return {{>getBaseLayerFieldValue}};{{/case}}{{!!
     }}{{#case "ENUM"}}return static_cast<{{type.functionReturnType}}>({{>getBaseLayerFieldValue}});{{/case}}{{!!
     }}{{#default}}return Conversion<{{type}}>::toBaseRef({{>getBaseLayerFieldValue}});{{/default}}

--- a/gluecodium/src/test/resources/namespace_smoke/basic/output/cbridge/src/root/space/smoke/cbridge_BasicTypes.cpp
+++ b/gluecodium/src/test/resources/namespace_smoke/basic/output/cbridge/src/root/space/smoke/cbridge_BasicTypes.cpp
@@ -36,5 +36,5 @@ void smoke_BasicTypes_SomeStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_BasicTypes_SomeStruct_someField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::root::space::smoke::SomeStruct>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->some_field);
+    return Conversion<std::string>::toBaseRef(struct_pointer->some_field);
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_Dates.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_Dates.cpp
@@ -61,7 +61,7 @@ void smoke_Dates_DateStruct_release_optional_handle(_baseRef handle) {
 }
 double smoke_Dates_DateStruct_dateField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Dates::DateStruct>(handle);
-return Conversion<std::chrono::system_clock::time_point>::toBaseRef(struct_pointer->date_field);
+    return Conversion<std::chrono::system_clock::time_point>::toBaseRef(struct_pointer->date_field);
 }
 double smoke_Dates_dateMethod(_baseRef _instance, double input) {
     return Conversion<std::chrono::system_clock::time_point>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Dates>>(_instance)->get()->date_method(Conversion<std::chrono::system_clock::time_point>::toCpp(input)));

--- a/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableClass.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableClass.cpp
@@ -73,17 +73,17 @@ void smoke_EquatableClass_EquatableStruct_release_optional_handle(_baseRef handl
 }
 int32_t smoke_EquatableClass_EquatableStruct_intField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::EquatableClass::EquatableStruct>(handle);
-return struct_pointer->int_field;
+    return struct_pointer->int_field;
 }
 _baseRef smoke_EquatableClass_EquatableStruct_stringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::EquatableClass::EquatableStruct>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->string_field);
+    return Conversion<std::string>::toBaseRef(struct_pointer->string_field);
 }
 _baseRef smoke_EquatableClass_EquatableStruct_nestedEquatableInstance_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::EquatableClass::EquatableStruct>(handle);
-return Conversion<std::shared_ptr<::smoke::EquatableClass>>::toBaseRef(struct_pointer->nested_equatable_instance);
+    return Conversion<std::shared_ptr<::smoke::EquatableClass>>::toBaseRef(struct_pointer->nested_equatable_instance);
 }
 _baseRef smoke_EquatableClass_EquatableStruct_nestedPointerEquatableInstance_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::EquatableClass::EquatableStruct>(handle);
-return Conversion<std::shared_ptr<::smoke::PointerEquatableClass>>::toBaseRef(struct_pointer->nested_pointer_equatable_instance);
+    return Conversion<std::shared_ptr<::smoke::PointerEquatableClass>>::toBaseRef(struct_pointer->nested_pointer_equatable_instance);
 }

--- a/gluecodium/src/test/resources/smoke/extensions/output/cbridge/src/smoke/cbridge_Extensions__extension.cpp
+++ b/gluecodium/src/test/resources/smoke/extensions/output/cbridge/src/smoke/cbridge_Extensions__extension.cpp
@@ -36,5 +36,5 @@ void smoke_Extensions_FooStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_Extensions_FooStruct_fooField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::FooStruct>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->foo_field);
+    return Conversion<std::string>::toBaseRef(struct_pointer->foo_field);
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_ExternalClass.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_ExternalClass.cpp
@@ -60,7 +60,7 @@ void smoke_ExternalClass_SomeStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_ExternalClass_SomeStruct_someField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::fire::Baz::some_Struct>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->some_Field);
+    return Conversion<std::string>::toBaseRef(struct_pointer->some_Field);
 }
 void smoke_ExternalClass_someMethod(_baseRef _instance, int8_t someParameter) {
     return get_pointer<std::shared_ptr<::fire::Baz>>(_instance)->get()->some_Method(someParameter);

--- a/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_ExternalInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_ExternalInterface.cpp
@@ -76,7 +76,7 @@ void smoke_ExternalInterface_SomeStruct_release_optional_handle(_baseRef handle)
 }
 _baseRef smoke_ExternalInterface_SomeStruct_someField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::ExternalInterface::some_Struct>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->some_Field);
+    return Conversion<std::string>::toBaseRef(struct_pointer->some_Field);
 }
 void smoke_ExternalInterface_someMethod(_baseRef _instance, int8_t someParameter) {
     return get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(_instance)->get()->some_Method(someParameter);

--- a/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_Structs.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_Structs.cpp
@@ -70,19 +70,19 @@ void smoke_Structs_ExternalStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_Structs_ExternalStruct_stringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::ExternalStruct>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->stringField);
+    return Conversion<std::string>::toBaseRef(struct_pointer->stringField);
 }
 _baseRef smoke_Structs_ExternalStruct_externalStringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::ExternalStruct>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->get_some_string());
+    return Conversion<std::string>::toBaseRef(struct_pointer->get_some_string());
 }
 _baseRef smoke_Structs_ExternalStruct_externalArrayField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::ExternalStruct>(handle);
-return Conversion<std::vector<int8_t>>::toBaseRef(struct_pointer->get_some_array());
+    return Conversion<std::vector<int8_t>>::toBaseRef(struct_pointer->get_some_array());
 }
 _baseRef smoke_Structs_ExternalStruct_externalStructField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::ExternalStruct>(handle);
-return Conversion<::fire::SomeVeryExternalStruct>::toBaseRef(struct_pointer->get_some_struct());
+    return Conversion<::fire::SomeVeryExternalStruct>::toBaseRef(struct_pointer->get_some_struct());
 }
 _baseRef
 smoke_Structs_AnotherExternalStruct_create_handle( int8_t intField )
@@ -113,7 +113,7 @@ void smoke_Structs_AnotherExternalStruct_release_optional_handle(_baseRef handle
 }
 int8_t smoke_Structs_AnotherExternalStruct_intField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::fire::SomeVeryExternalStruct>(handle);
-return struct_pointer->intField;
+    return struct_pointer->intField;
 }
 _baseRef smoke_Structs_getExternalStruct() {
     return Conversion<::smoke::Structs::ExternalStruct>::toBaseRef(::smoke::Structs::get_external_struct());

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithBasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithBasicTypes.cpp
@@ -66,15 +66,15 @@ void smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_optional_handle
 }
 _baseRef smoke_GenericTypesWithBasicTypes_StructWithGenerics_numbersList_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::GenericTypesWithBasicTypes::StructWithGenerics>(handle);
-return Conversion<std::vector<uint8_t>>::toBaseRef(struct_pointer->numbers_list);
+    return Conversion<std::vector<uint8_t>>::toBaseRef(struct_pointer->numbers_list);
 }
 _baseRef smoke_GenericTypesWithBasicTypes_StructWithGenerics_numbersMap_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::GenericTypesWithBasicTypes::StructWithGenerics>(handle);
-return Conversion<std::unordered_map<uint8_t, std::string>>::toBaseRef(struct_pointer->numbers_map);
+    return Conversion<std::unordered_map<uint8_t, std::string>>::toBaseRef(struct_pointer->numbers_map);
 }
 _baseRef smoke_GenericTypesWithBasicTypes_StructWithGenerics_numbersSet_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::GenericTypesWithBasicTypes::StructWithGenerics>(handle);
-return Conversion<std::unordered_set<uint8_t>>::toBaseRef(struct_pointer->numbers_set);
+    return Conversion<std::unordered_set<uint8_t>>::toBaseRef(struct_pointer->numbers_set);
 }
 _baseRef smoke_GenericTypesWithBasicTypes_methodWithList(_baseRef _instance, _baseRef input) {
     return Conversion<std::vector<int32_t>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_list(Conversion<std::vector<int32_t>>::toCpp(input)));

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithCompoundTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithCompoundTypes.cpp
@@ -65,7 +65,7 @@ void smoke_GenericTypesWithCompoundTypes_BasicStruct_release_optional_handle(_ba
 }
 double smoke_GenericTypesWithCompoundTypes_BasicStruct_value_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::GenericTypesWithCompoundTypes::BasicStruct>(handle);
-return struct_pointer->value;
+    return struct_pointer->value;
 }
 _baseRef
 smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle( _baseRef string )
@@ -96,7 +96,7 @@ void smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_optional_handle(
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_ExternalStruct_string_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::alien::FooStruct>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->string);
+    return Conversion<std::string>::toBaseRef(struct_pointer->string);
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_methodWithStructList(_baseRef _instance, _baseRef input) {
     return Conversion<std::vector<::alien::FooStruct>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_struct_list(Conversion<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toCpp(input)));

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_StructWithClass.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_StructWithClass.cpp
@@ -36,5 +36,5 @@ void smoke_StructWithClass_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_StructWithClass_classInstance_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::StructWithClass>(handle);
-return Conversion<std::shared_ptr<::smoke::SimpleClass>>::toBaseRef(struct_pointer->class_instance);
+    return Conversion<std::shared_ptr<::smoke::SimpleClass>>::toBaseRef(struct_pointer->class_instance);
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_StructWithInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_StructWithInterface.cpp
@@ -36,5 +36,5 @@ void smoke_StructWithInterface_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_StructWithInterface_interfaceInstance_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::StructWithInterface>(handle);
-return Conversion<std::shared_ptr<::smoke::SimpleInterface>>::toBaseRef(struct_pointer->interface_instance);
+    return Conversion<std::shared_ptr<::smoke::SimpleInterface>>::toBaseRef(struct_pointer->interface_instance);
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_CalculatorListener.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_CalculatorListener.cpp
@@ -78,7 +78,7 @@ void smoke_CalculatorListener_ResultStruct_release_optional_handle(_baseRef hand
 }
 double smoke_CalculatorListener_ResultStruct_result_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::CalculatorListener::ResultStruct>(handle);
-return struct_pointer->result;
+    return struct_pointer->result;
 }
 void smoke_CalculatorListener_onCalculationResult(_baseRef _instance, double calculationResult) {
     return get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result(calculationResult);

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenerWithProperties.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenerWithProperties.cpp
@@ -79,7 +79,7 @@ void smoke_ListenerWithProperties_ResultStruct_release_optional_handle(_baseRef 
 }
 double smoke_ListenerWithProperties_ResultStruct_result_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::ListenerWithProperties::ResultStruct>(handle);
-return struct_pointer->result;
+    return struct_pointer->result;
 }
 _baseRef smoke_ListenerWithProperties_message_get(_baseRef _instance) {
     return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_message());

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenersWithReturnValues.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenersWithReturnValues.cpp
@@ -79,7 +79,7 @@ void smoke_ListenersWithReturnValues_ResultStruct_release_optional_handle(_baseR
 }
 double smoke_ListenersWithReturnValues_ResultStruct_result_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::ListenersWithReturnValues::ResultStruct>(handle);
-return struct_pointer->result;
+    return struct_pointer->result;
 }
 double smoke_ListenersWithReturnValues_fetchDataDouble(_baseRef _instance) {
     return get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_double();

--- a/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/smoke/cbridge_Locales.cpp
+++ b/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/smoke/cbridge_Locales.cpp
@@ -60,7 +60,7 @@ void smoke_Locales_LocaleStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_Locales_LocaleStruct_localeField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Locales::LocaleStruct>(handle);
-return Conversion<gluecodium::Locale>::toBaseRef(struct_pointer->locale_field);
+    return Conversion<gluecodium::Locale>::toBaseRef(struct_pointer->locale_field);
 }
 _baseRef smoke_Locales_localeMethod(_baseRef _instance, _baseRef input) {
     return Conversion<gluecodium::Locale>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Locales>>(_instance)->get()->locale_method(Conversion<gluecodium::Locale>::toCpp(input)));

--- a/gluecodium/src/test/resources/smoke/name_rules/output/cbridge/src/namerules/cbridge_NameRules.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/cbridge/src/namerules/cbridge_NameRules.cpp
@@ -62,11 +62,11 @@ void namerules_NameRules_ExampleStruct_release_optional_handle(_baseRef handle) 
 }
 double namerules_NameRules_ExampleStruct_iValue_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::namerules::NameRules::ExampleStruct>(handle);
-return struct_pointer->m_value;
+    return struct_pointer->m_value;
 }
 _baseRef namerules_NameRules_ExampleStruct_iIntValue_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::namerules::NameRules::ExampleStruct>(handle);
-return Conversion<std::vector<int64_t>>::toBaseRef(struct_pointer->m_int_value);
+    return Conversion<std::vector<int64_t>>::toBaseRef(struct_pointer->m_int_value);
 }
 _baseRef namerules_NameRules_create() {
     return Conversion<std::shared_ptr<::namerules::NameRules>>::toBaseRef(::namerules::NameRules::create());

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_FreePoint.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_FreePoint.cpp
@@ -37,11 +37,11 @@ void smoke_FreePoint_release_optional_handle(_baseRef handle) {
 }
 double smoke_FreePoint_x_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::FreePoint>(handle);
-return struct_pointer->x;
+    return struct_pointer->x;
 }
 double smoke_FreePoint_y_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::FreePoint>(handle);
-return struct_pointer->y;
+    return struct_pointer->y;
 }
 _baseRef smoke_FreePoint_flip(_baseRef _instance) {
     return Conversion<::smoke::FreePoint>::toBaseRef(get_pointer<::smoke::FreePoint>(_instance)->flip());

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_LevelOne.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_LevelOne.cpp
@@ -104,7 +104,7 @@ void smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_optional_handle(_baseR
 }
 _baseRef smoke_LevelOne_LevelTwo_LevelThree_LevelFour_stringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->string_field);
+    return Conversion<std::string>::toBaseRef(struct_pointer->string_field);
 }
 _baseRef smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fooFactory() {
     return Conversion<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>::toBaseRef(::smoke::LevelOne::LevelTwo::LevelThree::LevelFour::foo_factory());

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterStruct.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterStruct.cpp
@@ -39,7 +39,7 @@ void smoke_OuterStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_OuterStruct_field_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::OuterStruct>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->field);
+    return Conversion<std::string>::toBaseRef(struct_pointer->field);
 }
 _baseRef
 smoke_OuterStruct_InnerStruct_create_handle( _baseRef otherField )
@@ -70,7 +70,7 @@ void smoke_OuterStruct_InnerStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_OuterStruct_InnerStruct_otherField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::OuterStruct::InnerStruct>(handle);
-return Conversion<std::vector<std::chrono::system_clock::time_point>>::toBaseRef(struct_pointer->other_field);
+    return Conversion<std::vector<std::chrono::system_clock::time_point>>::toBaseRef(struct_pointer->other_field);
 }
 void smoke_OuterStruct_InnerStruct_doSomething(_baseRef _instance) {
     return get_pointer<::smoke::OuterStruct::InnerStruct>(_instance)->do_something();

--- a/gluecodium/src/test/resources/smoke/nullable/output/cbridge/src/smoke/cbridge_NullableCollectionsStruct.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/cbridge/src/smoke/cbridge_NullableCollectionsStruct.cpp
@@ -39,9 +39,9 @@ void smoke_NullableCollectionsStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_NullableCollectionsStruct_dates_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::NullableCollectionsStruct>(handle);
-return Conversion<std::vector<::gluecodium::optional< ::std::chrono::system_clock::time_point >>>::toBaseRef(struct_pointer->dates);
+    return Conversion<std::vector<::gluecodium::optional< ::std::chrono::system_clock::time_point >>>::toBaseRef(struct_pointer->dates);
 }
 _baseRef smoke_NullableCollectionsStruct_structs_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::NullableCollectionsStruct>(handle);
-return Conversion<std::unordered_map<int32_t, ::gluecodium::optional< ::smoke::Nullable::SomeStruct >>>::toBaseRef(struct_pointer->structs);
+    return Conversion<std::unordered_map<int32_t, ::gluecodium::optional< ::smoke::Nullable::SomeStruct >>>::toBaseRef(struct_pointer->structs);
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_Structs.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_Structs.cpp
@@ -64,11 +64,11 @@ void smoke_Structs_Point_release_optional_handle(_baseRef handle) {
 }
 double smoke_Structs_Point_x_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::Point>(handle);
-return struct_pointer->x;
+    return struct_pointer->x;
 }
 double smoke_Structs_Point_y_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::Point>(handle);
-return struct_pointer->y;
+    return struct_pointer->y;
 }
 _baseRef
 smoke_Structs_Line_create_handle( _baseRef a, _baseRef b )
@@ -101,11 +101,11 @@ void smoke_Structs_Line_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_Structs_Line_a_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::Line>(handle);
-return Conversion<::smoke::Structs::Point>::toBaseRef(struct_pointer->a);
+    return Conversion<::smoke::Structs::Point>::toBaseRef(struct_pointer->a);
 }
 _baseRef smoke_Structs_Line_b_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::Line>(handle);
-return Conversion<::smoke::Structs::Point>::toBaseRef(struct_pointer->b);
+    return Conversion<::smoke::Structs::Point>::toBaseRef(struct_pointer->b);
 }
 _baseRef
 smoke_Structs_AllTypesStruct_create_handle( int8_t int8Field, uint8_t uint8Field, int16_t int16Field, uint16_t uint16Field, int32_t int32Field, uint32_t uint32Field, int64_t int64Field, uint64_t uint64Field, float floatField, double doubleField, _baseRef stringField, bool booleanField, _baseRef bytesField, _baseRef pointField )
@@ -162,59 +162,59 @@ void smoke_Structs_AllTypesStruct_release_optional_handle(_baseRef handle) {
 }
 int8_t smoke_Structs_AllTypesStruct_int8Field_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return struct_pointer->int8_field;
+    return struct_pointer->int8_field;
 }
 uint8_t smoke_Structs_AllTypesStruct_uint8Field_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return struct_pointer->uint8_field;
+    return struct_pointer->uint8_field;
 }
 int16_t smoke_Structs_AllTypesStruct_int16Field_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return struct_pointer->int16_field;
+    return struct_pointer->int16_field;
 }
 uint16_t smoke_Structs_AllTypesStruct_uint16Field_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return struct_pointer->uint16_field;
+    return struct_pointer->uint16_field;
 }
 int32_t smoke_Structs_AllTypesStruct_int32Field_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return struct_pointer->int32_field;
+    return struct_pointer->int32_field;
 }
 uint32_t smoke_Structs_AllTypesStruct_uint32Field_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return struct_pointer->uint32_field;
+    return struct_pointer->uint32_field;
 }
 int64_t smoke_Structs_AllTypesStruct_int64Field_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return struct_pointer->int64_field;
+    return struct_pointer->int64_field;
 }
 uint64_t smoke_Structs_AllTypesStruct_uint64Field_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return struct_pointer->uint64_field;
+    return struct_pointer->uint64_field;
 }
 float smoke_Structs_AllTypesStruct_floatField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return struct_pointer->float_field;
+    return struct_pointer->float_field;
 }
 double smoke_Structs_AllTypesStruct_doubleField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return struct_pointer->double_field;
+    return struct_pointer->double_field;
 }
 _baseRef smoke_Structs_AllTypesStruct_stringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->string_field);
+    return Conversion<std::string>::toBaseRef(struct_pointer->string_field);
 }
 bool smoke_Structs_AllTypesStruct_booleanField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return struct_pointer->boolean_field;
+    return struct_pointer->boolean_field;
 }
 _baseRef smoke_Structs_AllTypesStruct_bytesField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return Conversion<::std::shared_ptr< ::std::vector< uint8_t > >>::toBaseRef(struct_pointer->bytes_field);
+    return Conversion<::std::shared_ptr< ::std::vector< uint8_t > >>::toBaseRef(struct_pointer->bytes_field);
 }
 _baseRef smoke_Structs_AllTypesStruct_pointField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-return Conversion<::smoke::Structs::Point>::toBaseRef(struct_pointer->point_field);
+    return Conversion<::smoke::Structs::Point>::toBaseRef(struct_pointer->point_field);
 }
 _baseRef
 smoke_Structs_NestingImmutableStruct_create_handle( _baseRef structField )
@@ -245,7 +245,7 @@ void smoke_Structs_NestingImmutableStruct_release_optional_handle(_baseRef handl
 }
 _baseRef smoke_Structs_NestingImmutableStruct_structField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::NestingImmutableStruct>(handle);
-return Conversion<::smoke::Structs::AllTypesStruct>::toBaseRef(struct_pointer->struct_field);
+    return Conversion<::smoke::Structs::AllTypesStruct>::toBaseRef(struct_pointer->struct_field);
 }
 _baseRef
 smoke_Structs_DoubleNestingImmutableStruct_create_handle( _baseRef nestingStructField )
@@ -276,7 +276,7 @@ void smoke_Structs_DoubleNestingImmutableStruct_release_optional_handle(_baseRef
 }
 _baseRef smoke_Structs_DoubleNestingImmutableStruct_nestingStructField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::DoubleNestingImmutableStruct>(handle);
-return Conversion<::smoke::Structs::NestingImmutableStruct>::toBaseRef(struct_pointer->nesting_struct_field);
+    return Conversion<::smoke::Structs::NestingImmutableStruct>::toBaseRef(struct_pointer->nesting_struct_field);
 }
 _baseRef
 smoke_Structs_StructWithArrayOfImmutable_create_handle( _baseRef arrayField )
@@ -307,7 +307,7 @@ void smoke_Structs_StructWithArrayOfImmutable_release_optional_handle(_baseRef h
 }
 _baseRef smoke_Structs_StructWithArrayOfImmutable_arrayField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::StructWithArrayOfImmutable>(handle);
-return Conversion<std::vector<::smoke::Structs::AllTypesStruct>>::toBaseRef(struct_pointer->array_field);
+    return Conversion<std::vector<::smoke::Structs::AllTypesStruct>>::toBaseRef(struct_pointer->array_field);
 }
 _baseRef
 smoke_Structs_ImmutableStructWithCppAccessors_create_handle( _baseRef stringField )
@@ -338,7 +338,7 @@ void smoke_Structs_ImmutableStructWithCppAccessors_release_optional_handle(_base
 }
 _baseRef smoke_Structs_ImmutableStructWithCppAccessors_stringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::ImmutableStructWithCppAccessors>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->get_string_field());
+    return Conversion<std::string>::toBaseRef(struct_pointer->get_string_field());
 }
 _baseRef
 smoke_Structs_MutableStructWithCppAccessors_create_handle( _baseRef stringField )
@@ -369,7 +369,7 @@ void smoke_Structs_MutableStructWithCppAccessors_release_optional_handle(_baseRe
 }
 _baseRef smoke_Structs_MutableStructWithCppAccessors_stringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::MutableStructWithCppAccessors>(handle);
-return Conversion<std::string>::toBaseRef(struct_pointer->get_string_field());
+    return Conversion<std::string>::toBaseRef(struct_pointer->get_string_field());
 }
 _baseRef smoke_Structs_swapPointCoordinates(_baseRef input) {
     return Conversion<::smoke::Structs::Point>::toBaseRef(::smoke::Structs::swap_point_coordinates(Conversion<::smoke::Structs::Point>::toCpp(input)));

--- a/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethods.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethods.cpp
@@ -38,11 +38,11 @@ void smoke_StructsWithMethods_Vector_release_optional_handle(_baseRef handle) {
 }
 double smoke_StructsWithMethods_Vector_x_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Vector>(handle);
-return struct_pointer->x;
+    return struct_pointer->x;
 }
 double smoke_StructsWithMethods_Vector_y_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Vector>(handle);
-return struct_pointer->y;
+    return struct_pointer->y;
 }
 double smoke_StructsWithMethods_Vector_distanceTo(_baseRef _instance, _baseRef other) {
     return get_pointer<::smoke::Vector>(_instance)->distance_to(Conversion<::smoke::Vector>::toCpp(other));

--- a/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethodsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethodsInterface.cpp
@@ -65,15 +65,15 @@ void smoke_StructsWithMethodsInterface_Vector3_release_optional_handle(_baseRef 
 }
 double smoke_StructsWithMethodsInterface_Vector3_x_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::StructsWithMethodsInterface::Vector3>(handle);
-return struct_pointer->x;
+    return struct_pointer->x;
 }
 double smoke_StructsWithMethodsInterface_Vector3_y_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::StructsWithMethodsInterface::Vector3>(handle);
-return struct_pointer->y;
+    return struct_pointer->y;
 }
 double smoke_StructsWithMethodsInterface_Vector3_z_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::StructsWithMethodsInterface::Vector3>(handle);
-return struct_pointer->z;
+    return struct_pointer->z;
 }
 double smoke_StructsWithMethodsInterface_Vector3_distanceTo(_baseRef _instance, _baseRef other) {
     return get_pointer<::smoke::StructsWithMethodsInterface::Vector3>(_instance)->distance_to(Conversion<::smoke::StructsWithMethodsInterface::Vector3>::toCpp(other));


### PR DESCRIPTION
Updated CBridge template for struct field getter function to properly indent the "return" statement there.

Updated affected smoke tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>