### PR TITLE
Extract common functionality from name resolvers

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/ReferenceMapNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/ReferenceMapNameResolver.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.common
+
+import com.here.gluecodium.cli.GluecodiumExecutionException
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeParameter
+import com.here.gluecodium.model.lime.LimePath
+
+internal abstract class ReferenceMapNameResolver(
+    protected val limeReferenceMap: Map<String, LimeElement>
+) : NameResolver {
+
+    protected fun getParentElement(limeElement: LimeNamedElement): LimeNamedElement =
+        getParentElement(limeElement.path, limeElement is LimeParameter)
+
+    protected fun getParentElement(limePath: LimePath, withSuffix: Boolean = false): LimeNamedElement {
+        val parentPath = when {
+            withSuffix -> limePath.parent.withSuffix(limePath.disambiguator)
+            else -> limePath.parent
+        }
+        return (limeReferenceMap[parentPath.toString()] as? LimeNamedElement
+            ?: throw GluecodiumExecutionException(
+                "Failed to resolve parent for element $limePath"
+            ))
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppNameResolver.kt
@@ -20,7 +20,7 @@
 package com.here.gluecodium.generator.ffi
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
-import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.common.ReferenceMapNameResolver
 import com.here.gluecodium.generator.cpp.CppLibraryIncludes
 import com.here.gluecodium.generator.cpp.CppNameResolver
 import com.here.gluecodium.generator.cpp.CppNameRules
@@ -46,11 +46,11 @@ import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeRef
 
 internal class FfiCppNameResolver(
-    private val limeReferenceMap: Map<String, LimeElement>,
+    limeReferenceMap: Map<String, LimeElement>,
     nameRules: CppNameRules,
     rootNamespace: List<String>,
     internalNamespace: List<String>
-) : NameResolver {
+) : ReferenceMapNameResolver(limeReferenceMap) {
 
     private val cppNameResolver = CppNameResolver(rootNamespace, limeReferenceMap, nameRules)
     private val internalNamespace = internalNamespace.joinToString("::")
@@ -144,12 +144,6 @@ internal class FfiCppNameResolver(
                 throw GluecodiumExecutionException("Invalid property accessor ${limeFunction.path}")
         }
     }
-
-    private fun getParentElement(limeElement: LimeNamedElement) =
-        (limeReferenceMap[limeElement.path.parent.toString()] as? LimeNamedElement
-                ?: throw GluecodiumExecutionException(
-                    "Failed to resolve parent for element ${limeElement.fullName}"
-                ))
 
     private fun getGenericTypeName(limeType: LimeGenericType): String {
         val templateName: String

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
@@ -21,7 +21,7 @@ package com.here.gluecodium.generator.java
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
-import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.common.ReferenceMapNameResolver
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeAttributeValueType.FUNCTION_NAME
 import com.here.gluecodium.model.lime.LimeBasicType
@@ -37,8 +37,6 @@ import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeNamedElement
-import com.here.gluecodium.model.lime.LimeParameter
-import com.here.gluecodium.model.lime.LimePath
 import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeSet
@@ -52,12 +50,12 @@ import com.here.gluecodium.model.lime.LimeVisibility
 import com.here.gluecodium.platform.common.CommentsProcessor
 
 internal class JavaNameResolver(
-    private val limeReferenceMap: Map<String, LimeElement>,
+    limeReferenceMap: Map<String, LimeElement>,
     private val basePackages: List<String>,
     private val javaNameRules: JavaNameRules,
     private val limeLogger: LimeLogger,
     private val commentsProcessor: CommentsProcessor
-) : NameResolver {
+) : ReferenceMapNameResolver(limeReferenceMap) {
 
     private val valueResolver = JavaValueResolver(this)
     private val signatureResolver = JavaSignatureResolver(limeReferenceMap, javaNameRules)
@@ -184,18 +182,6 @@ internal class JavaNameResolver(
             TypeId.DATE -> "Date"
             TypeId.LOCALE -> "Locale"
         }
-
-    private fun getParentElement(limeElement: LimeNamedElement): LimeNamedElement =
-        getParentElement(limeElement.path, limeElement is LimeParameter)
-
-    private fun getParentElement(limePath: LimePath, withSuffix: Boolean = false): LimeNamedElement {
-        val parentPath = when {
-            withSuffix -> limePath.parent.withSuffix(limePath.disambiguator)
-            else -> limePath.parent
-        }
-        return (limeReferenceMap[parentPath.toString()] as? LimeNamedElement
-            ?: throw GluecodiumExecutionException("Failed to resolve parent for element $limePath"))
-    }
 
     private fun buildPathMap(): Map<String, String> {
         val result = limeReferenceMap.values

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniNameResolver.kt
@@ -20,7 +20,7 @@
 package com.here.gluecodium.generator.jni
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
-import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.common.ReferenceMapNameResolver
 import com.here.gluecodium.generator.java.JavaNameRules
 import com.here.gluecodium.model.lime.LimeAttributeType.CACHED
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
@@ -44,10 +44,10 @@ import com.here.gluecodium.model.lime.LimeTypedElement
 import com.here.gluecodium.model.lime.LimeTypesCollection
 
 internal class JniNameResolver(
-    private val limeReferenceMap: Map<String, LimeElement>,
+    limeReferenceMap: Map<String, LimeElement>,
     private val basePackages: List<String>,
     private val javaNameRules: JavaNameRules
-) : NameResolver {
+) : ReferenceMapNameResolver(limeReferenceMap) {
 
     override fun resolveName(element: Any): String =
         when (element) {
@@ -145,8 +145,4 @@ internal class JniNameResolver(
             TypeId.BLOB -> "jbyteArray"
             TypeId.DATE, TypeId.LOCALE -> "jobject"
         }
-
-    private fun getParentElement(limeElement: LimeNamedElement) =
-        (limeReferenceMap[limeElement.path.parent.toString()] as? LimeNamedElement
-            ?: throw GluecodiumExecutionException("Failed to resolve parent for element ${limeElement.path}"))
 }


### PR DESCRIPTION
Extracted common duplicated functionality of `getParentElement()` methods from several name resolvers into a dedicated
base abstract class `ReferenceMapNameResolver`.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>