### PR TITLE
Use "::std" consistently in CBridge generated code

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeTypeMapper.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeTypeMapper.kt
@@ -97,7 +97,7 @@ class CBridgeTypeMapper(
     fun createCustomTypeInfo(limeElement: LimeNamedElement, isClass: Boolean = false): CppTypeInfo {
 
         val baseApiName = cppNameResolver.getFullyQualifiedName(limeElement)
-        val baseApiCall = if (isClass) "std::shared_ptr<$baseApiName>" else baseApiName
+        val baseApiCall = if (isClass) "::std::shared_ptr<$baseApiName>" else baseApiName
 
         val publicInclude = includeResolver.resolveInclude(limeElement)
         val structCType = CType(BASE_REF_NAME, publicInclude)
@@ -161,10 +161,10 @@ class CBridgeTypeMapper(
         val keyTypeName = keyType.name
         val valueTypeName = valueType.name
         val cppName = if (hasStdHash) {
-            "std::unordered_map<$keyTypeName, $valueTypeName>"
+            "::std::unordered_map<$keyTypeName, $valueTypeName>"
         } else {
             val namespace = internalNamespace.joinToString("::")
-            "std::unordered_map<$keyTypeName, $valueTypeName, $namespace::hash<$keyTypeName>>"
+            "::std::unordered_map<$keyTypeName, $valueTypeName, $namespace::hash<$keyTypeName>>"
         }
         val result = CppMapTypeInfo(
             cppName,
@@ -194,10 +194,10 @@ class CBridgeTypeMapper(
         val keyTypeName = elementType.name
         val hasStdHash = CppLibraryIncludes.hasStdHash(limeType.elementType)
         val cppName = if (hasStdHash) {
-            "std::unordered_set<$keyTypeName>"
+            "::std::unordered_set<$keyTypeName>"
         } else {
             val namespace = internalNamespace.joinToString("::")
-            "std::unordered_set<$keyTypeName, $namespace::hash<$keyTypeName>>"
+            "::std::unordered_set<$keyTypeName, $namespace::hash<$keyTypeName>>"
         }
         val result = CppSetTypeInfo(
             cppName,
@@ -222,7 +222,7 @@ class CBridgeTypeMapper(
         }
 
         val result = CppArrayTypeInfo(
-            "std::vector<${elementType.name}>",
+            "::std::vector<${elementType.name}>",
             CType(BASE_REF_NAME),
             CType(BASE_REF_NAME),
             listOf(BASE_HANDLE_IMPL_INCLUDE, CppLibraryIncludes.VECTOR),

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CppTypeInfo.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CppTypeInfo.kt
@@ -52,7 +52,7 @@ open class CppTypeInfo(
 
     companion object {
         val STRING = CppTypeInfo(
-            name = "std::string",
+            name = "::std::string",
             cType = CType.STRING_REF,
             functionReturnType = CType.STRING_REF,
             includes = listOf(
@@ -63,7 +63,7 @@ open class CppTypeInfo(
             )
         )
         val DATE = CppTypeInfo(
-            name = "std::chrono::system_clock::time_point",
+            name = "::std::chrono::system_clock::time_point",
             cType = CType.DOUBLE,
             functionReturnType = CType.DOUBLE,
             includes = listOf(

--- a/gluecodium/src/main/resources/templates/cbridge/ArrayFunctionImplementations.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/ArrayFunctionImplementations.mustache
@@ -53,7 +53,7 @@ void {{name}}_append( _baseRef handle, {{argument}} item )
 }
 
 _baseRef {{name}}_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) {{>common/InternalNamespace}}optional<{{arrayType}}>( {{arrayType}}( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) {{>common/InternalNamespace}}optional<{{arrayType}}>( {{arrayType}}( ) ) );
 }
 
 void {{name}}_release_optional_handle(_baseRef handle) {

--- a/gluecodium/src/main/resources/templates/cbridge/BaseHandleImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/BaseHandleImpl.mustache
@@ -57,24 +57,24 @@ get_pointer( _baseRef handle )
 }
 
 template < typename T >
-inline static std::shared_ptr< T >*
-checked_pointer_copy( std::shared_ptr< T >&& pointer )
+inline static ::std::shared_ptr< T >*
+checked_pointer_copy( ::std::shared_ptr< T >&& pointer )
 {
-    return !pointer ? nullptr : new std::shared_ptr< T >( std::move( pointer ) );
+    return !pointer ? nullptr : new ::std::shared_ptr< T >( ::std::move( pointer ) );
 }
 
 template < typename T >
-inline static std::shared_ptr< T >*
-checked_pointer_copy( const std::shared_ptr< T >& pointer )
+inline static ::std::shared_ptr< T >*
+checked_pointer_copy( const ::std::shared_ptr< T >& pointer )
 {
-    return !pointer ? nullptr : new std::shared_ptr< T >( pointer );
+    return !pointer ? nullptr : new ::std::shared_ptr< T >( pointer );
 }
 
 template<class R, class... Args>
-inline static std::function<R(Args...)>*
-checked_pointer_copy(const std::function<R(Args...)>& pointer)
+inline static ::std::function<R(Args...)>*
+checked_pointer_copy(const ::std::function<R(Args...)>& pointer)
 {
-    return !pointer ? nullptr : new std::function<R(Args...)>(pointer);
+    return !pointer ? nullptr : new ::std::function<R(Args...)>(pointer);
 }
 
 template < typename T >
@@ -89,7 +89,7 @@ struct Conversion
     static _baseRef
     toBaseRef( T&& t )
     {
-        return reinterpret_cast< _baseRef >( new T( std::forward< T >( t ) ) );
+        return reinterpret_cast< _baseRef >( new T( ::std::forward< T >( t ) ) );
     }
 
     static _baseRef
@@ -115,40 +115,40 @@ struct Conversion
 };
 
 template < class T >
-struct Conversion< std::shared_ptr< T > >
+struct Conversion< ::std::shared_ptr< T > >
 {
     static _baseRef
-    toBaseRef( std::shared_ptr< T > ptr )
+    toBaseRef( ::std::shared_ptr< T > ptr )
     {
         return !ptr ? 0
-                    : reinterpret_cast< _baseRef >( new std::shared_ptr< T >( std::move( ptr ) ) );
+                    : reinterpret_cast< _baseRef >( new ::std::shared_ptr< T >( ::std::move( ptr ) ) );
     }
 
     static _baseRef
-    referenceBaseRef( const std::shared_ptr< T >& t )
+    referenceBaseRef( const ::std::shared_ptr< T >& t )
     {
         return reinterpret_cast< _baseRef >( &t );
     }
 
-    static std::shared_ptr< T >
+    static ::std::shared_ptr< T >
     toCpp( _baseRef ref )
     {
         if ( ref == 0 )
         {
             return {};
         }
-        return *reinterpret_cast< std::shared_ptr< T >* >( ref );
+        return *reinterpret_cast< ::std::shared_ptr< T >* >( ref );
     }
 
-    static std::shared_ptr< T >
+    static ::std::shared_ptr< T >
     toCppReturn( _baseRef ref )
     {
         if ( ref == 0 )
         {
             return {};
         }
-        auto ptr_ptr = reinterpret_cast< std::shared_ptr< T >* >( ref );
-        std::shared_ptr< T > ptr( std::move( *ptr_ptr ) );
+        auto ptr_ptr = reinterpret_cast< ::std::shared_ptr< T >* >( ref );
+        ::std::shared_ptr< T > ptr( ::std::move( *ptr_ptr ) );
         delete ptr_ptr;
         return ptr;
     }
@@ -157,16 +157,16 @@ struct Conversion< std::shared_ptr< T > >
 namespace
 {
 double
-time_point_to_seconds_since_epoch( const std::chrono::system_clock::time_point& timestamp )
+time_point_to_seconds_since_epoch( const ::std::chrono::system_clock::time_point& timestamp )
 {
     // Double can represent an integer up to 52 bits without a loss of precision. For big 64-bit
     // integers there is a loss, so those should be divided as integers, not as doubles.
 
-    using namespace std::chrono;
+    using namespace ::std::chrono;
     auto time_since_epoch_scaled =
         timestamp.time_since_epoch( ).count( ) * system_clock::period::num;
 
-    auto division_results = std::lldiv( time_since_epoch_scaled, system_clock::period::den );
+    auto division_results = ::std::lldiv( time_since_epoch_scaled, system_clock::period::den );
     return static_cast< double >( division_results.quot ) +
         static_cast< double >( division_results.rem ) / system_clock::period::den;
 }
@@ -177,14 +177,14 @@ seconds_since_epoch_to_time_point( double seconds_since_epoch )
     // Double can represent an integer up to 52 bits without a loss of precision. For big 64-bit
     // integers there is a loss, so those should be multiplied as integers, not as doubles.
 
-    using namespace std::chrono;
+    using namespace ::std::chrono;
     auto time_since_epoch_scaled = seconds_since_epoch / system_clock::period::num;
-    auto integralPart = std::floor( time_since_epoch_scaled );
+    auto integralPart = ::std::floor( time_since_epoch_scaled );
     auto decimalPart = time_since_epoch_scaled - integralPart;
 
     auto time_since_epoch =
         static_cast< int64_t >( integralPart ) * system_clock::period::den +
-        static_cast< int64_t >( std::round( decimalPart * system_clock::period::den ) );
+        static_cast< int64_t >( ::std::round( decimalPart * system_clock::period::den ) );
     return system_clock::time_point( system_clock::duration( time_since_epoch ) );
 }
 }
@@ -197,7 +197,7 @@ struct Conversion< {{>common/InternalNamespace}}optional< T > >
     {
         return !ptr ? 0
                     : reinterpret_cast< _baseRef >(
-                          new {{>common/InternalNamespace}}optional< T >( std::move( ptr ) ) );
+                          new {{>common/InternalNamespace}}optional< T >( ::std::move( ptr ) ) );
     }
 
     static _baseRef
@@ -224,40 +224,40 @@ struct Conversion< {{>common/InternalNamespace}}optional< T > >
             return {};
         }
         auto ptr_ptr = reinterpret_cast< {{>common/InternalNamespace}}optional< T >* >( ref );
-        {{>common/InternalNamespace}}optional< T > ptr( std::move( *ptr_ptr ) );
+        {{>common/InternalNamespace}}optional< T > ptr( ::std::move( *ptr_ptr ) );
         delete ptr_ptr;
         return ptr;
     }
 };
 
 template<>
-struct Conversion< std::chrono::system_clock::time_point >
+struct Conversion< ::std::chrono::system_clock::time_point >
 {
     static double
-    toBaseRef( const std::chrono::system_clock::time_point& timestamp )
+    toBaseRef( const ::std::chrono::system_clock::time_point& timestamp )
     {
         return time_point_to_seconds_since_epoch( timestamp );
     }
 
     static double
-    toBaseRef( std::chrono::system_clock::time_point&& timestamp )
+    toBaseRef( ::std::chrono::system_clock::time_point&& timestamp )
     {
         return time_point_to_seconds_since_epoch( timestamp );
     }
 
     static double
-    referenceBaseRef( std::chrono::system_clock::time_point& timestamp )
+    referenceBaseRef( ::std::chrono::system_clock::time_point& timestamp )
     {
         return time_point_to_seconds_since_epoch( timestamp );
     }
 
-    static std::chrono::system_clock::time_point
+    static ::std::chrono::system_clock::time_point
     toCpp( double seconds_since_epoch )
     {
         return seconds_since_epoch_to_time_point( seconds_since_epoch );
     }
 
-    static std::chrono::system_clock::time_point
+    static ::std::chrono::system_clock::time_point
     toCppReturn( double seconds_since_epoch )
     {
         return seconds_since_epoch_to_time_point( seconds_since_epoch );

--- a/gluecodium/src/main/resources/templates/cbridge/BuiltinHandle.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/BuiltinHandle.mustache
@@ -47,7 +47,7 @@
 #define DEFINE_HANDLE_METHODS( T )                                                                                      \
     _baseRef T##_create_handle( T t )                                                                                   \
     {                                                                                                                   \
-        return reinterpret_cast< _baseRef >( new ( std::nothrow ) {{>common/InternalNamespace}}optional< T >( t ) );    \
+        return reinterpret_cast< _baseRef >( new ( ::std::nothrow ) {{>common/InternalNamespace}}optional< T >( t ) );    \
     }                                                                                                                   \
     void T##_release_handle( _baseRef handle )                                                                          \
     {                                                                                                                   \

--- a/gluecodium/src/main/resources/templates/cbridge/ByteArrayHandle.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/ByteArrayHandle.mustache
@@ -48,60 +48,60 @@
 _baseRef
 byteArray_create_handle( )
 {
-    return reinterpret_cast< _baseRef >( new ( std::nothrow )
-                                             std::shared_ptr< std::vector< uint8_t > >(
-                                                 new ( std::nothrow ) std::vector< uint8_t >{} ) );
+    return reinterpret_cast< _baseRef >( new ( ::std::nothrow )
+                                             ::std::shared_ptr< ::std::vector< uint8_t > >(
+                                                 new ( ::std::nothrow ) ::std::vector< uint8_t >{} ) );
 }
 
 void
 byteArray_release_handle( _baseRef handle )
 {
-    delete get_pointer< std::shared_ptr< std::vector< uint8_t > > >( handle );
+    delete get_pointer< ::std::shared_ptr< ::std::vector< uint8_t > > >( handle );
 }
 
 void
 byteArray_assign( _baseRef handle, const uint8_t* data, const size_t size )
 {
-    ( *get_pointer< std::shared_ptr< std::vector< uint8_t > > >( handle ) )
+    ( *get_pointer< ::std::shared_ptr< ::std::vector< uint8_t > > >( handle ) )
         ->assign( data, data + size );
 }
 
 const uint8_t*
 byteArray_data_get( _baseRef handle )
 {
-    return ( *get_pointer< std::shared_ptr< std::vector< uint8_t > > >( handle ) )->data( );
+    return ( *get_pointer< ::std::shared_ptr< ::std::vector< uint8_t > > >( handle ) )->data( );
 }
 
 size_t
 byteArray_size_get( _baseRef handle )
 {
-    return ( *get_pointer< std::shared_ptr< std::vector< uint8_t > > >( handle ) )->size( );
+    return ( *get_pointer< ::std::shared_ptr< ::std::vector< uint8_t > > >( handle ) )->size( );
 }
 
 _baseRef
 byteArray_create_optional_handle( )
 {
     return reinterpret_cast< _baseRef >(
-        new ( std::nothrow ) {{>common/InternalNamespace}}optional< std::shared_ptr< std::vector< uint8_t > > >(
-            std::shared_ptr< std::vector< uint8_t > >( new ( std::nothrow ) std::vector< uint8_t >{} ) ) );
+        new ( ::std::nothrow ) {{>common/InternalNamespace}}optional< ::std::shared_ptr< ::std::vector< uint8_t > > >(
+            ::std::shared_ptr< ::std::vector< uint8_t > >( new ( ::std::nothrow ) ::std::vector< uint8_t >{} ) ) );
 }
 
 void
 byteArray_release_optional_handle( _baseRef handle )
 {
-    delete reinterpret_cast< {{>common/InternalNamespace}}optional <std::shared_ptr< std::vector< uint8_t > > >* >(handle);
+    delete reinterpret_cast< {{>common/InternalNamespace}}optional <::std::shared_ptr< ::std::vector< uint8_t > > >* >(handle);
 }
 
 _baseRef
 byteArray_unwrap_optional_handle( _baseRef handle )
 {
     return reinterpret_cast< _baseRef >(
-        &**reinterpret_cast< {{>common/InternalNamespace}}optional< std::shared_ptr< std::vector< uint8_t > > >* >( handle ) );
+        &**reinterpret_cast< {{>common/InternalNamespace}}optional< ::std::shared_ptr< ::std::vector< uint8_t > > >* >( handle ) );
 }
 
 void
 byteArray_assign_optional( _baseRef handle, const uint8_t* data, const size_t size )
 {
-    ( **get_pointer< {{>common/InternalNamespace}}optional< std::shared_ptr< std::vector< uint8_t > > > >( handle ) )
+    ( **get_pointer< {{>common/InternalNamespace}}optional< ::std::shared_ptr< ::std::vector< uint8_t > > > >( handle ) )
         ->assign( data, data + size );
 }

--- a/gluecodium/src/main/resources/templates/cbridge/CppProxy.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CppProxy.mustache
@@ -21,7 +21,7 @@
 class {{name}}Proxy :{{#unless isFunctionalInterface}} public {{selfType.name}}::element_type,{{/unless}} public CachedProxyBase<{{name}}Proxy> {
 public:
     {{name}}Proxy({{functionTableName}}&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
 
@@ -59,19 +59,19 @@ private:
 };
 
 _baseRef {{name}}_create_proxy({{functionTableName}} functionTable) {
-    auto proxy = {{name}}Proxy::get_proxy(std::move(functionTable));
+    auto proxy = {{name}}Proxy::get_proxy(::std::move(functionTable));
     return proxy ? reinterpret_cast<_baseRef>(new {{selfType}}({{!!
     }}{{#unless isFunctionalInterface}}proxy{{/unless}}{{!!
-    }}{{#if isFunctionalInterface}}std::bind(&{{name}}Proxy::operator(), proxy{{!!
-    }}{{#functions.0.parameters}}, std::placeholders::_{{iter.index}}{{/functions.0.parameters}}){{/if}})) : 0;
+    }}{{#if isFunctionalInterface}}::std::bind(&{{name}}Proxy::operator(), proxy{{!!
+    }}{{#functions.0.parameters}}, ::std::placeholders::_{{iter.index}}{{/functions.0.parameters}}){{/if}})) : 0;
 }
 {{#if isFunctionalInterface}}
 
 _baseRef {{name}}_create_optional_proxy({{functionTableName}} functionTable) {
-    auto proxy = {{name}}Proxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new (std::nothrow) {{>common/InternalNamespace}}optional<{{selfType}}>({{!!
-    }}std::bind(&{{name}}Proxy::operator(), proxy{{!!
-    }}{{#functions.0.parameters}}, std::placeholders::_{{iter.index}}{{/functions.0.parameters}}))) : 0;
+    auto proxy = {{name}}Proxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new (::std::nothrow) {{>common/InternalNamespace}}optional<{{selfType}}>({{!!
+    }}::std::bind(&{{name}}Proxy::operator(), proxy{{!!
+    }}{{#functions.0.parameters}}, ::std::placeholders::_{{iter.index}}{{/functions.0.parameters}}))) : 0;
 }
 {{/if}}
 
@@ -97,7 +97,7 @@ const void* {{name}}_get_swift_object_from_cache(_baseRef handle) {
 {{/returnConversion}}{{!!
 }}{{+errorConversion}}{{#switch error.typeCategory.toString}}{{!!
     }}{{#case "BUILTIN_SIMPLE"}}_result_with_error.error_value;{{/case}}{{!!
-    }}{{#case "ENUM"}}std::error_code{static_cast<{{error}}>(_result_with_error.error_value)};{{/case}}{{!!
+    }}{{#case "ENUM"}}::std::error_code{static_cast<{{error}}>(_result_with_error.error_value)};{{/case}}{{!!
     }}{{#default}}Conversion<{{error}}>::toCppReturn(_result_with_error.error_value);{{/default}}{{!!
 }}{{/switch}}
 {{/errorConversion}}{{!!

--- a/gluecodium/src/main/resources/templates/cbridge/DateHandle.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/DateHandle.mustache
@@ -45,13 +45,13 @@
 #include <memory>
 #include <new>
 
-using namespace std::chrono;
+using namespace ::std::chrono;
 
 _baseRef
 chrono_time_point_create_optional_handle( double seconds_since_epoch )
 {
     return reinterpret_cast< _baseRef >(
-        new ( std::nothrow ) {{>common/InternalNamespace}}optional< system_clock::time_point >(
+        new ( ::std::nothrow ) {{>common/InternalNamespace}}optional< system_clock::time_point >(
             seconds_since_epoch_to_time_point( seconds_since_epoch ) ) );
 }
 

--- a/gluecodium/src/main/resources/templates/cbridge/LocaleHandle.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/LocaleHandle.mustache
@@ -53,7 +53,7 @@ locale_create_handle(_baseRef language_code_handle,
                      _baseRef language_tag_handle)
 {
     return reinterpret_cast<_baseRef>(
-        new (std::nothrow) {{>common/InternalNamespace}}Locale(
+        new (::std::nothrow) {{>common/InternalNamespace}}Locale(
             Conversion<{{>common/InternalNamespace}}optional<std::string>>::toCpp(language_code_handle),
             Conversion<{{>common/InternalNamespace}}optional<std::string>>::toCpp(country_code_handle),
             Conversion<{{>common/InternalNamespace}}optional<std::string>>::toCpp(script_code_handle),
@@ -104,7 +104,7 @@ _baseRef
 locale_create_optional_handle(_baseRef locale_handle)
 {
     return reinterpret_cast<_baseRef>(
-        new (std::nothrow) {{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>(
+        new (::std::nothrow) {{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>(
             *get_pointer<{{>common/InternalNamespace}}Locale>(locale_handle)
         )
     );

--- a/gluecodium/src/main/resources/templates/cbridge/MapFunctionImplementations.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/MapFunctionImplementations.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 _baseRef {{name}}_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) {{>baseApi}}() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) {{>baseApi}}() );
 }
 
 void {{name}}_release_handle(_baseRef handle) {
@@ -27,7 +27,7 @@ void {{name}}_release_handle(_baseRef handle) {
 }
 
 _baseRef {{name}}_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) {{>baseApi}}::iterator( get_pointer<{{>baseApi}}>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) {{>baseApi}}::iterator( get_pointer<{{>baseApi}}>(handle)->begin() ) );
 }
 
 void {{name}}_iterator_release_handle(_baseRef iterator_handle) {
@@ -58,7 +58,7 @@ void {{name}}_iterator_increment(_baseRef iterator_handle) {
 }
 
 _baseRef {{name}}_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) {{>common/InternalNamespace}}optional<{{>baseApi}}>( {{>baseApi}}( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) {{>common/InternalNamespace}}optional<{{>baseApi}}>( {{>baseApi}}( ) ) );
 }
 
 void {{name}}_release_optional_handle(_baseRef handle) {
@@ -71,7 +71,7 @@ _baseRef {{name}}_unwrap_optional_handle(_baseRef handle) {
 
 {{!!
 
-}}{{+baseApi}}std::unordered_map<{{keyType.name}}, {{valueType.name}}{{#unless hasStdHash}}, {{>common/InternalNamespace}}hash<{{keyType.name}}>{{/unless}}>{{/baseApi}}{{!!
+}}{{+baseApi}}::std::unordered_map<{{keyType.name}}, {{valueType.name}}{{#unless hasStdHash}}, {{>common/InternalNamespace}}hash<{{keyType.name}}>{{/unless}}>{{/baseApi}}{{!!
 
 }}{{+ConvertToCpp}}{{!!
 }}{{#switch variableType.typeCategory.toString}}{{!!

--- a/gluecodium/src/main/resources/templates/cbridge/SetFunctionImplementations.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/SetFunctionImplementations.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 _baseRef {{name}}_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) {{>baseApi}}() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) {{>baseApi}}() );
 }
 
 void {{name}}_release_handle(_baseRef handle) {
@@ -27,11 +27,11 @@ void {{name}}_release_handle(_baseRef handle) {
 }
 
 void {{name}}_insert(_baseRef handle, {{elementType.functionReturnType}} value) {
-    (*get_pointer<{{>baseApi}}>(handle)).insert(std::move({{>ConvertToCpp}}));
+    (*get_pointer<{{>baseApi}}>(handle)).insert(::std::move({{>ConvertToCpp}}));
 }
 
 _baseRef {{name}}_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) {{>baseApi}}::iterator( get_pointer<{{>baseApi}}>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) {{>baseApi}}::iterator( get_pointer<{{>baseApi}}>(handle)->begin() ) );
 }
 
 void {{name}}_iterator_release_handle(_baseRef iterator_handle) {
@@ -52,7 +52,7 @@ void {{name}}_iterator_increment(_baseRef iterator_handle) {
 }
 
 _baseRef {{name}}_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) {{>common/InternalNamespace}}optional<{{>baseApi}}>( {{>baseApi}}( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) {{>common/InternalNamespace}}optional<{{>baseApi}}>( {{>baseApi}}( ) ) );
 }
 
 void {{name}}_release_optional_handle(_baseRef handle) {
@@ -65,7 +65,7 @@ _baseRef {{name}}_unwrap_optional_handle(_baseRef handle) {
 
 {{!!
 
-}}{{+baseApi}}std::unordered_set<{{elementType.name}}{{#unless hasStdHash}}, {{>common/InternalNamespace}}hash<{{elementType.name}}>{{/unless}}>{{/baseApi}}{{!!
+}}{{+baseApi}}::std::unordered_set<{{elementType.name}}{{#unless hasStdHash}}, {{>common/InternalNamespace}}hash<{{elementType.name}}>{{/unless}}>{{/baseApi}}{{!!
 
 }}{{+ConvertToCpp}}{{!!
 }}{{#switch elementType.typeCategory.toString}}{{!!

--- a/gluecodium/src/main/resources/templates/cbridge/StringHandle.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/StringHandle.mustache
@@ -49,49 +49,49 @@ namespace {
 template<class T>
 _baseRef create_handle( T t ) {
     return reinterpret_cast< _baseRef >(
-        new ( std::nothrow ) std::shared_ptr< T >( new ( std::nothrow ) T( t ) ) );
+        new ( ::std::nothrow ) ::std::shared_ptr< T >( new ( ::std::nothrow ) T( t ) ) );
 }
 template<class T>
 void release_handle( _baseRef handle )
 {
-    delete reinterpret_cast< std::shared_ptr< T >*>( handle );
+    delete reinterpret_cast< ::std::shared_ptr< T >*>( handle );
 }
 template<class T>
 T value_get( _baseRef handle )
 {
-    return **reinterpret_cast< std::shared_ptr< T >*>( handle );
+    return **reinterpret_cast< ::std::shared_ptr< T >*>( handle );
 }
 }
 
 _baseRef
 std_string_create_handle( const char* c_str )
 {
-    return reinterpret_cast< _baseRef >( new ( std::nothrow ) std::string( c_str ) );
+    return reinterpret_cast< _baseRef >( new ( ::std::nothrow ) ::std::string( c_str ) );
 }
 
 void
 std_string_release_handle( _baseRef handle )
 {
-    delete get_pointer< std::string >( handle );
+    delete get_pointer< ::std::string >( handle );
 }
 
 const char*
 std_string_data_get( _baseRef handle )
 {
-    return get_pointer< std::string >( handle )->data( );
+    return get_pointer< ::std::string >( handle )->data( );
 }
 
 int64_t
 std_string_size_get( _baseRef handle )
 {
-    return get_pointer< std::string >( handle )->size( );
+    return get_pointer< ::std::string >( handle )->size( );
 }
 
 _baseRef
 std_string_create_optional_handle( const char* c_str )
 {
     return reinterpret_cast< _baseRef >(
-        new ( std::nothrow ) {{>common/InternalNamespace}}optional<std::string>( std::string( c_str ) ) );
+        new ( ::std::nothrow ) {{>common/InternalNamespace}}optional<std::string>( ::std::string( c_str ) ) );
 }
 
 void

--- a/gluecodium/src/main/resources/templates/cbridge/StructImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/StructImplementation.mustache
@@ -22,7 +22,7 @@
 _baseRef
 {{name}}_create_handle( {{#fields}}{{type.cType}} {{name}}{{#if iter.hasNext}}, {{/if}}{{/fields}} )
 {
-{{#unless hasImmutableFields}}    {{baseApiName}}* _struct = new ( std::nothrow ) {{baseApiName}}();{{/unless}}
+{{#unless hasImmutableFields}}    {{baseApiName}}* _struct = new ( ::std::nothrow ) {{baseApiName}}();{{/unless}}
 {{#fields}}
 {{#if hasImmutableFields}}    auto _{{name}} = {{/if}}{{!!
 }}{{#unless hasImmutableFields}}    _struct->{{#if baseLayerSetterName}}{{baseLayerSetterName}}( {{/if}}{{!!
@@ -33,7 +33,7 @@ _baseRef
     }}{{#default}}Conversion<{{type}}>::toCpp( {{name}} ){{/default}}{{!!
 }}{{/switch}}{{#unless hasImmutableFields}}{{#if baseLayerSetterName}} ){{/if}}{{/unless}};
 {{/fields}}
-{{#if hasImmutableFields}}    {{baseApiName}}* _struct = new ( std::nothrow ) {{baseApiName}}( {{#fields}}_{{name}}{{#if iter.hasNext}}, {{/if}}{{/fields}} );{{/if}}
+{{#if hasImmutableFields}}    {{baseApiName}}* _struct = new ( ::std::nothrow ) {{baseApiName}}( {{#fields}}_{{name}}{{#if iter.hasNext}}, {{/if}}{{/fields}} );{{/if}}
     return reinterpret_cast<_baseRef>( _struct );
 }
 
@@ -46,7 +46,7 @@ void
 _baseRef
 {{name}}_create_optional_handle({{#fields}}{{type.cType}} {{name}}{{#if iter.hasNext}}, {{/if}}{{/fields}})
 {
-{{#unless hasImmutableFields}}    auto _struct = new ( std::nothrow ) {{>common/InternalNamespace}}optional<{{baseApiName}}>( {{baseApiName}}( ) );{{/unless}}
+{{#unless hasImmutableFields}}    auto _struct = new ( ::std::nothrow ) {{>common/InternalNamespace}}optional<{{baseApiName}}>( {{baseApiName}}( ) );{{/unless}}
 {{#fields}}
 {{#if hasImmutableFields}}    auto _{{name}} = {{/if}}{{!!
 }}{{#unless hasImmutableFields}}    (*_struct)->{{#if baseLayerSetterName}}{{baseLayerSetterName}}( {{/if}}{{!!
@@ -57,7 +57,7 @@ _baseRef
     }}{{#default}}Conversion<{{type}}>::toCpp( {{name}} ){{/default}}{{!!
 }}{{/switch}}{{#unless hasImmutableFields}}{{#if baseLayerSetterName}} ){{/if}}{{/unless}};
 {{/fields}}
-{{#if hasImmutableFields}}    auto _struct = new ( std::nothrow ) {{>common/InternalNamespace}}optional<{{baseApiName}}>( {{baseApiName}}( {{#fields}}_{{name}}{{#if iter.hasNext}}, {{/if}}{{/fields}} ) );{{/if}}
+{{#if hasImmutableFields}}    auto _struct = new ( ::std::nothrow ) {{>common/InternalNamespace}}optional<{{baseApiName}}>( {{baseApiName}}( {{#fields}}_{{name}}{{#if iter.hasNext}}, {{/if}}{{/fields}} ) );{{/if}}
     return reinterpret_cast<_baseRef>( _struct );
 }
 

--- a/gluecodium/src/main/resources/templates/cbridge/TypeInitRepository.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/TypeInitRepository.mustache
@@ -53,8 +53,8 @@ public:
     ~TypeInitRepository();
 
     using InitFunction = void*(_baseRef);
-    void add_init(const std::string& id, InitFunction* init);
-    InitFunction* get_init(const std::string& id) const;
+    void add_init(const ::std::string& id, InitFunction* init);
+    InitFunction* get_init(const ::std::string& id) const;
 
 private:
     struct Impl;

--- a/gluecodium/src/main/resources/templates/cbridge/TypeInitRepositoryImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/TypeInitRepositoryImpl.mustache
@@ -44,7 +44,7 @@
 
 struct TypeInitRepository::Impl
 {
-    std::unordered_map<std::string, InitFunction*> m_init;
+    ::std::unordered_map<std::string, InitFunction*> m_init;
     mutable {{>common/InternalNamespace}}Mutex m_mutex;
 };
 
@@ -59,13 +59,13 @@ TypeInitRepository::~TypeInitRepository()
 }
 
 void
-TypeInitRepository::add_init(const std::string& id, TypeInitRepository::InitFunction* init) {
+TypeInitRepository::add_init(const ::std::string& id, TypeInitRepository::InitFunction* init) {
     {{>common/InternalNamespace}}WriteLock lock(pimpl->m_mutex);
     pimpl->m_init[id] = init;
 }
 
 TypeInitRepository::InitFunction*
-TypeInitRepository::get_init(const std::string& id) const {
+TypeInitRepository::get_init(const ::std::string& id) const {
     {{>common/InternalNamespace}}ReadLock lock(pimpl->m_mutex);
     const auto& found = pimpl->m_init.find(id);
     return found != pimpl->m_init.end() ? found->second : nullptr;

--- a/gluecodium/src/main/resources/templates/cbridge/WrapperCacheHeader.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/WrapperCacheHeader.mustache
@@ -49,7 +49,7 @@ namespace {{.}} {
 {{/internalNamespace}}
 class WrapperCache {
 public:
-    static std::atomic<bool> is_alive;
+    static ::std::atomic<bool> is_alive;
 
     using CppPtr = const void*;
     using SwiftPtr = const void*;
@@ -62,8 +62,8 @@ public:
     void remove_cached_wrapper(CppPtr cpp_ptr);
 
 private:
-    std::mutex mutex;
-    std::unordered_map<CppPtr, SwiftPtr> cache;
+    ::std::mutex mutex;
+    ::std::unordered_map<CppPtr, SwiftPtr> cache;
 };
 
 WrapperCache& get_wrapper_cache();

--- a/gluecodium/src/main/resources/templates/cbridge/WrapperCacheImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/WrapperCacheImpl.mustache
@@ -53,20 +53,20 @@ WrapperCache::~WrapperCache() { is_alive = false; }
 
 void
 WrapperCache::cache_wrapper(WrapperCache::CppPtr cpp_ptr, WrapperCache::SwiftPtr swift_ptr) {
-    std::lock_guard<std::mutex> lock(mutex);
+    ::std::lock_guard<std::mutex> lock(mutex);
     cache[cpp_ptr] = swift_ptr;
 }
 
 WrapperCache::SwiftPtr
 WrapperCache::get_cached_wrapper(WrapperCache::CppPtr cpp_ptr) {
-    std::lock_guard<std::mutex> lock(mutex);
+    ::std::lock_guard<std::mutex> lock(mutex);
     auto iter = cache.find(cpp_ptr);
     return (iter != cache.end()) ? iter->second : nullptr;
 }
 
 void
 WrapperCache::remove_cached_wrapper(WrapperCache::CppPtr cpp_ptr) {
-    std::lock_guard<std::mutex> lock(mutex);
+    ::std::lock_guard<std::mutex> lock(mutex);
     cache.erase(cpp_ptr);
 }
 

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/cbridge/CBridgeTypeMapperTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/cbridge/CBridgeTypeMapperTest.kt
@@ -90,13 +90,13 @@ class CBridgeTypeMapperTest {
 
         val result = typeMapper.mapType(LimeDirectTypeRef(limeElement), cppTemplateTypeRef)
 
-        assertEquals("std::unordered_map<std::string, double>", result.name)
+        assertEquals("::std::unordered_map<::std::string, double>", result.name)
         assertEquals(BASE_REF_NAME, result.cType.name)
         assertEquals(BASE_REF_NAME, result.functionReturnType.name)
         assertEquals(2, result.includes.size)
         assertEquals(CBridgeNameRules.BASE_HANDLE_IMPL_FILE, result.includes.first().fileName)
         assertEquals(CppLibraryIncludes.MAP, result.includes.last())
-        assertEquals("std::string", (result as CppMapTypeInfo).keyType.name)
+        assertEquals("::std::string", (result as CppMapTypeInfo).keyType.name)
         assertEquals("double", result.valueType.name)
     }
 
@@ -122,7 +122,7 @@ class CBridgeTypeMapperTest {
 
         val result = typeMapper.mapType(LimeDirectTypeRef(limeElement), cppTemplateTypeRef)
 
-        assertEquals("std::unordered_set<double>", result.name)
+        assertEquals("::std::unordered_set<double>", result.name)
         assertEquals(BASE_REF_NAME, result.cType.name)
         assertEquals(BASE_REF_NAME, result.functionReturnType.name)
         assertEquals(2, result.includes.size)
@@ -137,7 +137,7 @@ class CBridgeTypeMapperTest {
 
         val result = typeMapper.mapType(LimeDirectTypeRef(limeElement), cppTemplateTypeRef)
 
-        assertEquals("std::vector<float>", result.name)
+        assertEquals("::std::vector<float>", result.name)
         assertEquals(BASE_REF_NAME, result.cType.name)
         assertEquals(BASE_REF_NAME, result.functionReturnType.name)
         assertEquals(2, result.includes.size)

--- a/gluecodium/src/test/resources/namespace_smoke/basic/output/cbridge/src/root/space/smoke/cbridge_Basic.cpp
+++ b/gluecodium/src/test/resources/namespace_smoke/basic/output/cbridge/src/root/space/smoke/cbridge_Basic.cpp
@@ -11,26 +11,26 @@
 #include <new>
 #include <string>
 void smoke_Basic_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle);
+    delete get_pointer<::std::shared_ptr<::root::space::smoke::Basic>>(handle);
 }
 _baseRef smoke_Basic_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::root::space::smoke::Basic>>(handle)))
         : 0;
 }
 const void* smoke_Basic_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::root::space::smoke::Basic>>(handle)->get())
         : nullptr;
 }
 void smoke_Basic_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::root::space::smoke::Basic>>(handle)->get(), swift_pointer);
 }
 void smoke_Basic_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::root::space::smoke::Basic>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::root::space::smoke::Basic>>(handle)->get());
 }
 _baseRef smoke_Basic_basicMethod(_baseRef inputString) {
-    return Conversion<std::string>::toBaseRef(::root::space::smoke::Basic::basic_method(Conversion<std::string>::toCpp(inputString)));
+    return Conversion<::std::string>::toBaseRef(::root::space::smoke::Basic::basic_method(Conversion<::std::string>::toCpp(inputString)));
 }

--- a/gluecodium/src/test/resources/namespace_smoke/basic/output/cbridge/src/root/space/smoke/cbridge_BasicTypes.cpp
+++ b/gluecodium/src/test/resources/namespace_smoke/basic/output/cbridge/src/root/space/smoke/cbridge_BasicTypes.cpp
@@ -10,8 +10,8 @@
 _baseRef
 smoke_BasicTypes_SomeStruct_create_handle( _baseRef someField )
 {
-    ::root::space::smoke::SomeStruct* _struct = new ( std::nothrow ) ::root::space::smoke::SomeStruct();
-    _struct->some_field = Conversion<std::string>::toCpp( someField );
+    ::root::space::smoke::SomeStruct* _struct = new ( ::std::nothrow ) ::root::space::smoke::SomeStruct();
+    _struct->some_field = Conversion<::std::string>::toCpp( someField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -22,8 +22,8 @@ smoke_BasicTypes_SomeStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_BasicTypes_SomeStruct_create_optional_handle(_baseRef someField)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::root::space::smoke::SomeStruct>( ::root::space::smoke::SomeStruct( ) );
-    (*_struct)->some_field = Conversion<std::string>::toCpp( someField );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::root::space::smoke::SomeStruct>( ::root::space::smoke::SomeStruct( ) );
+    (*_struct)->some_field = Conversion<::std::string>::toCpp( someField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -36,5 +36,5 @@ void smoke_BasicTypes_SomeStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_BasicTypes_SomeStruct_someField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::root::space::smoke::SomeStruct>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->some_field);
+    return Conversion<::std::string>::toBaseRef(struct_pointer->some_field);
 }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cbridge/src/smoke/cbridge_BasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cbridge/src/smoke/cbridge_BasicTypes.cpp
@@ -11,28 +11,28 @@
 #include <new>
 #include <string>
 void smoke_BasicTypes_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::BasicTypes>>(handle);
 }
 _baseRef smoke_BasicTypes_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::BasicTypes>>(handle)))
         : 0;
 }
 const void* smoke_BasicTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::BasicTypes>>(handle)->get())
         : nullptr;
 }
 void smoke_BasicTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::BasicTypes>>(handle)->get(), swift_pointer);
 }
 void smoke_BasicTypes_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::BasicTypes>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::BasicTypes>>(handle)->get());
 }
 _baseRef smoke_BasicTypes_stringFunction(_baseRef input) {
-    return Conversion<std::string>::toBaseRef(::smoke::BasicTypes::string_function(Conversion<std::string>::toCpp(input)));
+    return Conversion<::std::string>::toBaseRef(::smoke::BasicTypes::string_function(Conversion<::std::string>::toCpp(input)));
 }
 bool smoke_BasicTypes_boolFunction(bool input) {
     return ::smoke::BasicTypes::bool_function(input);

--- a/gluecodium/src/test/resources/smoke/constructors/output/cbridge/src/smoke/cbridge_Constructors.cpp
+++ b/gluecodium/src/test/resources/smoke/constructors/output/cbridge/src/smoke/cbridge_Constructors.cpp
@@ -12,25 +12,25 @@
 #include <string>
 #include <vector>
 void smoke_Constructors_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Constructors>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::Constructors>>(handle);
 }
 _baseRef smoke_Constructors_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::Constructors>>(handle)))
         : 0;
 }
 const void* smoke_Constructors_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Constructors>>(handle)->get())
         : nullptr;
 }
 void smoke_Constructors_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::Constructors>>(handle)->get(), swift_pointer);
 }
 void smoke_Constructors_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Constructors>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_Constructors(_baseRef handle);
@@ -43,27 +43,27 @@ struct smoke_ConstructorsRegisterInit {
 } s_smoke_Constructors_register_init;
 }
 void* smoke_Constructors_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::Constructors>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::Constructors>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::Constructors>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::Constructors>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_Constructors(handle);
 }
 _baseRef smoke_Constructors_create_() {
-    return Conversion<std::shared_ptr<::smoke::Constructors>>::toBaseRef(::smoke::Constructors::create());
+    return Conversion<::std::shared_ptr<::smoke::Constructors>>::toBaseRef(::smoke::Constructors::create());
 }
 _baseRef smoke_Constructors_create_Constructors(_baseRef other) {
-    return Conversion<std::shared_ptr<::smoke::Constructors>>::toBaseRef(::smoke::Constructors::create(Conversion<std::shared_ptr<::smoke::Constructors>>::toCpp(other)));
+    return Conversion<::std::shared_ptr<::smoke::Constructors>>::toBaseRef(::smoke::Constructors::create(Conversion<::std::shared_ptr<::smoke::Constructors>>::toCpp(other)));
 }
 _baseRef smoke_Constructors_create_String_ULong(_baseRef foo, uint64_t bar) {
-    return Conversion<std::shared_ptr<::smoke::Constructors>>::toBaseRef(::smoke::Constructors::create(Conversion<std::string>::toCpp(foo), bar));
+    return Conversion<::std::shared_ptr<::smoke::Constructors>>::toBaseRef(::smoke::Constructors::create(Conversion<::std::string>::toCpp(foo), bar));
 }
 smoke_Constructors_create_String_result smoke_Constructors_create_String(_baseRef input) {
-    auto&& RESULT = ::smoke::Constructors::create(Conversion<std::string>::toCpp(input));
+    auto&& RESULT = ::smoke::Constructors::create(Conversion<::std::string>::toCpp(input));
     if (RESULT.has_value()) {
-        return {true, .returned_value = Conversion<std::shared_ptr<::smoke::Constructors>>::toBaseRef(RESULT.unsafe_value())};
+        return {true, .returned_value = Conversion<::std::shared_ptr<::smoke::Constructors>>::toBaseRef(RESULT.unsafe_value())};
     } else {
         return {false, .error_value = static_cast< smoke_Constructors_ErrorEnum >(RESULT.error().value())};
     }
 }
 _baseRef smoke_Constructors_create__3Double_4(_baseRef input) {
-    return Conversion<std::shared_ptr<::smoke::Constructors>>::toBaseRef(::smoke::Constructors::create(Conversion<std::vector<double>>::toCpp(input)));
+    return Conversion<::std::shared_ptr<::smoke::Constructors>>::toBaseRef(::smoke::Constructors::create(Conversion<::std::vector<double>>::toCpp(input)));
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_Dates.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_Dates.cpp
@@ -12,31 +12,31 @@
 #include <memory>
 #include <new>
 void smoke_Dates_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Dates>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::Dates>>(handle);
 }
 _baseRef smoke_Dates_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Dates>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::Dates>>(handle)))
         : 0;
 }
 const void* smoke_Dates_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Dates>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Dates>>(handle)->get())
         : nullptr;
 }
 void smoke_Dates_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Dates>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::Dates>>(handle)->get(), swift_pointer);
 }
 void smoke_Dates_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Dates>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Dates>>(handle)->get());
 }
 _baseRef
 smoke_Dates_DateStruct_create_handle( double dateField )
 {
-    ::smoke::Dates::DateStruct* _struct = new ( std::nothrow ) ::smoke::Dates::DateStruct();
-    _struct->date_field = Conversion<std::chrono::system_clock::time_point>::toCpp( dateField );
+    ::smoke::Dates::DateStruct* _struct = new ( ::std::nothrow ) ::smoke::Dates::DateStruct();
+    _struct->date_field = Conversion<::std::chrono::system_clock::time_point>::toCpp( dateField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -47,8 +47,8 @@ smoke_Dates_DateStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_Dates_DateStruct_create_optional_handle(double dateField)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Dates::DateStruct>( ::smoke::Dates::DateStruct( ) );
-    (*_struct)->date_field = Conversion<std::chrono::system_clock::time_point>::toCpp( dateField );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::Dates::DateStruct>( ::smoke::Dates::DateStruct( ) );
+    (*_struct)->date_field = Conversion<::std::chrono::system_clock::time_point>::toCpp( dateField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -61,14 +61,14 @@ void smoke_Dates_DateStruct_release_optional_handle(_baseRef handle) {
 }
 double smoke_Dates_DateStruct_dateField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Dates::DateStruct>(handle);
-    return Conversion<std::chrono::system_clock::time_point>::toBaseRef(struct_pointer->date_field);
+    return Conversion<::std::chrono::system_clock::time_point>::toBaseRef(struct_pointer->date_field);
 }
 double smoke_Dates_dateMethod(_baseRef _instance, double input) {
-    return Conversion<std::chrono::system_clock::time_point>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Dates>>(_instance)->get()->date_method(Conversion<std::chrono::system_clock::time_point>::toCpp(input)));
+    return Conversion<::std::chrono::system_clock::time_point>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::Dates>>(_instance)->get()->date_method(Conversion<::std::chrono::system_clock::time_point>::toCpp(input)));
 }
 double smoke_Dates_dateProperty_get(_baseRef _instance) {
-    return Conversion<std::chrono::system_clock::time_point>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Dates>>(_instance)->get()->get_date_property());
+    return Conversion<::std::chrono::system_clock::time_point>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::Dates>>(_instance)->get()->get_date_property());
 }
 void smoke_Dates_dateProperty_set(_baseRef _instance, double newValue) {
-    return get_pointer<std::shared_ptr<::smoke::Dates>>(_instance)->get()->set_date_property(Conversion<std::chrono::system_clock::time_point>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::Dates>>(_instance)->get()->set_date_property(Conversion<::std::chrono::system_clock::time_point>::toCpp(newValue));
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableClass.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableClass.cpp
@@ -12,40 +12,40 @@
 #include <new>
 #include <string>
 void smoke_EquatableClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::EquatableClass>>(handle);
 }
 _baseRef smoke_EquatableClass_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::EquatableClass>>(handle)))
         : 0;
 }
 const void* smoke_EquatableClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::EquatableClass>>(handle)->get())
         : nullptr;
 }
 void smoke_EquatableClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::EquatableClass>>(handle)->get(), swift_pointer);
 }
 void smoke_EquatableClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::EquatableClass>>(handle)->get());
 }
 bool smoke_EquatableClass_equal(_baseRef lhs, _baseRef rhs) {
-    return **get_pointer<std::shared_ptr<::smoke::EquatableClass>>(lhs) == **get_pointer<std::shared_ptr<::smoke::EquatableClass>>(rhs);
+    return **get_pointer<::std::shared_ptr<::smoke::EquatableClass>>(lhs) == **get_pointer<::std::shared_ptr<::smoke::EquatableClass>>(rhs);
 }
 uint64_t smoke_EquatableClass_hash(_baseRef handle) {
-    return ::gluecodium::hash<std::shared_ptr<::smoke::EquatableClass>::element_type>()(**get_pointer<std::shared_ptr<::smoke::EquatableClass>>(handle));
+    return ::gluecodium::hash<::std::shared_ptr<::smoke::EquatableClass>::element_type>()(**get_pointer<::std::shared_ptr<::smoke::EquatableClass>>(handle));
 }
 _baseRef
 smoke_EquatableClass_EquatableStruct_create_handle( int32_t intField, _baseRef stringField, _baseRef nestedEquatableInstance, _baseRef nestedPointerEquatableInstance )
 {
-    ::smoke::EquatableClass::EquatableStruct* _struct = new ( std::nothrow ) ::smoke::EquatableClass::EquatableStruct();
+    ::smoke::EquatableClass::EquatableStruct* _struct = new ( ::std::nothrow ) ::smoke::EquatableClass::EquatableStruct();
     _struct->int_field = intField;
-    _struct->string_field = Conversion<std::string>::toCpp( stringField );
-    _struct->nested_equatable_instance = Conversion<std::shared_ptr<::smoke::EquatableClass>>::toCpp( nestedEquatableInstance );
-    _struct->nested_pointer_equatable_instance = Conversion<std::shared_ptr<::smoke::PointerEquatableClass>>::toCpp( nestedPointerEquatableInstance );
+    _struct->string_field = Conversion<::std::string>::toCpp( stringField );
+    _struct->nested_equatable_instance = Conversion<::std::shared_ptr<::smoke::EquatableClass>>::toCpp( nestedEquatableInstance );
+    _struct->nested_pointer_equatable_instance = Conversion<::std::shared_ptr<::smoke::PointerEquatableClass>>::toCpp( nestedPointerEquatableInstance );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -56,11 +56,11 @@ smoke_EquatableClass_EquatableStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_EquatableClass_EquatableStruct_create_optional_handle(int32_t intField, _baseRef stringField, _baseRef nestedEquatableInstance, _baseRef nestedPointerEquatableInstance)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::EquatableClass::EquatableStruct>( ::smoke::EquatableClass::EquatableStruct( ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::EquatableClass::EquatableStruct>( ::smoke::EquatableClass::EquatableStruct( ) );
     (*_struct)->int_field = intField;
-    (*_struct)->string_field = Conversion<std::string>::toCpp( stringField );
-    (*_struct)->nested_equatable_instance = Conversion<std::shared_ptr<::smoke::EquatableClass>>::toCpp( nestedEquatableInstance );
-    (*_struct)->nested_pointer_equatable_instance = Conversion<std::shared_ptr<::smoke::PointerEquatableClass>>::toCpp( nestedPointerEquatableInstance );
+    (*_struct)->string_field = Conversion<::std::string>::toCpp( stringField );
+    (*_struct)->nested_equatable_instance = Conversion<::std::shared_ptr<::smoke::EquatableClass>>::toCpp( nestedEquatableInstance );
+    (*_struct)->nested_pointer_equatable_instance = Conversion<::std::shared_ptr<::smoke::PointerEquatableClass>>::toCpp( nestedPointerEquatableInstance );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -77,13 +77,13 @@ int32_t smoke_EquatableClass_EquatableStruct_intField_get(_baseRef handle) {
 }
 _baseRef smoke_EquatableClass_EquatableStruct_stringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::EquatableClass::EquatableStruct>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->string_field);
+    return Conversion<::std::string>::toBaseRef(struct_pointer->string_field);
 }
 _baseRef smoke_EquatableClass_EquatableStruct_nestedEquatableInstance_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::EquatableClass::EquatableStruct>(handle);
-    return Conversion<std::shared_ptr<::smoke::EquatableClass>>::toBaseRef(struct_pointer->nested_equatable_instance);
+    return Conversion<::std::shared_ptr<::smoke::EquatableClass>>::toBaseRef(struct_pointer->nested_equatable_instance);
 }
 _baseRef smoke_EquatableClass_EquatableStruct_nestedPointerEquatableInstance_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::EquatableClass::EquatableStruct>(handle);
-    return Conversion<std::shared_ptr<::smoke::PointerEquatableClass>>::toBaseRef(struct_pointer->nested_pointer_equatable_instance);
+    return Conversion<::std::shared_ptr<::smoke::PointerEquatableClass>>::toBaseRef(struct_pointer->nested_pointer_equatable_instance);
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_EquatableInterface.cpp
@@ -11,25 +11,25 @@
 #include <memory>
 #include <new>
 void smoke_EquatableInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::EquatableInterface>>(handle);
 }
 _baseRef smoke_EquatableInterface_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::EquatableInterface>>(handle)))
         : 0;
 }
 const void* smoke_EquatableInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::EquatableInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_EquatableInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::EquatableInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_EquatableInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::EquatableInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_EquatableInterface(_baseRef handle);
@@ -42,20 +42,20 @@ struct smoke_EquatableInterfaceRegisterInit {
 } s_smoke_EquatableInterface_register_init;
 }
 void* smoke_EquatableInterface_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::EquatableInterface>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::EquatableInterface>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::EquatableInterface>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_EquatableInterface(handle);
 }
 bool smoke_EquatableInterface_equal(_baseRef lhs, _baseRef rhs) {
-    return **get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(lhs) == **get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(rhs);
+    return **get_pointer<::std::shared_ptr<::smoke::EquatableInterface>>(lhs) == **get_pointer<::std::shared_ptr<::smoke::EquatableInterface>>(rhs);
 }
 uint64_t smoke_EquatableInterface_hash(_baseRef handle) {
-    return ::gluecodium::hash<std::shared_ptr<::smoke::EquatableInterface>::element_type>()(**get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle));
+    return ::gluecodium::hash<::std::shared_ptr<::smoke::EquatableInterface>::element_type>()(**get_pointer<::std::shared_ptr<::smoke::EquatableInterface>>(handle));
 }
-class smoke_EquatableInterfaceProxy : public std::shared_ptr<::smoke::EquatableInterface>::element_type, public CachedProxyBase<smoke_EquatableInterfaceProxy> {
+class smoke_EquatableInterfaceProxy : public ::std::shared_ptr<::smoke::EquatableInterface>::element_type, public CachedProxyBase<smoke_EquatableInterfaceProxy> {
 public:
     smoke_EquatableInterfaceProxy(smoke_EquatableInterface_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_EquatableInterfaceProxy() {
@@ -67,9 +67,9 @@ private:
     smoke_EquatableInterface_FunctionTable mFunctions;
 };
 _baseRef smoke_EquatableInterface_create_proxy(smoke_EquatableInterface_FunctionTable functionTable) {
-    auto proxy = smoke_EquatableInterfaceProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::EquatableInterface>(proxy)) : 0;
+    auto proxy = smoke_EquatableInterfaceProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::EquatableInterface>(proxy)) : 0;
 }
 const void* smoke_EquatableInterface_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_EquatableInterfaceProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::EquatableInterface>>(handle)->get()) : nullptr;
+    return handle ? smoke_EquatableInterfaceProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::EquatableInterface>>(handle)->get()) : nullptr;
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_PointerEquatableClass.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cbridge/src/smoke/cbridge_PointerEquatableClass.cpp
@@ -10,29 +10,29 @@
 #include <memory>
 #include <new>
 void smoke_PointerEquatableClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::PointerEquatableClass>>(handle);
 }
 _baseRef smoke_PointerEquatableClass_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::PointerEquatableClass>>(handle)))
         : 0;
 }
 const void* smoke_PointerEquatableClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get())
         : nullptr;
 }
 void smoke_PointerEquatableClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get(), swift_pointer);
 }
 void smoke_PointerEquatableClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::PointerEquatableClass>>(handle)->get());
 }
 bool smoke_PointerEquatableClass_equal(_baseRef lhs, _baseRef rhs) {
-    return *get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(lhs) == *get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(rhs);
+    return *get_pointer<::std::shared_ptr<::smoke::PointerEquatableClass>>(lhs) == *get_pointer<::std::shared_ptr<::smoke::PointerEquatableClass>>(rhs);
 }
 uint64_t smoke_PointerEquatableClass_hash(_baseRef handle) {
-    return ::gluecodium::hash<std::shared_ptr<::smoke::PointerEquatableClass>>()(*get_pointer<std::shared_ptr<::smoke::PointerEquatableClass>>(handle));
+    return ::gluecodium::hash<::std::shared_ptr<::smoke::PointerEquatableClass>>()(*get_pointer<::std::shared_ptr<::smoke::PointerEquatableClass>>(handle));
 }

--- a/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_Errors.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_Errors.cpp
@@ -13,25 +13,25 @@
 #include <new>
 #include <string>
 void smoke_Errors_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Errors>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::Errors>>(handle);
 }
 _baseRef smoke_Errors_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Errors>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::Errors>>(handle)))
         : 0;
 }
 const void* smoke_Errors_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Errors>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Errors>>(handle)->get())
         : nullptr;
 }
 void smoke_Errors_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Errors>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::Errors>>(handle)->get(), swift_pointer);
 }
 void smoke_Errors_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Errors>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Errors>>(handle)->get());
 }
 smoke_Errors_methodWithErrors_result smoke_Errors_methodWithErrors() {
     auto&& ERROR_VALUE = ::smoke::Errors::method_with_errors().value();
@@ -44,7 +44,7 @@ smoke_Errors_methodWithExternalErrors_result smoke_Errors_methodWithExternalErro
 smoke_Errors_methodWithErrorsAndReturnValue_result smoke_Errors_methodWithErrorsAndReturnValue() {
     auto&& RESULT = ::smoke::Errors::method_with_errors_and_return_value();
     if (RESULT.has_value()) {
-        return {true, .returned_value = Conversion<std::string>::toBaseRef(RESULT.unsafe_value())};
+        return {true, .returned_value = Conversion<::std::string>::toBaseRef(RESULT.unsafe_value())};
     } else {
         return {false, .error_value = static_cast< smoke_Errors_InternalErrorCode >(RESULT.error().value())};
     }
@@ -60,7 +60,7 @@ smoke_Errors_methodWithPayloadError_result smoke_Errors_methodWithPayloadError()
 smoke_Errors_methodWithPayloadErrorAndReturnValue_result smoke_Errors_methodWithPayloadErrorAndReturnValue() {
     auto&& RESULT = ::smoke::Errors::method_with_payload_error_and_return_value();
     if (RESULT.has_value()) {
-        return {true, .returned_value = Conversion<std::string>::toBaseRef(RESULT.unsafe_value())};
+        return {true, .returned_value = Conversion<::std::string>::toBaseRef(RESULT.unsafe_value())};
     } else {
         return {false, .error_value = Conversion<::smoke::Payload>::toBaseRef(RESULT.error())};
     }

--- a/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_ErrorsInterface.cpp
@@ -13,25 +13,25 @@
 #include <new>
 #include <string>
 void smoke_ErrorsInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::ErrorsInterface>>(handle);
 }
 _baseRef smoke_ErrorsInterface_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::ErrorsInterface>>(handle)))
         : 0;
 }
 const void* smoke_ErrorsInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_ErrorsInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_ErrorsInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ErrorsInterface(_baseRef handle);
@@ -44,22 +44,22 @@ struct smoke_ErrorsInterfaceRegisterInit {
 } s_smoke_ErrorsInterface_register_init;
 }
 void* smoke_ErrorsInterface_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::ErrorsInterface>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::ErrorsInterface>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_ErrorsInterface(handle);
 }
 smoke_ErrorsInterface_methodWithErrors_result smoke_ErrorsInterface_methodWithErrors(_baseRef _instance) {
-    auto&& ERROR_VALUE = get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(_instance)->get()->method_with_errors().value();
+    auto&& ERROR_VALUE = get_pointer<::std::shared_ptr<::smoke::ErrorsInterface>>(_instance)->get()->method_with_errors().value();
     return {ERROR_VALUE == 0, static_cast< smoke_ErrorsInterface_InternalError >(ERROR_VALUE)};
 }
 smoke_ErrorsInterface_methodWithExternalErrors_result smoke_ErrorsInterface_methodWithExternalErrors(_baseRef _instance) {
-    auto&& ERROR_VALUE = get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(_instance)->get()->method_with_external_errors().value();
+    auto&& ERROR_VALUE = get_pointer<::std::shared_ptr<::smoke::ErrorsInterface>>(_instance)->get()->method_with_external_errors().value();
     return {ERROR_VALUE == 0, static_cast< smoke_ErrorsInterface_ExternalErrors >(ERROR_VALUE)};
 }
 smoke_ErrorsInterface_methodWithErrorsAndReturnValue_result smoke_ErrorsInterface_methodWithErrorsAndReturnValue(_baseRef _instance) {
-    auto&& RESULT = get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(_instance)->get()->method_with_errors_and_return_value();
+    auto&& RESULT = get_pointer<::std::shared_ptr<::smoke::ErrorsInterface>>(_instance)->get()->method_with_errors_and_return_value();
     if (RESULT.has_value()) {
-        return {true, .returned_value = Conversion<std::string>::toBaseRef(RESULT.unsafe_value())};
+        return {true, .returned_value = Conversion<::std::string>::toBaseRef(RESULT.unsafe_value())};
     } else {
         return {false, .error_value = static_cast< smoke_ErrorsInterface_InternalError >(RESULT.error().value())};
     }
@@ -75,15 +75,15 @@ smoke_ErrorsInterface_methodWithPayloadError_result smoke_ErrorsInterface_method
 smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_result smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue() {
     auto&& RESULT = ::smoke::ErrorsInterface::method_with_payload_error_and_return_value();
     if (RESULT.has_value()) {
-        return {true, .returned_value = Conversion<std::string>::toBaseRef(RESULT.unsafe_value())};
+        return {true, .returned_value = Conversion<::std::string>::toBaseRef(RESULT.unsafe_value())};
     } else {
         return {false, .error_value = Conversion<::smoke::Payload>::toBaseRef(RESULT.error())};
     }
 }
-class smoke_ErrorsInterfaceProxy : public std::shared_ptr<::smoke::ErrorsInterface>::element_type, public CachedProxyBase<smoke_ErrorsInterfaceProxy> {
+class smoke_ErrorsInterfaceProxy : public ::std::shared_ptr<::smoke::ErrorsInterface>::element_type, public CachedProxyBase<smoke_ErrorsInterfaceProxy> {
 public:
     smoke_ErrorsInterfaceProxy(smoke_ErrorsInterface_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_ErrorsInterfaceProxy() {
@@ -95,7 +95,7 @@ public:
         auto _result_with_error = mFunctions.smoke_ErrorsInterface_methodWithErrors(mFunctions.swift_pointer);
         if (!_result_with_error.has_value)
         {
-            return std::error_code{static_cast<::smoke::ErrorsInterface::InternalError>(_result_with_error.error_value)};
+            return ::std::error_code{static_cast<::smoke::ErrorsInterface::InternalError>(_result_with_error.error_value)};
         }
         return {};
     }
@@ -103,7 +103,7 @@ public:
         auto _result_with_error = mFunctions.smoke_ErrorsInterface_methodWithExternalErrors(mFunctions.swift_pointer);
         if (!_result_with_error.has_value)
         {
-            return std::error_code{static_cast<::smoke::ErrorsInterface::ExternalErrors>(_result_with_error.error_value)};
+            return ::std::error_code{static_cast<::smoke::ErrorsInterface::ExternalErrors>(_result_with_error.error_value)};
         }
         return {};
     }
@@ -111,18 +111,18 @@ public:
         auto _result_with_error = mFunctions.smoke_ErrorsInterface_methodWithErrorsAndReturnValue(mFunctions.swift_pointer);
         if (!_result_with_error.has_value)
         {
-            return std::error_code{static_cast<::smoke::ErrorsInterface::InternalError>(_result_with_error.error_value)};
+            return ::std::error_code{static_cast<::smoke::ErrorsInterface::InternalError>(_result_with_error.error_value)};
         }
         auto _call_result = _result_with_error.returned_value;
-        return Conversion<std::string>::toCppReturn(_call_result);
+        return Conversion<::std::string>::toCppReturn(_call_result);
     }
 private:
     smoke_ErrorsInterface_FunctionTable mFunctions;
 };
 _baseRef smoke_ErrorsInterface_create_proxy(smoke_ErrorsInterface_FunctionTable functionTable) {
-    auto proxy = smoke_ErrorsInterfaceProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::ErrorsInterface>(proxy)) : 0;
+    auto proxy = smoke_ErrorsInterfaceProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::ErrorsInterface>(proxy)) : 0;
 }
 const void* smoke_ErrorsInterface_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_ErrorsInterfaceProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get()) : nullptr;
+    return handle ? smoke_ErrorsInterfaceProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::ErrorsInterface>>(handle)->get()) : nullptr;
 }

--- a/gluecodium/src/test/resources/smoke/extensions/output/cbridge/src/smoke/cbridge_Extensions__extension.cpp
+++ b/gluecodium/src/test/resources/smoke/extensions/output/cbridge/src/smoke/cbridge_Extensions__extension.cpp
@@ -10,8 +10,8 @@
 _baseRef
 smoke_Extensions_FooStruct_create_handle( _baseRef fooField )
 {
-    ::smoke::FooStruct* _struct = new ( std::nothrow ) ::smoke::FooStruct();
-    _struct->foo_field = Conversion<std::string>::toCpp( fooField );
+    ::smoke::FooStruct* _struct = new ( ::std::nothrow ) ::smoke::FooStruct();
+    _struct->foo_field = Conversion<::std::string>::toCpp( fooField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -22,8 +22,8 @@ smoke_Extensions_FooStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_Extensions_FooStruct_create_optional_handle(_baseRef fooField)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::FooStruct>( ::smoke::FooStruct( ) );
-    (*_struct)->foo_field = Conversion<std::string>::toCpp( fooField );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::FooStruct>( ::smoke::FooStruct( ) );
+    (*_struct)->foo_field = Conversion<::std::string>::toCpp( fooField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -36,5 +36,5 @@ void smoke_Extensions_FooStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_Extensions_FooStruct_fooField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::FooStruct>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->foo_field);
+    return Conversion<::std::string>::toBaseRef(struct_pointer->foo_field);
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_Enums.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_Enums.cpp
@@ -11,25 +11,25 @@
 #include <memory>
 #include <new>
 void smoke_Enums_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Enums>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::Enums>>(handle);
 }
 _baseRef smoke_Enums_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Enums>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::Enums>>(handle)))
         : 0;
 }
 const void* smoke_Enums_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Enums>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Enums>>(handle)->get())
         : nullptr;
 }
 void smoke_Enums_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Enums>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::Enums>>(handle)->get(), swift_pointer);
 }
 void smoke_Enums_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Enums>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Enums>>(handle)->get());
 }
 void smoke_Enums_methodWithExternalEnum(smoke_Enums_ExternalEnum input) {
     return ::smoke::Enums::method_with_external_enum(static_cast<::smoke::Enums::External_Enum>(input));

--- a/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_ExternalClass.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_ExternalClass.cpp
@@ -11,31 +11,31 @@
 #include <new>
 #include <string>
 void smoke_ExternalClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::fire::Baz>>(handle);
+    delete get_pointer<::std::shared_ptr<::fire::Baz>>(handle);
 }
 _baseRef smoke_ExternalClass_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::fire::Baz>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::fire::Baz>>(handle)))
         : 0;
 }
 const void* smoke_ExternalClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::fire::Baz>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::fire::Baz>>(handle)->get())
         : nullptr;
 }
 void smoke_ExternalClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::fire::Baz>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::fire::Baz>>(handle)->get(), swift_pointer);
 }
 void smoke_ExternalClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::fire::Baz>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::fire::Baz>>(handle)->get());
 }
 _baseRef
 smoke_ExternalClass_SomeStruct_create_handle( _baseRef someField )
 {
-    ::fire::Baz::some_Struct* _struct = new ( std::nothrow ) ::fire::Baz::some_Struct();
-    _struct->some_Field = Conversion<std::string>::toCpp( someField );
+    ::fire::Baz::some_Struct* _struct = new ( ::std::nothrow ) ::fire::Baz::some_Struct();
+    _struct->some_Field = Conversion<::std::string>::toCpp( someField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -46,8 +46,8 @@ smoke_ExternalClass_SomeStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_ExternalClass_SomeStruct_create_optional_handle(_baseRef someField)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::fire::Baz::some_Struct>( ::fire::Baz::some_Struct( ) );
-    (*_struct)->some_Field = Conversion<std::string>::toCpp( someField );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::fire::Baz::some_Struct>( ::fire::Baz::some_Struct( ) );
+    (*_struct)->some_Field = Conversion<::std::string>::toCpp( someField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -60,11 +60,11 @@ void smoke_ExternalClass_SomeStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_ExternalClass_SomeStruct_someField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::fire::Baz::some_Struct>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->some_Field);
+    return Conversion<::std::string>::toBaseRef(struct_pointer->some_Field);
 }
 void smoke_ExternalClass_someMethod(_baseRef _instance, int8_t someParameter) {
-    return get_pointer<std::shared_ptr<::fire::Baz>>(_instance)->get()->some_Method(someParameter);
+    return get_pointer<::std::shared_ptr<::fire::Baz>>(_instance)->get()->some_Method(someParameter);
 }
 _baseRef smoke_ExternalClass_someProperty_get(_baseRef _instance) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::fire::Baz>>(_instance)->get()->get_Me());
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::fire::Baz>>(_instance)->get()->get_Me());
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_ExternalInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_ExternalInterface.cpp
@@ -12,25 +12,25 @@
 #include <new>
 #include <string>
 void smoke_ExternalInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::ExternalInterface>>(handle);
 }
 _baseRef smoke_ExternalInterface_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::ExternalInterface>>(handle)))
         : 0;
 }
 const void* smoke_ExternalInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ExternalInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_ExternalInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::ExternalInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_ExternalInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ExternalInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ExternalInterface(_baseRef handle);
@@ -43,15 +43,15 @@ struct smoke_ExternalInterfaceRegisterInit {
 } s_smoke_ExternalInterface_register_init;
 }
 void* smoke_ExternalInterface_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::ExternalInterface>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::ExternalInterface>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::ExternalInterface>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_ExternalInterface(handle);
 }
 _baseRef
 smoke_ExternalInterface_SomeStruct_create_handle( _baseRef someField )
 {
-    ::smoke::ExternalInterface::some_Struct* _struct = new ( std::nothrow ) ::smoke::ExternalInterface::some_Struct();
-    _struct->some_Field = Conversion<std::string>::toCpp( someField );
+    ::smoke::ExternalInterface::some_Struct* _struct = new ( ::std::nothrow ) ::smoke::ExternalInterface::some_Struct();
+    _struct->some_Field = Conversion<::std::string>::toCpp( someField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -62,8 +62,8 @@ smoke_ExternalInterface_SomeStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_ExternalInterface_SomeStruct_create_optional_handle(_baseRef someField)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::ExternalInterface::some_Struct>( ::smoke::ExternalInterface::some_Struct( ) );
-    (*_struct)->some_Field = Conversion<std::string>::toCpp( someField );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::ExternalInterface::some_Struct>( ::smoke::ExternalInterface::some_Struct( ) );
+    (*_struct)->some_Field = Conversion<::std::string>::toCpp( someField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -76,18 +76,18 @@ void smoke_ExternalInterface_SomeStruct_release_optional_handle(_baseRef handle)
 }
 _baseRef smoke_ExternalInterface_SomeStruct_someField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::ExternalInterface::some_Struct>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->some_Field);
+    return Conversion<::std::string>::toBaseRef(struct_pointer->some_Field);
 }
 void smoke_ExternalInterface_someMethod(_baseRef _instance, int8_t someParameter) {
-    return get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(_instance)->get()->some_Method(someParameter);
+    return get_pointer<::std::shared_ptr<::smoke::ExternalInterface>>(_instance)->get()->some_Method(someParameter);
 }
 _baseRef smoke_ExternalInterface_someProperty_get(_baseRef _instance) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(_instance)->get()->get_Me());
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::ExternalInterface>>(_instance)->get()->get_Me());
 }
-class smoke_ExternalInterfaceProxy : public std::shared_ptr<::smoke::ExternalInterface>::element_type, public CachedProxyBase<smoke_ExternalInterfaceProxy> {
+class smoke_ExternalInterfaceProxy : public ::std::shared_ptr<::smoke::ExternalInterface>::element_type, public CachedProxyBase<smoke_ExternalInterfaceProxy> {
 public:
     smoke_ExternalInterfaceProxy(smoke_ExternalInterface_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_ExternalInterfaceProxy() {
@@ -100,15 +100,15 @@ public:
     }
     ::std::string get_Me() const override {
         auto _call_result = mFunctions.smoke_ExternalInterface_someProperty_get(mFunctions.swift_pointer);
-        return Conversion<std::string>::toCppReturn(_call_result);
+        return Conversion<::std::string>::toCppReturn(_call_result);
     }
 private:
     smoke_ExternalInterface_FunctionTable mFunctions;
 };
 _baseRef smoke_ExternalInterface_create_proxy(smoke_ExternalInterface_FunctionTable functionTable) {
-    auto proxy = smoke_ExternalInterfaceProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::ExternalInterface>(proxy)) : 0;
+    auto proxy = smoke_ExternalInterfaceProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::ExternalInterface>(proxy)) : 0;
 }
 const void* smoke_ExternalInterface_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_ExternalInterfaceProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::ExternalInterface>>(handle)->get()) : nullptr;
+    return handle ? smoke_ExternalInterfaceProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::ExternalInterface>>(handle)->get()) : nullptr;
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_Structs.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_Structs.cpp
@@ -15,33 +15,33 @@
 #include <string>
 #include <vector>
 void smoke_Structs_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Structs>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::Structs>>(handle);
 }
 _baseRef smoke_Structs_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Structs>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::Structs>>(handle)))
         : 0;
 }
 const void* smoke_Structs_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Structs>>(handle)->get())
         : nullptr;
 }
 void smoke_Structs_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::Structs>>(handle)->get(), swift_pointer);
 }
 void smoke_Structs_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Structs>>(handle)->get());
 }
 _baseRef
 smoke_Structs_ExternalStruct_create_handle( _baseRef stringField, _baseRef externalStringField, _baseRef externalArrayField, _baseRef externalStructField )
 {
-    ::smoke::Structs::ExternalStruct* _struct = new ( std::nothrow ) ::smoke::Structs::ExternalStruct();
-    _struct->stringField = Conversion<std::string>::toCpp( stringField );
-    _struct->set_some_string( Conversion<std::string>::toCpp( externalStringField ) );
-    _struct->set_some_array( Conversion<std::vector<int8_t>>::toCpp( externalArrayField ) );
+    ::smoke::Structs::ExternalStruct* _struct = new ( ::std::nothrow ) ::smoke::Structs::ExternalStruct();
+    _struct->stringField = Conversion<::std::string>::toCpp( stringField );
+    _struct->set_some_string( Conversion<::std::string>::toCpp( externalStringField ) );
+    _struct->set_some_array( Conversion<::std::vector<int8_t>>::toCpp( externalArrayField ) );
     _struct->set_some_struct( Conversion<::fire::SomeVeryExternalStruct>::toCpp( externalStructField ) );
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -53,10 +53,10 @@ smoke_Structs_ExternalStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_Structs_ExternalStruct_create_optional_handle(_baseRef stringField, _baseRef externalStringField, _baseRef externalArrayField, _baseRef externalStructField)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Structs::ExternalStruct>( ::smoke::Structs::ExternalStruct( ) );
-    (*_struct)->stringField = Conversion<std::string>::toCpp( stringField );
-    (*_struct)->set_some_string( Conversion<std::string>::toCpp( externalStringField ) );
-    (*_struct)->set_some_array( Conversion<std::vector<int8_t>>::toCpp( externalArrayField ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::Structs::ExternalStruct>( ::smoke::Structs::ExternalStruct( ) );
+    (*_struct)->stringField = Conversion<::std::string>::toCpp( stringField );
+    (*_struct)->set_some_string( Conversion<::std::string>::toCpp( externalStringField ) );
+    (*_struct)->set_some_array( Conversion<::std::vector<int8_t>>::toCpp( externalArrayField ) );
     (*_struct)->set_some_struct( Conversion<::fire::SomeVeryExternalStruct>::toCpp( externalStructField ) );
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -70,15 +70,15 @@ void smoke_Structs_ExternalStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_Structs_ExternalStruct_stringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::ExternalStruct>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->stringField);
+    return Conversion<::std::string>::toBaseRef(struct_pointer->stringField);
 }
 _baseRef smoke_Structs_ExternalStruct_externalStringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::ExternalStruct>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->get_some_string());
+    return Conversion<::std::string>::toBaseRef(struct_pointer->get_some_string());
 }
 _baseRef smoke_Structs_ExternalStruct_externalArrayField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::ExternalStruct>(handle);
-    return Conversion<std::vector<int8_t>>::toBaseRef(struct_pointer->get_some_array());
+    return Conversion<::std::vector<int8_t>>::toBaseRef(struct_pointer->get_some_array());
 }
 _baseRef smoke_Structs_ExternalStruct_externalStructField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::ExternalStruct>(handle);
@@ -87,7 +87,7 @@ _baseRef smoke_Structs_ExternalStruct_externalStructField_get(_baseRef handle) {
 _baseRef
 smoke_Structs_AnotherExternalStruct_create_handle( int8_t intField )
 {
-    ::fire::SomeVeryExternalStruct* _struct = new ( std::nothrow ) ::fire::SomeVeryExternalStruct();
+    ::fire::SomeVeryExternalStruct* _struct = new ( ::std::nothrow ) ::fire::SomeVeryExternalStruct();
     _struct->intField = intField;
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -99,7 +99,7 @@ smoke_Structs_AnotherExternalStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_Structs_AnotherExternalStruct_create_optional_handle(int8_t intField)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::fire::SomeVeryExternalStruct>( ::fire::SomeVeryExternalStruct( ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::fire::SomeVeryExternalStruct>( ::fire::SomeVeryExternalStruct( ) );
     (*_struct)->intField = intField;
     return reinterpret_cast<_baseRef>( _struct );
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_UseSwiftExternalTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_UseSwiftExternalTypes.cpp
@@ -14,25 +14,25 @@
 #include <memory>
 #include <new>
 void smoke_UseSwiftExternalTypes_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle);
 }
 _baseRef smoke_UseSwiftExternalTypes_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle)))
         : 0;
 }
 const void* smoke_UseSwiftExternalTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle)->get())
         : nullptr;
 }
 void smoke_UseSwiftExternalTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle)->get(), swift_pointer);
 }
 void smoke_UseSwiftExternalTypes_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::UseSwiftExternalTypes>>(handle)->get());
 }
 _baseRef smoke_UseSwiftExternalTypes_dateIntervalRoundTrip(_baseRef input) {
     return Conversion<::smoke::DateInterval>::toBaseRef(::smoke::UseSwiftExternalTypes::date_interval_round_trip(Conversion<::smoke::DateInterval>::toCpp(input)));

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/GenericCollections.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/GenericCollections.cpp
@@ -23,1412 +23,1412 @@
 #include <unordered_set>
 #include <vector>
 _baseRef foobar_ArrayOf__Float_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<float>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<float>( ) );
 }
 _baseRef foobar_ArrayOf__Float_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<float>( *reinterpret_cast<std::vector<float>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<float>( *reinterpret_cast<::std::vector<float>*>( handle ) ) );
 }
 void foobar_ArrayOf__Float_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<float>*>( handle );
+    delete reinterpret_cast<::std::vector<float>*>( handle );
 }
 uint64_t foobar_ArrayOf__Float_count(_baseRef handle) {
-    return Conversion<std::vector<float>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<float>>::toCpp( handle ).size( );
 }
 float foobar_ArrayOf__Float_get( _baseRef handle, uint64_t index ) {
-    return Conversion<std::vector<float>>::toCpp(handle)[ index ];
+    return Conversion<::std::vector<float>>::toCpp(handle)[ index ];
 }
 void foobar_ArrayOf__Float_append( _baseRef handle, float item )
 {
-    Conversion<std::vector<float>>::toCpp(handle).push_back( item );
+    Conversion<::std::vector<float>>::toCpp(handle).push_back( item );
 }
 _baseRef foobar_ArrayOf__Float_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<float>>( std::vector<float>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<float>>( ::std::vector<float>( ) ) );
 }
 void foobar_ArrayOf__Float_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<float>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<float>>*>( handle );
 }
 _baseRef foobar_ArrayOf__Float_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<float>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<float>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf__Int_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<int32_t>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<int32_t>( ) );
 }
 _baseRef foobar_ArrayOf__Int_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<int32_t>( *reinterpret_cast<std::vector<int32_t>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<int32_t>( *reinterpret_cast<::std::vector<int32_t>*>( handle ) ) );
 }
 void foobar_ArrayOf__Int_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<int32_t>*>( handle );
+    delete reinterpret_cast<::std::vector<int32_t>*>( handle );
 }
 uint64_t foobar_ArrayOf__Int_count(_baseRef handle) {
-    return Conversion<std::vector<int32_t>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<int32_t>>::toCpp( handle ).size( );
 }
 int32_t foobar_ArrayOf__Int_get( _baseRef handle, uint64_t index ) {
-    return Conversion<std::vector<int32_t>>::toCpp(handle)[ index ];
+    return Conversion<::std::vector<int32_t>>::toCpp(handle)[ index ];
 }
 void foobar_ArrayOf__Int_append( _baseRef handle, int32_t item )
 {
-    Conversion<std::vector<int32_t>>::toCpp(handle).push_back( item );
+    Conversion<::std::vector<int32_t>>::toCpp(handle).push_back( item );
 }
 _baseRef foobar_ArrayOf__Int_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<int32_t>>( std::vector<int32_t>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<int32_t>>( ::std::vector<int32_t>( ) ) );
 }
 void foobar_ArrayOf__Int_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<int32_t>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<int32_t>>*>( handle );
 }
 _baseRef foobar_ArrayOf__Int_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<int32_t>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<int32_t>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf__String_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<std::string>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::string>( ) );
 }
 _baseRef foobar_ArrayOf__String_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<std::string>( *reinterpret_cast<std::vector<std::string>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::string>( *reinterpret_cast<::std::vector<::std::string>*>( handle ) ) );
 }
 void foobar_ArrayOf__String_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<std::string>*>( handle );
+    delete reinterpret_cast<::std::vector<::std::string>*>( handle );
 }
 uint64_t foobar_ArrayOf__String_count(_baseRef handle) {
-    return Conversion<std::vector<std::string>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<::std::string>>::toCpp( handle ).size( );
 }
 _baseRef foobar_ArrayOf__String_get( _baseRef handle, uint64_t index ) {
-    return Conversion<std::string>::referenceBaseRef(Conversion<std::vector<std::string>>::toCpp( handle )[index]);
+    return Conversion<::std::string>::referenceBaseRef(Conversion<::std::vector<::std::string>>::toCpp( handle )[index]);
 }
 void foobar_ArrayOf__String_append( _baseRef handle, _baseRef item )
 {
-    Conversion<std::vector<std::string>>::toCpp(handle).push_back(Conversion<std::string>::toCpp(item));
+    Conversion<::std::vector<::std::string>>::toCpp(handle).push_back(Conversion<::std::string>::toCpp(item));
 }
 _baseRef foobar_ArrayOf__String_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<std::string>>( std::vector<std::string>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<::std::string>>( ::std::vector<::std::string>( ) ) );
 }
 void foobar_ArrayOf__String_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<std::string>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<::std::string>>*>( handle );
 }
 _baseRef foobar_ArrayOf__String_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<std::string>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<::std::string>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf__UByte_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<uint8_t>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<uint8_t>( ) );
 }
 _baseRef foobar_ArrayOf__UByte_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<uint8_t>( *reinterpret_cast<std::vector<uint8_t>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<uint8_t>( *reinterpret_cast<::std::vector<uint8_t>*>( handle ) ) );
 }
 void foobar_ArrayOf__UByte_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<uint8_t>*>( handle );
+    delete reinterpret_cast<::std::vector<uint8_t>*>( handle );
 }
 uint64_t foobar_ArrayOf__UByte_count(_baseRef handle) {
-    return Conversion<std::vector<uint8_t>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<uint8_t>>::toCpp( handle ).size( );
 }
 uint8_t foobar_ArrayOf__UByte_get( _baseRef handle, uint64_t index ) {
-    return Conversion<std::vector<uint8_t>>::toCpp(handle)[ index ];
+    return Conversion<::std::vector<uint8_t>>::toCpp(handle)[ index ];
 }
 void foobar_ArrayOf__UByte_append( _baseRef handle, uint8_t item )
 {
-    Conversion<std::vector<uint8_t>>::toCpp(handle).push_back( item );
+    Conversion<::std::vector<uint8_t>>::toCpp(handle).push_back( item );
 }
 _baseRef foobar_ArrayOf__UByte_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<uint8_t>>( std::vector<uint8_t>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<uint8_t>>( ::std::vector<uint8_t>( ) ) );
 }
 void foobar_ArrayOf__UByte_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<uint8_t>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<uint8_t>>*>( handle );
 }
 _baseRef foobar_ArrayOf__UByte_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<uint8_t>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<uint8_t>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf_foobar_ArrayOf__Int_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<std::vector<int32_t>>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::vector<int32_t>>( ) );
 }
 _baseRef foobar_ArrayOf_foobar_ArrayOf__Int_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<std::vector<int32_t>>( *reinterpret_cast<std::vector<std::vector<int32_t>>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::vector<int32_t>>( *reinterpret_cast<::std::vector<::std::vector<int32_t>>*>( handle ) ) );
 }
 void foobar_ArrayOf_foobar_ArrayOf__Int_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<std::vector<int32_t>>*>( handle );
+    delete reinterpret_cast<::std::vector<::std::vector<int32_t>>*>( handle );
 }
 uint64_t foobar_ArrayOf_foobar_ArrayOf__Int_count(_baseRef handle) {
-    return Conversion<std::vector<std::vector<int32_t>>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<::std::vector<int32_t>>>::toCpp( handle ).size( );
 }
 _baseRef foobar_ArrayOf_foobar_ArrayOf__Int_get( _baseRef handle, uint64_t index ) {
-    return Conversion<std::vector<int32_t>>::referenceBaseRef(Conversion<std::vector<std::vector<int32_t>>>::toCpp( handle )[index]);
+    return Conversion<::std::vector<int32_t>>::referenceBaseRef(Conversion<::std::vector<::std::vector<int32_t>>>::toCpp( handle )[index]);
 }
 void foobar_ArrayOf_foobar_ArrayOf__Int_append( _baseRef handle, _baseRef item )
 {
-    Conversion<std::vector<std::vector<int32_t>>>::toCpp(handle).push_back(Conversion<std::vector<int32_t>>::toCpp(item));
+    Conversion<::std::vector<::std::vector<int32_t>>>::toCpp(handle).push_back(Conversion<::std::vector<int32_t>>::toCpp(item));
 }
 _baseRef foobar_ArrayOf_foobar_ArrayOf__Int_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<std::vector<int32_t>>>( std::vector<std::vector<int32_t>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<::std::vector<int32_t>>>( ::std::vector<::std::vector<int32_t>>( ) ) );
 }
 void foobar_ArrayOf_foobar_ArrayOf__Int_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<std::vector<int32_t>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<::std::vector<int32_t>>>*>( handle );
 }
 _baseRef foobar_ArrayOf_foobar_ArrayOf__Int_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<std::vector<int32_t>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<::std::vector<int32_t>>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<std::unordered_map<int32_t, bool>>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::unordered_map<int32_t, bool>>( ) );
 }
 _baseRef foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<std::unordered_map<int32_t, bool>>( *reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::unordered_map<int32_t, bool>>( *reinterpret_cast<::std::vector<::std::unordered_map<int32_t, bool>>*>( handle ) ) );
 }
 void foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<std::unordered_map<int32_t, bool>>*>( handle );
+    delete reinterpret_cast<::std::vector<::std::unordered_map<int32_t, bool>>*>( handle );
 }
 uint64_t foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_count(_baseRef handle) {
-    return Conversion<std::vector<std::unordered_map<int32_t, bool>>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<::std::unordered_map<int32_t, bool>>>::toCpp( handle ).size( );
 }
 _baseRef foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_get( _baseRef handle, uint64_t index ) {
-    return Conversion<std::unordered_map<int32_t, bool>>::referenceBaseRef(Conversion<std::vector<std::unordered_map<int32_t, bool>>>::toCpp( handle )[index]);
+    return Conversion<::std::unordered_map<int32_t, bool>>::referenceBaseRef(Conversion<::std::vector<::std::unordered_map<int32_t, bool>>>::toCpp( handle )[index]);
 }
 void foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_append( _baseRef handle, _baseRef item )
 {
-    Conversion<std::vector<std::unordered_map<int32_t, bool>>>::toCpp(handle).push_back(Conversion<std::unordered_map<int32_t, bool>>::toCpp(item));
+    Conversion<::std::vector<::std::unordered_map<int32_t, bool>>>::toCpp(handle).push_back(Conversion<::std::unordered_map<int32_t, bool>>::toCpp(item));
 }
 _baseRef foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<std::unordered_map<int32_t, bool>>>( std::vector<std::unordered_map<int32_t, bool>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<::std::unordered_map<int32_t, bool>>>( ::std::vector<::std::unordered_map<int32_t, bool>>( ) ) );
 }
 void foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<std::unordered_map<int32_t, bool>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<::std::unordered_map<int32_t, bool>>>*>( handle );
 }
 _baseRef foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<std::unordered_map<int32_t, bool>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<::std::unordered_map<int32_t, bool>>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf_foobar_SetOf__Int_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<std::unordered_set<int32_t>>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::unordered_set<int32_t>>( ) );
 }
 _baseRef foobar_ArrayOf_foobar_SetOf__Int_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<std::unordered_set<int32_t>>( *reinterpret_cast<std::vector<std::unordered_set<int32_t>>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::unordered_set<int32_t>>( *reinterpret_cast<::std::vector<::std::unordered_set<int32_t>>*>( handle ) ) );
 }
 void foobar_ArrayOf_foobar_SetOf__Int_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<std::unordered_set<int32_t>>*>( handle );
+    delete reinterpret_cast<::std::vector<::std::unordered_set<int32_t>>*>( handle );
 }
 uint64_t foobar_ArrayOf_foobar_SetOf__Int_count(_baseRef handle) {
-    return Conversion<std::vector<std::unordered_set<int32_t>>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<::std::unordered_set<int32_t>>>::toCpp( handle ).size( );
 }
 _baseRef foobar_ArrayOf_foobar_SetOf__Int_get( _baseRef handle, uint64_t index ) {
-    return Conversion<std::unordered_set<int32_t>>::referenceBaseRef(Conversion<std::vector<std::unordered_set<int32_t>>>::toCpp( handle )[index]);
+    return Conversion<::std::unordered_set<int32_t>>::referenceBaseRef(Conversion<::std::vector<::std::unordered_set<int32_t>>>::toCpp( handle )[index]);
 }
 void foobar_ArrayOf_foobar_SetOf__Int_append( _baseRef handle, _baseRef item )
 {
-    Conversion<std::vector<std::unordered_set<int32_t>>>::toCpp(handle).push_back(Conversion<std::unordered_set<int32_t>>::toCpp(item));
+    Conversion<::std::vector<::std::unordered_set<int32_t>>>::toCpp(handle).push_back(Conversion<::std::unordered_set<int32_t>>::toCpp(item));
 }
 _baseRef foobar_ArrayOf_foobar_SetOf__Int_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<std::unordered_set<int32_t>>>( std::vector<std::unordered_set<int32_t>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<::std::unordered_set<int32_t>>>( ::std::vector<::std::unordered_set<int32_t>>( ) ) );
 }
 void foobar_ArrayOf_foobar_SetOf__Int_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<std::unordered_set<int32_t>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<::std::unordered_set<int32_t>>>*>( handle );
 }
 _baseRef foobar_ArrayOf_foobar_SetOf__Int_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<std::unordered_set<int32_t>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<::std::unordered_set<int32_t>>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf_smoke_AnotherDummyClass_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::shared_ptr<::smoke::AnotherDummyClass>>( ) );
 }
 _baseRef foobar_ArrayOf_smoke_AnotherDummyClass_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>( *reinterpret_cast<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::shared_ptr<::smoke::AnotherDummyClass>>( *reinterpret_cast<::std::vector<::std::shared_ptr<::smoke::AnotherDummyClass>>*>( handle ) ) );
 }
 void foobar_ArrayOf_smoke_AnotherDummyClass_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>*>( handle );
+    delete reinterpret_cast<::std::vector<::std::shared_ptr<::smoke::AnotherDummyClass>>*>( handle );
 }
 uint64_t foobar_ArrayOf_smoke_AnotherDummyClass_count(_baseRef handle) {
-    return Conversion<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<::std::shared_ptr<::smoke::AnotherDummyClass>>>::toCpp( handle ).size( );
 }
 _baseRef foobar_ArrayOf_smoke_AnotherDummyClass_get( _baseRef handle, uint64_t index ) {
-    return Conversion<std::shared_ptr<::smoke::AnotherDummyClass>>::referenceBaseRef(Conversion<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>::toCpp( handle )[index]);
+    return Conversion<::std::shared_ptr<::smoke::AnotherDummyClass>>::referenceBaseRef(Conversion<::std::vector<::std::shared_ptr<::smoke::AnotherDummyClass>>>::toCpp( handle )[index]);
 }
 void foobar_ArrayOf_smoke_AnotherDummyClass_append( _baseRef handle, _baseRef item )
 {
-    Conversion<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>::toCpp(handle).push_back(Conversion<std::shared_ptr<::smoke::AnotherDummyClass>>::toCpp(item));
+    Conversion<::std::vector<::std::shared_ptr<::smoke::AnotherDummyClass>>>::toCpp(handle).push_back(Conversion<::std::shared_ptr<::smoke::AnotherDummyClass>>::toCpp(item));
 }
 _baseRef foobar_ArrayOf_smoke_AnotherDummyClass_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>( std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<::std::shared_ptr<::smoke::AnotherDummyClass>>>( ::std::vector<::std::shared_ptr<::smoke::AnotherDummyClass>>( ) ) );
 }
 void foobar_ArrayOf_smoke_AnotherDummyClass_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<::std::shared_ptr<::smoke::AnotherDummyClass>>>*>( handle );
 }
 _baseRef foobar_ArrayOf_smoke_AnotherDummyClass_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<std::shared_ptr<::smoke::AnotherDummyClass>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<::std::shared_ptr<::smoke::AnotherDummyClass>>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf_smoke_DummyClass_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<std::shared_ptr<::smoke::DummyClass>>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::shared_ptr<::smoke::DummyClass>>( ) );
 }
 _baseRef foobar_ArrayOf_smoke_DummyClass_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<std::shared_ptr<::smoke::DummyClass>>( *reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyClass>>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::shared_ptr<::smoke::DummyClass>>( *reinterpret_cast<::std::vector<::std::shared_ptr<::smoke::DummyClass>>*>( handle ) ) );
 }
 void foobar_ArrayOf_smoke_DummyClass_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyClass>>*>( handle );
+    delete reinterpret_cast<::std::vector<::std::shared_ptr<::smoke::DummyClass>>*>( handle );
 }
 uint64_t foobar_ArrayOf_smoke_DummyClass_count(_baseRef handle) {
-    return Conversion<std::vector<std::shared_ptr<::smoke::DummyClass>>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<::std::shared_ptr<::smoke::DummyClass>>>::toCpp( handle ).size( );
 }
 _baseRef foobar_ArrayOf_smoke_DummyClass_get( _baseRef handle, uint64_t index ) {
-    return Conversion<std::shared_ptr<::smoke::DummyClass>>::referenceBaseRef(Conversion<std::vector<std::shared_ptr<::smoke::DummyClass>>>::toCpp( handle )[index]);
+    return Conversion<::std::shared_ptr<::smoke::DummyClass>>::referenceBaseRef(Conversion<::std::vector<::std::shared_ptr<::smoke::DummyClass>>>::toCpp( handle )[index]);
 }
 void foobar_ArrayOf_smoke_DummyClass_append( _baseRef handle, _baseRef item )
 {
-    Conversion<std::vector<std::shared_ptr<::smoke::DummyClass>>>::toCpp(handle).push_back(Conversion<std::shared_ptr<::smoke::DummyClass>>::toCpp(item));
+    Conversion<::std::vector<::std::shared_ptr<::smoke::DummyClass>>>::toCpp(handle).push_back(Conversion<::std::shared_ptr<::smoke::DummyClass>>::toCpp(item));
 }
 _baseRef foobar_ArrayOf_smoke_DummyClass_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<std::shared_ptr<::smoke::DummyClass>>>( std::vector<std::shared_ptr<::smoke::DummyClass>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<::std::shared_ptr<::smoke::DummyClass>>>( ::std::vector<::std::shared_ptr<::smoke::DummyClass>>( ) ) );
 }
 void foobar_ArrayOf_smoke_DummyClass_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<std::shared_ptr<::smoke::DummyClass>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<::std::shared_ptr<::smoke::DummyClass>>>*>( handle );
 }
 _baseRef foobar_ArrayOf_smoke_DummyClass_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<std::shared_ptr<::smoke::DummyClass>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<::std::shared_ptr<::smoke::DummyClass>>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf_smoke_DummyInterface_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<std::shared_ptr<::smoke::DummyInterface>>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::shared_ptr<::smoke::DummyInterface>>( ) );
 }
 _baseRef foobar_ArrayOf_smoke_DummyInterface_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<std::shared_ptr<::smoke::DummyInterface>>( *reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyInterface>>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::shared_ptr<::smoke::DummyInterface>>( *reinterpret_cast<::std::vector<::std::shared_ptr<::smoke::DummyInterface>>*>( handle ) ) );
 }
 void foobar_ArrayOf_smoke_DummyInterface_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<std::shared_ptr<::smoke::DummyInterface>>*>( handle );
+    delete reinterpret_cast<::std::vector<::std::shared_ptr<::smoke::DummyInterface>>*>( handle );
 }
 uint64_t foobar_ArrayOf_smoke_DummyInterface_count(_baseRef handle) {
-    return Conversion<std::vector<std::shared_ptr<::smoke::DummyInterface>>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<::std::shared_ptr<::smoke::DummyInterface>>>::toCpp( handle ).size( );
 }
 _baseRef foobar_ArrayOf_smoke_DummyInterface_get( _baseRef handle, uint64_t index ) {
-    return Conversion<std::shared_ptr<::smoke::DummyInterface>>::referenceBaseRef(Conversion<std::vector<std::shared_ptr<::smoke::DummyInterface>>>::toCpp( handle )[index]);
+    return Conversion<::std::shared_ptr<::smoke::DummyInterface>>::referenceBaseRef(Conversion<::std::vector<::std::shared_ptr<::smoke::DummyInterface>>>::toCpp( handle )[index]);
 }
 void foobar_ArrayOf_smoke_DummyInterface_append( _baseRef handle, _baseRef item )
 {
-    Conversion<std::vector<std::shared_ptr<::smoke::DummyInterface>>>::toCpp(handle).push_back(Conversion<std::shared_ptr<::smoke::DummyInterface>>::toCpp(item));
+    Conversion<::std::vector<::std::shared_ptr<::smoke::DummyInterface>>>::toCpp(handle).push_back(Conversion<::std::shared_ptr<::smoke::DummyInterface>>::toCpp(item));
 }
 _baseRef foobar_ArrayOf_smoke_DummyInterface_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<std::shared_ptr<::smoke::DummyInterface>>>( std::vector<std::shared_ptr<::smoke::DummyInterface>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<::std::shared_ptr<::smoke::DummyInterface>>>( ::std::vector<::std::shared_ptr<::smoke::DummyInterface>>( ) ) );
 }
 void foobar_ArrayOf_smoke_DummyInterface_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<std::shared_ptr<::smoke::DummyInterface>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<::std::shared_ptr<::smoke::DummyInterface>>>*>( handle );
 }
 _baseRef foobar_ArrayOf_smoke_DummyInterface_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<std::shared_ptr<::smoke::DummyInterface>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<::std::shared_ptr<::smoke::DummyInterface>>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>( ) );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>( *reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>( *reinterpret_cast<::std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>*>( handle ) ) );
 }
 void foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>*>( handle );
+    delete reinterpret_cast<::std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>*>( handle );
 }
 uint64_t foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_count(_baseRef handle) {
-    return Conversion<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toCpp( handle ).size( );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get( _baseRef handle, uint64_t index ) {
-    return Conversion<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::referenceBaseRef(Conversion<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toCpp( handle )[index]);
+    return Conversion<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::referenceBaseRef(Conversion<::std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toCpp( handle )[index]);
 }
 void foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_append( _baseRef handle, _baseRef item )
 {
-    Conversion<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toCpp(handle).push_back(Conversion<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::toCpp(item));
+    Conversion<::std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toCpp(handle).push_back(Conversion<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::toCpp(item));
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>( std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>( ::std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>( ) ) );
 }
 void foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>*>( handle );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<::alien::FooEnum>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::alien::FooEnum>( ) );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<::alien::FooEnum>( *reinterpret_cast<std::vector<::alien::FooEnum>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::alien::FooEnum>( *reinterpret_cast<::std::vector<::alien::FooEnum>*>( handle ) ) );
 }
 void foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<::alien::FooEnum>*>( handle );
+    delete reinterpret_cast<::std::vector<::alien::FooEnum>*>( handle );
 }
 uint64_t foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_count(_baseRef handle) {
-    return Conversion<std::vector<::alien::FooEnum>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<::alien::FooEnum>>::toCpp( handle ).size( );
 }
 smoke_GenericTypesWithCompoundTypes_ExternalEnum foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get( _baseRef handle, uint64_t index ) {
-    return static_cast<smoke_GenericTypesWithCompoundTypes_ExternalEnum>(Conversion<std::vector<::alien::FooEnum>>::toCpp(handle)[ index ]);
+    return static_cast<smoke_GenericTypesWithCompoundTypes_ExternalEnum>(Conversion<::std::vector<::alien::FooEnum>>::toCpp(handle)[ index ]);
 }
 void foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_append( _baseRef handle, smoke_GenericTypesWithCompoundTypes_ExternalEnum item )
 {
-    Conversion<std::vector<::alien::FooEnum>>::toCpp(handle).push_back( static_cast<::alien::FooEnum>( item ) );
+    Conversion<::std::vector<::alien::FooEnum>>::toCpp(handle).push_back( static_cast<::alien::FooEnum>( item ) );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<::alien::FooEnum>>( std::vector<::alien::FooEnum>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<::alien::FooEnum>>( ::std::vector<::alien::FooEnum>( ) ) );
 }
 void foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<::alien::FooEnum>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<::alien::FooEnum>>*>( handle );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<::alien::FooEnum>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<::alien::FooEnum>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<::alien::FooStruct>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::alien::FooStruct>( ) );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<::alien::FooStruct>( *reinterpret_cast<std::vector<::alien::FooStruct>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::alien::FooStruct>( *reinterpret_cast<::std::vector<::alien::FooStruct>*>( handle ) ) );
 }
 void foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<::alien::FooStruct>*>( handle );
+    delete reinterpret_cast<::std::vector<::alien::FooStruct>*>( handle );
 }
 uint64_t foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_count(_baseRef handle) {
-    return Conversion<std::vector<::alien::FooStruct>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<::alien::FooStruct>>::toCpp( handle ).size( );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get( _baseRef handle, uint64_t index ) {
-    return Conversion<::alien::FooStruct>::referenceBaseRef(Conversion<std::vector<::alien::FooStruct>>::toCpp( handle )[index]);
+    return Conversion<::alien::FooStruct>::referenceBaseRef(Conversion<::std::vector<::alien::FooStruct>>::toCpp( handle )[index]);
 }
 void foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_append( _baseRef handle, _baseRef item )
 {
-    Conversion<std::vector<::alien::FooStruct>>::toCpp(handle).push_back(Conversion<::alien::FooStruct>::toCpp(item));
+    Conversion<::std::vector<::alien::FooStruct>>::toCpp(handle).push_back(Conversion<::alien::FooStruct>::toCpp(item));
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<::alien::FooStruct>>( std::vector<::alien::FooStruct>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<::alien::FooStruct>>( ::std::vector<::alien::FooStruct>( ) ) );
 }
 void foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<::alien::FooStruct>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<::alien::FooStruct>>*>( handle );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<::alien::FooStruct>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<::alien::FooStruct>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>( ) );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>( *reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>( *reinterpret_cast<::std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>*>( handle ) ) );
 }
 void foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>*>( handle );
+    delete reinterpret_cast<::std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>*>( handle );
 }
 uint64_t foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_count(_baseRef handle) {
-    return Conversion<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::toCpp( handle ).size( );
 }
 smoke_GenericTypesWithCompoundTypes_SomeEnum foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get( _baseRef handle, uint64_t index ) {
-    return static_cast<smoke_GenericTypesWithCompoundTypes_SomeEnum>(Conversion<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::toCpp(handle)[ index ]);
+    return static_cast<smoke_GenericTypesWithCompoundTypes_SomeEnum>(Conversion<::std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::toCpp(handle)[ index ]);
 }
 void foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_append( _baseRef handle, smoke_GenericTypesWithCompoundTypes_SomeEnum item )
 {
-    Conversion<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::toCpp(handle).push_back( static_cast<::smoke::GenericTypesWithCompoundTypes::SomeEnum>( item ) );
+    Conversion<::std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::toCpp(handle).push_back( static_cast<::smoke::GenericTypesWithCompoundTypes::SomeEnum>( item ) );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>( std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>( ::std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>( ) ) );
 }
 void foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>( handle );
 }
 _baseRef foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>( handle ) );
 }
 _baseRef foobar_ArrayOf_smoke_YetAnotherDummyClass_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<std::shared_ptr<::smoke::YetAnotherDummyClass>>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::shared_ptr<::smoke::YetAnotherDummyClass>>( ) );
 }
 _baseRef foobar_ArrayOf_smoke_YetAnotherDummyClass_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<std::shared_ptr<::smoke::YetAnotherDummyClass>>( *reinterpret_cast<std::vector<std::shared_ptr<::smoke::YetAnotherDummyClass>>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<::std::shared_ptr<::smoke::YetAnotherDummyClass>>( *reinterpret_cast<::std::vector<::std::shared_ptr<::smoke::YetAnotherDummyClass>>*>( handle ) ) );
 }
 void foobar_ArrayOf_smoke_YetAnotherDummyClass_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<std::shared_ptr<::smoke::YetAnotherDummyClass>>*>( handle );
+    delete reinterpret_cast<::std::vector<::std::shared_ptr<::smoke::YetAnotherDummyClass>>*>( handle );
 }
 uint64_t foobar_ArrayOf_smoke_YetAnotherDummyClass_count(_baseRef handle) {
-    return Conversion<std::vector<std::shared_ptr<::smoke::YetAnotherDummyClass>>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<::std::shared_ptr<::smoke::YetAnotherDummyClass>>>::toCpp( handle ).size( );
 }
 _baseRef foobar_ArrayOf_smoke_YetAnotherDummyClass_get( _baseRef handle, uint64_t index ) {
-    return Conversion<std::shared_ptr<::smoke::YetAnotherDummyClass>>::referenceBaseRef(Conversion<std::vector<std::shared_ptr<::smoke::YetAnotherDummyClass>>>::toCpp( handle )[index]);
+    return Conversion<::std::shared_ptr<::smoke::YetAnotherDummyClass>>::referenceBaseRef(Conversion<::std::vector<::std::shared_ptr<::smoke::YetAnotherDummyClass>>>::toCpp( handle )[index]);
 }
 void foobar_ArrayOf_smoke_YetAnotherDummyClass_append( _baseRef handle, _baseRef item )
 {
-    Conversion<std::vector<std::shared_ptr<::smoke::YetAnotherDummyClass>>>::toCpp(handle).push_back(Conversion<std::shared_ptr<::smoke::YetAnotherDummyClass>>::toCpp(item));
+    Conversion<::std::vector<::std::shared_ptr<::smoke::YetAnotherDummyClass>>>::toCpp(handle).push_back(Conversion<::std::shared_ptr<::smoke::YetAnotherDummyClass>>::toCpp(item));
 }
 _baseRef foobar_ArrayOf_smoke_YetAnotherDummyClass_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<std::shared_ptr<::smoke::YetAnotherDummyClass>>>( std::vector<std::shared_ptr<::smoke::YetAnotherDummyClass>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<::std::shared_ptr<::smoke::YetAnotherDummyClass>>>( ::std::vector<::std::shared_ptr<::smoke::YetAnotherDummyClass>>( ) ) );
 }
 void foobar_ArrayOf_smoke_YetAnotherDummyClass_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<std::shared_ptr<::smoke::YetAnotherDummyClass>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<::std::shared_ptr<::smoke::YetAnotherDummyClass>>>*>( handle );
 }
 _baseRef foobar_ArrayOf_smoke_YetAnotherDummyClass_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<std::shared_ptr<::smoke::YetAnotherDummyClass>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<::std::shared_ptr<::smoke::YetAnotherDummyClass>>>*>( handle ) );
 }
 _baseRef foobar_MapOf__Float_To__Double_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<float, double>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<float, double>() );
 }
 void foobar_MapOf__Float_To__Double_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<float, double>>(handle);
+    delete get_pointer<::std::unordered_map<float, double>>(handle);
 }
 _baseRef foobar_MapOf__Float_To__Double_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<float, double>::iterator( get_pointer<std::unordered_map<float, double>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<float, double>::iterator( get_pointer<::std::unordered_map<float, double>>(handle)->begin() ) );
 }
 void foobar_MapOf__Float_To__Double_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<float, double>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<float, double>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__Float_To__Double_put(_baseRef handle, float key, double value) {
-    (*get_pointer<std::unordered_map<float, double>>(handle)).emplace(key, value);
+    (*get_pointer<::std::unordered_map<float, double>>(handle)).emplace(key, value);
 }
 bool foobar_MapOf__Float_To__Double_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<float, double>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<float, double>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<float, double>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<float, double>>(handle)->end();
 }
 void foobar_MapOf__Float_To__Double_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<float, double>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<float, double>::iterator*>( iterator_handle );
 }
 float foobar_MapOf__Float_To__Double_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<float, double>::iterator*>( iterator_handle ))->first;
+    auto& key = (*reinterpret_cast<::std::unordered_map<float, double>::iterator*>( iterator_handle ))->first;
     return key;
 }
 double foobar_MapOf__Float_To__Double_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<float, double>::iterator*>( iterator_handle ))->second;
+    auto& value = (*reinterpret_cast<::std::unordered_map<float, double>::iterator*>( iterator_handle ))->second;
     return value;
 }
 _baseRef foobar_MapOf__Float_To__Double_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<float, double>>( std::unordered_map<float, double>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<float, double>>( ::std::unordered_map<float, double>( ) ) );
 }
 void foobar_MapOf__Float_To__Double_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<float, double>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<float, double>>*>( handle );
 }
 _baseRef foobar_MapOf__Float_To__Double_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<float, double>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<float, double>>*>( handle ) );
 }
 _baseRef foobar_MapOf__Int_To__Boolean_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, bool>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, bool>() );
 }
 void foobar_MapOf__Int_To__Boolean_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<int32_t, bool>>(handle);
+    delete get_pointer<::std::unordered_map<int32_t, bool>>(handle);
 }
 _baseRef foobar_MapOf__Int_To__Boolean_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, bool>::iterator( get_pointer<std::unordered_map<int32_t, bool>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, bool>::iterator( get_pointer<::std::unordered_map<int32_t, bool>>(handle)->begin() ) );
 }
 void foobar_MapOf__Int_To__Boolean_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<int32_t, bool>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<int32_t, bool>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__Int_To__Boolean_put(_baseRef handle, int32_t key, bool value) {
-    (*get_pointer<std::unordered_map<int32_t, bool>>(handle)).emplace(key, value);
+    (*get_pointer<::std::unordered_map<int32_t, bool>>(handle)).emplace(key, value);
 }
 bool foobar_MapOf__Int_To__Boolean_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<int32_t, bool>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<int32_t, bool>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<int32_t, bool>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<int32_t, bool>>(handle)->end();
 }
 void foobar_MapOf__Int_To__Boolean_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<int32_t, bool>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<int32_t, bool>::iterator*>( iterator_handle );
 }
 int32_t foobar_MapOf__Int_To__Boolean_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<int32_t, bool>::iterator*>( iterator_handle ))->first;
+    auto& key = (*reinterpret_cast<::std::unordered_map<int32_t, bool>::iterator*>( iterator_handle ))->first;
     return key;
 }
 bool foobar_MapOf__Int_To__Boolean_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<int32_t, bool>::iterator*>( iterator_handle ))->second;
+    auto& value = (*reinterpret_cast<::std::unordered_map<int32_t, bool>::iterator*>( iterator_handle ))->second;
     return value;
 }
 _baseRef foobar_MapOf__Int_To__Boolean_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<int32_t, bool>>( std::unordered_map<int32_t, bool>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<int32_t, bool>>( ::std::unordered_map<int32_t, bool>( ) ) );
 }
 void foobar_MapOf__Int_To__Boolean_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, bool>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, bool>>*>( handle );
 }
 _baseRef foobar_MapOf__Int_To__Boolean_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, bool>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, bool>>*>( handle ) );
 }
 _baseRef foobar_MapOf__Int_To_foobar_ArrayOf__Int_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, std::vector<int32_t>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::std::vector<int32_t>>() );
 }
 void foobar_MapOf__Int_To_foobar_ArrayOf__Int_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<int32_t, std::vector<int32_t>>>(handle);
+    delete get_pointer<::std::unordered_map<int32_t, ::std::vector<int32_t>>>(handle);
 }
 _baseRef foobar_MapOf__Int_To_foobar_ArrayOf__Int_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, std::vector<int32_t>>::iterator( get_pointer<std::unordered_map<int32_t, std::vector<int32_t>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::std::vector<int32_t>>::iterator( get_pointer<::std::unordered_map<int32_t, ::std::vector<int32_t>>>(handle)->begin() ) );
 }
 void foobar_MapOf__Int_To_foobar_ArrayOf__Int_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<int32_t, ::std::vector<int32_t>>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__Int_To_foobar_ArrayOf__Int_put(_baseRef handle, int32_t key, _baseRef value) {
-    (*get_pointer<std::unordered_map<int32_t, std::vector<int32_t>>>(handle)).emplace(key, Conversion<std::vector<int32_t>>::toCpp(value));
+    (*get_pointer<::std::unordered_map<int32_t, ::std::vector<int32_t>>>(handle)).emplace(key, Conversion<::std::vector<int32_t>>::toCpp(value));
 }
 bool foobar_MapOf__Int_To_foobar_ArrayOf__Int_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<int32_t, std::vector<int32_t>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<int32_t, ::std::vector<int32_t>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<int32_t, ::std::vector<int32_t>>>(handle)->end();
 }
 void foobar_MapOf__Int_To_foobar_ArrayOf__Int_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<int32_t, ::std::vector<int32_t>>::iterator*>( iterator_handle );
 }
 int32_t foobar_MapOf__Int_To_foobar_ArrayOf__Int_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>::iterator*>( iterator_handle ))->first;
+    auto& key = (*reinterpret_cast<::std::unordered_map<int32_t, ::std::vector<int32_t>>::iterator*>( iterator_handle ))->first;
     return key;
 }
 _baseRef foobar_MapOf__Int_To_foobar_ArrayOf__Int_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<int32_t, std::vector<int32_t>>::iterator*>( iterator_handle ))->second;
-    return Conversion<std::vector<int32_t>>::toBaseRef(value);
+    auto& value = (*reinterpret_cast<::std::unordered_map<int32_t, ::std::vector<int32_t>>::iterator*>( iterator_handle ))->second;
+    return Conversion<::std::vector<int32_t>>::toBaseRef(value);
 }
 _baseRef foobar_MapOf__Int_To_foobar_ArrayOf__Int_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<int32_t, std::vector<int32_t>>>( std::unordered_map<int32_t, std::vector<int32_t>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<int32_t, ::std::vector<int32_t>>>( ::std::unordered_map<int32_t, ::std::vector<int32_t>>( ) ) );
 }
 void foobar_MapOf__Int_To_foobar_ArrayOf__Int_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, std::vector<int32_t>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::std::vector<int32_t>>>*>( handle );
 }
 _baseRef foobar_MapOf__Int_To_foobar_ArrayOf__Int_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, std::vector<int32_t>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::std::vector<int32_t>>>*>( handle ) );
 }
 _baseRef foobar_MapOf__Int_To_foobar_MapOf__Int_To__Boolean_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>() );
 }
 void foobar_MapOf__Int_To_foobar_MapOf__Int_To__Boolean_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>>(handle);
+    delete get_pointer<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>>(handle);
 }
 _baseRef foobar_MapOf__Int_To_foobar_MapOf__Int_To__Boolean_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>::iterator( get_pointer<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>::iterator( get_pointer<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>>(handle)->begin() ) );
 }
 void foobar_MapOf__Int_To_foobar_MapOf__Int_To__Boolean_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__Int_To_foobar_MapOf__Int_To__Boolean_put(_baseRef handle, int32_t key, _baseRef value) {
-    (*get_pointer<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>>(handle)).emplace(key, Conversion<std::unordered_map<int32_t, bool>>::toCpp(value));
+    (*get_pointer<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>>(handle)).emplace(key, Conversion<::std::unordered_map<int32_t, bool>>::toCpp(value));
 }
 bool foobar_MapOf__Int_To_foobar_MapOf__Int_To__Boolean_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>>(handle)->end();
 }
 void foobar_MapOf__Int_To_foobar_MapOf__Int_To__Boolean_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>::iterator*>( iterator_handle );
 }
 int32_t foobar_MapOf__Int_To_foobar_MapOf__Int_To__Boolean_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>::iterator*>( iterator_handle ))->first;
+    auto& key = (*reinterpret_cast<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>::iterator*>( iterator_handle ))->first;
     return key;
 }
 _baseRef foobar_MapOf__Int_To_foobar_MapOf__Int_To__Boolean_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>::iterator*>( iterator_handle ))->second;
-    return Conversion<std::unordered_map<int32_t, bool>>::toBaseRef(value);
+    auto& value = (*reinterpret_cast<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>::iterator*>( iterator_handle ))->second;
+    return Conversion<::std::unordered_map<int32_t, bool>>::toBaseRef(value);
 }
 _baseRef foobar_MapOf__Int_To_foobar_MapOf__Int_To__Boolean_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>>( std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>>( ::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>( ) ) );
 }
 void foobar_MapOf__Int_To_foobar_MapOf__Int_To__Boolean_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>>*>( handle );
 }
 _baseRef foobar_MapOf__Int_To_foobar_MapOf__Int_To__Boolean_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>>*>( handle ) );
 }
 _baseRef foobar_MapOf__Int_To_foobar_SetOf__Int_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, std::unordered_set<int32_t>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>() );
 }
 void foobar_MapOf__Int_To_foobar_SetOf__Int_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<int32_t, std::unordered_set<int32_t>>>(handle);
+    delete get_pointer<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>>(handle);
 }
 _baseRef foobar_MapOf__Int_To_foobar_SetOf__Int_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, std::unordered_set<int32_t>>::iterator( get_pointer<std::unordered_map<int32_t, std::unordered_set<int32_t>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>::iterator( get_pointer<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>>(handle)->begin() ) );
 }
 void foobar_MapOf__Int_To_foobar_SetOf__Int_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__Int_To_foobar_SetOf__Int_put(_baseRef handle, int32_t key, _baseRef value) {
-    (*get_pointer<std::unordered_map<int32_t, std::unordered_set<int32_t>>>(handle)).emplace(key, Conversion<std::unordered_set<int32_t>>::toCpp(value));
+    (*get_pointer<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>>(handle)).emplace(key, Conversion<::std::unordered_set<int32_t>>::toCpp(value));
 }
 bool foobar_MapOf__Int_To_foobar_SetOf__Int_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<int32_t, std::unordered_set<int32_t>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>>(handle)->end();
 }
 void foobar_MapOf__Int_To_foobar_SetOf__Int_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>::iterator*>( iterator_handle );
 }
 int32_t foobar_MapOf__Int_To_foobar_SetOf__Int_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>::iterator*>( iterator_handle ))->first;
+    auto& key = (*reinterpret_cast<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>::iterator*>( iterator_handle ))->first;
     return key;
 }
 _baseRef foobar_MapOf__Int_To_foobar_SetOf__Int_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<int32_t, std::unordered_set<int32_t>>::iterator*>( iterator_handle ))->second;
-    return Conversion<std::unordered_set<int32_t>>::toBaseRef(value);
+    auto& value = (*reinterpret_cast<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>::iterator*>( iterator_handle ))->second;
+    return Conversion<::std::unordered_set<int32_t>>::toBaseRef(value);
 }
 _baseRef foobar_MapOf__Int_To_foobar_SetOf__Int_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<int32_t, std::unordered_set<int32_t>>>( std::unordered_map<int32_t, std::unordered_set<int32_t>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>>( ::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>( ) ) );
 }
 void foobar_MapOf__Int_To_foobar_SetOf__Int_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, std::unordered_set<int32_t>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>>*>( handle );
 }
 _baseRef foobar_MapOf__Int_To_foobar_SetOf__Int_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, std::unordered_set<int32_t>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>>*>( handle ) );
 }
 _baseRef foobar_MapOf__Int_To_smoke_DummyClass_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>() );
 }
 void foobar_MapOf__Int_To_smoke_DummyClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>>(handle);
+    delete get_pointer<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>>(handle);
 }
 _baseRef foobar_MapOf__Int_To_smoke_DummyClass_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>::iterator( get_pointer<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>::iterator( get_pointer<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>>(handle)->begin() ) );
 }
 void foobar_MapOf__Int_To_smoke_DummyClass_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__Int_To_smoke_DummyClass_put(_baseRef handle, int32_t key, _baseRef value) {
-    (*get_pointer<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>>(handle)).emplace(key, Conversion<std::shared_ptr<::smoke::DummyClass>>::toCpp(value));
+    (*get_pointer<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>>(handle)).emplace(key, Conversion<::std::shared_ptr<::smoke::DummyClass>>::toCpp(value));
 }
 bool foobar_MapOf__Int_To_smoke_DummyClass_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>>(handle)->end();
 }
 void foobar_MapOf__Int_To_smoke_DummyClass_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>::iterator*>( iterator_handle );
 }
 int32_t foobar_MapOf__Int_To_smoke_DummyClass_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>::iterator*>( iterator_handle ))->first;
+    auto& key = (*reinterpret_cast<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>::iterator*>( iterator_handle ))->first;
     return key;
 }
 _baseRef foobar_MapOf__Int_To_smoke_DummyClass_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>::iterator*>( iterator_handle ))->second;
-    return Conversion<std::shared_ptr<::smoke::DummyClass>>::toBaseRef(value);
+    auto& value = (*reinterpret_cast<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>::iterator*>( iterator_handle ))->second;
+    return Conversion<::std::shared_ptr<::smoke::DummyClass>>::toBaseRef(value);
 }
 _baseRef foobar_MapOf__Int_To_smoke_DummyClass_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>>( std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>>( ::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>( ) ) );
 }
 void foobar_MapOf__Int_To_smoke_DummyClass_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>>*>( handle );
 }
 _baseRef foobar_MapOf__Int_To_smoke_DummyClass_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>>*>( handle ) );
 }
 _baseRef foobar_MapOf__Int_To_smoke_DummyInterface_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>() );
 }
 void foobar_MapOf__Int_To_smoke_DummyInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>>(handle);
+    delete get_pointer<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>>(handle);
 }
 _baseRef foobar_MapOf__Int_To_smoke_DummyInterface_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>::iterator( get_pointer<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>::iterator( get_pointer<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>>(handle)->begin() ) );
 }
 void foobar_MapOf__Int_To_smoke_DummyInterface_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__Int_To_smoke_DummyInterface_put(_baseRef handle, int32_t key, _baseRef value) {
-    (*get_pointer<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>>(handle)).emplace(key, Conversion<std::shared_ptr<::smoke::DummyInterface>>::toCpp(value));
+    (*get_pointer<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>>(handle)).emplace(key, Conversion<::std::shared_ptr<::smoke::DummyInterface>>::toCpp(value));
 }
 bool foobar_MapOf__Int_To_smoke_DummyInterface_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>>(handle)->end();
 }
 void foobar_MapOf__Int_To_smoke_DummyInterface_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>::iterator*>( iterator_handle );
 }
 int32_t foobar_MapOf__Int_To_smoke_DummyInterface_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>::iterator*>( iterator_handle ))->first;
+    auto& key = (*reinterpret_cast<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>::iterator*>( iterator_handle ))->first;
     return key;
 }
 _baseRef foobar_MapOf__Int_To_smoke_DummyInterface_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>::iterator*>( iterator_handle ))->second;
-    return Conversion<std::shared_ptr<::smoke::DummyInterface>>::toBaseRef(value);
+    auto& value = (*reinterpret_cast<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>::iterator*>( iterator_handle ))->second;
+    return Conversion<::std::shared_ptr<::smoke::DummyInterface>>::toBaseRef(value);
 }
 _baseRef foobar_MapOf__Int_To_smoke_DummyInterface_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>>( std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>>( ::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>( ) ) );
 }
 void foobar_MapOf__Int_To_smoke_DummyInterface_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>>*>( handle );
 }
 _baseRef foobar_MapOf__Int_To_smoke_DummyInterface_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>>*>( handle ) );
 }
 _baseRef foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, ::alien::FooEnum>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::alien::FooEnum>() );
 }
 void foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<int32_t, ::alien::FooEnum>>(handle);
+    delete get_pointer<::std::unordered_map<int32_t, ::alien::FooEnum>>(handle);
 }
 _baseRef foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, ::alien::FooEnum>::iterator( get_pointer<std::unordered_map<int32_t, ::alien::FooEnum>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::alien::FooEnum>::iterator( get_pointer<::std::unordered_map<int32_t, ::alien::FooEnum>>(handle)->begin() ) );
 }
 void foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_put(_baseRef handle, int32_t key, smoke_GenericTypesWithCompoundTypes_ExternalEnum value) {
-    (*get_pointer<std::unordered_map<int32_t, ::alien::FooEnum>>(handle)).emplace(key, static_cast<::alien::FooEnum>(value));
+    (*get_pointer<::std::unordered_map<int32_t, ::alien::FooEnum>>(handle)).emplace(key, static_cast<::alien::FooEnum>(value));
 }
 bool foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<int32_t, ::alien::FooEnum>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<int32_t, ::alien::FooEnum>>(handle)->end();
 }
 void foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>( iterator_handle );
 }
 int32_t foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>( iterator_handle ))->first;
+    auto& key = (*reinterpret_cast<::std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>( iterator_handle ))->first;
     return key;
 }
 smoke_GenericTypesWithCompoundTypes_ExternalEnum foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>( iterator_handle ))->second;
+    auto& value = (*reinterpret_cast<::std::unordered_map<int32_t, ::alien::FooEnum>::iterator*>( iterator_handle ))->second;
     return static_cast<smoke_GenericTypesWithCompoundTypes_ExternalEnum>(value);
 }
 _baseRef foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<int32_t, ::alien::FooEnum>>( std::unordered_map<int32_t, ::alien::FooEnum>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<int32_t, ::alien::FooEnum>>( ::std::unordered_map<int32_t, ::alien::FooEnum>( ) ) );
 }
 void foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, ::alien::FooEnum>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::alien::FooEnum>>*>( handle );
 }
 _baseRef foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, ::alien::FooEnum>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::alien::FooEnum>>*>( handle ) );
 }
 _baseRef foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>() );
 }
 void foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>(handle);
+    delete get_pointer<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>(handle);
 }
 _baseRef foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator( get_pointer<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator( get_pointer<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>(handle)->begin() ) );
 }
 void foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_put(_baseRef handle, int32_t key, smoke_GenericTypesWithCompoundTypes_SomeEnum value) {
-    (*get_pointer<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>(handle)).emplace(key, static_cast<::smoke::GenericTypesWithCompoundTypes::SomeEnum>(value));
+    (*get_pointer<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>(handle)).emplace(key, static_cast<::smoke::GenericTypesWithCompoundTypes::SomeEnum>(value));
 }
 bool foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>(handle)->end();
 }
 void foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>( iterator_handle );
 }
 int32_t foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>( iterator_handle ))->first;
+    auto& key = (*reinterpret_cast<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>( iterator_handle ))->first;
     return key;
 }
 smoke_GenericTypesWithCompoundTypes_SomeEnum foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>( iterator_handle ))->second;
+    auto& value = (*reinterpret_cast<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>::iterator*>( iterator_handle ))->second;
     return static_cast<smoke_GenericTypesWithCompoundTypes_SomeEnum>(value);
 }
 _baseRef foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>( std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>( ::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>( ) ) );
 }
 void foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>( handle );
 }
 _baseRef foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>*>( handle ) );
 }
 _baseRef foobar_MapOf__String_To__String_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::string, std::string>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::string, ::std::string>() );
 }
 void foobar_MapOf__String_To__String_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<std::string, std::string>>(handle);
+    delete get_pointer<::std::unordered_map<::std::string, ::std::string>>(handle);
 }
 _baseRef foobar_MapOf__String_To__String_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::string, std::string>::iterator( get_pointer<std::unordered_map<std::string, std::string>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::string, ::std::string>::iterator( get_pointer<::std::unordered_map<::std::string, ::std::string>>(handle)->begin() ) );
 }
 void foobar_MapOf__String_To__String_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<std::string, std::string>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<::std::string, ::std::string>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__String_To__String_put(_baseRef handle, _baseRef key, _baseRef value) {
-    (*get_pointer<std::unordered_map<std::string, std::string>>(handle)).emplace(Conversion<std::string>::toCpp(key), Conversion<std::string>::toCpp(value));
+    (*get_pointer<::std::unordered_map<::std::string, ::std::string>>(handle)).emplace(Conversion<::std::string>::toCpp(key), Conversion<::std::string>::toCpp(value));
 }
 bool foobar_MapOf__String_To__String_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<std::string, std::string>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<std::string, std::string>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<::std::string, ::std::string>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<::std::string, ::std::string>>(handle)->end();
 }
 void foobar_MapOf__String_To__String_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<std::string, std::string>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<::std::string, ::std::string>::iterator*>( iterator_handle );
 }
 _baseRef foobar_MapOf__String_To__String_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<std::string, std::string>::iterator*>( iterator_handle ))->first;
-    return Conversion<std::string>::toBaseRef(key);
+    auto& key = (*reinterpret_cast<::std::unordered_map<::std::string, ::std::string>::iterator*>( iterator_handle ))->first;
+    return Conversion<::std::string>::toBaseRef(key);
 }
 _baseRef foobar_MapOf__String_To__String_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<std::string, std::string>::iterator*>( iterator_handle ))->second;
-    return Conversion<std::string>::toBaseRef(value);
+    auto& value = (*reinterpret_cast<::std::unordered_map<::std::string, ::std::string>::iterator*>( iterator_handle ))->second;
+    return Conversion<::std::string>::toBaseRef(value);
 }
 _baseRef foobar_MapOf__String_To__String_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<std::string, std::string>>( std::unordered_map<std::string, std::string>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<::std::string, ::std::string>>( ::std::unordered_map<::std::string, ::std::string>( ) ) );
 }
 void foobar_MapOf__String_To__String_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<std::string, std::string>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::string, ::std::string>>*>( handle );
 }
 _baseRef foobar_MapOf__String_To__String_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<std::string, std::string>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::string, ::std::string>>*>( handle ) );
 }
 _baseRef foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>() );
 }
 void foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>(handle);
+    delete get_pointer<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>(handle);
 }
 _baseRef foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator( get_pointer<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator( get_pointer<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>(handle)->begin() ) );
 }
 void foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_put(_baseRef handle, _baseRef key, _baseRef value) {
-    (*get_pointer<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>(handle)).emplace(Conversion<std::string>::toCpp(key), Conversion<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::toCpp(value));
+    (*get_pointer<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>(handle)).emplace(Conversion<::std::string>::toCpp(key), Conversion<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::toCpp(value));
 }
 bool foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>(handle)->end();
 }
 void foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>( iterator_handle );
 }
 _baseRef foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>( iterator_handle ))->first;
-    return Conversion<std::string>::toBaseRef(key);
+    auto& key = (*reinterpret_cast<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>( iterator_handle ))->first;
+    return Conversion<::std::string>::toBaseRef(key);
 }
 _baseRef foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>( iterator_handle ))->second;
+    auto& value = (*reinterpret_cast<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>::iterator*>( iterator_handle ))->second;
     return Conversion<::smoke::GenericTypesWithCompoundTypes::BasicStruct>::toBaseRef(value);
 }
 _baseRef foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>( std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>( ::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>( ) ) );
 }
 void foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>*>( handle );
 }
 _baseRef foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>*>( handle ) );
 }
 _baseRef foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::string, ::alien::FooStruct>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::string, ::alien::FooStruct>() );
 }
 void foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<std::string, ::alien::FooStruct>>(handle);
+    delete get_pointer<::std::unordered_map<::std::string, ::alien::FooStruct>>(handle);
 }
 _baseRef foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::string, ::alien::FooStruct>::iterator( get_pointer<std::unordered_map<std::string, ::alien::FooStruct>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::string, ::alien::FooStruct>::iterator( get_pointer<::std::unordered_map<::std::string, ::alien::FooStruct>>(handle)->begin() ) );
 }
 void foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<::std::string, ::alien::FooStruct>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_put(_baseRef handle, _baseRef key, _baseRef value) {
-    (*get_pointer<std::unordered_map<std::string, ::alien::FooStruct>>(handle)).emplace(Conversion<std::string>::toCpp(key), Conversion<::alien::FooStruct>::toCpp(value));
+    (*get_pointer<::std::unordered_map<::std::string, ::alien::FooStruct>>(handle)).emplace(Conversion<::std::string>::toCpp(key), Conversion<::alien::FooStruct>::toCpp(value));
 }
 bool foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<std::string, ::alien::FooStruct>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<::std::string, ::alien::FooStruct>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<::std::string, ::alien::FooStruct>>(handle)->end();
 }
 void foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<::std::string, ::alien::FooStruct>::iterator*>( iterator_handle );
 }
 _baseRef foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>::iterator*>( iterator_handle ))->first;
-    return Conversion<std::string>::toBaseRef(key);
+    auto& key = (*reinterpret_cast<::std::unordered_map<::std::string, ::alien::FooStruct>::iterator*>( iterator_handle ))->first;
+    return Conversion<::std::string>::toBaseRef(key);
 }
 _baseRef foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<std::string, ::alien::FooStruct>::iterator*>( iterator_handle ))->second;
+    auto& value = (*reinterpret_cast<::std::unordered_map<::std::string, ::alien::FooStruct>::iterator*>( iterator_handle ))->second;
     return Conversion<::alien::FooStruct>::toBaseRef(value);
 }
 _baseRef foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<std::string, ::alien::FooStruct>>( std::unordered_map<std::string, ::alien::FooStruct>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<::std::string, ::alien::FooStruct>>( ::std::unordered_map<::std::string, ::alien::FooStruct>( ) ) );
 }
 void foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<std::string, ::alien::FooStruct>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::string, ::alien::FooStruct>>*>( handle );
 }
 _baseRef foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<std::string, ::alien::FooStruct>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::string, ::alien::FooStruct>>*>( handle ) );
 }
 _baseRef foobar_MapOf__UByte_To__String_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<uint8_t, std::string>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<uint8_t, ::std::string>() );
 }
 void foobar_MapOf__UByte_To__String_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<uint8_t, std::string>>(handle);
+    delete get_pointer<::std::unordered_map<uint8_t, ::std::string>>(handle);
 }
 _baseRef foobar_MapOf__UByte_To__String_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<uint8_t, std::string>::iterator( get_pointer<std::unordered_map<uint8_t, std::string>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<uint8_t, ::std::string>::iterator( get_pointer<::std::unordered_map<uint8_t, ::std::string>>(handle)->begin() ) );
 }
 void foobar_MapOf__UByte_To__String_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<uint8_t, std::string>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<uint8_t, ::std::string>::iterator*>( iterator_handle );
 }
 void foobar_MapOf__UByte_To__String_put(_baseRef handle, uint8_t key, _baseRef value) {
-    (*get_pointer<std::unordered_map<uint8_t, std::string>>(handle)).emplace(key, Conversion<std::string>::toCpp(value));
+    (*get_pointer<::std::unordered_map<uint8_t, ::std::string>>(handle)).emplace(key, Conversion<::std::string>::toCpp(value));
 }
 bool foobar_MapOf__UByte_To__String_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<uint8_t, std::string>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<uint8_t, std::string>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<uint8_t, ::std::string>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<uint8_t, ::std::string>>(handle)->end();
 }
 void foobar_MapOf__UByte_To__String_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<uint8_t, std::string>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<uint8_t, ::std::string>::iterator*>( iterator_handle );
 }
 uint8_t foobar_MapOf__UByte_To__String_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<uint8_t, std::string>::iterator*>( iterator_handle ))->first;
+    auto& key = (*reinterpret_cast<::std::unordered_map<uint8_t, ::std::string>::iterator*>( iterator_handle ))->first;
     return key;
 }
 _baseRef foobar_MapOf__UByte_To__String_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<uint8_t, std::string>::iterator*>( iterator_handle ))->second;
-    return Conversion<std::string>::toBaseRef(value);
+    auto& value = (*reinterpret_cast<::std::unordered_map<uint8_t, ::std::string>::iterator*>( iterator_handle ))->second;
+    return Conversion<::std::string>::toBaseRef(value);
 }
 _baseRef foobar_MapOf__UByte_To__String_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<uint8_t, std::string>>( std::unordered_map<uint8_t, std::string>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<uint8_t, ::std::string>>( ::std::unordered_map<uint8_t, ::std::string>( ) ) );
 }
 void foobar_MapOf__UByte_To__String_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<uint8_t, std::string>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<uint8_t, ::std::string>>*>( handle );
 }
 _baseRef foobar_MapOf__UByte_To__String_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<uint8_t, std::string>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<uint8_t, ::std::string>>*>( handle ) );
 }
 _baseRef foobar_MapOf_foobar_ArrayOf__Int_To__Boolean_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>() );
 }
 void foobar_MapOf_foobar_ArrayOf__Int_To__Boolean_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>>(handle);
+    delete get_pointer<::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>>(handle);
 }
 _baseRef foobar_MapOf_foobar_ArrayOf__Int_To__Boolean_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>::iterator( get_pointer<std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>::iterator( get_pointer<::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>>(handle)->begin() ) );
 }
 void foobar_MapOf_foobar_ArrayOf__Int_To__Boolean_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>::iterator*>( iterator_handle );
 }
 void foobar_MapOf_foobar_ArrayOf__Int_To__Boolean_put(_baseRef handle, _baseRef key, bool value) {
-    (*get_pointer<std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>>(handle)).emplace(Conversion<std::vector<int32_t>>::toCpp(key), value);
+    (*get_pointer<::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>>(handle)).emplace(Conversion<::std::vector<int32_t>>::toCpp(key), value);
 }
 bool foobar_MapOf_foobar_ArrayOf__Int_To__Boolean_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>>(handle)->end();
 }
 void foobar_MapOf_foobar_ArrayOf__Int_To__Boolean_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>::iterator*>( iterator_handle );
 }
 _baseRef foobar_MapOf_foobar_ArrayOf__Int_To__Boolean_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>::iterator*>( iterator_handle ))->first;
-    return Conversion<std::vector<int32_t>>::toBaseRef(key);
+    auto& key = (*reinterpret_cast<::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>::iterator*>( iterator_handle ))->first;
+    return Conversion<::std::vector<int32_t>>::toBaseRef(key);
 }
 bool foobar_MapOf_foobar_ArrayOf__Int_To__Boolean_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>::iterator*>( iterator_handle ))->second;
+    auto& value = (*reinterpret_cast<::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>::iterator*>( iterator_handle ))->second;
     return value;
 }
 _baseRef foobar_MapOf_foobar_ArrayOf__Int_To__Boolean_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>>( std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>>( ::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>( ) ) );
 }
 void foobar_MapOf_foobar_ArrayOf__Int_To__Boolean_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>>*>( handle );
 }
 _baseRef foobar_MapOf_foobar_ArrayOf__Int_To__Boolean_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<std::vector<int32_t>, bool, ::gluecodium::hash<std::vector<int32_t>>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::vector<int32_t>, bool, ::gluecodium::hash<::std::vector<int32_t>>>>*>( handle ) );
 }
 _baseRef foobar_MapOf_foobar_MapOf__Int_To__Boolean_To__Boolean_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>() );
 }
 void foobar_MapOf_foobar_MapOf__Int_To__Boolean_To__Boolean_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>(handle);
+    delete get_pointer<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>(handle);
 }
 _baseRef foobar_MapOf_foobar_MapOf__Int_To__Boolean_To__Boolean_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator( get_pointer<std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>::iterator( get_pointer<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>(handle)->begin() ) );
 }
 void foobar_MapOf_foobar_MapOf__Int_To__Boolean_To__Boolean_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle );
 }
 void foobar_MapOf_foobar_MapOf__Int_To__Boolean_To__Boolean_put(_baseRef handle, _baseRef key, bool value) {
-    (*get_pointer<std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>(handle)).emplace(Conversion<std::unordered_map<int32_t, bool>>::toCpp(key), value);
+    (*get_pointer<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>(handle)).emplace(Conversion<::std::unordered_map<int32_t, bool>>::toCpp(key), value);
 }
 bool foobar_MapOf_foobar_MapOf__Int_To__Boolean_To__Boolean_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>(handle)->end();
 }
 void foobar_MapOf_foobar_MapOf__Int_To__Boolean_To__Boolean_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle );
 }
 _baseRef foobar_MapOf_foobar_MapOf__Int_To__Boolean_To__Boolean_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle ))->first;
-    return Conversion<std::unordered_map<int32_t, bool>>::toBaseRef(key);
+    auto& key = (*reinterpret_cast<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle ))->first;
+    return Conversion<::std::unordered_map<int32_t, bool>>::toBaseRef(key);
 }
 bool foobar_MapOf_foobar_MapOf__Int_To__Boolean_To__Boolean_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle ))->second;
+    auto& value = (*reinterpret_cast<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle ))->second;
     return value;
 }
 _baseRef foobar_MapOf_foobar_MapOf__Int_To__Boolean_To__Boolean_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>( std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>( ::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>( ) ) );
 }
 void foobar_MapOf_foobar_MapOf__Int_To__Boolean_To__Boolean_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>*>( handle );
 }
 _baseRef foobar_MapOf_foobar_MapOf__Int_To__Boolean_To__Boolean_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>*>( handle ) );
 }
 _baseRef foobar_MapOf_foobar_SetOf__Int_To__Boolean_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>() );
 }
 void foobar_MapOf_foobar_SetOf__Int_To__Boolean_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>>(handle);
+    delete get_pointer<::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>>(handle);
 }
 _baseRef foobar_MapOf_foobar_SetOf__Int_To__Boolean_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>::iterator( get_pointer<std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>::iterator( get_pointer<::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>>(handle)->begin() ) );
 }
 void foobar_MapOf_foobar_SetOf__Int_To__Boolean_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>::iterator*>( iterator_handle );
 }
 void foobar_MapOf_foobar_SetOf__Int_To__Boolean_put(_baseRef handle, _baseRef key, bool value) {
-    (*get_pointer<std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>>(handle)).emplace(Conversion<std::unordered_set<int32_t>>::toCpp(key), value);
+    (*get_pointer<::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>>(handle)).emplace(Conversion<::std::unordered_set<int32_t>>::toCpp(key), value);
 }
 bool foobar_MapOf_foobar_SetOf__Int_To__Boolean_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>>(handle)->end();
 }
 void foobar_MapOf_foobar_SetOf__Int_To__Boolean_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>::iterator*>( iterator_handle );
 }
 _baseRef foobar_MapOf_foobar_SetOf__Int_To__Boolean_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>( iterator_handle ))->first;
-    return Conversion<std::unordered_set<int32_t>>::toBaseRef(key);
+    auto& key = (*reinterpret_cast<::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>::iterator*>( iterator_handle ))->first;
+    return Conversion<::std::unordered_set<int32_t>>::toBaseRef(key);
 }
 bool foobar_MapOf_foobar_SetOf__Int_To__Boolean_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>( iterator_handle ))->second;
+    auto& value = (*reinterpret_cast<::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>::iterator*>( iterator_handle ))->second;
     return value;
 }
 _baseRef foobar_MapOf_foobar_SetOf__Int_To__Boolean_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>>( std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>>( ::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>( ) ) );
 }
 void foobar_MapOf_foobar_SetOf__Int_To__Boolean_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>>*>( handle );
 }
 _baseRef foobar_MapOf_foobar_SetOf__Int_To__Boolean_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<std::unordered_set<int32_t>, bool, ::gluecodium::hash<std::unordered_set<int32_t>>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::unordered_set<int32_t>, bool, ::gluecodium::hash<::std::unordered_set<int32_t>>>>*>( handle ) );
 }
 _baseRef foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>() );
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>(handle);
+    delete get_pointer<::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>(handle);
 }
 _baseRef foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>::iterator( get_pointer<std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>::iterator( get_pointer<::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>(handle)->begin() ) );
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle );
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_put(_baseRef handle, smoke_GenericTypesWithCompoundTypes_ExternalEnum key, bool value) {
-    (*get_pointer<std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>(handle)).emplace(static_cast<::alien::FooEnum>(key), value);
+    (*get_pointer<::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>(handle)).emplace(static_cast<::alien::FooEnum>(key), value);
 }
 bool foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>(handle)->end();
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle );
 }
 smoke_GenericTypesWithCompoundTypes_ExternalEnum foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle ))->first;
+    auto& key = (*reinterpret_cast<::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle ))->first;
     return static_cast<smoke_GenericTypesWithCompoundTypes_ExternalEnum>(key);
 }
 bool foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle ))->second;
+    auto& value = (*reinterpret_cast<::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle ))->second;
     return value;
 }
 _baseRef foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>( std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>( ::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>( ) ) );
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>*>( handle );
 }
 _baseRef foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<::alien::FooEnum, bool, ::gluecodium::hash<::alien::FooEnum>>>*>( handle ) );
 }
 _baseRef foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>() );
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle);
+    delete get_pointer<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle);
 }
 _baseRef foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator( get_pointer<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator( get_pointer<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle)->begin() ) );
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle );
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_put(_baseRef handle, smoke_GenericTypesWithCompoundTypes_SomeEnum key, bool value) {
-    (*get_pointer<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle)).emplace(static_cast<::smoke::GenericTypesWithCompoundTypes::SomeEnum>(key), value);
+    (*get_pointer<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle)).emplace(static_cast<::smoke::GenericTypesWithCompoundTypes::SomeEnum>(key), value);
 }
 bool foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle)->end();
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle );
 }
 smoke_GenericTypesWithCompoundTypes_SomeEnum foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle ))->first;
+    auto& key = (*reinterpret_cast<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle ))->first;
     return static_cast<smoke_GenericTypesWithCompoundTypes_SomeEnum>(key);
 }
 bool foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle ))->second;
+    auto& value = (*reinterpret_cast<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle ))->second;
     return value;
 }
 _baseRef foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>( std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>( ::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>( ) ) );
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>*>( handle );
 }
 _baseRef foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>*>( handle ) );
 }
 _baseRef foobar_SetOf__Float_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<float>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<float>() );
 }
 void foobar_SetOf__Float_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_set<float>>(handle);
+    delete get_pointer<::std::unordered_set<float>>(handle);
 }
 void foobar_SetOf__Float_insert(_baseRef handle, float value) {
-    (*get_pointer<std::unordered_set<float>>(handle)).insert(std::move(value));
+    (*get_pointer<::std::unordered_set<float>>(handle)).insert(::std::move(value));
 }
 _baseRef foobar_SetOf__Float_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<float>::iterator( get_pointer<std::unordered_set<float>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<float>::iterator( get_pointer<::std::unordered_set<float>>(handle)->begin() ) );
 }
 void foobar_SetOf__Float_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_set<float>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_set<float>::iterator*>( iterator_handle );
 }
 bool foobar_SetOf__Float_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_set<float>::iterator*>( iterator_handle ) != get_pointer<std::unordered_set<float>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_set<float>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_set<float>>(handle)->end();
 }
 void foobar_SetOf__Float_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_set<float>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_set<float>::iterator*>( iterator_handle );
 }
 float foobar_SetOf__Float_iterator_get(_baseRef iterator_handle) {
-    auto& value = **reinterpret_cast<std::unordered_set<float>::iterator*>( iterator_handle );
+    auto& value = **reinterpret_cast<::std::unordered_set<float>::iterator*>( iterator_handle );
     return value;
 }
 _baseRef foobar_SetOf__Float_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_set<float>>( std::unordered_set<float>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_set<float>>( ::std::unordered_set<float>( ) ) );
 }
 void foobar_SetOf__Float_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_set<float>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_set<float>>*>( handle );
 }
 _baseRef foobar_SetOf__Float_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_set<float>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_set<float>>*>( handle ) );
 }
 _baseRef foobar_SetOf__Int_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<int32_t>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<int32_t>() );
 }
 void foobar_SetOf__Int_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_set<int32_t>>(handle);
+    delete get_pointer<::std::unordered_set<int32_t>>(handle);
 }
 void foobar_SetOf__Int_insert(_baseRef handle, int32_t value) {
-    (*get_pointer<std::unordered_set<int32_t>>(handle)).insert(std::move(value));
+    (*get_pointer<::std::unordered_set<int32_t>>(handle)).insert(::std::move(value));
 }
 _baseRef foobar_SetOf__Int_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<int32_t>::iterator( get_pointer<std::unordered_set<int32_t>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<int32_t>::iterator( get_pointer<::std::unordered_set<int32_t>>(handle)->begin() ) );
 }
 void foobar_SetOf__Int_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_set<int32_t>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_set<int32_t>::iterator*>( iterator_handle );
 }
 bool foobar_SetOf__Int_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_set<int32_t>::iterator*>( iterator_handle ) != get_pointer<std::unordered_set<int32_t>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_set<int32_t>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_set<int32_t>>(handle)->end();
 }
 void foobar_SetOf__Int_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_set<int32_t>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_set<int32_t>::iterator*>( iterator_handle );
 }
 int32_t foobar_SetOf__Int_iterator_get(_baseRef iterator_handle) {
-    auto& value = **reinterpret_cast<std::unordered_set<int32_t>::iterator*>( iterator_handle );
+    auto& value = **reinterpret_cast<::std::unordered_set<int32_t>::iterator*>( iterator_handle );
     return value;
 }
 _baseRef foobar_SetOf__Int_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_set<int32_t>>( std::unordered_set<int32_t>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_set<int32_t>>( ::std::unordered_set<int32_t>( ) ) );
 }
 void foobar_SetOf__Int_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_set<int32_t>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_set<int32_t>>*>( handle );
 }
 _baseRef foobar_SetOf__Int_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_set<int32_t>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_set<int32_t>>*>( handle ) );
 }
 _baseRef foobar_SetOf__String_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<std::string>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<::std::string>() );
 }
 void foobar_SetOf__String_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_set<std::string>>(handle);
+    delete get_pointer<::std::unordered_set<::std::string>>(handle);
 }
 void foobar_SetOf__String_insert(_baseRef handle, _baseRef value) {
-    (*get_pointer<std::unordered_set<std::string>>(handle)).insert(std::move(Conversion<std::string>::toCpp(value)));
+    (*get_pointer<::std::unordered_set<::std::string>>(handle)).insert(::std::move(Conversion<::std::string>::toCpp(value)));
 }
 _baseRef foobar_SetOf__String_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<std::string>::iterator( get_pointer<std::unordered_set<std::string>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<::std::string>::iterator( get_pointer<::std::unordered_set<::std::string>>(handle)->begin() ) );
 }
 void foobar_SetOf__String_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_set<std::string>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_set<::std::string>::iterator*>( iterator_handle );
 }
 bool foobar_SetOf__String_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_set<std::string>::iterator*>( iterator_handle ) != get_pointer<std::unordered_set<std::string>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_set<::std::string>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_set<::std::string>>(handle)->end();
 }
 void foobar_SetOf__String_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_set<std::string>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_set<::std::string>::iterator*>( iterator_handle );
 }
 _baseRef foobar_SetOf__String_iterator_get(_baseRef iterator_handle) {
-    auto& value = **reinterpret_cast<std::unordered_set<std::string>::iterator*>( iterator_handle );
-    return Conversion<std::string>::referenceBaseRef(value);
+    auto& value = **reinterpret_cast<::std::unordered_set<::std::string>::iterator*>( iterator_handle );
+    return Conversion<::std::string>::referenceBaseRef(value);
 }
 _baseRef foobar_SetOf__String_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_set<std::string>>( std::unordered_set<std::string>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_set<::std::string>>( ::std::unordered_set<::std::string>( ) ) );
 }
 void foobar_SetOf__String_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_set<std::string>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_set<::std::string>>*>( handle );
 }
 _baseRef foobar_SetOf__String_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_set<std::string>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_set<::std::string>>*>( handle ) );
 }
 _baseRef foobar_SetOf__UByte_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<uint8_t>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<uint8_t>() );
 }
 void foobar_SetOf__UByte_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_set<uint8_t>>(handle);
+    delete get_pointer<::std::unordered_set<uint8_t>>(handle);
 }
 void foobar_SetOf__UByte_insert(_baseRef handle, uint8_t value) {
-    (*get_pointer<std::unordered_set<uint8_t>>(handle)).insert(std::move(value));
+    (*get_pointer<::std::unordered_set<uint8_t>>(handle)).insert(::std::move(value));
 }
 _baseRef foobar_SetOf__UByte_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<uint8_t>::iterator( get_pointer<std::unordered_set<uint8_t>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<uint8_t>::iterator( get_pointer<::std::unordered_set<uint8_t>>(handle)->begin() ) );
 }
 void foobar_SetOf__UByte_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_set<uint8_t>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_set<uint8_t>::iterator*>( iterator_handle );
 }
 bool foobar_SetOf__UByte_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_set<uint8_t>::iterator*>( iterator_handle ) != get_pointer<std::unordered_set<uint8_t>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_set<uint8_t>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_set<uint8_t>>(handle)->end();
 }
 void foobar_SetOf__UByte_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_set<uint8_t>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_set<uint8_t>::iterator*>( iterator_handle );
 }
 uint8_t foobar_SetOf__UByte_iterator_get(_baseRef iterator_handle) {
-    auto& value = **reinterpret_cast<std::unordered_set<uint8_t>::iterator*>( iterator_handle );
+    auto& value = **reinterpret_cast<::std::unordered_set<uint8_t>::iterator*>( iterator_handle );
     return value;
 }
 _baseRef foobar_SetOf__UByte_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_set<uint8_t>>( std::unordered_set<uint8_t>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_set<uint8_t>>( ::std::unordered_set<uint8_t>( ) ) );
 }
 void foobar_SetOf__UByte_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_set<uint8_t>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_set<uint8_t>>*>( handle );
 }
 _baseRef foobar_SetOf__UByte_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_set<uint8_t>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_set<uint8_t>>*>( handle ) );
 }
 _baseRef foobar_SetOf_foobar_ArrayOf__Int_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>() );
 }
 void foobar_SetOf_foobar_ArrayOf__Int_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>>(handle);
+    delete get_pointer<::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>>(handle);
 }
 void foobar_SetOf_foobar_ArrayOf__Int_insert(_baseRef handle, _baseRef value) {
-    (*get_pointer<std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>>(handle)).insert(std::move(Conversion<std::vector<int32_t>>::toCpp(value)));
+    (*get_pointer<::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>>(handle)).insert(::std::move(Conversion<::std::vector<int32_t>>::toCpp(value)));
 }
 _baseRef foobar_SetOf_foobar_ArrayOf__Int_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>::iterator( get_pointer<std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>::iterator( get_pointer<::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>>(handle)->begin() ) );
 }
 void foobar_SetOf_foobar_ArrayOf__Int_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>::iterator*>( iterator_handle );
 }
 bool foobar_SetOf_foobar_ArrayOf__Int_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>>(handle)->end();
 }
 void foobar_SetOf_foobar_ArrayOf__Int_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>::iterator*>( iterator_handle );
 }
 _baseRef foobar_SetOf_foobar_ArrayOf__Int_iterator_get(_baseRef iterator_handle) {
-    auto& value = **reinterpret_cast<std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>::iterator*>( iterator_handle );
-    return Conversion<std::vector<int32_t>>::referenceBaseRef(value);
+    auto& value = **reinterpret_cast<::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>::iterator*>( iterator_handle );
+    return Conversion<::std::vector<int32_t>>::referenceBaseRef(value);
 }
 _baseRef foobar_SetOf_foobar_ArrayOf__Int_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>>( std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>>( ::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>( ) ) );
 }
 void foobar_SetOf_foobar_ArrayOf__Int_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>>*>( handle );
 }
 _baseRef foobar_SetOf_foobar_ArrayOf__Int_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_set<std::vector<int32_t>, ::gluecodium::hash<std::vector<int32_t>>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_set<::std::vector<int32_t>, ::gluecodium::hash<::std::vector<int32_t>>>>*>( handle ) );
 }
 _baseRef foobar_SetOf_foobar_MapOf__Int_To__Boolean_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>() );
 }
 void foobar_SetOf_foobar_MapOf__Int_To__Boolean_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>(handle);
+    delete get_pointer<::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>(handle);
 }
 void foobar_SetOf_foobar_MapOf__Int_To__Boolean_insert(_baseRef handle, _baseRef value) {
-    (*get_pointer<std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>(handle)).insert(std::move(Conversion<std::unordered_map<int32_t, bool>>::toCpp(value)));
+    (*get_pointer<::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>(handle)).insert(::std::move(Conversion<::std::unordered_map<int32_t, bool>>::toCpp(value)));
 }
 _baseRef foobar_SetOf_foobar_MapOf__Int_To__Boolean_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator( get_pointer<std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>::iterator( get_pointer<::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>(handle)->begin() ) );
 }
 void foobar_SetOf_foobar_MapOf__Int_To__Boolean_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle );
 }
 bool foobar_SetOf_foobar_MapOf__Int_To__Boolean_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>(handle)->end();
 }
 void foobar_SetOf_foobar_MapOf__Int_To__Boolean_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle );
 }
 _baseRef foobar_SetOf_foobar_MapOf__Int_To__Boolean_iterator_get(_baseRef iterator_handle) {
-    auto& value = **reinterpret_cast<std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle );
-    return Conversion<std::unordered_map<int32_t, bool>>::referenceBaseRef(value);
+    auto& value = **reinterpret_cast<::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>::iterator*>( iterator_handle );
+    return Conversion<::std::unordered_map<int32_t, bool>>::referenceBaseRef(value);
 }
 _baseRef foobar_SetOf_foobar_MapOf__Int_To__Boolean_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>( std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>( ::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>( ) ) );
 }
 void foobar_SetOf_foobar_MapOf__Int_To__Boolean_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>*>( handle );
 }
 _baseRef foobar_SetOf_foobar_MapOf__Int_To__Boolean_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_set<std::unordered_map<int32_t, bool>, ::gluecodium::hash<std::unordered_map<int32_t, bool>>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_set<::std::unordered_map<int32_t, bool>, ::gluecodium::hash<::std::unordered_map<int32_t, bool>>>>*>( handle ) );
 }
 _baseRef foobar_SetOf_foobar_SetOf__Int_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>() );
 }
 void foobar_SetOf_foobar_SetOf__Int_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>>(handle);
+    delete get_pointer<::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>>(handle);
 }
 void foobar_SetOf_foobar_SetOf__Int_insert(_baseRef handle, _baseRef value) {
-    (*get_pointer<std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>>(handle)).insert(std::move(Conversion<std::unordered_set<int32_t>>::toCpp(value)));
+    (*get_pointer<::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>>(handle)).insert(::std::move(Conversion<::std::unordered_set<int32_t>>::toCpp(value)));
 }
 _baseRef foobar_SetOf_foobar_SetOf__Int_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>::iterator( get_pointer<std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>::iterator( get_pointer<::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>>(handle)->begin() ) );
 }
 void foobar_SetOf_foobar_SetOf__Int_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>::iterator*>( iterator_handle );
 }
 bool foobar_SetOf_foobar_SetOf__Int_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>>(handle)->end();
 }
 void foobar_SetOf_foobar_SetOf__Int_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>::iterator*>( iterator_handle );
 }
 _baseRef foobar_SetOf_foobar_SetOf__Int_iterator_get(_baseRef iterator_handle) {
-    auto& value = **reinterpret_cast<std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>::iterator*>( iterator_handle );
-    return Conversion<std::unordered_set<int32_t>>::referenceBaseRef(value);
+    auto& value = **reinterpret_cast<::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>::iterator*>( iterator_handle );
+    return Conversion<::std::unordered_set<int32_t>>::referenceBaseRef(value);
 }
 _baseRef foobar_SetOf_foobar_SetOf__Int_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>>( std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>>( ::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>( ) ) );
 }
 void foobar_SetOf_foobar_SetOf__Int_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>>*>( handle );
 }
 _baseRef foobar_SetOf_foobar_SetOf__Int_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_set<std::unordered_set<int32_t>, ::gluecodium::hash<std::unordered_set<int32_t>>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_set<::std::unordered_set<int32_t>, ::gluecodium::hash<::std::unordered_set<int32_t>>>>*>( handle ) );
 }
 _baseRef foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>() );
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>(handle);
+    delete get_pointer<::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>(handle);
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(_baseRef handle, smoke_GenericTypesWithCompoundTypes_ExternalEnum value) {
-    (*get_pointer<std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>(handle)).insert(std::move(static_cast<::alien::FooEnum>(value)));
+    (*get_pointer<::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>(handle)).insert(::std::move(static_cast<::alien::FooEnum>(value)));
 }
 _baseRef foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>::iterator( get_pointer<std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>::iterator( get_pointer<::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>(handle)->begin() ) );
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle );
 }
 bool foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>(handle)->end();
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle );
 }
 smoke_GenericTypesWithCompoundTypes_ExternalEnum foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get(_baseRef iterator_handle) {
-    auto& value = **reinterpret_cast<std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle );
+    auto& value = **reinterpret_cast<::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>::iterator*>( iterator_handle );
     return static_cast<smoke_GenericTypesWithCompoundTypes_ExternalEnum>(value);
 }
 _baseRef foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>( std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>( ::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>( ) ) );
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>*>( handle );
 }
 _baseRef foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_set<::alien::FooEnum, ::gluecodium::hash<::alien::FooEnum>>>*>( handle ) );
 }
 _baseRef foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>() );
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle);
+    delete get_pointer<::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle);
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(_baseRef handle, smoke_GenericTypesWithCompoundTypes_SomeEnum value) {
-    (*get_pointer<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle)).insert(std::move(static_cast<::smoke::GenericTypesWithCompoundTypes::SomeEnum>(value)));
+    (*get_pointer<::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle)).insert(::std::move(static_cast<::smoke::GenericTypesWithCompoundTypes::SomeEnum>(value)));
 }
 _baseRef foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator( get_pointer<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator( get_pointer<::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle)->begin() ) );
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle );
 }
 bool foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle ) != get_pointer<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>(handle)->end();
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle );
 }
 smoke_GenericTypesWithCompoundTypes_SomeEnum foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get(_baseRef iterator_handle) {
-    auto& value = **reinterpret_cast<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle );
+    auto& value = **reinterpret_cast<::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::iterator*>( iterator_handle );
     return static_cast<smoke_GenericTypesWithCompoundTypes_SomeEnum>(value);
 }
 _baseRef foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>( std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>( ::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>( ) ) );
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>*>( handle );
 }
 _baseRef foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>*>( handle ) );
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithBasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithBasicTypes.cpp
@@ -13,33 +13,33 @@
 #include <unordered_set>
 #include <vector>
 void smoke_GenericTypesWithBasicTypes_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle);
 }
 _baseRef smoke_GenericTypesWithBasicTypes_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)))
         : 0;
 }
 const void* smoke_GenericTypesWithBasicTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get())
         : nullptr;
 }
 void smoke_GenericTypesWithBasicTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get(), swift_pointer);
 }
 void smoke_GenericTypesWithBasicTypes_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(handle)->get());
 }
 _baseRef
 smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle( _baseRef numbersList, _baseRef numbersMap, _baseRef numbersSet )
 {
-    ::smoke::GenericTypesWithBasicTypes::StructWithGenerics* _struct = new ( std::nothrow ) ::smoke::GenericTypesWithBasicTypes::StructWithGenerics();
-    _struct->numbers_list = Conversion<std::vector<uint8_t>>::toCpp( numbersList );
-    _struct->numbers_map = Conversion<std::unordered_map<uint8_t, std::string>>::toCpp( numbersMap );
-    _struct->numbers_set = Conversion<std::unordered_set<uint8_t>>::toCpp( numbersSet );
+    ::smoke::GenericTypesWithBasicTypes::StructWithGenerics* _struct = new ( ::std::nothrow ) ::smoke::GenericTypesWithBasicTypes::StructWithGenerics();
+    _struct->numbers_list = Conversion<::std::vector<uint8_t>>::toCpp( numbersList );
+    _struct->numbers_map = Conversion<::std::unordered_map<uint8_t, ::std::string>>::toCpp( numbersMap );
+    _struct->numbers_set = Conversion<::std::unordered_set<uint8_t>>::toCpp( numbersSet );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -50,10 +50,10 @@ smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle( _baseRef han
 _baseRef
 smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_optional_handle(_baseRef numbersList, _baseRef numbersMap, _baseRef numbersSet)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::GenericTypesWithBasicTypes::StructWithGenerics>( ::smoke::GenericTypesWithBasicTypes::StructWithGenerics( ) );
-    (*_struct)->numbers_list = Conversion<std::vector<uint8_t>>::toCpp( numbersList );
-    (*_struct)->numbers_map = Conversion<std::unordered_map<uint8_t, std::string>>::toCpp( numbersMap );
-    (*_struct)->numbers_set = Conversion<std::unordered_set<uint8_t>>::toCpp( numbersSet );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::GenericTypesWithBasicTypes::StructWithGenerics>( ::smoke::GenericTypesWithBasicTypes::StructWithGenerics( ) );
+    (*_struct)->numbers_list = Conversion<::std::vector<uint8_t>>::toCpp( numbersList );
+    (*_struct)->numbers_map = Conversion<::std::unordered_map<uint8_t, ::std::string>>::toCpp( numbersMap );
+    (*_struct)->numbers_set = Conversion<::std::unordered_set<uint8_t>>::toCpp( numbersSet );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -66,49 +66,49 @@ void smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_optional_handle
 }
 _baseRef smoke_GenericTypesWithBasicTypes_StructWithGenerics_numbersList_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::GenericTypesWithBasicTypes::StructWithGenerics>(handle);
-    return Conversion<std::vector<uint8_t>>::toBaseRef(struct_pointer->numbers_list);
+    return Conversion<::std::vector<uint8_t>>::toBaseRef(struct_pointer->numbers_list);
 }
 _baseRef smoke_GenericTypesWithBasicTypes_StructWithGenerics_numbersMap_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::GenericTypesWithBasicTypes::StructWithGenerics>(handle);
-    return Conversion<std::unordered_map<uint8_t, std::string>>::toBaseRef(struct_pointer->numbers_map);
+    return Conversion<::std::unordered_map<uint8_t, ::std::string>>::toBaseRef(struct_pointer->numbers_map);
 }
 _baseRef smoke_GenericTypesWithBasicTypes_StructWithGenerics_numbersSet_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::GenericTypesWithBasicTypes::StructWithGenerics>(handle);
-    return Conversion<std::unordered_set<uint8_t>>::toBaseRef(struct_pointer->numbers_set);
+    return Conversion<::std::unordered_set<uint8_t>>::toBaseRef(struct_pointer->numbers_set);
 }
 _baseRef smoke_GenericTypesWithBasicTypes_methodWithList(_baseRef _instance, _baseRef input) {
-    return Conversion<std::vector<int32_t>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_list(Conversion<std::vector<int32_t>>::toCpp(input)));
+    return Conversion<::std::vector<int32_t>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_list(Conversion<::std::vector<int32_t>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithBasicTypes_methodWithMap(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_map<int32_t, bool>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_map(Conversion<std::unordered_map<int32_t, bool>>::toCpp(input)));
+    return Conversion<::std::unordered_map<int32_t, bool>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_map(Conversion<::std::unordered_map<int32_t, bool>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithBasicTypes_methodWithSet(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_set<int32_t>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_set(Conversion<std::unordered_set<int32_t>>::toCpp(input)));
+    return Conversion<::std::unordered_set<int32_t>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_set(Conversion<::std::unordered_set<int32_t>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias(_baseRef _instance, _baseRef input) {
-    return Conversion<std::vector<std::string>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_list_type_alias(Conversion<std::vector<std::string>>::toCpp(input)));
+    return Conversion<::std::vector<::std::string>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_list_type_alias(Conversion<::std::vector<::std::string>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_map<std::string, std::string>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_map_type_alias(Conversion<std::unordered_map<std::string, std::string>>::toCpp(input)));
+    return Conversion<::std::unordered_map<::std::string, ::std::string>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_map_type_alias(Conversion<::std::unordered_map<::std::string, ::std::string>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_set<std::string>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_set_type_alias(Conversion<std::unordered_set<std::string>>::toCpp(input)));
+    return Conversion<::std::unordered_set<::std::string>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->method_with_set_type_alias(Conversion<::std::unordered_set<::std::string>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithBasicTypes_listProperty_get(_baseRef _instance) {
-    return Conversion<std::vector<float>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->get_list_property());
+    return Conversion<::std::vector<float>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->get_list_property());
 }
 void smoke_GenericTypesWithBasicTypes_listProperty_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->set_list_property(Conversion<std::vector<float>>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->set_list_property(Conversion<::std::vector<float>>::toCpp(newValue));
 }
 _baseRef smoke_GenericTypesWithBasicTypes_mapProperty_get(_baseRef _instance) {
-    return Conversion<std::unordered_map<float, double>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->get_map_property());
+    return Conversion<::std::unordered_map<float, double>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->get_map_property());
 }
 void smoke_GenericTypesWithBasicTypes_mapProperty_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->set_map_property(Conversion<std::unordered_map<float, double>>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->set_map_property(Conversion<::std::unordered_map<float, double>>::toCpp(newValue));
 }
 _baseRef smoke_GenericTypesWithBasicTypes_setProperty_get(_baseRef _instance) {
-    return Conversion<std::unordered_set<float>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->get_set_property());
+    return Conversion<::std::unordered_set<float>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->get_set_property());
 }
 void smoke_GenericTypesWithBasicTypes_setProperty_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->set_set_property(Conversion<std::unordered_set<float>>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::GenericTypesWithBasicTypes>>(_instance)->get()->set_set_property(Conversion<::std::unordered_set<float>>::toCpp(newValue));
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithCompoundTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithCompoundTypes.cpp
@@ -16,30 +16,30 @@
 #include <unordered_set>
 #include <vector>
 void smoke_GenericTypesWithCompoundTypes_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle);
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)))
         : 0;
 }
 const void* smoke_GenericTypesWithCompoundTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get())
         : nullptr;
 }
 void smoke_GenericTypesWithCompoundTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get(), swift_pointer);
 }
 void smoke_GenericTypesWithCompoundTypes_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(handle)->get());
 }
 _baseRef
 smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle( double value )
 {
-    ::smoke::GenericTypesWithCompoundTypes::BasicStruct* _struct = new ( std::nothrow ) ::smoke::GenericTypesWithCompoundTypes::BasicStruct();
+    ::smoke::GenericTypesWithCompoundTypes::BasicStruct* _struct = new ( ::std::nothrow ) ::smoke::GenericTypesWithCompoundTypes::BasicStruct();
     _struct->value = value;
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -51,7 +51,7 @@ smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle( _baseRef handle 
 _baseRef
 smoke_GenericTypesWithCompoundTypes_BasicStruct_create_optional_handle(double value)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::GenericTypesWithCompoundTypes::BasicStruct>( ::smoke::GenericTypesWithCompoundTypes::BasicStruct( ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::GenericTypesWithCompoundTypes::BasicStruct>( ::smoke::GenericTypesWithCompoundTypes::BasicStruct( ) );
     (*_struct)->value = value;
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -70,8 +70,8 @@ double smoke_GenericTypesWithCompoundTypes_BasicStruct_value_get(_baseRef handle
 _baseRef
 smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle( _baseRef string )
 {
-    ::alien::FooStruct* _struct = new ( std::nothrow ) ::alien::FooStruct();
-    _struct->string = Conversion<std::string>::toCpp( string );
+    ::alien::FooStruct* _struct = new ( ::std::nothrow ) ::alien::FooStruct();
+    _struct->string = Conversion<::std::string>::toCpp( string );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -82,8 +82,8 @@ smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle( _baseRef hand
 _baseRef
 smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_optional_handle(_baseRef string)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::alien::FooStruct>( ::alien::FooStruct( ) );
-    (*_struct)->string = Conversion<std::string>::toCpp( string );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::alien::FooStruct>( ::alien::FooStruct( ) );
+    (*_struct)->string = Conversion<::std::string>::toCpp( string );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -96,29 +96,29 @@ void smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_optional_handle(
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_ExternalStruct_string_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::alien::FooStruct>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->string);
+    return Conversion<::std::string>::toBaseRef(struct_pointer->string);
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_methodWithStructList(_baseRef _instance, _baseRef input) {
-    return Conversion<std::vector<::alien::FooStruct>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_struct_list(Conversion<std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toCpp(input)));
+    return Conversion<::std::vector<::alien::FooStruct>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_struct_list(Conversion<::std::vector<::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_methodWithStructMap(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_map<std::string, ::alien::FooStruct>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_struct_map(Conversion<std::unordered_map<std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toCpp(input)));
+    return Conversion<::std::unordered_map<::std::string, ::alien::FooStruct>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_struct_map(Conversion<::std::unordered_map<::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_methodWithEnumList(_baseRef _instance, _baseRef input) {
-    return Conversion<std::vector<::alien::FooEnum>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_enum_list(Conversion<std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::toCpp(input)));
+    return Conversion<::std::vector<::alien::FooEnum>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_enum_list(Conversion<::std::vector<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_enum_map_key(Conversion<std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>::toCpp(input)));
+    return Conversion<::std::unordered_map<::alien::FooEnum, bool, gluecodium::hash<::alien::FooEnum>>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_enum_map_key(Conversion<::std::unordered_map<::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_map<int32_t, ::alien::FooEnum>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_enum_map_value(Conversion<std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::toCpp(input)));
+    return Conversion<::std::unordered_map<int32_t, ::alien::FooEnum>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_enum_map_value(Conversion<::std::unordered_map<int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_methodWithEnumSet(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_enum_set(Conversion<std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>::toCpp(input)));
+    return Conversion<::std::unordered_set<::alien::FooEnum, gluecodium::hash<::alien::FooEnum>>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_enum_set(Conversion<::std::unordered_set<::smoke::GenericTypesWithCompoundTypes::SomeEnum, gluecodium::hash<::smoke::GenericTypesWithCompoundTypes::SomeEnum>>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_methodWithInstancesList(_baseRef _instance, _baseRef input) {
-    return Conversion<std::vector<std::shared_ptr<::smoke::DummyInterface>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_instances_list(Conversion<std::vector<std::shared_ptr<::smoke::DummyClass>>>::toCpp(input)));
+    return Conversion<::std::vector<::std::shared_ptr<::smoke::DummyInterface>>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_instances_list(Conversion<::std::vector<::std::shared_ptr<::smoke::DummyClass>>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyInterface>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_instances_map(Conversion<std::unordered_map<int32_t, std::shared_ptr<::smoke::DummyClass>>>::toCpp(input)));
+    return Conversion<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyInterface>>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithCompoundTypes>>(_instance)->get()->method_with_instances_map(Conversion<::std::unordered_map<int32_t, ::std::shared_ptr<::smoke::DummyClass>>>::toCpp(input)));
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithGenericTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cbridge/src/smoke/cbridge_GenericTypesWithGenericTypes.cpp
@@ -13,44 +13,44 @@
 #include <unordered_set>
 #include <vector>
 void smoke_GenericTypesWithGenericTypes_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle);
 }
 _baseRef smoke_GenericTypesWithGenericTypes_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)))
         : 0;
 }
 const void* smoke_GenericTypesWithGenericTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get())
         : nullptr;
 }
 void smoke_GenericTypesWithGenericTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get(), swift_pointer);
 }
 void smoke_GenericTypesWithGenericTypes_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(handle)->get());
 }
 _baseRef smoke_GenericTypesWithGenericTypes_methodWithListOfLists(_baseRef _instance, _baseRef input) {
-    return Conversion<std::vector<std::vector<int32_t>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_list_of_lists(Conversion<std::vector<std::vector<int32_t>>>::toCpp(input)));
+    return Conversion<::std::vector<::std::vector<int32_t>>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_list_of_lists(Conversion<::std::vector<::std::vector<int32_t>>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_map<std::unordered_map<int32_t, bool>, bool, gluecodium::hash<std::unordered_map<int32_t, bool>>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_map_of_maps(Conversion<std::unordered_map<int32_t, std::unordered_map<int32_t, bool>>>::toCpp(input)));
+    return Conversion<::std::unordered_map<::std::unordered_map<int32_t, bool>, bool, gluecodium::hash<::std::unordered_map<int32_t, bool>>>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_map_of_maps(Conversion<::std::unordered_map<int32_t, ::std::unordered_map<int32_t, bool>>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithGenericTypes_methodWithSetOfSets(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_set_of_sets(Conversion<std::unordered_set<std::unordered_set<int32_t>, gluecodium::hash<std::unordered_set<int32_t>>>>::toCpp(input)));
+    return Conversion<::std::unordered_set<::std::unordered_set<int32_t>, gluecodium::hash<::std::unordered_set<int32_t>>>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_set_of_sets(Conversion<::std::unordered_set<::std::unordered_set<int32_t>, gluecodium::hash<::std::unordered_set<int32_t>>>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithGenericTypes_methodWithListAndMap(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_map<int32_t, std::vector<int32_t>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_list_and_map(Conversion<std::vector<std::unordered_map<int32_t, bool>>>::toCpp(input)));
+    return Conversion<::std::unordered_map<int32_t, ::std::vector<int32_t>>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_list_and_map(Conversion<::std::vector<::std::unordered_map<int32_t, bool>>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithGenericTypes_methodWithListAndSet(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_set<std::vector<int32_t>, gluecodium::hash<std::vector<int32_t>>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_list_and_set(Conversion<std::vector<std::unordered_set<int32_t>>>::toCpp(input)));
+    return Conversion<::std::unordered_set<::std::vector<int32_t>, gluecodium::hash<::std::vector<int32_t>>>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_list_and_set(Conversion<::std::vector<::std::unordered_set<int32_t>>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithGenericTypes_methodWithMapAndSet(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_set<std::unordered_map<int32_t, bool>, gluecodium::hash<std::unordered_map<int32_t, bool>>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_map_and_set(Conversion<std::unordered_map<int32_t, std::unordered_set<int32_t>>>::toCpp(input)));
+    return Conversion<::std::unordered_set<::std::unordered_map<int32_t, bool>, gluecodium::hash<::std::unordered_map<int32_t, bool>>>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_map_and_set(Conversion<::std::unordered_map<int32_t, ::std::unordered_set<int32_t>>>::toCpp(input)));
 }
 _baseRef smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys(_baseRef _instance, _baseRef input) {
-    return Conversion<std::unordered_map<std::vector<int32_t>, bool, gluecodium::hash<std::vector<int32_t>>>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_map_generic_keys(Conversion<std::unordered_map<std::unordered_set<int32_t>, bool, gluecodium::hash<std::unordered_set<int32_t>>>>::toCpp(input)));
+    return Conversion<::std::unordered_map<::std::vector<int32_t>, bool, gluecodium::hash<::std::vector<int32_t>>>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::GenericTypesWithGenericTypes>>(_instance)->get()->method_with_map_generic_keys(Conversion<::std::unordered_map<::std::unordered_set<int32_t>, bool, gluecodium::hash<::std::unordered_set<int32_t>>>>::toCpp(input)));
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromClass.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromClass.cpp
@@ -12,25 +12,25 @@
 #include <memory>
 #include <new>
 void smoke_ChildClassFromClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::ChildClassFromClass>>(handle);
 }
 _baseRef smoke_ChildClassFromClass_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::ChildClassFromClass>>(handle)))
         : 0;
 }
 const void* smoke_ChildClassFromClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get())
         : nullptr;
 }
 void smoke_ChildClassFromClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get(), swift_pointer);
 }
 void smoke_ChildClassFromClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ChildClassFromClass(_baseRef handle);
@@ -43,10 +43,10 @@ struct smoke_ChildClassFromClassRegisterInit {
 } s_smoke_ChildClassFromClass_register_init;
 }
 void* smoke_ChildClassFromClass_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::ChildClassFromClass>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::ChildClassFromClass>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::ChildClassFromClass>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_ChildClassFromClass(handle);
 }
 void smoke_ChildClassFromClass_childClassMethod(_baseRef _instance) {
-    return get_pointer<std::shared_ptr<::smoke::ChildClassFromClass>>(_instance)->get()->child_class_method();
+    return get_pointer<::std::shared_ptr<::smoke::ChildClassFromClass>>(_instance)->get()->child_class_method();
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromInterface.cpp
@@ -14,25 +14,25 @@
 #include <new>
 #include <string>
 void smoke_ChildClassFromInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::ChildClassFromInterface>>(handle);
 }
 _baseRef smoke_ChildClassFromInterface_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)))
         : 0;
 }
 const void* smoke_ChildClassFromInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_ChildClassFromInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_ChildClassFromInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ChildClassFromInterface(_baseRef handle);
@@ -45,10 +45,10 @@ struct smoke_ChildClassFromInterfaceRegisterInit {
 } s_smoke_ChildClassFromInterface_register_init;
 }
 void* smoke_ChildClassFromInterface_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::ChildClassFromInterface>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::ChildClassFromInterface>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::ChildClassFromInterface>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_ChildClassFromInterface(handle);
 }
 void smoke_ChildClassFromInterface_childClassMethod(_baseRef _instance) {
-    return get_pointer<std::shared_ptr<::smoke::ChildClassFromInterface>>(_instance)->get()->child_class_method();
+    return get_pointer<::std::shared_ptr<::smoke::ChildClassFromInterface>>(_instance)->get()->child_class_method();
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildInterface.cpp
@@ -15,25 +15,25 @@
 #include <new>
 #include <string>
 void smoke_ChildInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::ChildInterface>>(handle);
 }
 _baseRef smoke_ChildInterface_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::ChildInterface>>(handle)))
         : 0;
 }
 const void* smoke_ChildInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ChildInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_ChildInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::ChildInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_ChildInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ChildInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ChildInterface(_baseRef handle);
@@ -46,17 +46,17 @@ struct smoke_ChildInterfaceRegisterInit {
 } s_smoke_ChildInterface_register_init;
 }
 void* smoke_ChildInterface_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::ChildInterface>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::ChildInterface>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::ChildInterface>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_ChildInterface(handle);
 }
 void smoke_ChildInterface_childMethod(_baseRef _instance) {
-    return get_pointer<std::shared_ptr<::smoke::ChildInterface>>(_instance)->get()->child_method();
+    return get_pointer<::std::shared_ptr<::smoke::ChildInterface>>(_instance)->get()->child_method();
 }
-class smoke_ChildInterfaceProxy : public std::shared_ptr<::smoke::ChildInterface>::element_type, public CachedProxyBase<smoke_ChildInterfaceProxy> {
+class smoke_ChildInterfaceProxy : public ::std::shared_ptr<::smoke::ChildInterface>::element_type, public CachedProxyBase<smoke_ChildInterfaceProxy> {
 public:
     smoke_ChildInterfaceProxy(smoke_ChildInterface_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_ChildInterfaceProxy() {
@@ -69,10 +69,10 @@ public:
     }
     ::std::string get_root_property() const override {
         auto _call_result = mFunctions.smoke_ParentInterface_rootProperty_get(mFunctions.swift_pointer);
-        return Conversion<std::string>::toCppReturn(_call_result);
+        return Conversion<::std::string>::toCppReturn(_call_result);
     }
-    void set_root_property(const std::string& newValue) override {
-        mFunctions.smoke_ParentInterface_rootProperty_set(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(newValue));
+    void set_root_property(const ::std::string& newValue) override {
+        mFunctions.smoke_ParentInterface_rootProperty_set(mFunctions.swift_pointer, Conversion<::std::string>::toBaseRef(newValue));
     }
     void child_method() override {
         mFunctions.smoke_ChildInterface_childMethod(mFunctions.swift_pointer);
@@ -81,9 +81,9 @@ private:
     smoke_ChildInterface_FunctionTable mFunctions;
 };
 _baseRef smoke_ChildInterface_create_proxy(smoke_ChildInterface_FunctionTable functionTable) {
-    auto proxy = smoke_ChildInterfaceProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::ChildInterface>(proxy)) : 0;
+    auto proxy = smoke_ChildInterfaceProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::ChildInterface>(proxy)) : 0;
 }
 const void* smoke_ChildInterface_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_ChildInterfaceProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::ChildInterface>>(handle)->get()) : nullptr;
+    return handle ? smoke_ChildInterfaceProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::ChildInterface>>(handle)->get()) : nullptr;
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleClass.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleClass.cpp
@@ -11,29 +11,29 @@
 #include <new>
 #include <string>
 void smoke_SimpleClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::SimpleClass>>(handle);
 }
 _baseRef smoke_SimpleClass_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::SimpleClass>>(handle)))
         : 0;
 }
 const void* smoke_SimpleClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::SimpleClass>>(handle)->get())
         : nullptr;
 }
 void smoke_SimpleClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::SimpleClass>>(handle)->get(), swift_pointer);
 }
 void smoke_SimpleClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::SimpleClass>>(handle)->get());
 }
 _baseRef smoke_SimpleClass_getStringValue(_baseRef _instance) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(_instance)->get()->get_string_value());
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::SimpleClass>>(_instance)->get()->get_string_value());
 }
 _baseRef smoke_SimpleClass_useSimpleClass(_baseRef _instance, _baseRef input) {
-    return Conversion<std::shared_ptr<::smoke::SimpleClass>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::SimpleClass>>(_instance)->get()->use_simple_class(Conversion<std::shared_ptr<::smoke::SimpleClass>>::toCpp(input)));
+    return Conversion<::std::shared_ptr<::smoke::SimpleClass>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::SimpleClass>>(_instance)->get()->use_simple_class(Conversion<::std::shared_ptr<::smoke::SimpleClass>>::toCpp(input)));
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_SimpleInterface.cpp
@@ -12,25 +12,25 @@
 #include <new>
 #include <string>
 void smoke_SimpleInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::SimpleInterface>>(handle);
 }
 _baseRef smoke_SimpleInterface_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::SimpleInterface>>(handle)))
         : 0;
 }
 const void* smoke_SimpleInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::SimpleInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_SimpleInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::SimpleInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_SimpleInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::SimpleInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_SimpleInterface(_baseRef handle);
@@ -43,20 +43,20 @@ struct smoke_SimpleInterfaceRegisterInit {
 } s_smoke_SimpleInterface_register_init;
 }
 void* smoke_SimpleInterface_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::SimpleInterface>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::SimpleInterface>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::SimpleInterface>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_SimpleInterface(handle);
 }
 _baseRef smoke_SimpleInterface_getStringValue(_baseRef _instance) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(_instance)->get()->get_string_value());
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::SimpleInterface>>(_instance)->get()->get_string_value());
 }
 _baseRef smoke_SimpleInterface_useSimpleInterface(_baseRef _instance, _baseRef input) {
-    return Conversion<std::shared_ptr<::smoke::SimpleInterface>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(_instance)->get()->use_simple_interface(Conversion<std::shared_ptr<::smoke::SimpleInterface>>::toCpp(input)));
+    return Conversion<::std::shared_ptr<::smoke::SimpleInterface>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::SimpleInterface>>(_instance)->get()->use_simple_interface(Conversion<::std::shared_ptr<::smoke::SimpleInterface>>::toCpp(input)));
 }
-class smoke_SimpleInterfaceProxy : public std::shared_ptr<::smoke::SimpleInterface>::element_type, public CachedProxyBase<smoke_SimpleInterfaceProxy> {
+class smoke_SimpleInterfaceProxy : public ::std::shared_ptr<::smoke::SimpleInterface>::element_type, public CachedProxyBase<smoke_SimpleInterfaceProxy> {
 public:
     smoke_SimpleInterfaceProxy(smoke_SimpleInterface_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_SimpleInterfaceProxy() {
@@ -66,19 +66,19 @@ public:
     smoke_SimpleInterfaceProxy& operator=(const smoke_SimpleInterfaceProxy&) = delete;
     ::std::string get_string_value() override {
         auto _call_result = mFunctions.smoke_SimpleInterface_getStringValue(mFunctions.swift_pointer);
-        return Conversion<std::string>::toCppReturn(_call_result);
+        return Conversion<::std::string>::toCppReturn(_call_result);
     }
-    ::std::shared_ptr< ::smoke::SimpleInterface > use_simple_interface(const std::shared_ptr<::smoke::SimpleInterface>& input) override {
-        auto _call_result = mFunctions.smoke_SimpleInterface_useSimpleInterface(mFunctions.swift_pointer, Conversion<std::shared_ptr<::smoke::SimpleInterface>>::toBaseRef(input));
-        return Conversion<std::shared_ptr<::smoke::SimpleInterface>>::toCppReturn(_call_result);
+    ::std::shared_ptr< ::smoke::SimpleInterface > use_simple_interface(const ::std::shared_ptr<::smoke::SimpleInterface>& input) override {
+        auto _call_result = mFunctions.smoke_SimpleInterface_useSimpleInterface(mFunctions.swift_pointer, Conversion<::std::shared_ptr<::smoke::SimpleInterface>>::toBaseRef(input));
+        return Conversion<::std::shared_ptr<::smoke::SimpleInterface>>::toCppReturn(_call_result);
     }
 private:
     smoke_SimpleInterface_FunctionTable mFunctions;
 };
 _baseRef smoke_SimpleInterface_create_proxy(smoke_SimpleInterface_FunctionTable functionTable) {
-    auto proxy = smoke_SimpleInterfaceProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::SimpleInterface>(proxy)) : 0;
+    auto proxy = smoke_SimpleInterfaceProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::SimpleInterface>(proxy)) : 0;
 }
 const void* smoke_SimpleInterface_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_SimpleInterfaceProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::SimpleInterface>>(handle)->get()) : nullptr;
+    return handle ? smoke_SimpleInterfaceProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::SimpleInterface>>(handle)->get()) : nullptr;
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_StructWithClass.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_StructWithClass.cpp
@@ -10,8 +10,8 @@
 _baseRef
 smoke_StructWithClass_create_handle( _baseRef classInstance )
 {
-    ::smoke::StructWithClass* _struct = new ( std::nothrow ) ::smoke::StructWithClass();
-    _struct->class_instance = Conversion<std::shared_ptr<::smoke::SimpleClass>>::toCpp( classInstance );
+    ::smoke::StructWithClass* _struct = new ( ::std::nothrow ) ::smoke::StructWithClass();
+    _struct->class_instance = Conversion<::std::shared_ptr<::smoke::SimpleClass>>::toCpp( classInstance );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -22,8 +22,8 @@ smoke_StructWithClass_release_handle( _baseRef handle )
 _baseRef
 smoke_StructWithClass_create_optional_handle(_baseRef classInstance)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::StructWithClass>( ::smoke::StructWithClass( ) );
-    (*_struct)->class_instance = Conversion<std::shared_ptr<::smoke::SimpleClass>>::toCpp( classInstance );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::StructWithClass>( ::smoke::StructWithClass( ) );
+    (*_struct)->class_instance = Conversion<::std::shared_ptr<::smoke::SimpleClass>>::toCpp( classInstance );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -36,5 +36,5 @@ void smoke_StructWithClass_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_StructWithClass_classInstance_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::StructWithClass>(handle);
-    return Conversion<std::shared_ptr<::smoke::SimpleClass>>::toBaseRef(struct_pointer->class_instance);
+    return Conversion<::std::shared_ptr<::smoke::SimpleClass>>::toBaseRef(struct_pointer->class_instance);
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_StructWithInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/cbridge/src/smoke/cbridge_StructWithInterface.cpp
@@ -10,8 +10,8 @@
 _baseRef
 smoke_StructWithInterface_create_handle( _baseRef interfaceInstance )
 {
-    ::smoke::StructWithInterface* _struct = new ( std::nothrow ) ::smoke::StructWithInterface();
-    _struct->interface_instance = Conversion<std::shared_ptr<::smoke::SimpleInterface>>::toCpp( interfaceInstance );
+    ::smoke::StructWithInterface* _struct = new ( ::std::nothrow ) ::smoke::StructWithInterface();
+    _struct->interface_instance = Conversion<::std::shared_ptr<::smoke::SimpleInterface>>::toCpp( interfaceInstance );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -22,8 +22,8 @@ smoke_StructWithInterface_release_handle( _baseRef handle )
 _baseRef
 smoke_StructWithInterface_create_optional_handle(_baseRef interfaceInstance)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::StructWithInterface>( ::smoke::StructWithInterface( ) );
-    (*_struct)->interface_instance = Conversion<std::shared_ptr<::smoke::SimpleInterface>>::toCpp( interfaceInstance );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::StructWithInterface>( ::smoke::StructWithInterface( ) );
+    (*_struct)->interface_instance = Conversion<::std::shared_ptr<::smoke::SimpleInterface>>::toCpp( interfaceInstance );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -36,5 +36,5 @@ void smoke_StructWithInterface_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_StructWithInterface_interfaceInstance_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::StructWithInterface>(handle);
-    return Conversion<std::shared_ptr<::smoke::SimpleInterface>>::toBaseRef(struct_pointer->interface_instance);
+    return Conversion<::std::shared_ptr<::smoke::SimpleInterface>>::toBaseRef(struct_pointer->interface_instance);
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/cbridge/src/smoke/cbridge_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/cbridge/src/smoke/cbridge_Lambdas.cpp
@@ -14,31 +14,31 @@
 #include <unordered_map>
 #include <vector>
 void smoke_Lambdas_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::Lambdas>>(handle);
 }
 _baseRef smoke_Lambdas_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::Lambdas>>(handle)))
         : 0;
 }
 const void* smoke_Lambdas_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Lambdas>>(handle)->get())
         : nullptr;
 }
 void smoke_Lambdas_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::Lambdas>>(handle)->get(), swift_pointer);
 }
 void smoke_Lambdas_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Lambdas>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Lambdas>>(handle)->get());
 }
 _baseRef smoke_Lambdas_deconfuse(_baseRef _instance, _baseRef value, _baseRef confuser) {
-    return Conversion<::smoke::Lambdas::Producer>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Lambdas>>(_instance)->get()->deconfuse(Conversion<std::string>::toCpp(value), Conversion<::smoke::Lambdas::Confuser>::toCpp(confuser)));
+    return Conversion<::smoke::Lambdas::Producer>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::Lambdas>>(_instance)->get()->deconfuse(Conversion<::std::string>::toCpp(value), Conversion<::smoke::Lambdas::Confuser>::toCpp(confuser)));
 }
 _baseRef smoke_Lambdas_fuse(_baseRef items, _baseRef callback) {
-    return Conversion<std::unordered_map<int32_t, std::string>>::toBaseRef(::smoke::Lambdas::fuse(Conversion<std::vector<std::string>>::toCpp(items), Conversion<::smoke::Lambdas::Indexer>::toCpp(callback)));
+    return Conversion<::std::unordered_map<int32_t, ::std::string>>::toBaseRef(::smoke::Lambdas::fuse(Conversion<::std::vector<::std::string>>::toCpp(items), Conversion<::smoke::Lambdas::Indexer>::toCpp(callback)));
 }
 void smoke_Lambdas_Producer_release_handle(_baseRef handle) {
     delete get_pointer<::smoke::Lambdas::Producer>(handle);
@@ -49,12 +49,12 @@ _baseRef smoke_Lambdas_Producer_copy_handle(_baseRef handle) {
         : 0;
 }
 _baseRef smoke_Lambdas_Producer_call(_baseRef _instance) {
-    return Conversion<std::string>::toBaseRef(get_pointer<::smoke::Lambdas::Producer>(_instance)->operator()());
+    return Conversion<::std::string>::toBaseRef(get_pointer<::smoke::Lambdas::Producer>(_instance)->operator()());
 }
 class smoke_Lambdas_ProducerProxy : public CachedProxyBase<smoke_Lambdas_ProducerProxy> {
 public:
     smoke_Lambdas_ProducerProxy(smoke_Lambdas_Producer_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_Lambdas_ProducerProxy() {
@@ -64,18 +64,18 @@ public:
     smoke_Lambdas_ProducerProxy& operator=(const smoke_Lambdas_ProducerProxy&) = delete;
     ::std::string operator()() {
         auto _call_result = mFunctions.smoke_Lambdas_Producer_call(mFunctions.swift_pointer);
-        return Conversion<std::string>::toCppReturn(_call_result);
+        return Conversion<::std::string>::toCppReturn(_call_result);
     }
 private:
     smoke_Lambdas_Producer_FunctionTable mFunctions;
 };
 _baseRef smoke_Lambdas_Producer_create_proxy(smoke_Lambdas_Producer_FunctionTable functionTable) {
-    auto proxy = smoke_Lambdas_ProducerProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new ::smoke::Lambdas::Producer(std::bind(&smoke_Lambdas_ProducerProxy::operator(), proxy))) : 0;
+    auto proxy = smoke_Lambdas_ProducerProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::smoke::Lambdas::Producer(::std::bind(&smoke_Lambdas_ProducerProxy::operator(), proxy))) : 0;
 }
 _baseRef smoke_Lambdas_Producer_create_optional_proxy(smoke_Lambdas_Producer_FunctionTable functionTable) {
-    auto proxy = smoke_Lambdas_ProducerProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new (std::nothrow) ::gluecodium::optional<::smoke::Lambdas::Producer>(std::bind(&smoke_Lambdas_ProducerProxy::operator(), proxy))) : 0;
+    auto proxy = smoke_Lambdas_ProducerProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new (::std::nothrow) ::gluecodium::optional<::smoke::Lambdas::Producer>(::std::bind(&smoke_Lambdas_ProducerProxy::operator(), proxy))) : 0;
 }
 const void* smoke_Lambdas_Producer_get_swift_object_from_cache(_baseRef handle) {
     return handle ? smoke_Lambdas_ProducerProxy::get_swift_object(get_pointer<::smoke::Lambdas::Producer>(handle)) : nullptr;
@@ -89,12 +89,12 @@ _baseRef smoke_Lambdas_Confuser_copy_handle(_baseRef handle) {
         : 0;
 }
 _baseRef smoke_Lambdas_Confuser_call(_baseRef _instance, _baseRef p0) {
-    return Conversion<::smoke::Lambdas::Producer>::toBaseRef(get_pointer<::smoke::Lambdas::Confuser>(_instance)->operator()(Conversion<std::string>::toCpp(p0)));
+    return Conversion<::smoke::Lambdas::Producer>::toBaseRef(get_pointer<::smoke::Lambdas::Confuser>(_instance)->operator()(Conversion<::std::string>::toCpp(p0)));
 }
 class smoke_Lambdas_ConfuserProxy : public CachedProxyBase<smoke_Lambdas_ConfuserProxy> {
 public:
     smoke_Lambdas_ConfuserProxy(smoke_Lambdas_Confuser_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_Lambdas_ConfuserProxy() {
@@ -102,20 +102,20 @@ public:
     }
     smoke_Lambdas_ConfuserProxy(const smoke_Lambdas_ConfuserProxy&) = delete;
     smoke_Lambdas_ConfuserProxy& operator=(const smoke_Lambdas_ConfuserProxy&) = delete;
-    ::smoke::Lambdas::Producer operator()(const std::string& p0) {
-        auto _call_result = mFunctions.smoke_Lambdas_Confuser_call(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(p0));
+    ::smoke::Lambdas::Producer operator()(const ::std::string& p0) {
+        auto _call_result = mFunctions.smoke_Lambdas_Confuser_call(mFunctions.swift_pointer, Conversion<::std::string>::toBaseRef(p0));
         return Conversion<::smoke::Lambdas::Producer>::toCppReturn(_call_result);
     }
 private:
     smoke_Lambdas_Confuser_FunctionTable mFunctions;
 };
 _baseRef smoke_Lambdas_Confuser_create_proxy(smoke_Lambdas_Confuser_FunctionTable functionTable) {
-    auto proxy = smoke_Lambdas_ConfuserProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new ::smoke::Lambdas::Confuser(std::bind(&smoke_Lambdas_ConfuserProxy::operator(), proxy, std::placeholders::_1))) : 0;
+    auto proxy = smoke_Lambdas_ConfuserProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::smoke::Lambdas::Confuser(::std::bind(&smoke_Lambdas_ConfuserProxy::operator(), proxy, ::std::placeholders::_1))) : 0;
 }
 _baseRef smoke_Lambdas_Confuser_create_optional_proxy(smoke_Lambdas_Confuser_FunctionTable functionTable) {
-    auto proxy = smoke_Lambdas_ConfuserProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new (std::nothrow) ::gluecodium::optional<::smoke::Lambdas::Confuser>(std::bind(&smoke_Lambdas_ConfuserProxy::operator(), proxy, std::placeholders::_1))) : 0;
+    auto proxy = smoke_Lambdas_ConfuserProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new (::std::nothrow) ::gluecodium::optional<::smoke::Lambdas::Confuser>(::std::bind(&smoke_Lambdas_ConfuserProxy::operator(), proxy, ::std::placeholders::_1))) : 0;
 }
 const void* smoke_Lambdas_Confuser_get_swift_object_from_cache(_baseRef handle) {
     return handle ? smoke_Lambdas_ConfuserProxy::get_swift_object(get_pointer<::smoke::Lambdas::Confuser>(handle)) : nullptr;
@@ -129,12 +129,12 @@ _baseRef smoke_Lambdas_Consumer_copy_handle(_baseRef handle) {
         : 0;
 }
 void smoke_Lambdas_Consumer_call(_baseRef _instance, _baseRef p0) {
-    return get_pointer<::smoke::Lambdas::Consumer>(_instance)->operator()(Conversion<std::string>::toCpp(p0));
+    return get_pointer<::smoke::Lambdas::Consumer>(_instance)->operator()(Conversion<::std::string>::toCpp(p0));
 }
 class smoke_Lambdas_ConsumerProxy : public CachedProxyBase<smoke_Lambdas_ConsumerProxy> {
 public:
     smoke_Lambdas_ConsumerProxy(smoke_Lambdas_Consumer_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_Lambdas_ConsumerProxy() {
@@ -142,19 +142,19 @@ public:
     }
     smoke_Lambdas_ConsumerProxy(const smoke_Lambdas_ConsumerProxy&) = delete;
     smoke_Lambdas_ConsumerProxy& operator=(const smoke_Lambdas_ConsumerProxy&) = delete;
-    void operator()(const std::string& p0) {
-        mFunctions.smoke_Lambdas_Consumer_call(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(p0));
+    void operator()(const ::std::string& p0) {
+        mFunctions.smoke_Lambdas_Consumer_call(mFunctions.swift_pointer, Conversion<::std::string>::toBaseRef(p0));
     }
 private:
     smoke_Lambdas_Consumer_FunctionTable mFunctions;
 };
 _baseRef smoke_Lambdas_Consumer_create_proxy(smoke_Lambdas_Consumer_FunctionTable functionTable) {
-    auto proxy = smoke_Lambdas_ConsumerProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new ::smoke::Lambdas::Consumer(std::bind(&smoke_Lambdas_ConsumerProxy::operator(), proxy, std::placeholders::_1))) : 0;
+    auto proxy = smoke_Lambdas_ConsumerProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::smoke::Lambdas::Consumer(::std::bind(&smoke_Lambdas_ConsumerProxy::operator(), proxy, ::std::placeholders::_1))) : 0;
 }
 _baseRef smoke_Lambdas_Consumer_create_optional_proxy(smoke_Lambdas_Consumer_FunctionTable functionTable) {
-    auto proxy = smoke_Lambdas_ConsumerProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new (std::nothrow) ::gluecodium::optional<::smoke::Lambdas::Consumer>(std::bind(&smoke_Lambdas_ConsumerProxy::operator(), proxy, std::placeholders::_1))) : 0;
+    auto proxy = smoke_Lambdas_ConsumerProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new (::std::nothrow) ::gluecodium::optional<::smoke::Lambdas::Consumer>(::std::bind(&smoke_Lambdas_ConsumerProxy::operator(), proxy, ::std::placeholders::_1))) : 0;
 }
 const void* smoke_Lambdas_Consumer_get_swift_object_from_cache(_baseRef handle) {
     return handle ? smoke_Lambdas_ConsumerProxy::get_swift_object(get_pointer<::smoke::Lambdas::Consumer>(handle)) : nullptr;
@@ -168,12 +168,12 @@ _baseRef smoke_Lambdas_Indexer_copy_handle(_baseRef handle) {
         : 0;
 }
 int32_t smoke_Lambdas_Indexer_call(_baseRef _instance, _baseRef p0, float p1) {
-    return get_pointer<::smoke::Lambdas::Indexer>(_instance)->operator()(Conversion<std::string>::toCpp(p0), p1);
+    return get_pointer<::smoke::Lambdas::Indexer>(_instance)->operator()(Conversion<::std::string>::toCpp(p0), p1);
 }
 class smoke_Lambdas_IndexerProxy : public CachedProxyBase<smoke_Lambdas_IndexerProxy> {
 public:
     smoke_Lambdas_IndexerProxy(smoke_Lambdas_Indexer_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_Lambdas_IndexerProxy() {
@@ -181,20 +181,20 @@ public:
     }
     smoke_Lambdas_IndexerProxy(const smoke_Lambdas_IndexerProxy&) = delete;
     smoke_Lambdas_IndexerProxy& operator=(const smoke_Lambdas_IndexerProxy&) = delete;
-    int32_t operator()(const std::string& p0, float p1) {
-        auto _call_result = mFunctions.smoke_Lambdas_Indexer_call(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(p0), p1);
+    int32_t operator()(const ::std::string& p0, float p1) {
+        auto _call_result = mFunctions.smoke_Lambdas_Indexer_call(mFunctions.swift_pointer, Conversion<::std::string>::toBaseRef(p0), p1);
         return _call_result;
     }
 private:
     smoke_Lambdas_Indexer_FunctionTable mFunctions;
 };
 _baseRef smoke_Lambdas_Indexer_create_proxy(smoke_Lambdas_Indexer_FunctionTable functionTable) {
-    auto proxy = smoke_Lambdas_IndexerProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new ::smoke::Lambdas::Indexer(std::bind(&smoke_Lambdas_IndexerProxy::operator(), proxy, std::placeholders::_1, std::placeholders::_2))) : 0;
+    auto proxy = smoke_Lambdas_IndexerProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::smoke::Lambdas::Indexer(::std::bind(&smoke_Lambdas_IndexerProxy::operator(), proxy, ::std::placeholders::_1, ::std::placeholders::_2))) : 0;
 }
 _baseRef smoke_Lambdas_Indexer_create_optional_proxy(smoke_Lambdas_Indexer_FunctionTable functionTable) {
-    auto proxy = smoke_Lambdas_IndexerProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new (std::nothrow) ::gluecodium::optional<::smoke::Lambdas::Indexer>(std::bind(&smoke_Lambdas_IndexerProxy::operator(), proxy, std::placeholders::_1, std::placeholders::_2))) : 0;
+    auto proxy = smoke_Lambdas_IndexerProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new (::std::nothrow) ::gluecodium::optional<::smoke::Lambdas::Indexer>(::std::bind(&smoke_Lambdas_IndexerProxy::operator(), proxy, ::std::placeholders::_1, ::std::placeholders::_2))) : 0;
 }
 const void* smoke_Lambdas_Indexer_get_swift_object_from_cache(_baseRef handle) {
     return handle ? smoke_Lambdas_IndexerProxy::get_swift_object(get_pointer<::smoke::Lambdas::Indexer>(handle)) : nullptr;
@@ -213,7 +213,7 @@ _baseRef smoke_Lambdas_NullableConfuser_call(_baseRef _instance, _baseRef p0) {
 class smoke_Lambdas_NullableConfuserProxy : public CachedProxyBase<smoke_Lambdas_NullableConfuserProxy> {
 public:
     smoke_Lambdas_NullableConfuserProxy(smoke_Lambdas_NullableConfuser_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_Lambdas_NullableConfuserProxy() {
@@ -229,12 +229,12 @@ private:
     smoke_Lambdas_NullableConfuser_FunctionTable mFunctions;
 };
 _baseRef smoke_Lambdas_NullableConfuser_create_proxy(smoke_Lambdas_NullableConfuser_FunctionTable functionTable) {
-    auto proxy = smoke_Lambdas_NullableConfuserProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new ::smoke::Lambdas::NullableConfuser(std::bind(&smoke_Lambdas_NullableConfuserProxy::operator(), proxy, std::placeholders::_1))) : 0;
+    auto proxy = smoke_Lambdas_NullableConfuserProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::smoke::Lambdas::NullableConfuser(::std::bind(&smoke_Lambdas_NullableConfuserProxy::operator(), proxy, ::std::placeholders::_1))) : 0;
 }
 _baseRef smoke_Lambdas_NullableConfuser_create_optional_proxy(smoke_Lambdas_NullableConfuser_FunctionTable functionTable) {
-    auto proxy = smoke_Lambdas_NullableConfuserProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new (std::nothrow) ::gluecodium::optional<::smoke::Lambdas::NullableConfuser>(std::bind(&smoke_Lambdas_NullableConfuserProxy::operator(), proxy, std::placeholders::_1))) : 0;
+    auto proxy = smoke_Lambdas_NullableConfuserProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new (::std::nothrow) ::gluecodium::optional<::smoke::Lambdas::NullableConfuser>(::std::bind(&smoke_Lambdas_NullableConfuserProxy::operator(), proxy, ::std::placeholders::_1))) : 0;
 }
 const void* smoke_Lambdas_NullableConfuser_get_swift_object_from_cache(_baseRef handle) {
     return handle ? smoke_Lambdas_NullableConfuserProxy::get_swift_object(get_pointer<::smoke::Lambdas::NullableConfuser>(handle)) : nullptr;

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_CalculatorListener.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_CalculatorListener.cpp
@@ -14,25 +14,25 @@
 #include <unordered_map>
 #include <vector>
 void smoke_CalculatorListener_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(handle);
 }
 _baseRef smoke_CalculatorListener_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(handle)))
         : 0;
 }
 const void* smoke_CalculatorListener_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(handle)->get())
         : nullptr;
 }
 void smoke_CalculatorListener_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(handle)->get(), swift_pointer);
 }
 void smoke_CalculatorListener_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_CalculatorListener(_baseRef handle);
@@ -45,14 +45,14 @@ struct smoke_CalculatorListenerRegisterInit {
 } s_smoke_CalculatorListener_register_init;
 }
 void* smoke_CalculatorListener_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::CalculatorListener>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::CalculatorListener>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_CalculatorListener(handle);
 }
 _baseRef
 smoke_CalculatorListener_ResultStruct_create_handle( double result )
 {
-    ::smoke::CalculatorListener::ResultStruct* _struct = new ( std::nothrow ) ::smoke::CalculatorListener::ResultStruct();
+    ::smoke::CalculatorListener::ResultStruct* _struct = new ( ::std::nothrow ) ::smoke::CalculatorListener::ResultStruct();
     _struct->result = result;
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -64,7 +64,7 @@ smoke_CalculatorListener_ResultStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_CalculatorListener_ResultStruct_create_optional_handle(double result)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::CalculatorListener::ResultStruct>( ::smoke::CalculatorListener::ResultStruct( ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::CalculatorListener::ResultStruct>( ::smoke::CalculatorListener::ResultStruct( ) );
     (*_struct)->result = result;
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -81,27 +81,27 @@ double smoke_CalculatorListener_ResultStruct_result_get(_baseRef handle) {
     return struct_pointer->result;
 }
 void smoke_CalculatorListener_onCalculationResult(_baseRef _instance, double calculationResult) {
-    return get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result(calculationResult);
+    return get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result(calculationResult);
 }
 void smoke_CalculatorListener_onCalculationResultConst(_baseRef _instance, double calculationResult) {
-    return get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result_const(calculationResult);
+    return get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result_const(calculationResult);
 }
 void smoke_CalculatorListener_onCalculationResultStruct(_baseRef _instance, _baseRef calculationResult) {
-    return get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result_struct(Conversion<::smoke::CalculatorListener::ResultStruct>::toCpp(calculationResult));
+    return get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result_struct(Conversion<::smoke::CalculatorListener::ResultStruct>::toCpp(calculationResult));
 }
 void smoke_CalculatorListener_onCalculationResultArray(_baseRef _instance, _baseRef calculationResult) {
-    return get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result_array(Conversion<std::vector<double>>::toCpp(calculationResult));
+    return get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result_array(Conversion<::std::vector<double>>::toCpp(calculationResult));
 }
 void smoke_CalculatorListener_onCalculationResultMap(_baseRef _instance, _baseRef calculationResults) {
-    return get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result_map(Conversion<std::unordered_map<std::string, double>>::toCpp(calculationResults));
+    return get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result_map(Conversion<::std::unordered_map<::std::string, double>>::toCpp(calculationResults));
 }
 void smoke_CalculatorListener_onCalculationResultInstance(_baseRef _instance, _baseRef calculationResult) {
-    return get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result_instance(Conversion<std::shared_ptr<::smoke::CalculationResult>>::toCpp(calculationResult));
+    return get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(_instance)->get()->on_calculation_result_instance(Conversion<::std::shared_ptr<::smoke::CalculationResult>>::toCpp(calculationResult));
 }
-class smoke_CalculatorListenerProxy : public std::shared_ptr<::smoke::CalculatorListener>::element_type, public CachedProxyBase<smoke_CalculatorListenerProxy> {
+class smoke_CalculatorListenerProxy : public ::std::shared_ptr<::smoke::CalculatorListener>::element_type, public CachedProxyBase<smoke_CalculatorListenerProxy> {
 public:
     smoke_CalculatorListenerProxy(smoke_CalculatorListener_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_CalculatorListenerProxy() {
@@ -118,22 +118,22 @@ public:
     void on_calculation_result_struct(const ::smoke::CalculatorListener::ResultStruct& calculationResult) override {
         mFunctions.smoke_CalculatorListener_onCalculationResultStruct(mFunctions.swift_pointer, Conversion<::smoke::CalculatorListener::ResultStruct>::toBaseRef(calculationResult));
     }
-    void on_calculation_result_array(const std::vector<double>& calculationResult) override {
-        mFunctions.smoke_CalculatorListener_onCalculationResultArray(mFunctions.swift_pointer, Conversion<std::vector<double>>::toBaseRef(calculationResult));
+    void on_calculation_result_array(const ::std::vector<double>& calculationResult) override {
+        mFunctions.smoke_CalculatorListener_onCalculationResultArray(mFunctions.swift_pointer, Conversion<::std::vector<double>>::toBaseRef(calculationResult));
     }
-    void on_calculation_result_map(const std::unordered_map<std::string, double>& calculationResults) override {
-        mFunctions.smoke_CalculatorListener_onCalculationResultMap(mFunctions.swift_pointer, Conversion<std::unordered_map<std::string, double>>::toBaseRef(calculationResults));
+    void on_calculation_result_map(const ::std::unordered_map<::std::string, double>& calculationResults) override {
+        mFunctions.smoke_CalculatorListener_onCalculationResultMap(mFunctions.swift_pointer, Conversion<::std::unordered_map<::std::string, double>>::toBaseRef(calculationResults));
     }
-    void on_calculation_result_instance(const std::shared_ptr<::smoke::CalculationResult>& calculationResult) override {
-        mFunctions.smoke_CalculatorListener_onCalculationResultInstance(mFunctions.swift_pointer, Conversion<std::shared_ptr<::smoke::CalculationResult>>::toBaseRef(calculationResult));
+    void on_calculation_result_instance(const ::std::shared_ptr<::smoke::CalculationResult>& calculationResult) override {
+        mFunctions.smoke_CalculatorListener_onCalculationResultInstance(mFunctions.swift_pointer, Conversion<::std::shared_ptr<::smoke::CalculationResult>>::toBaseRef(calculationResult));
     }
 private:
     smoke_CalculatorListener_FunctionTable mFunctions;
 };
 _baseRef smoke_CalculatorListener_create_proxy(smoke_CalculatorListener_FunctionTable functionTable) {
-    auto proxy = smoke_CalculatorListenerProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::CalculatorListener>(proxy)) : 0;
+    auto proxy = smoke_CalculatorListenerProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::CalculatorListener>(proxy)) : 0;
 }
 const void* smoke_CalculatorListener_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_CalculatorListenerProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::CalculatorListener>>(handle)->get()) : nullptr;
+    return handle ? smoke_CalculatorListenerProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::CalculatorListener>>(handle)->get()) : nullptr;
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenerWithProperties.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenerWithProperties.cpp
@@ -15,25 +15,25 @@
 #include <unordered_map>
 #include <vector>
 void smoke_ListenerWithProperties_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(handle);
 }
 _baseRef smoke_ListenerWithProperties_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(handle)))
         : 0;
 }
 const void* smoke_ListenerWithProperties_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get())
         : nullptr;
 }
 void smoke_ListenerWithProperties_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get(), swift_pointer);
 }
 void smoke_ListenerWithProperties_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ListenerWithProperties(_baseRef handle);
@@ -46,14 +46,14 @@ struct smoke_ListenerWithPropertiesRegisterInit {
 } s_smoke_ListenerWithProperties_register_init;
 }
 void* smoke_ListenerWithProperties_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::ListenerWithProperties>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::ListenerWithProperties>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_ListenerWithProperties(handle);
 }
 _baseRef
 smoke_ListenerWithProperties_ResultStruct_create_handle( double result )
 {
-    ::smoke::ListenerWithProperties::ResultStruct* _struct = new ( std::nothrow ) ::smoke::ListenerWithProperties::ResultStruct();
+    ::smoke::ListenerWithProperties::ResultStruct* _struct = new ( ::std::nothrow ) ::smoke::ListenerWithProperties::ResultStruct();
     _struct->result = result;
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -65,7 +65,7 @@ smoke_ListenerWithProperties_ResultStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_ListenerWithProperties_ResultStruct_create_optional_handle(double result)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::ListenerWithProperties::ResultStruct>( ::smoke::ListenerWithProperties::ResultStruct( ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::ListenerWithProperties::ResultStruct>( ::smoke::ListenerWithProperties::ResultStruct( ) );
     (*_struct)->result = result;
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -82,51 +82,51 @@ double smoke_ListenerWithProperties_ResultStruct_result_get(_baseRef handle) {
     return struct_pointer->result;
 }
 _baseRef smoke_ListenerWithProperties_message_get(_baseRef _instance) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_message());
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_message());
 }
 void smoke_ListenerWithProperties_message_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_message(Conversion<std::string>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_message(Conversion<::std::string>::toCpp(newValue));
 }
 _baseRef smoke_ListenerWithProperties_packedMessage_get(_baseRef _instance) {
-    return Conversion<std::shared_ptr<::smoke::CalculationResult>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_packed_message());
+    return Conversion<::std::shared_ptr<::smoke::CalculationResult>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_packed_message());
 }
 void smoke_ListenerWithProperties_packedMessage_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_packed_message(Conversion<std::shared_ptr<::smoke::CalculationResult>>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_packed_message(Conversion<::std::shared_ptr<::smoke::CalculationResult>>::toCpp(newValue));
 }
 _baseRef smoke_ListenerWithProperties_structuredMessage_get(_baseRef _instance) {
-    return Conversion<::smoke::ListenerWithProperties::ResultStruct>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_structured_message());
+    return Conversion<::smoke::ListenerWithProperties::ResultStruct>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_structured_message());
 }
 void smoke_ListenerWithProperties_structuredMessage_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_structured_message(Conversion<::smoke::ListenerWithProperties::ResultStruct>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_structured_message(Conversion<::smoke::ListenerWithProperties::ResultStruct>::toCpp(newValue));
 }
 smoke_ListenerWithProperties_ResultEnum smoke_ListenerWithProperties_enumeratedMessage_get(_baseRef _instance) {
-    return static_cast<smoke_ListenerWithProperties_ResultEnum>(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_enumerated_message());
+    return static_cast<smoke_ListenerWithProperties_ResultEnum>(get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_enumerated_message());
 }
 void smoke_ListenerWithProperties_enumeratedMessage_set(_baseRef _instance, smoke_ListenerWithProperties_ResultEnum newValue) {
-    return get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_enumerated_message(static_cast<::smoke::ListenerWithProperties::ResultEnum>(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_enumerated_message(static_cast<::smoke::ListenerWithProperties::ResultEnum>(newValue));
 }
 _baseRef smoke_ListenerWithProperties_arrayedMessage_get(_baseRef _instance) {
-    return Conversion<std::vector<std::string>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_arrayed_message());
+    return Conversion<::std::vector<::std::string>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_arrayed_message());
 }
 void smoke_ListenerWithProperties_arrayedMessage_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_arrayed_message(Conversion<std::vector<std::string>>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_arrayed_message(Conversion<::std::vector<::std::string>>::toCpp(newValue));
 }
 _baseRef smoke_ListenerWithProperties_mappedMessage_get(_baseRef _instance) {
-    return Conversion<std::unordered_map<std::string, double>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_mapped_message());
+    return Conversion<::std::unordered_map<::std::string, double>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_mapped_message());
 }
 void smoke_ListenerWithProperties_mappedMessage_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_mapped_message(Conversion<std::unordered_map<std::string, double>>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_mapped_message(Conversion<::std::unordered_map<::std::string, double>>::toCpp(newValue));
 }
 _baseRef smoke_ListenerWithProperties_bufferedMessage_get(_baseRef _instance) {
-    return Conversion<::std::shared_ptr< ::std::vector< uint8_t > >>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_buffered_message());
+    return Conversion<::std::shared_ptr< ::std::vector< uint8_t > >>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->get_buffered_message());
 }
 void smoke_ListenerWithProperties_bufferedMessage_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_buffered_message(Conversion<::std::shared_ptr< ::std::vector< uint8_t > >>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(_instance)->get()->set_buffered_message(Conversion<::std::shared_ptr< ::std::vector< uint8_t > >>::toCpp(newValue));
 }
-class smoke_ListenerWithPropertiesProxy : public std::shared_ptr<::smoke::ListenerWithProperties>::element_type, public CachedProxyBase<smoke_ListenerWithPropertiesProxy> {
+class smoke_ListenerWithPropertiesProxy : public ::std::shared_ptr<::smoke::ListenerWithProperties>::element_type, public CachedProxyBase<smoke_ListenerWithPropertiesProxy> {
 public:
     smoke_ListenerWithPropertiesProxy(smoke_ListenerWithProperties_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_ListenerWithPropertiesProxy() {
@@ -136,17 +136,17 @@ public:
     smoke_ListenerWithPropertiesProxy& operator=(const smoke_ListenerWithPropertiesProxy&) = delete;
     ::std::string get_message() const override {
         auto _call_result = mFunctions.smoke_ListenerWithProperties_message_get(mFunctions.swift_pointer);
-        return Conversion<std::string>::toCppReturn(_call_result);
+        return Conversion<::std::string>::toCppReturn(_call_result);
     }
-    void set_message(const std::string& newValue) override {
-        mFunctions.smoke_ListenerWithProperties_message_set(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(newValue));
+    void set_message(const ::std::string& newValue) override {
+        mFunctions.smoke_ListenerWithProperties_message_set(mFunctions.swift_pointer, Conversion<::std::string>::toBaseRef(newValue));
     }
     ::std::shared_ptr< ::smoke::CalculationResult > get_packed_message() const override {
         auto _call_result = mFunctions.smoke_ListenerWithProperties_packedMessage_get(mFunctions.swift_pointer);
-        return Conversion<std::shared_ptr<::smoke::CalculationResult>>::toCppReturn(_call_result);
+        return Conversion<::std::shared_ptr<::smoke::CalculationResult>>::toCppReturn(_call_result);
     }
-    void set_packed_message(const std::shared_ptr<::smoke::CalculationResult>& newValue) override {
-        mFunctions.smoke_ListenerWithProperties_packedMessage_set(mFunctions.swift_pointer, Conversion<std::shared_ptr<::smoke::CalculationResult>>::toBaseRef(newValue));
+    void set_packed_message(const ::std::shared_ptr<::smoke::CalculationResult>& newValue) override {
+        mFunctions.smoke_ListenerWithProperties_packedMessage_set(mFunctions.swift_pointer, Conversion<::std::shared_ptr<::smoke::CalculationResult>>::toBaseRef(newValue));
     }
     ::smoke::ListenerWithProperties::ResultStruct get_structured_message() const override {
         auto _call_result = mFunctions.smoke_ListenerWithProperties_structuredMessage_get(mFunctions.swift_pointer);
@@ -164,17 +164,17 @@ public:
     }
     ::std::vector< ::std::string > get_arrayed_message() const override {
         auto _call_result = mFunctions.smoke_ListenerWithProperties_arrayedMessage_get(mFunctions.swift_pointer);
-        return Conversion<std::vector<std::string>>::toCppReturn(_call_result);
+        return Conversion<::std::vector<::std::string>>::toCppReturn(_call_result);
     }
-    void set_arrayed_message(const std::vector<std::string>& newValue) override {
-        mFunctions.smoke_ListenerWithProperties_arrayedMessage_set(mFunctions.swift_pointer, Conversion<std::vector<std::string>>::toBaseRef(newValue));
+    void set_arrayed_message(const ::std::vector<::std::string>& newValue) override {
+        mFunctions.smoke_ListenerWithProperties_arrayedMessage_set(mFunctions.swift_pointer, Conversion<::std::vector<::std::string>>::toBaseRef(newValue));
     }
     ::smoke::ListenerWithProperties::StringToDouble get_mapped_message() const override {
         auto _call_result = mFunctions.smoke_ListenerWithProperties_mappedMessage_get(mFunctions.swift_pointer);
-        return Conversion<std::unordered_map<std::string, double>>::toCppReturn(_call_result);
+        return Conversion<::std::unordered_map<::std::string, double>>::toCppReturn(_call_result);
     }
-    void set_mapped_message(const std::unordered_map<std::string, double>& newValue) override {
-        mFunctions.smoke_ListenerWithProperties_mappedMessage_set(mFunctions.swift_pointer, Conversion<std::unordered_map<std::string, double>>::toBaseRef(newValue));
+    void set_mapped_message(const ::std::unordered_map<::std::string, double>& newValue) override {
+        mFunctions.smoke_ListenerWithProperties_mappedMessage_set(mFunctions.swift_pointer, Conversion<::std::unordered_map<::std::string, double>>::toBaseRef(newValue));
     }
     ::std::shared_ptr< ::std::vector< uint8_t > > get_buffered_message() const override {
         auto _call_result = mFunctions.smoke_ListenerWithProperties_bufferedMessage_get(mFunctions.swift_pointer);
@@ -187,9 +187,9 @@ private:
     smoke_ListenerWithProperties_FunctionTable mFunctions;
 };
 _baseRef smoke_ListenerWithProperties_create_proxy(smoke_ListenerWithProperties_FunctionTable functionTable) {
-    auto proxy = smoke_ListenerWithPropertiesProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::ListenerWithProperties>(proxy)) : 0;
+    auto proxy = smoke_ListenerWithPropertiesProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::ListenerWithProperties>(proxy)) : 0;
 }
 const void* smoke_ListenerWithProperties_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_ListenerWithPropertiesProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get()) : nullptr;
+    return handle ? smoke_ListenerWithPropertiesProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::ListenerWithProperties>>(handle)->get()) : nullptr;
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenersWithReturnValues.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_ListenersWithReturnValues.cpp
@@ -15,25 +15,25 @@
 #include <unordered_map>
 #include <vector>
 void smoke_ListenersWithReturnValues_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle);
 }
 _baseRef smoke_ListenersWithReturnValues_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)))
         : 0;
 }
 const void* smoke_ListenersWithReturnValues_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get())
         : nullptr;
 }
 void smoke_ListenersWithReturnValues_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get(), swift_pointer);
 }
 void smoke_ListenersWithReturnValues_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_ListenersWithReturnValues(_baseRef handle);
@@ -46,14 +46,14 @@ struct smoke_ListenersWithReturnValuesRegisterInit {
 } s_smoke_ListenersWithReturnValues_register_init;
 }
 void* smoke_ListenersWithReturnValues_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::ListenersWithReturnValues>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::ListenersWithReturnValues>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_ListenersWithReturnValues(handle);
 }
 _baseRef
 smoke_ListenersWithReturnValues_ResultStruct_create_handle( double result )
 {
-    ::smoke::ListenersWithReturnValues::ResultStruct* _struct = new ( std::nothrow ) ::smoke::ListenersWithReturnValues::ResultStruct();
+    ::smoke::ListenersWithReturnValues::ResultStruct* _struct = new ( ::std::nothrow ) ::smoke::ListenersWithReturnValues::ResultStruct();
     _struct->result = result;
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -65,7 +65,7 @@ smoke_ListenersWithReturnValues_ResultStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_ListenersWithReturnValues_ResultStruct_create_optional_handle(double result)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::ListenersWithReturnValues::ResultStruct>( ::smoke::ListenersWithReturnValues::ResultStruct( ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::ListenersWithReturnValues::ResultStruct>( ::smoke::ListenersWithReturnValues::ResultStruct( ) );
     (*_struct)->result = result;
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -82,30 +82,30 @@ double smoke_ListenersWithReturnValues_ResultStruct_result_get(_baseRef handle) 
     return struct_pointer->result;
 }
 double smoke_ListenersWithReturnValues_fetchDataDouble(_baseRef _instance) {
-    return get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_double();
+    return get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_double();
 }
 _baseRef smoke_ListenersWithReturnValues_fetchDataString(_baseRef _instance) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_string());
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_string());
 }
 _baseRef smoke_ListenersWithReturnValues_fetchDataStruct(_baseRef _instance) {
-    return Conversion<::smoke::ListenersWithReturnValues::ResultStruct>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_struct());
+    return Conversion<::smoke::ListenersWithReturnValues::ResultStruct>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_struct());
 }
 smoke_ListenersWithReturnValues_ResultEnum smoke_ListenersWithReturnValues_fetchDataEnum(_baseRef _instance) {
-    return static_cast<smoke_ListenersWithReturnValues_ResultEnum>(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_enum());
+    return static_cast<smoke_ListenersWithReturnValues_ResultEnum>(get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_enum());
 }
 _baseRef smoke_ListenersWithReturnValues_fetchDataArray(_baseRef _instance) {
-    return Conversion<std::vector<double>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_array());
+    return Conversion<::std::vector<double>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_array());
 }
 _baseRef smoke_ListenersWithReturnValues_fetchDataMap(_baseRef _instance) {
-    return Conversion<std::unordered_map<std::string, double>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_map());
+    return Conversion<::std::unordered_map<::std::string, double>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_map());
 }
 _baseRef smoke_ListenersWithReturnValues_fetchDataInstance(_baseRef _instance) {
-    return Conversion<std::shared_ptr<::smoke::CalculationResult>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_instance());
+    return Conversion<::std::shared_ptr<::smoke::CalculationResult>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(_instance)->get()->fetch_data_instance());
 }
-class smoke_ListenersWithReturnValuesProxy : public std::shared_ptr<::smoke::ListenersWithReturnValues>::element_type, public CachedProxyBase<smoke_ListenersWithReturnValuesProxy> {
+class smoke_ListenersWithReturnValuesProxy : public ::std::shared_ptr<::smoke::ListenersWithReturnValues>::element_type, public CachedProxyBase<smoke_ListenersWithReturnValuesProxy> {
 public:
     smoke_ListenersWithReturnValuesProxy(smoke_ListenersWithReturnValues_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_ListenersWithReturnValuesProxy() {
@@ -119,7 +119,7 @@ public:
     }
     ::std::string fetch_data_string() override {
         auto _call_result = mFunctions.smoke_ListenersWithReturnValues_fetchDataString(mFunctions.swift_pointer);
-        return Conversion<std::string>::toCppReturn(_call_result);
+        return Conversion<::std::string>::toCppReturn(_call_result);
     }
     ::smoke::ListenersWithReturnValues::ResultStruct fetch_data_struct() override {
         auto _call_result = mFunctions.smoke_ListenersWithReturnValues_fetchDataStruct(mFunctions.swift_pointer);
@@ -131,23 +131,23 @@ public:
     }
     ::std::vector< double > fetch_data_array() override {
         auto _call_result = mFunctions.smoke_ListenersWithReturnValues_fetchDataArray(mFunctions.swift_pointer);
-        return Conversion<std::vector<double>>::toCppReturn(_call_result);
+        return Conversion<::std::vector<double>>::toCppReturn(_call_result);
     }
     ::smoke::ListenersWithReturnValues::StringToDouble fetch_data_map() override {
         auto _call_result = mFunctions.smoke_ListenersWithReturnValues_fetchDataMap(mFunctions.swift_pointer);
-        return Conversion<std::unordered_map<std::string, double>>::toCppReturn(_call_result);
+        return Conversion<::std::unordered_map<::std::string, double>>::toCppReturn(_call_result);
     }
     ::std::shared_ptr< ::smoke::CalculationResult > fetch_data_instance() override {
         auto _call_result = mFunctions.smoke_ListenersWithReturnValues_fetchDataInstance(mFunctions.swift_pointer);
-        return Conversion<std::shared_ptr<::smoke::CalculationResult>>::toCppReturn(_call_result);
+        return Conversion<::std::shared_ptr<::smoke::CalculationResult>>::toCppReturn(_call_result);
     }
 private:
     smoke_ListenersWithReturnValues_FunctionTable mFunctions;
 };
 _baseRef smoke_ListenersWithReturnValues_create_proxy(smoke_ListenersWithReturnValues_FunctionTable functionTable) {
-    auto proxy = smoke_ListenersWithReturnValuesProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::ListenersWithReturnValues>(proxy)) : 0;
+    auto proxy = smoke_ListenersWithReturnValuesProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::ListenersWithReturnValues>(proxy)) : 0;
 }
 const void* smoke_ListenersWithReturnValues_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_ListenersWithReturnValuesProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get()) : nullptr;
+    return handle ? smoke_ListenersWithReturnValuesProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::ListenersWithReturnValues>>(handle)->get()) : nullptr;
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_Weakling.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cbridge/src/smoke/cbridge_Weakling.cpp
@@ -13,25 +13,25 @@
 #include <memory>
 #include <new>
 void smoke_Weakling_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Weakling>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::Weakling>>(handle);
 }
 _baseRef smoke_Weakling_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Weakling>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::Weakling>>(handle)))
         : 0;
 }
 const void* smoke_Weakling_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Weakling>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Weakling>>(handle)->get())
         : nullptr;
 }
 void smoke_Weakling_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Weakling>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::Weakling>>(handle)->get(), swift_pointer);
 }
 void smoke_Weakling_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Weakling>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Weakling>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_Weakling(_baseRef handle);
@@ -44,20 +44,20 @@ struct smoke_WeaklingRegisterInit {
 } s_smoke_Weakling_register_init;
 }
 void* smoke_Weakling_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::Weakling>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::Weakling>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::Weakling>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::Weakling>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_Weakling(handle);
 }
 _baseRef smoke_Weakling_listener_get(_baseRef _instance) {
-    return Conversion<::std::shared_ptr< ::smoke::ListenerInterface >>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Weakling>>(_instance)->get()->get_listener());
+    return Conversion<::std::shared_ptr< ::smoke::ListenerInterface >>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::Weakling>>(_instance)->get()->get_listener());
 }
 void smoke_Weakling_listener_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::smoke::Weakling>>(_instance)->get()->set_listener(Conversion<::std::shared_ptr< ::smoke::ListenerInterface >>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::Weakling>>(_instance)->get()->set_listener(Conversion<::std::shared_ptr< ::smoke::ListenerInterface >>::toCpp(newValue));
 }
-class smoke_WeaklingProxy : public std::shared_ptr<::smoke::Weakling>::element_type, public CachedProxyBase<smoke_WeaklingProxy> {
+class smoke_WeaklingProxy : public ::std::shared_ptr<::smoke::Weakling>::element_type, public CachedProxyBase<smoke_WeaklingProxy> {
 public:
     smoke_WeaklingProxy(smoke_Weakling_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_WeaklingProxy() {
@@ -76,9 +76,9 @@ private:
     smoke_Weakling_FunctionTable mFunctions;
 };
 _baseRef smoke_Weakling_create_proxy(smoke_Weakling_FunctionTable functionTable) {
-    auto proxy = smoke_WeaklingProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::Weakling>(proxy)) : 0;
+    auto proxy = smoke_WeaklingProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::Weakling>(proxy)) : 0;
 }
 const void* smoke_Weakling_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_WeaklingProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::Weakling>>(handle)->get()) : nullptr;
+    return handle ? smoke_WeaklingProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::Weakling>>(handle)->get()) : nullptr;
 }

--- a/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/GenericCollections.cpp
+++ b/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/GenericCollections.cpp
@@ -9,68 +9,68 @@
 #include <unordered_map>
 #include <vector>
 _baseRef ArrayOf__Locale_create_handle() {
-    return reinterpret_cast<_baseRef>( new std::vector<gluecodium::Locale>( ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<gluecodium::Locale>( ) );
 }
 _baseRef ArrayOf__Locale_copy_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new std::vector<gluecodium::Locale>( *reinterpret_cast<std::vector<gluecodium::Locale>*>( handle ) ) );
+    return reinterpret_cast<_baseRef>( new ::std::vector<gluecodium::Locale>( *reinterpret_cast<::std::vector<gluecodium::Locale>*>( handle ) ) );
 }
 void ArrayOf__Locale_release_handle(_baseRef handle) {
-    delete reinterpret_cast<std::vector<gluecodium::Locale>*>( handle );
+    delete reinterpret_cast<::std::vector<gluecodium::Locale>*>( handle );
 }
 uint64_t ArrayOf__Locale_count(_baseRef handle) {
-    return Conversion<std::vector<gluecodium::Locale>>::toCpp( handle ).size( );
+    return Conversion<::std::vector<gluecodium::Locale>>::toCpp( handle ).size( );
 }
 _baseRef ArrayOf__Locale_get( _baseRef handle, uint64_t index ) {
-    return Conversion<gluecodium::Locale>::referenceBaseRef(Conversion<std::vector<gluecodium::Locale>>::toCpp( handle )[index]);
+    return Conversion<gluecodium::Locale>::referenceBaseRef(Conversion<::std::vector<gluecodium::Locale>>::toCpp( handle )[index]);
 }
 void ArrayOf__Locale_append( _baseRef handle, _baseRef item )
 {
-    Conversion<std::vector<gluecodium::Locale>>::toCpp(handle).push_back(Conversion<gluecodium::Locale>::toCpp(item));
+    Conversion<::std::vector<gluecodium::Locale>>::toCpp(handle).push_back(Conversion<gluecodium::Locale>::toCpp(item));
 }
 _baseRef ArrayOf__Locale_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::vector<gluecodium::Locale>>( std::vector<gluecodium::Locale>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector<gluecodium::Locale>>( ::std::vector<gluecodium::Locale>( ) ) );
 }
 void ArrayOf__Locale_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::vector<gluecodium::Locale>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::vector<gluecodium::Locale>>*>( handle );
 }
 _baseRef ArrayOf__Locale_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::vector<gluecodium::Locale>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector<gluecodium::Locale>>*>( handle ) );
 }
 _baseRef MapOf__String_To__Locale_create_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::string, gluecodium::Locale>() );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::string, gluecodium::Locale>() );
 }
 void MapOf__String_To__Locale_release_handle(_baseRef handle) {
-    delete get_pointer<std::unordered_map<std::string, gluecodium::Locale>>(handle);
+    delete get_pointer<::std::unordered_map<::std::string, gluecodium::Locale>>(handle);
 }
 _baseRef MapOf__String_To__Locale_iterator(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) std::unordered_map<std::string, gluecodium::Locale>::iterator( get_pointer<std::unordered_map<std::string, gluecodium::Locale>>(handle)->begin() ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map<::std::string, gluecodium::Locale>::iterator( get_pointer<::std::unordered_map<::std::string, gluecodium::Locale>>(handle)->begin() ) );
 }
 void MapOf__String_To__Locale_iterator_release_handle(_baseRef iterator_handle) {
-    delete reinterpret_cast<std::unordered_map<std::string, gluecodium::Locale>::iterator*>( iterator_handle );
+    delete reinterpret_cast<::std::unordered_map<::std::string, gluecodium::Locale>::iterator*>( iterator_handle );
 }
 void MapOf__String_To__Locale_put(_baseRef handle, _baseRef key, _baseRef value) {
-    (*get_pointer<std::unordered_map<std::string, gluecodium::Locale>>(handle)).emplace(Conversion<std::string>::toCpp(key), Conversion<gluecodium::Locale>::toCpp(value));
+    (*get_pointer<::std::unordered_map<::std::string, gluecodium::Locale>>(handle)).emplace(Conversion<::std::string>::toCpp(key), Conversion<gluecodium::Locale>::toCpp(value));
 }
 bool MapOf__String_To__Locale_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
-    return *reinterpret_cast<std::unordered_map<std::string, gluecodium::Locale>::iterator*>( iterator_handle ) != get_pointer<std::unordered_map<std::string, gluecodium::Locale>>(handle)->end();
+    return *reinterpret_cast<::std::unordered_map<::std::string, gluecodium::Locale>::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map<::std::string, gluecodium::Locale>>(handle)->end();
 }
 void MapOf__String_To__Locale_iterator_increment(_baseRef iterator_handle) {
-    ++*reinterpret_cast<std::unordered_map<std::string, gluecodium::Locale>::iterator*>( iterator_handle );
+    ++*reinterpret_cast<::std::unordered_map<::std::string, gluecodium::Locale>::iterator*>( iterator_handle );
 }
 _baseRef MapOf__String_To__Locale_iterator_key(_baseRef iterator_handle) {
-    auto& key = (*reinterpret_cast<std::unordered_map<std::string, gluecodium::Locale>::iterator*>( iterator_handle ))->first;
-    return Conversion<std::string>::toBaseRef(key);
+    auto& key = (*reinterpret_cast<::std::unordered_map<::std::string, gluecodium::Locale>::iterator*>( iterator_handle ))->first;
+    return Conversion<::std::string>::toBaseRef(key);
 }
 _baseRef MapOf__String_To__Locale_iterator_value(_baseRef iterator_handle) {
-    auto& value = (*reinterpret_cast<std::unordered_map<std::string, gluecodium::Locale>::iterator*>( iterator_handle ))->second;
+    auto& value = (*reinterpret_cast<::std::unordered_map<::std::string, gluecodium::Locale>::iterator*>( iterator_handle ))->second;
     return Conversion<gluecodium::Locale>::toBaseRef(value);
 }
 _baseRef MapOf__String_To__Locale_create_optional_handle() {
-    return reinterpret_cast<_baseRef>( new ( std::nothrow ) ::gluecodium::optional<std::unordered_map<std::string, gluecodium::Locale>>( std::unordered_map<std::string, gluecodium::Locale>( ) ) );
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map<::std::string, gluecodium::Locale>>( ::std::unordered_map<::std::string, gluecodium::Locale>( ) ) );
 }
 void MapOf__String_To__Locale_release_optional_handle(_baseRef handle) {
-    delete reinterpret_cast<::gluecodium::optional<std::unordered_map<std::string, gluecodium::Locale>>*>( handle );
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::string, gluecodium::Locale>>*>( handle );
 }
 _baseRef MapOf__String_To__Locale_unwrap_optional_handle(_baseRef handle) {
-    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::unordered_map<std::string, gluecodium::Locale>>*>( handle ) );
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map<::std::string, gluecodium::Locale>>*>( handle ) );
 }

--- a/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/smoke/cbridge_Locales.cpp
+++ b/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/smoke/cbridge_Locales.cpp
@@ -11,30 +11,30 @@
 #include <memory>
 #include <new>
 void smoke_Locales_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Locales>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::Locales>>(handle);
 }
 _baseRef smoke_Locales_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Locales>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::Locales>>(handle)))
         : 0;
 }
 const void* smoke_Locales_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Locales>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Locales>>(handle)->get())
         : nullptr;
 }
 void smoke_Locales_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Locales>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::Locales>>(handle)->get(), swift_pointer);
 }
 void smoke_Locales_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Locales>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Locales>>(handle)->get());
 }
 _baseRef
 smoke_Locales_LocaleStruct_create_handle( _baseRef localeField )
 {
-    ::smoke::Locales::LocaleStruct* _struct = new ( std::nothrow ) ::smoke::Locales::LocaleStruct();
+    ::smoke::Locales::LocaleStruct* _struct = new ( ::std::nothrow ) ::smoke::Locales::LocaleStruct();
     _struct->locale_field = Conversion<gluecodium::Locale>::toCpp( localeField );
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -46,7 +46,7 @@ smoke_Locales_LocaleStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_Locales_LocaleStruct_create_optional_handle(_baseRef localeField)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Locales::LocaleStruct>( ::smoke::Locales::LocaleStruct( ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::Locales::LocaleStruct>( ::smoke::Locales::LocaleStruct( ) );
     (*_struct)->locale_field = Conversion<gluecodium::Locale>::toCpp( localeField );
     return reinterpret_cast<_baseRef>( _struct );
 }
@@ -63,11 +63,11 @@ _baseRef smoke_Locales_LocaleStruct_localeField_get(_baseRef handle) {
     return Conversion<gluecodium::Locale>::toBaseRef(struct_pointer->locale_field);
 }
 _baseRef smoke_Locales_localeMethod(_baseRef _instance, _baseRef input) {
-    return Conversion<gluecodium::Locale>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Locales>>(_instance)->get()->locale_method(Conversion<gluecodium::Locale>::toCpp(input)));
+    return Conversion<gluecodium::Locale>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::Locales>>(_instance)->get()->locale_method(Conversion<gluecodium::Locale>::toCpp(input)));
 }
 _baseRef smoke_Locales_localeProperty_get(_baseRef _instance) {
-    return Conversion<gluecodium::Locale>::toBaseRef(get_pointer<std::shared_ptr<::smoke::Locales>>(_instance)->get()->get_locale_property());
+    return Conversion<gluecodium::Locale>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::Locales>>(_instance)->get()->get_locale_property());
 }
 void smoke_Locales_localeProperty_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::smoke::Locales>>(_instance)->get()->set_locale_property(Conversion<gluecodium::Locale>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::Locales>>(_instance)->get()->set_locale_property(Conversion<gluecodium::Locale>::toCpp(newValue));
 }

--- a/gluecodium/src/test/resources/smoke/name_rules/output/cbridge/src/namerules/cbridge_NameRules.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/cbridge/src/namerules/cbridge_NameRules.cpp
@@ -11,32 +11,32 @@
 #include <new>
 #include <vector>
 void namerules_NameRules_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::namerules::NameRules>>(handle);
+    delete get_pointer<::std::shared_ptr<::namerules::NameRules>>(handle);
 }
 _baseRef namerules_NameRules_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::namerules::NameRules>>(handle)))
         : 0;
 }
 const void* namerules_NameRules_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)->get())
+        ? ::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::namerules::NameRules>>(handle)->get())
         : nullptr;
 }
 void namerules_NameRules_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)->get(), swift_pointer);
+    ::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::namerules::NameRules>>(handle)->get(), swift_pointer);
 }
 void namerules_NameRules_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::WrapperCache::is_alive) return;
-    ::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::namerules::NameRules>>(handle)->get());
+    ::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::namerules::NameRules>>(handle)->get());
 }
 _baseRef
 namerules_NameRules_ExampleStruct_create_handle( double iValue, _baseRef iIntValue )
 {
-    ::namerules::NameRules::ExampleStruct* _struct = new ( std::nothrow ) ::namerules::NameRules::ExampleStruct();
+    ::namerules::NameRules::ExampleStruct* _struct = new ( ::std::nothrow ) ::namerules::NameRules::ExampleStruct();
     _struct->m_value = iValue;
-    _struct->m_int_value = Conversion<std::vector<int64_t>>::toCpp( iIntValue );
+    _struct->m_int_value = Conversion<::std::vector<int64_t>>::toCpp( iIntValue );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -47,9 +47,9 @@ namerules_NameRules_ExampleStruct_release_handle( _baseRef handle )
 _baseRef
 namerules_NameRules_ExampleStruct_create_optional_handle(double iValue, _baseRef iIntValue)
 {
-    auto _struct = new ( std::nothrow ) ::optional<::namerules::NameRules::ExampleStruct>( ::namerules::NameRules::ExampleStruct( ) );
+    auto _struct = new ( ::std::nothrow ) ::optional<::namerules::NameRules::ExampleStruct>( ::namerules::NameRules::ExampleStruct( ) );
     (*_struct)->m_value = iValue;
-    (*_struct)->m_int_value = Conversion<std::vector<int64_t>>::toCpp( iIntValue );
+    (*_struct)->m_int_value = Conversion<::std::vector<int64_t>>::toCpp( iIntValue );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -66,13 +66,13 @@ double namerules_NameRules_ExampleStruct_iValue_get(_baseRef handle) {
 }
 _baseRef namerules_NameRules_ExampleStruct_iIntValue_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::namerules::NameRules::ExampleStruct>(handle);
-    return Conversion<std::vector<int64_t>>::toBaseRef(struct_pointer->m_int_value);
+    return Conversion<::std::vector<int64_t>>::toBaseRef(struct_pointer->m_int_value);
 }
 _baseRef namerules_NameRules_create() {
-    return Conversion<std::shared_ptr<::namerules::NameRules>>::toBaseRef(::namerules::NameRules::create());
+    return Conversion<::std::shared_ptr<::namerules::NameRules>>::toBaseRef(::namerules::NameRules::create());
 }
 namerules_NameRules_someMethod_result namerules_NameRules_someMethod(_baseRef _instance, _baseRef someArgument) {
-    auto&& RESULT = get_pointer<std::shared_ptr<::namerules::NameRules>>(_instance)->get()->someMethod(Conversion<::namerules::NameRules::ExampleStruct>::toCpp(someArgument));
+    auto&& RESULT = get_pointer<::std::shared_ptr<::namerules::NameRules>>(_instance)->get()->someMethod(Conversion<::namerules::NameRules::ExampleStruct>::toCpp(someArgument));
     if (RESULT.has_value()) {
         return {true, .returned_value = RESULT.unsafe_value()};
     } else {
@@ -80,20 +80,20 @@ namerules_NameRules_someMethod_result namerules_NameRules_someMethod(_baseRef _i
     }
 }
 uint32_t namerules_NameRules_intProperty_get(_baseRef _instance) {
-    return get_pointer<std::shared_ptr<::namerules::NameRules>>(_instance)->get()->retrieve_int_property();
+    return get_pointer<::std::shared_ptr<::namerules::NameRules>>(_instance)->get()->retrieve_int_property();
 }
 void namerules_NameRules_intProperty_set(_baseRef _instance, uint32_t newValue) {
-    return get_pointer<std::shared_ptr<::namerules::NameRules>>(_instance)->get()->STORE_INT_PROPERTY_NOW(newValue);
+    return get_pointer<::std::shared_ptr<::namerules::NameRules>>(_instance)->get()->STORE_INT_PROPERTY_NOW(newValue);
 }
 bool namerules_NameRules_booleanProperty_get(_baseRef _instance) {
-    return get_pointer<std::shared_ptr<::namerules::NameRules>>(_instance)->get()->really_boolean_property();
+    return get_pointer<::std::shared_ptr<::namerules::NameRules>>(_instance)->get()->really_boolean_property();
 }
 void namerules_NameRules_booleanProperty_set(_baseRef _instance, bool newValue) {
-    return get_pointer<std::shared_ptr<::namerules::NameRules>>(_instance)->get()->STORE_BOOLEAN_PROPERTY_NOW(newValue);
+    return get_pointer<::std::shared_ptr<::namerules::NameRules>>(_instance)->get()->STORE_BOOLEAN_PROPERTY_NOW(newValue);
 }
 _baseRef namerules_NameRules_structProperty_get(_baseRef _instance) {
-    return Conversion<::namerules::NameRules::ExampleStruct>::toBaseRef(get_pointer<std::shared_ptr<::namerules::NameRules>>(_instance)->get()->retrieve_struct_property());
+    return Conversion<::namerules::NameRules::ExampleStruct>::toBaseRef(get_pointer<::std::shared_ptr<::namerules::NameRules>>(_instance)->get()->retrieve_struct_property());
 }
 void namerules_NameRules_structProperty_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::namerules::NameRules>>(_instance)->get()->STORE_STRUCT_PROPERTY_NOW(Conversion<::namerules::NameRules::ExampleStruct>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::namerules::NameRules>>(_instance)->get()->STORE_STRUCT_PROPERTY_NOW(Conversion<::namerules::NameRules::ExampleStruct>::toCpp(newValue));
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_FreePoint.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_FreePoint.cpp
@@ -9,7 +9,7 @@
 _baseRef
 smoke_FreePoint_create_handle( double x, double y )
 {
-    ::smoke::FreePoint* _struct = new ( std::nothrow ) ::smoke::FreePoint();
+    ::smoke::FreePoint* _struct = new ( ::std::nothrow ) ::smoke::FreePoint();
     _struct->x = x;
     _struct->y = y;
     return reinterpret_cast<_baseRef>( _struct );
@@ -22,7 +22,7 @@ smoke_FreePoint_release_handle( _baseRef handle )
 _baseRef
 smoke_FreePoint_create_optional_handle(double x, double y)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::FreePoint>( ::smoke::FreePoint( ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::FreePoint>( ::smoke::FreePoint( ) );
     (*_struct)->x = x;
     (*_struct)->y = y;
     return reinterpret_cast<_baseRef>( _struct );

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_LevelOne.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_LevelOne.cpp
@@ -13,73 +13,73 @@
 #include <new>
 #include <string>
 void smoke_LevelOne_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::LevelOne>>(handle);
 }
 _baseRef smoke_LevelOne_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::LevelOne>>(handle)))
         : 0;
 }
 const void* smoke_LevelOne_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::LevelOne>>(handle)->get())
         : nullptr;
 }
 void smoke_LevelOne_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::LevelOne>>(handle)->get(), swift_pointer);
 }
 void smoke_LevelOne_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::LevelOne>>(handle)->get());
 }
 void smoke_LevelOne_LevelTwo_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle);
 }
 _baseRef smoke_LevelOne_LevelTwo_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)))
         : 0;
 }
 const void* smoke_LevelOne_LevelTwo_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get())
         : nullptr;
 }
 void smoke_LevelOne_LevelTwo_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get(), swift_pointer);
 }
 void smoke_LevelOne_LevelTwo_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::LevelOne::LevelTwo>>(handle)->get());
 }
 void smoke_LevelOne_LevelTwo_LevelThree_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle);
 }
 _baseRef smoke_LevelOne_LevelTwo_LevelThree_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)))
         : 0;
 }
 const void* smoke_LevelOne_LevelTwo_LevelThree_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get())
         : nullptr;
 }
 void smoke_LevelOne_LevelTwo_LevelThree_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get(), swift_pointer);
 }
 void smoke_LevelOne_LevelTwo_LevelThree_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(handle)->get());
 }
 _baseRef
 smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle( _baseRef stringField )
 {
-    ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour* _struct = new ( std::nothrow ) ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour();
-    _struct->string_field = Conversion<std::string>::toCpp( stringField );
+    ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour* _struct = new ( ::std::nothrow ) ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour();
+    _struct->string_field = Conversion<::std::string>::toCpp( stringField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -90,8 +90,8 @@ smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle( _baseRef handle )
 _baseRef
 smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_optional_handle(_baseRef stringField)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>( ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour( ) );
-    (*_struct)->string_field = Conversion<std::string>::toCpp( stringField );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>( ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour( ) );
+    (*_struct)->string_field = Conversion<::std::string>::toCpp( stringField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -104,11 +104,11 @@ void smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_optional_handle(_baseR
 }
 _baseRef smoke_LevelOne_LevelTwo_LevelThree_LevelFour_stringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->string_field);
+    return Conversion<::std::string>::toBaseRef(struct_pointer->string_field);
 }
 _baseRef smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fooFactory() {
     return Conversion<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>::toBaseRef(::smoke::LevelOne::LevelTwo::LevelThree::LevelFour::foo_factory());
 }
 _baseRef smoke_LevelOne_LevelTwo_LevelThree_foo(_baseRef _instance, _baseRef input) {
-    return Conversion<std::shared_ptr<::smoke::OuterInterface::InnerClass>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(_instance)->get()->foo(Conversion<std::shared_ptr<::smoke::OuterClass::InnerInterface>>::toCpp(input)));
+    return Conversion<::std::shared_ptr<::smoke::OuterInterface::InnerClass>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>(_instance)->get()->foo(Conversion<::std::shared_ptr<::smoke::OuterClass::InnerInterface>>::toCpp(input)));
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterClass.cpp
@@ -12,73 +12,73 @@
 #include <new>
 #include <string>
 void smoke_OuterClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::OuterClass>>(handle);
 }
 _baseRef smoke_OuterClass_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::OuterClass>>(handle)))
         : 0;
 }
 const void* smoke_OuterClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterClass>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterClass>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterClass>>(handle)->get());
 }
 _baseRef smoke_OuterClass_foo(_baseRef _instance, _baseRef input) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterClass>>(_instance)->get()->foo(Conversion<std::string>::toCpp(input)));
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::OuterClass>>(_instance)->get()->foo(Conversion<::std::string>::toCpp(input)));
 }
 void smoke_OuterClass_InnerClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle);
 }
 _baseRef smoke_OuterClass_InnerClass_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)))
         : 0;
 }
 const void* smoke_OuterClass_InnerClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterClass_InnerClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterClass_InnerClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerClass>>(handle)->get());
 }
 _baseRef smoke_OuterClass_InnerClass_foo(_baseRef _instance, _baseRef input) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerClass>>(_instance)->get()->foo(Conversion<std::string>::toCpp(input)));
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerClass>>(_instance)->get()->foo(Conversion<::std::string>::toCpp(input)));
 }
 void smoke_OuterClass_InnerInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle);
 }
 _baseRef smoke_OuterClass_InnerInterface_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)))
         : 0;
 }
 const void* smoke_OuterClass_InnerInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterClass_InnerInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterClass_InnerInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_OuterClass_InnerInterface(_baseRef handle);
@@ -91,17 +91,17 @@ struct smoke_OuterClass_InnerInterfaceRegisterInit {
 } s_smoke_OuterClass_InnerInterface_register_init;
 }
 void* smoke_OuterClass_InnerInterface_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::OuterClass::InnerInterface>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::OuterClass::InnerInterface>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_OuterClass_InnerInterface(handle);
 }
 _baseRef smoke_OuterClass_InnerInterface_foo(_baseRef _instance, _baseRef input) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(_instance)->get()->foo(Conversion<std::string>::toCpp(input)));
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerInterface>>(_instance)->get()->foo(Conversion<::std::string>::toCpp(input)));
 }
-class smoke_OuterClass_InnerInterfaceProxy : public std::shared_ptr<::smoke::OuterClass::InnerInterface>::element_type, public CachedProxyBase<smoke_OuterClass_InnerInterfaceProxy> {
+class smoke_OuterClass_InnerInterfaceProxy : public ::std::shared_ptr<::smoke::OuterClass::InnerInterface>::element_type, public CachedProxyBase<smoke_OuterClass_InnerInterfaceProxy> {
 public:
     smoke_OuterClass_InnerInterfaceProxy(smoke_OuterClass_InnerInterface_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_OuterClass_InnerInterfaceProxy() {
@@ -109,17 +109,17 @@ public:
     }
     smoke_OuterClass_InnerInterfaceProxy(const smoke_OuterClass_InnerInterfaceProxy&) = delete;
     smoke_OuterClass_InnerInterfaceProxy& operator=(const smoke_OuterClass_InnerInterfaceProxy&) = delete;
-    ::std::string foo(const std::string& input) override {
-        auto _call_result = mFunctions.smoke_OuterClass_InnerInterface_foo(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(input));
-        return Conversion<std::string>::toCppReturn(_call_result);
+    ::std::string foo(const ::std::string& input) override {
+        auto _call_result = mFunctions.smoke_OuterClass_InnerInterface_foo(mFunctions.swift_pointer, Conversion<::std::string>::toBaseRef(input));
+        return Conversion<::std::string>::toCppReturn(_call_result);
     }
 private:
     smoke_OuterClass_InnerInterface_FunctionTable mFunctions;
 };
 _baseRef smoke_OuterClass_InnerInterface_create_proxy(smoke_OuterClass_InnerInterface_FunctionTable functionTable) {
-    auto proxy = smoke_OuterClass_InnerInterfaceProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::OuterClass::InnerInterface>(proxy)) : 0;
+    auto proxy = smoke_OuterClass_InnerInterfaceProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::OuterClass::InnerInterface>(proxy)) : 0;
 }
 const void* smoke_OuterClass_InnerInterface_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_OuterClass_InnerInterfaceProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get()) : nullptr;
+    return handle ? smoke_OuterClass_InnerInterfaceProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::OuterClass::InnerInterface>>(handle)->get()) : nullptr;
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterInterface.cpp
@@ -12,25 +12,25 @@
 #include <new>
 #include <string>
 void smoke_OuterInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::OuterInterface>>(handle);
 }
 _baseRef smoke_OuterInterface_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::OuterInterface>>(handle)))
         : 0;
 }
 const void* smoke_OuterInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_OuterInterface(_baseRef handle);
@@ -43,17 +43,17 @@ struct smoke_OuterInterfaceRegisterInit {
 } s_smoke_OuterInterface_register_init;
 }
 void* smoke_OuterInterface_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::OuterInterface>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::OuterInterface>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::OuterInterface>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_OuterInterface(handle);
 }
 _baseRef smoke_OuterInterface_foo(_baseRef _instance, _baseRef input) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(_instance)->get()->foo(Conversion<std::string>::toCpp(input)));
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::OuterInterface>>(_instance)->get()->foo(Conversion<::std::string>::toCpp(input)));
 }
-class smoke_OuterInterfaceProxy : public std::shared_ptr<::smoke::OuterInterface>::element_type, public CachedProxyBase<smoke_OuterInterfaceProxy> {
+class smoke_OuterInterfaceProxy : public ::std::shared_ptr<::smoke::OuterInterface>::element_type, public CachedProxyBase<smoke_OuterInterfaceProxy> {
 public:
     smoke_OuterInterfaceProxy(smoke_OuterInterface_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_OuterInterfaceProxy() {
@@ -61,64 +61,64 @@ public:
     }
     smoke_OuterInterfaceProxy(const smoke_OuterInterfaceProxy&) = delete;
     smoke_OuterInterfaceProxy& operator=(const smoke_OuterInterfaceProxy&) = delete;
-    ::std::string foo(const std::string& input) override {
-        auto _call_result = mFunctions.smoke_OuterInterface_foo(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(input));
-        return Conversion<std::string>::toCppReturn(_call_result);
+    ::std::string foo(const ::std::string& input) override {
+        auto _call_result = mFunctions.smoke_OuterInterface_foo(mFunctions.swift_pointer, Conversion<::std::string>::toBaseRef(input));
+        return Conversion<::std::string>::toCppReturn(_call_result);
     }
 private:
     smoke_OuterInterface_FunctionTable mFunctions;
 };
 _baseRef smoke_OuterInterface_create_proxy(smoke_OuterInterface_FunctionTable functionTable) {
-    auto proxy = smoke_OuterInterfaceProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::OuterInterface>(proxy)) : 0;
+    auto proxy = smoke_OuterInterfaceProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::OuterInterface>(proxy)) : 0;
 }
 const void* smoke_OuterInterface_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_OuterInterfaceProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::OuterInterface>>(handle)->get()) : nullptr;
+    return handle ? smoke_OuterInterfaceProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::OuterInterface>>(handle)->get()) : nullptr;
 }
 void smoke_OuterInterface_InnerClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle);
 }
 _baseRef smoke_OuterInterface_InnerClass_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)))
         : 0;
 }
 const void* smoke_OuterInterface_InnerClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterInterface_InnerClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterInterface_InnerClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerClass>>(handle)->get());
 }
 _baseRef smoke_OuterInterface_InnerClass_foo(_baseRef _instance, _baseRef input) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerClass>>(_instance)->get()->foo(Conversion<std::string>::toCpp(input)));
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerClass>>(_instance)->get()->foo(Conversion<::std::string>::toCpp(input)));
 }
 void smoke_OuterInterface_InnerInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle);
 }
 _baseRef smoke_OuterInterface_InnerInterface_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)))
         : 0;
 }
 const void* smoke_OuterInterface_InnerInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterInterface_InnerInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterInterface_InnerInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_OuterInterface_InnerInterface(_baseRef handle);
@@ -131,17 +131,17 @@ struct smoke_OuterInterface_InnerInterfaceRegisterInit {
 } s_smoke_OuterInterface_InnerInterface_register_init;
 }
 void* smoke_OuterInterface_InnerInterface_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::OuterInterface::InnerInterface>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::OuterInterface::InnerInterface>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_OuterInterface_InnerInterface(handle);
 }
 _baseRef smoke_OuterInterface_InnerInterface_foo(_baseRef _instance, _baseRef input) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(_instance)->get()->foo(Conversion<std::string>::toCpp(input)));
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(_instance)->get()->foo(Conversion<::std::string>::toCpp(input)));
 }
-class smoke_OuterInterface_InnerInterfaceProxy : public std::shared_ptr<::smoke::OuterInterface::InnerInterface>::element_type, public CachedProxyBase<smoke_OuterInterface_InnerInterfaceProxy> {
+class smoke_OuterInterface_InnerInterfaceProxy : public ::std::shared_ptr<::smoke::OuterInterface::InnerInterface>::element_type, public CachedProxyBase<smoke_OuterInterface_InnerInterfaceProxy> {
 public:
     smoke_OuterInterface_InnerInterfaceProxy(smoke_OuterInterface_InnerInterface_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_OuterInterface_InnerInterfaceProxy() {
@@ -149,17 +149,17 @@ public:
     }
     smoke_OuterInterface_InnerInterfaceProxy(const smoke_OuterInterface_InnerInterfaceProxy&) = delete;
     smoke_OuterInterface_InnerInterfaceProxy& operator=(const smoke_OuterInterface_InnerInterfaceProxy&) = delete;
-    ::std::string foo(const std::string& input) override {
-        auto _call_result = mFunctions.smoke_OuterInterface_InnerInterface_foo(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(input));
-        return Conversion<std::string>::toCppReturn(_call_result);
+    ::std::string foo(const ::std::string& input) override {
+        auto _call_result = mFunctions.smoke_OuterInterface_InnerInterface_foo(mFunctions.swift_pointer, Conversion<::std::string>::toBaseRef(input));
+        return Conversion<::std::string>::toCppReturn(_call_result);
     }
 private:
     smoke_OuterInterface_InnerInterface_FunctionTable mFunctions;
 };
 _baseRef smoke_OuterInterface_InnerInterface_create_proxy(smoke_OuterInterface_InnerInterface_FunctionTable functionTable) {
-    auto proxy = smoke_OuterInterface_InnerInterfaceProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::OuterInterface::InnerInterface>(proxy)) : 0;
+    auto proxy = smoke_OuterInterface_InnerInterfaceProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::OuterInterface::InnerInterface>(proxy)) : 0;
 }
 const void* smoke_OuterInterface_InnerInterface_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_OuterInterface_InnerInterfaceProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get()) : nullptr;
+    return handle ? smoke_OuterInterface_InnerInterfaceProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::OuterInterface::InnerInterface>>(handle)->get()) : nullptr;
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterStruct.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterStruct.cpp
@@ -13,8 +13,8 @@
 _baseRef
 smoke_OuterStruct_create_handle( _baseRef field )
 {
-    ::smoke::OuterStruct* _struct = new ( std::nothrow ) ::smoke::OuterStruct();
-    _struct->field = Conversion<std::string>::toCpp( field );
+    ::smoke::OuterStruct* _struct = new ( ::std::nothrow ) ::smoke::OuterStruct();
+    _struct->field = Conversion<::std::string>::toCpp( field );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -25,8 +25,8 @@ smoke_OuterStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_OuterStruct_create_optional_handle(_baseRef field)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::OuterStruct>( ::smoke::OuterStruct( ) );
-    (*_struct)->field = Conversion<std::string>::toCpp( field );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::OuterStruct>( ::smoke::OuterStruct( ) );
+    (*_struct)->field = Conversion<::std::string>::toCpp( field );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -39,13 +39,13 @@ void smoke_OuterStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_OuterStruct_field_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::OuterStruct>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->field);
+    return Conversion<::std::string>::toBaseRef(struct_pointer->field);
 }
 _baseRef
 smoke_OuterStruct_InnerStruct_create_handle( _baseRef otherField )
 {
-    ::smoke::OuterStruct::InnerStruct* _struct = new ( std::nothrow ) ::smoke::OuterStruct::InnerStruct();
-    _struct->other_field = Conversion<std::vector<std::chrono::system_clock::time_point>>::toCpp( otherField );
+    ::smoke::OuterStruct::InnerStruct* _struct = new ( ::std::nothrow ) ::smoke::OuterStruct::InnerStruct();
+    _struct->other_field = Conversion<::std::vector<::std::chrono::system_clock::time_point>>::toCpp( otherField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -56,8 +56,8 @@ smoke_OuterStruct_InnerStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_OuterStruct_InnerStruct_create_optional_handle(_baseRef otherField)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::OuterStruct::InnerStruct>( ::smoke::OuterStruct::InnerStruct( ) );
-    (*_struct)->other_field = Conversion<std::vector<std::chrono::system_clock::time_point>>::toCpp( otherField );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::OuterStruct::InnerStruct>( ::smoke::OuterStruct::InnerStruct( ) );
+    (*_struct)->other_field = Conversion<::std::vector<::std::chrono::system_clock::time_point>>::toCpp( otherField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -70,55 +70,55 @@ void smoke_OuterStruct_InnerStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_OuterStruct_InnerStruct_otherField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::OuterStruct::InnerStruct>(handle);
-    return Conversion<std::vector<std::chrono::system_clock::time_point>>::toBaseRef(struct_pointer->other_field);
+    return Conversion<::std::vector<::std::chrono::system_clock::time_point>>::toBaseRef(struct_pointer->other_field);
 }
 void smoke_OuterStruct_InnerStruct_doSomething(_baseRef _instance) {
     return get_pointer<::smoke::OuterStruct::InnerStruct>(_instance)->do_something();
 }
 void smoke_OuterStruct_InnerClass_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle);
 }
 _baseRef smoke_OuterStruct_InnerClass_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle)))
         : 0;
 }
 const void* smoke_OuterStruct_InnerClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterStruct_InnerClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterStruct_InnerClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerClass>>(handle)->get());
 }
 _baseRef smoke_OuterStruct_InnerClass_fooBar(_baseRef _instance) {
-    return Conversion<std::unordered_set<gluecodium::Locale>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerClass>>(_instance)->get()->foo_bar());
+    return Conversion<::std::unordered_set<gluecodium::Locale>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerClass>>(_instance)->get()->foo_bar());
 }
 void smoke_OuterStruct_InnerInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle);
 }
 _baseRef smoke_OuterStruct_InnerInterface_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)))
         : 0;
 }
 const void* smoke_OuterStruct_InnerInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_OuterStruct_InnerInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_OuterStruct_InnerInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_OuterStruct_InnerInterface(_baseRef handle);
@@ -131,17 +131,17 @@ struct smoke_OuterStruct_InnerInterfaceRegisterInit {
 } s_smoke_OuterStruct_InnerInterface_register_init;
 }
 void* smoke_OuterStruct_InnerInterface_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::OuterStruct::InnerInterface>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::OuterStruct::InnerInterface>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_OuterStruct_InnerInterface(handle);
 }
 _baseRef smoke_OuterStruct_InnerInterface_barBaz(_baseRef _instance) {
-    return Conversion<std::unordered_map<std::string, ::std::shared_ptr< ::std::vector< uint8_t > >>>::toBaseRef(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(_instance)->get()->bar_baz());
+    return Conversion<::std::unordered_map<::std::string, ::std::shared_ptr< ::std::vector< uint8_t > >>>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(_instance)->get()->bar_baz());
 }
-class smoke_OuterStruct_InnerInterfaceProxy : public std::shared_ptr<::smoke::OuterStruct::InnerInterface>::element_type, public CachedProxyBase<smoke_OuterStruct_InnerInterfaceProxy> {
+class smoke_OuterStruct_InnerInterfaceProxy : public ::std::shared_ptr<::smoke::OuterStruct::InnerInterface>::element_type, public CachedProxyBase<smoke_OuterStruct_InnerInterfaceProxy> {
 public:
     smoke_OuterStruct_InnerInterfaceProxy(smoke_OuterStruct_InnerInterface_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_OuterStruct_InnerInterfaceProxy() {
@@ -151,17 +151,17 @@ public:
     smoke_OuterStruct_InnerInterfaceProxy& operator=(const smoke_OuterStruct_InnerInterfaceProxy&) = delete;
     ::std::unordered_map< ::std::string, ::std::shared_ptr< ::std::vector< uint8_t > > > bar_baz() override {
         auto _call_result = mFunctions.smoke_OuterStruct_InnerInterface_barBaz(mFunctions.swift_pointer);
-        return Conversion<std::unordered_map<std::string, ::std::shared_ptr< ::std::vector< uint8_t > >>>::toCppReturn(_call_result);
+        return Conversion<::std::unordered_map<::std::string, ::std::shared_ptr< ::std::vector< uint8_t > >>>::toCppReturn(_call_result);
     }
 private:
     smoke_OuterStruct_InnerInterface_FunctionTable mFunctions;
 };
 _baseRef smoke_OuterStruct_InnerInterface_create_proxy(smoke_OuterStruct_InnerInterface_FunctionTable functionTable) {
-    auto proxy = smoke_OuterStruct_InnerInterfaceProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::OuterStruct::InnerInterface>(proxy)) : 0;
+    auto proxy = smoke_OuterStruct_InnerInterfaceProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::OuterStruct::InnerInterface>(proxy)) : 0;
 }
 const void* smoke_OuterStruct_InnerInterface_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_OuterStruct_InnerInterfaceProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get()) : nullptr;
+    return handle ? smoke_OuterStruct_InnerInterfaceProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::OuterStruct::InnerInterface>>(handle)->get()) : nullptr;
 }
 void smoke_OuterStruct_doNothing(_baseRef _instance) {
     return get_pointer<::smoke::OuterStruct>(_instance)->do_nothing();

--- a/gluecodium/src/test/resources/smoke/nullable/output/cbridge/src/smoke/cbridge_NullableCollectionsStruct.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/cbridge/src/smoke/cbridge_NullableCollectionsStruct.cpp
@@ -11,9 +11,9 @@
 _baseRef
 smoke_NullableCollectionsStruct_create_handle( _baseRef dates, _baseRef structs )
 {
-    ::smoke::NullableCollectionsStruct* _struct = new ( std::nothrow ) ::smoke::NullableCollectionsStruct();
-    _struct->dates = Conversion<std::vector<::gluecodium::optional< ::std::chrono::system_clock::time_point >>>::toCpp( dates );
-    _struct->structs = Conversion<std::unordered_map<int32_t, ::gluecodium::optional< ::smoke::Nullable::SomeStruct >>>::toCpp( structs );
+    ::smoke::NullableCollectionsStruct* _struct = new ( ::std::nothrow ) ::smoke::NullableCollectionsStruct();
+    _struct->dates = Conversion<::std::vector<::gluecodium::optional< ::std::chrono::system_clock::time_point >>>::toCpp( dates );
+    _struct->structs = Conversion<::std::unordered_map<int32_t, ::gluecodium::optional< ::smoke::Nullable::SomeStruct >>>::toCpp( structs );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -24,9 +24,9 @@ smoke_NullableCollectionsStruct_release_handle( _baseRef handle )
 _baseRef
 smoke_NullableCollectionsStruct_create_optional_handle(_baseRef dates, _baseRef structs)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::NullableCollectionsStruct>( ::smoke::NullableCollectionsStruct( ) );
-    (*_struct)->dates = Conversion<std::vector<::gluecodium::optional< ::std::chrono::system_clock::time_point >>>::toCpp( dates );
-    (*_struct)->structs = Conversion<std::unordered_map<int32_t, ::gluecodium::optional< ::smoke::Nullable::SomeStruct >>>::toCpp( structs );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::NullableCollectionsStruct>( ::smoke::NullableCollectionsStruct( ) );
+    (*_struct)->dates = Conversion<::std::vector<::gluecodium::optional< ::std::chrono::system_clock::time_point >>>::toCpp( dates );
+    (*_struct)->structs = Conversion<::std::unordered_map<int32_t, ::gluecodium::optional< ::smoke::Nullable::SomeStruct >>>::toCpp( structs );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -39,9 +39,9 @@ void smoke_NullableCollectionsStruct_release_optional_handle(_baseRef handle) {
 }
 _baseRef smoke_NullableCollectionsStruct_dates_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::NullableCollectionsStruct>(handle);
-    return Conversion<std::vector<::gluecodium::optional< ::std::chrono::system_clock::time_point >>>::toBaseRef(struct_pointer->dates);
+    return Conversion<::std::vector<::gluecodium::optional< ::std::chrono::system_clock::time_point >>>::toBaseRef(struct_pointer->dates);
 }
 _baseRef smoke_NullableCollectionsStruct_structs_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::NullableCollectionsStruct>(handle);
-    return Conversion<std::unordered_map<int32_t, ::gluecodium::optional< ::smoke::Nullable::SomeStruct >>>::toBaseRef(struct_pointer->structs);
+    return Conversion<::std::unordered_map<int32_t, ::gluecodium::optional< ::smoke::Nullable::SomeStruct >>>::toBaseRef(struct_pointer->structs);
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipProxy.cpp
@@ -12,25 +12,25 @@
 #include <new>
 #include <string>
 void smoke_SkipProxy_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(handle);
 }
 _baseRef smoke_SkipProxy_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(handle)))
         : 0;
 }
 const void* smoke_SkipProxy_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(handle)->get())
         : nullptr;
 }
 void smoke_SkipProxy_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(handle)->get(), swift_pointer);
 }
 void smoke_SkipProxy_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(handle)->get());
 }
 extern "C" {
 extern void* _CBridgeInitsmoke_SkipProxy(_baseRef handle);
@@ -43,32 +43,32 @@ struct smoke_SkipProxyRegisterInit {
 } s_smoke_SkipProxy_register_init;
 }
 void* smoke_SkipProxy_get_typed(_baseRef handle) {
-    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<std::shared_ptr<::smoke::SkipProxy>::element_type*>(nullptr)).get_id(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle)->get());
+    const auto& real_type_id = ::gluecodium::get_type_repository(static_cast<::std::shared_ptr<::smoke::SkipProxy>::element_type*>(nullptr)).get_id(get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_SkipProxy(handle);
 }
 _baseRef smoke_SkipProxy_notInJava(_baseRef _instance, _baseRef input) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->not_in_java(Conversion<std::string>::toCpp(input)));
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->not_in_java(Conversion<::std::string>::toCpp(input)));
 }
 float smoke_SkipProxy_notInDart(_baseRef _instance, float input) {
-    return get_pointer<std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->not_in_dart(input);
+    return get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->not_in_dart(input);
 }
 _baseRef smoke_SkipProxy_skippedInJava_get(_baseRef _instance) {
-    return Conversion<std::string>::toBaseRef(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->get_skipped_in_java());
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->get_skipped_in_java());
 }
 void smoke_SkipProxy_skippedInJava_set(_baseRef _instance, _baseRef newValue) {
-    return get_pointer<std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->set_skipped_in_java(Conversion<std::string>::toCpp(newValue));
+    return get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->set_skipped_in_java(Conversion<::std::string>::toCpp(newValue));
 }
 float smoke_SkipProxy_skippedInDart_get(_baseRef _instance) {
-    return get_pointer<std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->get_skipped_in_dart();
+    return get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->get_skipped_in_dart();
 }
 void smoke_SkipProxy_skippedInDart_set(_baseRef _instance, float newValue) {
-    return get_pointer<std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->set_skipped_in_dart(newValue);
+    return get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(_instance)->get()->set_skipped_in_dart(newValue);
 }
-class smoke_SkipProxyProxy : public std::shared_ptr<::smoke::SkipProxy>::element_type, public CachedProxyBase<smoke_SkipProxyProxy> {
+class smoke_SkipProxyProxy : public ::std::shared_ptr<::smoke::SkipProxy>::element_type, public CachedProxyBase<smoke_SkipProxyProxy> {
 public:
     smoke_SkipProxyProxy(smoke_SkipProxy_FunctionTable&& functions)
-     : mFunctions(std::move(functions))
+     : mFunctions(::std::move(functions))
     {
     }
     virtual ~smoke_SkipProxyProxy() {
@@ -76,9 +76,9 @@ public:
     }
     smoke_SkipProxyProxy(const smoke_SkipProxyProxy&) = delete;
     smoke_SkipProxyProxy& operator=(const smoke_SkipProxyProxy&) = delete;
-    ::std::string not_in_java(const std::string& input) override {
-        auto _call_result = mFunctions.smoke_SkipProxy_notInJava(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(input));
-        return Conversion<std::string>::toCppReturn(_call_result);
+    ::std::string not_in_java(const ::std::string& input) override {
+        auto _call_result = mFunctions.smoke_SkipProxy_notInJava(mFunctions.swift_pointer, Conversion<::std::string>::toBaseRef(input));
+        return Conversion<::std::string>::toCppReturn(_call_result);
     }
     bool not_in_swift(bool input) override {
         return {};
@@ -89,10 +89,10 @@ public:
     }
     ::std::string get_skipped_in_java() const override {
         auto _call_result = mFunctions.smoke_SkipProxy_skippedInJava_get(mFunctions.swift_pointer);
-        return Conversion<std::string>::toCppReturn(_call_result);
+        return Conversion<::std::string>::toCppReturn(_call_result);
     }
-    void set_skipped_in_java(const std::string& newValue) override {
-        mFunctions.smoke_SkipProxy_skippedInJava_set(mFunctions.swift_pointer, Conversion<std::string>::toBaseRef(newValue));
+    void set_skipped_in_java(const ::std::string& newValue) override {
+        mFunctions.smoke_SkipProxy_skippedInJava_set(mFunctions.swift_pointer, Conversion<::std::string>::toBaseRef(newValue));
     }
     bool is_skipped_in_swift() const override {
         return {};
@@ -115,9 +115,9 @@ private:
     smoke_SkipProxy_FunctionTable mFunctions;
 };
 _baseRef smoke_SkipProxy_create_proxy(smoke_SkipProxy_FunctionTable functionTable) {
-    auto proxy = smoke_SkipProxyProxy::get_proxy(std::move(functionTable));
-    return proxy ? reinterpret_cast<_baseRef>(new std::shared_ptr<::smoke::SkipProxy>(proxy)) : 0;
+    auto proxy = smoke_SkipProxyProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr<::smoke::SkipProxy>(proxy)) : 0;
 }
 const void* smoke_SkipProxy_get_swift_object_from_cache(_baseRef handle) {
-    return handle ? smoke_SkipProxyProxy::get_swift_object(get_pointer<std::shared_ptr<::smoke::SkipProxy>>(handle)->get()) : nullptr;
+    return handle ? smoke_SkipProxyProxy::get_swift_object(get_pointer<::std::shared_ptr<::smoke::SkipProxy>>(handle)->get()) : nullptr;
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_Structs.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_Structs.cpp
@@ -13,30 +13,30 @@
 #include <string>
 #include <vector>
 void smoke_Structs_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::Structs>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::Structs>>(handle);
 }
 _baseRef smoke_Structs_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::Structs>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::Structs>>(handle)))
         : 0;
 }
 const void* smoke_Structs_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Structs>>(handle)->get())
         : nullptr;
 }
 void smoke_Structs_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::Structs>>(handle)->get(), swift_pointer);
 }
 void smoke_Structs_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::Structs>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::Structs>>(handle)->get());
 }
 _baseRef
 smoke_Structs_Point_create_handle( double x, double y )
 {
-    ::smoke::Structs::Point* _struct = new ( std::nothrow ) ::smoke::Structs::Point();
+    ::smoke::Structs::Point* _struct = new ( ::std::nothrow ) ::smoke::Structs::Point();
     _struct->x = x;
     _struct->y = y;
     return reinterpret_cast<_baseRef>( _struct );
@@ -49,7 +49,7 @@ smoke_Structs_Point_release_handle( _baseRef handle )
 _baseRef
 smoke_Structs_Point_create_optional_handle(double x, double y)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Structs::Point>( ::smoke::Structs::Point( ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::Structs::Point>( ::smoke::Structs::Point( ) );
     (*_struct)->x = x;
     (*_struct)->y = y;
     return reinterpret_cast<_baseRef>( _struct );
@@ -73,7 +73,7 @@ double smoke_Structs_Point_y_get(_baseRef handle) {
 _baseRef
 smoke_Structs_Line_create_handle( _baseRef a, _baseRef b )
 {
-    ::smoke::Structs::Line* _struct = new ( std::nothrow ) ::smoke::Structs::Line();
+    ::smoke::Structs::Line* _struct = new ( ::std::nothrow ) ::smoke::Structs::Line();
     _struct->a = Conversion<::smoke::Structs::Point>::toCpp( a );
     _struct->b = Conversion<::smoke::Structs::Point>::toCpp( b );
     return reinterpret_cast<_baseRef>( _struct );
@@ -86,7 +86,7 @@ smoke_Structs_Line_release_handle( _baseRef handle )
 _baseRef
 smoke_Structs_Line_create_optional_handle(_baseRef a, _baseRef b)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Structs::Line>( ::smoke::Structs::Line( ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::Structs::Line>( ::smoke::Structs::Line( ) );
     (*_struct)->a = Conversion<::smoke::Structs::Point>::toCpp( a );
     (*_struct)->b = Conversion<::smoke::Structs::Point>::toCpp( b );
     return reinterpret_cast<_baseRef>( _struct );
@@ -120,11 +120,11 @@ smoke_Structs_AllTypesStruct_create_handle( int8_t int8Field, uint8_t uint8Field
     auto _uint64Field = uint64Field;
     auto _floatField = floatField;
     auto _doubleField = doubleField;
-    auto _stringField = Conversion<std::string>::toCpp( stringField );
+    auto _stringField = Conversion<::std::string>::toCpp( stringField );
     auto _booleanField = booleanField;
     auto _bytesField = Conversion<::std::shared_ptr< ::std::vector< uint8_t > >>::toCpp( bytesField );
     auto _pointField = Conversion<::smoke::Structs::Point>::toCpp( pointField );
-    ::smoke::Structs::AllTypesStruct* _struct = new ( std::nothrow ) ::smoke::Structs::AllTypesStruct( _int8Field, _uint8Field, _int16Field, _uint16Field, _int32Field, _uint32Field, _int64Field, _uint64Field, _floatField, _doubleField, _stringField, _booleanField, _bytesField, _pointField );
+    ::smoke::Structs::AllTypesStruct* _struct = new ( ::std::nothrow ) ::smoke::Structs::AllTypesStruct( _int8Field, _uint8Field, _int16Field, _uint16Field, _int32Field, _uint32Field, _int64Field, _uint64Field, _floatField, _doubleField, _stringField, _booleanField, _bytesField, _pointField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -145,11 +145,11 @@ smoke_Structs_AllTypesStruct_create_optional_handle(int8_t int8Field, uint8_t ui
     auto _uint64Field = uint64Field;
     auto _floatField = floatField;
     auto _doubleField = doubleField;
-    auto _stringField = Conversion<std::string>::toCpp( stringField );
+    auto _stringField = Conversion<::std::string>::toCpp( stringField );
     auto _booleanField = booleanField;
     auto _bytesField = Conversion<::std::shared_ptr< ::std::vector< uint8_t > >>::toCpp( bytesField );
     auto _pointField = Conversion<::smoke::Structs::Point>::toCpp( pointField );
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Structs::AllTypesStruct>( ::smoke::Structs::AllTypesStruct( _int8Field, _uint8Field, _int16Field, _uint16Field, _int32Field, _uint32Field, _int64Field, _uint64Field, _floatField, _doubleField, _stringField, _booleanField, _bytesField, _pointField ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::Structs::AllTypesStruct>( ::smoke::Structs::AllTypesStruct( _int8Field, _uint8Field, _int16Field, _uint16Field, _int32Field, _uint32Field, _int64Field, _uint64Field, _floatField, _doubleField, _stringField, _booleanField, _bytesField, _pointField ) );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -202,7 +202,7 @@ double smoke_Structs_AllTypesStruct_doubleField_get(_baseRef handle) {
 }
 _baseRef smoke_Structs_AllTypesStruct_stringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->string_field);
+    return Conversion<::std::string>::toBaseRef(struct_pointer->string_field);
 }
 bool smoke_Structs_AllTypesStruct_booleanField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::AllTypesStruct>(handle);
@@ -220,7 +220,7 @@ _baseRef
 smoke_Structs_NestingImmutableStruct_create_handle( _baseRef structField )
 {
     auto _structField = Conversion<::smoke::Structs::AllTypesStruct>::toCpp( structField );
-    ::smoke::Structs::NestingImmutableStruct* _struct = new ( std::nothrow ) ::smoke::Structs::NestingImmutableStruct( _structField );
+    ::smoke::Structs::NestingImmutableStruct* _struct = new ( ::std::nothrow ) ::smoke::Structs::NestingImmutableStruct( _structField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -232,7 +232,7 @@ _baseRef
 smoke_Structs_NestingImmutableStruct_create_optional_handle(_baseRef structField)
 {
     auto _structField = Conversion<::smoke::Structs::AllTypesStruct>::toCpp( structField );
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Structs::NestingImmutableStruct>( ::smoke::Structs::NestingImmutableStruct( _structField ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::Structs::NestingImmutableStruct>( ::smoke::Structs::NestingImmutableStruct( _structField ) );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -251,7 +251,7 @@ _baseRef
 smoke_Structs_DoubleNestingImmutableStruct_create_handle( _baseRef nestingStructField )
 {
     auto _nestingStructField = Conversion<::smoke::Structs::NestingImmutableStruct>::toCpp( nestingStructField );
-    ::smoke::Structs::DoubleNestingImmutableStruct* _struct = new ( std::nothrow ) ::smoke::Structs::DoubleNestingImmutableStruct( _nestingStructField );
+    ::smoke::Structs::DoubleNestingImmutableStruct* _struct = new ( ::std::nothrow ) ::smoke::Structs::DoubleNestingImmutableStruct( _nestingStructField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -263,7 +263,7 @@ _baseRef
 smoke_Structs_DoubleNestingImmutableStruct_create_optional_handle(_baseRef nestingStructField)
 {
     auto _nestingStructField = Conversion<::smoke::Structs::NestingImmutableStruct>::toCpp( nestingStructField );
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Structs::DoubleNestingImmutableStruct>( ::smoke::Structs::DoubleNestingImmutableStruct( _nestingStructField ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::Structs::DoubleNestingImmutableStruct>( ::smoke::Structs::DoubleNestingImmutableStruct( _nestingStructField ) );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -281,8 +281,8 @@ _baseRef smoke_Structs_DoubleNestingImmutableStruct_nestingStructField_get(_base
 _baseRef
 smoke_Structs_StructWithArrayOfImmutable_create_handle( _baseRef arrayField )
 {
-    auto _arrayField = Conversion<std::vector<::smoke::Structs::AllTypesStruct>>::toCpp( arrayField );
-    ::smoke::Structs::StructWithArrayOfImmutable* _struct = new ( std::nothrow ) ::smoke::Structs::StructWithArrayOfImmutable( _arrayField );
+    auto _arrayField = Conversion<::std::vector<::smoke::Structs::AllTypesStruct>>::toCpp( arrayField );
+    ::smoke::Structs::StructWithArrayOfImmutable* _struct = new ( ::std::nothrow ) ::smoke::Structs::StructWithArrayOfImmutable( _arrayField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -293,8 +293,8 @@ smoke_Structs_StructWithArrayOfImmutable_release_handle( _baseRef handle )
 _baseRef
 smoke_Structs_StructWithArrayOfImmutable_create_optional_handle(_baseRef arrayField)
 {
-    auto _arrayField = Conversion<std::vector<::smoke::Structs::AllTypesStruct>>::toCpp( arrayField );
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Structs::StructWithArrayOfImmutable>( ::smoke::Structs::StructWithArrayOfImmutable( _arrayField ) );
+    auto _arrayField = Conversion<::std::vector<::smoke::Structs::AllTypesStruct>>::toCpp( arrayField );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::Structs::StructWithArrayOfImmutable>( ::smoke::Structs::StructWithArrayOfImmutable( _arrayField ) );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -307,13 +307,13 @@ void smoke_Structs_StructWithArrayOfImmutable_release_optional_handle(_baseRef h
 }
 _baseRef smoke_Structs_StructWithArrayOfImmutable_arrayField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::StructWithArrayOfImmutable>(handle);
-    return Conversion<std::vector<::smoke::Structs::AllTypesStruct>>::toBaseRef(struct_pointer->array_field);
+    return Conversion<::std::vector<::smoke::Structs::AllTypesStruct>>::toBaseRef(struct_pointer->array_field);
 }
 _baseRef
 smoke_Structs_ImmutableStructWithCppAccessors_create_handle( _baseRef stringField )
 {
-    auto _stringField = Conversion<std::string>::toCpp( stringField );
-    ::smoke::Structs::ImmutableStructWithCppAccessors* _struct = new ( std::nothrow ) ::smoke::Structs::ImmutableStructWithCppAccessors( _stringField );
+    auto _stringField = Conversion<::std::string>::toCpp( stringField );
+    ::smoke::Structs::ImmutableStructWithCppAccessors* _struct = new ( ::std::nothrow ) ::smoke::Structs::ImmutableStructWithCppAccessors( _stringField );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -324,8 +324,8 @@ smoke_Structs_ImmutableStructWithCppAccessors_release_handle( _baseRef handle )
 _baseRef
 smoke_Structs_ImmutableStructWithCppAccessors_create_optional_handle(_baseRef stringField)
 {
-    auto _stringField = Conversion<std::string>::toCpp( stringField );
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Structs::ImmutableStructWithCppAccessors>( ::smoke::Structs::ImmutableStructWithCppAccessors( _stringField ) );
+    auto _stringField = Conversion<::std::string>::toCpp( stringField );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::Structs::ImmutableStructWithCppAccessors>( ::smoke::Structs::ImmutableStructWithCppAccessors( _stringField ) );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -338,13 +338,13 @@ void smoke_Structs_ImmutableStructWithCppAccessors_release_optional_handle(_base
 }
 _baseRef smoke_Structs_ImmutableStructWithCppAccessors_stringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::ImmutableStructWithCppAccessors>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->get_string_field());
+    return Conversion<::std::string>::toBaseRef(struct_pointer->get_string_field());
 }
 _baseRef
 smoke_Structs_MutableStructWithCppAccessors_create_handle( _baseRef stringField )
 {
-    ::smoke::Structs::MutableStructWithCppAccessors* _struct = new ( std::nothrow ) ::smoke::Structs::MutableStructWithCppAccessors();
-    _struct->set_string_field( Conversion<std::string>::toCpp( stringField ) );
+    ::smoke::Structs::MutableStructWithCppAccessors* _struct = new ( ::std::nothrow ) ::smoke::Structs::MutableStructWithCppAccessors();
+    _struct->set_string_field( Conversion<::std::string>::toCpp( stringField ) );
     return reinterpret_cast<_baseRef>( _struct );
 }
 void
@@ -355,8 +355,8 @@ smoke_Structs_MutableStructWithCppAccessors_release_handle( _baseRef handle )
 _baseRef
 smoke_Structs_MutableStructWithCppAccessors_create_optional_handle(_baseRef stringField)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Structs::MutableStructWithCppAccessors>( ::smoke::Structs::MutableStructWithCppAccessors( ) );
-    (*_struct)->set_string_field( Conversion<std::string>::toCpp( stringField ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::Structs::MutableStructWithCppAccessors>( ::smoke::Structs::MutableStructWithCppAccessors( ) );
+    (*_struct)->set_string_field( Conversion<::std::string>::toCpp( stringField ) );
     return reinterpret_cast<_baseRef>( _struct );
 }
 _baseRef
@@ -369,7 +369,7 @@ void smoke_Structs_MutableStructWithCppAccessors_release_optional_handle(_baseRe
 }
 _baseRef smoke_Structs_MutableStructWithCppAccessors_stringField_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const ::smoke::Structs::MutableStructWithCppAccessors>(handle);
-    return Conversion<std::string>::toBaseRef(struct_pointer->get_string_field());
+    return Conversion<::std::string>::toBaseRef(struct_pointer->get_string_field());
 }
 _baseRef smoke_Structs_swapPointCoordinates(_baseRef input) {
     return Conversion<::smoke::Structs::Point>::toBaseRef(::smoke::Structs::swap_point_coordinates(Conversion<::smoke::Structs::Point>::toCpp(input)));

--- a/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethods.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethods.cpp
@@ -10,7 +10,7 @@
 _baseRef
 smoke_StructsWithMethods_Vector_create_handle( double x, double y )
 {
-    ::smoke::Vector* _struct = new ( std::nothrow ) ::smoke::Vector();
+    ::smoke::Vector* _struct = new ( ::std::nothrow ) ::smoke::Vector();
     _struct->x = x;
     _struct->y = y;
     return reinterpret_cast<_baseRef>( _struct );
@@ -23,7 +23,7 @@ smoke_StructsWithMethods_Vector_release_handle( _baseRef handle )
 _baseRef
 smoke_StructsWithMethods_Vector_create_optional_handle(double x, double y)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::Vector>( ::smoke::Vector( ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::Vector>( ::smoke::Vector( ) );
     (*_struct)->x = x;
     (*_struct)->y = y;
     return reinterpret_cast<_baseRef>( _struct );

--- a/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethodsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethodsInterface.cpp
@@ -12,30 +12,30 @@
 #include <new>
 #include <string>
 void smoke_StructsWithMethodsInterface_release_handle(_baseRef handle) {
-    delete get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle);
+    delete get_pointer<::std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle);
 }
 _baseRef smoke_StructsWithMethodsInterface_copy_handle(_baseRef handle) {
     return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)))
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)))
         : 0;
 }
 const void* smoke_StructsWithMethodsInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get())
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get())
         : nullptr;
 }
 void smoke_StructsWithMethodsInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get(), swift_pointer);
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get(), swift_pointer);
 }
 void smoke_StructsWithMethodsInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get());
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr<::smoke::StructsWithMethodsInterface>>(handle)->get());
 }
 _baseRef
 smoke_StructsWithMethodsInterface_Vector3_create_handle( double x, double y, double z )
 {
-    ::smoke::StructsWithMethodsInterface::Vector3* _struct = new ( std::nothrow ) ::smoke::StructsWithMethodsInterface::Vector3();
+    ::smoke::StructsWithMethodsInterface::Vector3* _struct = new ( ::std::nothrow ) ::smoke::StructsWithMethodsInterface::Vector3();
     _struct->x = x;
     _struct->y = y;
     _struct->z = z;
@@ -49,7 +49,7 @@ smoke_StructsWithMethodsInterface_Vector3_release_handle( _baseRef handle )
 _baseRef
 smoke_StructsWithMethodsInterface_Vector3_create_optional_handle(double x, double y, double z)
 {
-    auto _struct = new ( std::nothrow ) ::gluecodium::optional<::smoke::StructsWithMethodsInterface::Vector3>( ::smoke::StructsWithMethodsInterface::Vector3( ) );
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::StructsWithMethodsInterface::Vector3>( ::smoke::StructsWithMethodsInterface::Vector3( ) );
     (*_struct)->x = x;
     (*_struct)->y = y;
     (*_struct)->z = z;
@@ -85,7 +85,7 @@ bool smoke_StructsWithMethodsInterface_Vector3_validate(double x, double y, doub
     return ::smoke::StructsWithMethodsInterface::Vector3::validate(x, y, z);
 }
 _baseRef smoke_StructsWithMethodsInterface_Vector3_create_String(_baseRef input) {
-    return Conversion<::smoke::StructsWithMethodsInterface::Vector3>::toBaseRef(::smoke::StructsWithMethodsInterface::Vector3::create(Conversion<std::string>::toCpp(input)));
+    return Conversion<::smoke::StructsWithMethodsInterface::Vector3>::toBaseRef(::smoke::StructsWithMethodsInterface::Vector3::create(Conversion<::std::string>::toCpp(input)));
 }
 smoke_StructsWithMethodsInterface_Vector3_create_Vector3_result smoke_StructsWithMethodsInterface_Vector3_create_Vector3(_baseRef other) {
     auto&& RESULT = ::smoke::StructsWithMethodsInterface::Vector3::create(Conversion<::smoke::StructsWithMethodsInterface::Vector3>::toCpp(other));


### PR DESCRIPTION
Updated CBridge model and templates to consistently prefix "std" namespace with "::", similar to what C++ generator
does. Previously the usage was inconsistent throughout the CBridge templates. The new usage makes it also consistent
with C++ generator, enabling partial reuse of C++ generator infrastructure in the CBridge generator later.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>