### PR TITLE
Add CBridge enum header files to smoke tests

### DIFF
--- a/gluecodium/src/test/resources/smoke/enums/output/cbridge/include/smoke/cbridge_EnumsInTypeCollectionInterface.h
+++ b/gluecodium/src/test/resources/smoke/enums/output/cbridge/include/smoke/cbridge_EnumsInTypeCollectionInterface.h
@@ -1,0 +1,18 @@
+//
+//
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "cbridge/include/BaseHandle.h"
+#include "cbridge/include/Export.h"
+#include "cbridge/include/smoke/cbridge_EnumsInTypeCollection.h"
+_GLUECODIUM_C_EXPORT void smoke_EnumsInTypeCollectionInterface_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_EnumsInTypeCollectionInterface_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_EnumsInTypeCollectionInterface_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_EnumsInTypeCollectionInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
+_GLUECODIUM_C_EXPORT void smoke_EnumsInTypeCollectionInterface_remove_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT smoke_EnumsInTypeCollection_TCEnum smoke_EnumsInTypeCollectionInterface_flipEnumValue(smoke_EnumsInTypeCollection_TCEnum input);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/errors/input/Errors.lime
+++ b/gluecodium/src/test/resources/smoke/errors/input/Errors.lime
@@ -75,3 +75,7 @@ types SomeTypeCollection {
     }
     exception Some(SomeTypeCollectionError)
 }
+
+class UseTcException {
+    fun doNothing() throws SomeTypeCollection.Some
+}

--- a/gluecodium/src/test/resources/smoke/errors/output/cbridge/include/smoke/cbridge_UseTcException.h
+++ b/gluecodium/src/test/resources/smoke/errors/output/cbridge/include/smoke/cbridge_UseTcException.h
@@ -1,0 +1,23 @@
+//
+//
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "cbridge/include/BaseHandle.h"
+#include "cbridge/include/Export.h"
+#include "cbridge/include/smoke/cbridge_SomeTypeCollection.h"
+#include <stdbool.h>
+typedef struct {
+    bool has_value;
+    smoke_SomeTypeCollection_SomeTypeCollectionError error_value;
+} smoke_UseTcException_doNothing_result;
+_GLUECODIUM_C_EXPORT void smoke_UseTcException_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_UseTcException_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_UseTcException_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_UseTcException_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
+_GLUECODIUM_C_EXPORT void smoke_UseTcException_remove_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT smoke_UseTcException_doNothing_result smoke_UseTcException_doNothing(_baseRef _instance);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/external_types/output/cbridge/include/smoke/cbridge_Enums.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cbridge/include/smoke/cbridge_Enums.h
@@ -1,0 +1,20 @@
+//
+//
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "cbridge/include/BaseHandle.h"
+#include "cbridge/include/Export.h"
+#include <stdint.h>
+typedef uint32_t smoke_Enums_ExternalEnum;
+typedef uint32_t smoke_Enums_VeryExternalEnum;
+_GLUECODIUM_C_EXPORT void smoke_Enums_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_Enums_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_Enums_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_Enums_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
+_GLUECODIUM_C_EXPORT void smoke_Enums_remove_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_Enums_methodWithExternalEnum(smoke_Enums_ExternalEnum input);
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Updated smoke tests to include CBridge header reference files for enums an their usages. These files ensure that:
* enum typedef is named correctly
* enum typedef include is added at the point of usage

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>