### PR TITLE
Fix stack overflow in getAllFieldTypes()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unresolved
+### Bug fixes:
+  * Fixed crash caused by "recursive" IDL struct declarations.
+
 ## 8.6.0
 Release date: 2020-11-04
 ### Features:

--- a/gluecodium/src/test/resources/smoke/structs/input/RecursiveStructs.lime
+++ b/gluecodium/src/test/resources/smoke/structs/input/RecursiveStructs.lime
@@ -1,0 +1,39 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct StructWithList {
+    field: List<StructWithList>
+}
+
+@Equatable
+struct StructWithSet {
+    field: Set<StructWithSet>
+}
+
+struct StructWithMap {
+    field: Map<String, StructWithMap>
+}
+
+struct StructA {
+    field: List<StructB>
+}
+
+struct StructB {
+    field: List<StructA>
+}


### PR DESCRIPTION
Updated LimeTypeHelper.getAllFieldTypes() recursive function to track already visited types to prevent
StackOverflowException for structs with "recursive" declaration.

Added "recursive" use cases to "structs" smoke test.

Resolves: #600
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>