### PR TITLE
Add workaround for Dart-C++-Dart object round trip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,3 +113,19 @@ jobs:
         - pushd functional-tests
         - ./scripts/build-swift --valgrind --publish
         - popd
+
+    - stage: test
+      name: "Dart functional tests"
+      language: cpp
+      addons:
+        apt:
+          packages:
+            - ninja-build
+      before_install:
+        - export PATH="${PATH}:/usr/lib/dart/bin"
+      install:
+        - wget -nv https://storage.googleapis.com/dart-archive/channels/stable/release/2.9.0/linux_packages/dart_2.9.0-1_amd64.deb
+        - sudo apt -y install ./dart_2.9.0-1_amd64.deb
+      script:
+        - cd examples
+        - ./scripts/build-dart --buildGluecodium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed flaky crash for callbacks being sent from Dart to C++ and then back.
+
 ## 8.6.1
 Release date: 2020-11-18
 ### Bug fixes:

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -136,8 +136,8 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) =>
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
   final raw_handle = _{{resolveName "Ffi"}}_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as {{resolveName}};
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is {{resolveName}}) return instance as {{resolveName}};
 
 {{#if parent visibility.isOpen logic="or"}}
   final _type_id_handle = _{{resolveName "Ffi"}}_get_type_id(handle);

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -278,8 +278,8 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
   final raw_handle = _{{resolveName "Ffi"}}_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as {{resolveName}};
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is {{resolveName}}) return instance as {{resolveName}};
 
   final _type_id_handle = _{{resolveName "Ffi"}}_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -84,14 +84,11 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
     __lib.uncacheObjectFfi,{{#set parent=this}}{{#asFunction}}
     Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}_{{resolveName}}_static, __lib.unknownError){{/asFunction}}{{/set}}
   );
-  __lib.reverseCache[_{{resolveName "Ffi"}}_get_raw_pointer(result)] = value;
 
   return result;
 }
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_{{resolveName "Ffi"}}_get_raw_pointer(handle)] as {{resolveName}};
-  if (instance != null) return instance;
   final _impl = {{resolveName}}$Impl(_{{resolveName "Ffi"}}_copy_handle(handle));
   return ({{#asFunction}}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{/asFunction}}){{!!
   }} {

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -88,8 +88,8 @@ Pointer<Void> smoke_AttributesClass_toFfi(AttributesClass value) =>
   _smoke_AttributesClass_copy_handle((value as AttributesClass$Impl).handle);
 AttributesClass smoke_AttributesClass_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_AttributesClass_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as AttributesClass;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is AttributesClass) return instance as AttributesClass;
   final _copied_handle = _smoke_AttributesClass_copy_handle(handle);
   final result = AttributesClass$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -160,8 +160,8 @@ Pointer<Void> smoke_AttributesInterface_toFfi(AttributesInterface value) {
 }
 AttributesInterface smoke_AttributesInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_AttributesInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as AttributesInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is AttributesInterface) return instance as AttributesInterface;
   final _type_id_handle = _smoke_AttributesInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
@@ -53,12 +53,9 @@ Pointer<Void> smoke_AttributesLambda_toFfi(AttributesLambda value) {
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64)>(_AttributesLambda_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_AttributesLambda_get_raw_pointer(result)] = value;
   return result;
 }
 AttributesLambda smoke_AttributesLambda_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_AttributesLambda_get_raw_pointer(handle)] as AttributesLambda;
-  if (instance != null) return instance;
   final _impl = AttributesLambda$Impl(_smoke_AttributesLambda_copy_handle(handle));
   return () {
     final _result =_impl.call();

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -157,8 +157,8 @@ Pointer<Void> smoke_AttributesWithComments_toFfi(AttributesWithComments value) =
   _smoke_AttributesWithComments_copy_handle((value as AttributesWithComments$Impl).handle);
 AttributesWithComments smoke_AttributesWithComments_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_AttributesWithComments_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as AttributesWithComments;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is AttributesWithComments) return instance as AttributesWithComments;
   final _copied_handle = _smoke_AttributesWithComments_copy_handle(handle);
   final result = AttributesWithComments$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -157,8 +157,8 @@ Pointer<Void> smoke_AttributesWithDeprecated_toFfi(AttributesWithDeprecated valu
   _smoke_AttributesWithDeprecated_copy_handle((value as AttributesWithDeprecated$Impl).handle);
 AttributesWithDeprecated smoke_AttributesWithDeprecated_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_AttributesWithDeprecated_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as AttributesWithDeprecated;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is AttributesWithDeprecated) return instance as AttributesWithDeprecated;
   final _copied_handle = _smoke_AttributesWithDeprecated_copy_handle(handle);
   final result = AttributesWithDeprecated$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -115,8 +115,8 @@ Pointer<Void> smoke_MultipleAttributesDart_toFfi(MultipleAttributesDart value) =
   _smoke_MultipleAttributesDart_copy_handle((value as MultipleAttributesDart$Impl).handle);
 MultipleAttributesDart smoke_MultipleAttributesDart_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_MultipleAttributesDart_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as MultipleAttributesDart;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is MultipleAttributesDart) return instance as MultipleAttributesDart;
   final _copied_handle = _smoke_MultipleAttributesDart_copy_handle(handle);
   final result = MultipleAttributesDart$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -66,8 +66,8 @@ Pointer<Void> smoke_SpecialAttributes_toFfi(SpecialAttributes value) =>
   _smoke_SpecialAttributes_copy_handle((value as SpecialAttributes$Impl).handle);
 SpecialAttributes smoke_SpecialAttributes_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_SpecialAttributes_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as SpecialAttributes;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is SpecialAttributes) return instance as SpecialAttributes;
   final _copied_handle = _smoke_SpecialAttributes_copy_handle(handle);
   final result = SpecialAttributes$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -184,8 +184,8 @@ Pointer<Void> smoke_BasicTypes_toFfi(BasicTypes value) =>
   _smoke_BasicTypes_copy_handle((value as BasicTypes$Impl).handle);
 BasicTypes smoke_BasicTypes_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_BasicTypes_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as BasicTypes;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is BasicTypes) return instance as BasicTypes;
   final _copied_handle = _smoke_BasicTypes_copy_handle(handle);
   final result = BasicTypes$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -254,12 +254,9 @@ Pointer<Void> smoke_Comments_SomeLambda_toFfi(Comments_SomeLambda value) {
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Int32, Pointer<Double>)>(_Comments_SomeLambda_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_Comments_SomeLambda_get_raw_pointer(result)] = value;
   return result;
 }
 Comments_SomeLambda smoke_Comments_SomeLambda_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_Comments_SomeLambda_get_raw_pointer(handle)] as Comments_SomeLambda;
-  if (instance != null) return instance;
   final _impl = Comments_SomeLambda$Impl(_smoke_Comments_SomeLambda_copy_handle(handle));
   return (String p0, int p1) {
     final _result =_impl.call(p0, p1);
@@ -529,8 +526,8 @@ Pointer<Void> smoke_Comments_toFfi(Comments value) =>
   _smoke_Comments_copy_handle((value as Comments$Impl).handle);
 Comments smoke_Comments_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_Comments_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Comments;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Comments) return instance as Comments;
   final _copied_handle = _smoke_Comments_copy_handle(handle);
   final result = Comments$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -581,8 +581,8 @@ Pointer<Void> smoke_CommentsInterface_toFfi(CommentsInterface value) {
 }
 CommentsInterface smoke_CommentsInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_CommentsInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as CommentsInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is CommentsInterface) return instance as CommentsInterface;
   final _type_id_handle = _smoke_CommentsInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -211,8 +211,8 @@ Pointer<Void> smoke_CommentsLinks_toFfi(CommentsLinks value) =>
   _smoke_CommentsLinks_copy_handle((value as CommentsLinks$Impl).handle);
 CommentsLinks smoke_CommentsLinks_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_CommentsLinks_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as CommentsLinks;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is CommentsLinks) return instance as CommentsLinks;
   final _copied_handle = _smoke_CommentsLinks_copy_handle(handle);
   final result = CommentsLinks$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -300,8 +300,8 @@ Pointer<Void> smoke_DeprecationComments_toFfi(DeprecationComments value) {
 }
 DeprecationComments smoke_DeprecationComments_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_DeprecationComments_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as DeprecationComments;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is DeprecationComments) return instance as DeprecationComments;
   final _type_id_handle = _smoke_DeprecationComments_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -284,8 +284,8 @@ Pointer<Void> smoke_DeprecationCommentsOnly_toFfi(DeprecationCommentsOnly value)
 }
 DeprecationCommentsOnly smoke_DeprecationCommentsOnly_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_DeprecationCommentsOnly_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as DeprecationCommentsOnly;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is DeprecationCommentsOnly) return instance as DeprecationCommentsOnly;
   final _type_id_handle = _smoke_DeprecationCommentsOnly_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -223,12 +223,9 @@ Pointer<Void> smoke_ExcludedComments_SomeLambda_toFfi(ExcludedComments_SomeLambd
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Int32, Pointer<Double>)>(_ExcludedComments_SomeLambda_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_ExcludedComments_SomeLambda_get_raw_pointer(result)] = value;
   return result;
 }
 ExcludedComments_SomeLambda smoke_ExcludedComments_SomeLambda_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_ExcludedComments_SomeLambda_get_raw_pointer(handle)] as ExcludedComments_SomeLambda;
-  if (instance != null) return instance;
   final _impl = ExcludedComments_SomeLambda$Impl(_smoke_ExcludedComments_SomeLambda_copy_handle(handle));
   return (String p0, int p1) {
     final _result =_impl.call(p0, p1);
@@ -372,8 +369,8 @@ Pointer<Void> smoke_ExcludedComments_toFfi(ExcludedComments value) =>
   _smoke_ExcludedComments_copy_handle((value as ExcludedComments$Impl).handle);
 ExcludedComments smoke_ExcludedComments_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ExcludedComments_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ExcludedComments;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ExcludedComments) return instance as ExcludedComments;
   final _copied_handle = _smoke_ExcludedComments_copy_handle(handle);
   final result = ExcludedComments$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
@@ -59,8 +59,8 @@ Pointer<Void> smoke_ExcludedCommentsInterface_toFfi(ExcludedCommentsInterface va
 }
 ExcludedCommentsInterface smoke_ExcludedCommentsInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ExcludedCommentsInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ExcludedCommentsInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ExcludedCommentsInterface) return instance as ExcludedCommentsInterface;
   final _type_id_handle = _smoke_ExcludedCommentsInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -204,12 +204,9 @@ Pointer<Void> smoke_ExcludedCommentsOnly_SomeLambda_toFfi(ExcludedCommentsOnly_S
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Int32, Pointer<Double>)>(_ExcludedCommentsOnly_SomeLambda_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_ExcludedCommentsOnly_SomeLambda_get_raw_pointer(result)] = value;
   return result;
 }
 ExcludedCommentsOnly_SomeLambda smoke_ExcludedCommentsOnly_SomeLambda_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_ExcludedCommentsOnly_SomeLambda_get_raw_pointer(handle)] as ExcludedCommentsOnly_SomeLambda;
-  if (instance != null) return instance;
   final _impl = ExcludedCommentsOnly_SomeLambda$Impl(_smoke_ExcludedCommentsOnly_SomeLambda_copy_handle(handle));
   return (String p0, int p1) {
     final _result =_impl.call(p0, p1);
@@ -353,8 +350,8 @@ Pointer<Void> smoke_ExcludedCommentsOnly_toFfi(ExcludedCommentsOnly value) =>
   _smoke_ExcludedCommentsOnly_copy_handle((value as ExcludedCommentsOnly$Impl).handle);
 ExcludedCommentsOnly smoke_ExcludedCommentsOnly_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ExcludedCommentsOnly_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ExcludedCommentsOnly;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ExcludedCommentsOnly) return instance as ExcludedCommentsOnly;
   final _copied_handle = _smoke_ExcludedCommentsOnly_copy_handle(handle);
   final result = ExcludedCommentsOnly$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -56,8 +56,8 @@ Pointer<Void> smoke_InternalClassWithComments_toFfi(InternalClassWithComments va
   _smoke_InternalClassWithComments_copy_handle((value as InternalClassWithComments$Impl).handle);
 InternalClassWithComments smoke_InternalClassWithComments_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_InternalClassWithComments_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as InternalClassWithComments;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is InternalClassWithComments) return instance as InternalClassWithComments;
   final _copied_handle = _smoke_InternalClassWithComments_copy_handle(handle);
   final result = InternalClassWithComments$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -84,8 +84,8 @@ Pointer<Void> smoke_MultiLineComments_toFfi(MultiLineComments value) =>
   _smoke_MultiLineComments_copy_handle((value as MultiLineComments$Impl).handle);
 MultiLineComments smoke_MultiLineComments_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_MultiLineComments_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as MultiLineComments;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is MultiLineComments) return instance as MultiLineComments;
   final _copied_handle = _smoke_MultiLineComments_copy_handle(handle);
   final result = MultiLineComments$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -253,8 +253,8 @@ Pointer<Void> smoke_PlatformComments_toFfi(PlatformComments value) =>
   _smoke_PlatformComments_copy_handle((value as PlatformComments$Impl).handle);
 PlatformComments smoke_PlatformComments_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_PlatformComments_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as PlatformComments;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is PlatformComments) return instance as PlatformComments;
   final _copied_handle = _smoke_PlatformComments_copy_handle(handle);
   final result = PlatformComments$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -86,8 +86,8 @@ Pointer<Void> smoke_UnicodeComments_toFfi(UnicodeComments value) =>
   _smoke_UnicodeComments_copy_handle((value as UnicodeComments$Impl).handle);
 UnicodeComments smoke_UnicodeComments_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_UnicodeComments_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as UnicodeComments;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is UnicodeComments) return instance as UnicodeComments;
   final _copied_handle = _smoke_UnicodeComments_copy_handle(handle);
   final result = UnicodeComments$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
@@ -43,8 +43,8 @@ Pointer<Void> smoke_CollectionConstants_toFfi(CollectionConstants value) =>
   _smoke_CollectionConstants_copy_handle((value as CollectionConstants$Impl).handle);
 CollectionConstants smoke_CollectionConstants_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_CollectionConstants_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as CollectionConstants;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is CollectionConstants) return instance as CollectionConstants;
   final _copied_handle = _smoke_CollectionConstants_copy_handle(handle);
   final result = CollectionConstants$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
@@ -105,8 +105,8 @@ Pointer<Void> smoke_ConstantsInterface_toFfi(ConstantsInterface value) =>
   _smoke_ConstantsInterface_copy_handle((value as ConstantsInterface$Impl).handle);
 ConstantsInterface smoke_ConstantsInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ConstantsInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ConstantsInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ConstantsInterface) return instance as ConstantsInterface;
   final _copied_handle = _smoke_ConstantsInterface_copy_handle(handle);
   final result = ConstantsInterface$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
@@ -180,8 +180,8 @@ Pointer<Void> smoke_StructConstants_toFfi(StructConstants value) =>
   _smoke_StructConstants_copy_handle((value as StructConstants$Impl).handle);
 StructConstants smoke_StructConstants_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_StructConstants_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as StructConstants;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is StructConstants) return instance as StructConstants;
   final _copied_handle = _smoke_StructConstants_copy_handle(handle);
   final result = StructConstants$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -202,8 +202,8 @@ Pointer<Void> smoke_Constructors_toFfi(Constructors value) =>
   _smoke_Constructors_copy_handle((value as Constructors$Impl).handle);
 Constructors smoke_Constructors_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_Constructors_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Constructors;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Constructors) return instance as Constructors;
   final _type_id_handle = _smoke_Constructors_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -144,8 +144,8 @@ Pointer<Void> smoke_Dates_toFfi(Dates value) =>
   _smoke_Dates_copy_handle((value as Dates$Impl).handle);
 Dates smoke_Dates_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_Dates_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Dates;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Dates) return instance as Dates;
   final _copied_handle = _smoke_Dates_copy_handle(handle);
   final result = Dates$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -741,8 +741,8 @@ Pointer<Void> smoke_DefaultValues_toFfi(DefaultValues value) =>
   _smoke_DefaultValues_copy_handle((value as DefaultValues$Impl).handle);
 DefaultValues smoke_DefaultValues_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_DefaultValues_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as DefaultValues;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is DefaultValues) return instance as DefaultValues;
   final _copied_handle = _smoke_DefaultValues_copy_handle(handle);
   final result = DefaultValues$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -282,8 +282,8 @@ Pointer<Void> smoke_Enums_toFfi(Enums value) =>
   _smoke_Enums_copy_handle((value as Enums$Impl).handle);
 Enums smoke_Enums_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_Enums_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Enums;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Enums) return instance as Enums;
   final _copied_handle = _smoke_Enums_copy_handle(handle);
   final result = Enums$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
@@ -66,8 +66,8 @@ Pointer<Void> smoke_EquatableInterface_toFfi(EquatableInterface value) {
 }
 EquatableInterface smoke_EquatableInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_EquatableInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as EquatableInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is EquatableInterface) return instance as EquatableInterface;
   final _type_id_handle = _smoke_EquatableInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -351,8 +351,8 @@ Pointer<Void> smoke_Errors_toFfi(Errors value) =>
   _smoke_Errors_copy_handle((value as Errors$Impl).handle);
 Errors smoke_Errors_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_Errors_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Errors;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Errors) return instance as Errors;
   final _copied_handle = _smoke_Errors_copy_handle(handle);
   final result = Errors$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -496,8 +496,8 @@ Pointer<Void> smoke_ErrorsInterface_toFfi(ErrorsInterface value) {
 }
 ErrorsInterface smoke_ErrorsInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ErrorsInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ErrorsInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ErrorsInterface) return instance as ErrorsInterface;
   final _type_id_handle = _smoke_ErrorsInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -124,8 +124,8 @@ Pointer<Void> package_Class_toFfi(Class value) =>
   _package_Class_copy_handle((value as Class$Impl).handle);
 Class package_Class_fromFfi(Pointer<Void> handle) {
   final raw_handle = _package_Class_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Class;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Class) return instance as Class;
   final _type_id_handle = _package_Class_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
@@ -57,8 +57,8 @@ Pointer<Void> package_Interface_toFfi(Interface value) {
 }
 Interface package_Interface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _package_Interface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Interface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Interface) return instance as Interface;
   final _type_id_handle = _package_Interface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -170,8 +170,8 @@ Pointer<Void> smoke_Enums_toFfi(Enums value) =>
   _smoke_Enums_copy_handle((value as Enums$Impl).handle);
 Enums smoke_Enums_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_Enums_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Enums;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Enums) return instance as Enums;
   final _copied_handle = _smoke_Enums_copy_handle(handle);
   final result = Enums$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -182,8 +182,8 @@ Pointer<Void> smoke_ExternalClass_toFfi(ExternalClass value) =>
   _smoke_ExternalClass_copy_handle((value as ExternalClass$Impl).handle);
 ExternalClass smoke_ExternalClass_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ExternalClass_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ExternalClass;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ExternalClass) return instance as ExternalClass;
   final _copied_handle = _smoke_ExternalClass_copy_handle(handle);
   final result = ExternalClass$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -238,8 +238,8 @@ Pointer<Void> smoke_ExternalInterface_toFfi(ExternalInterface value) {
 }
 ExternalInterface smoke_ExternalInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ExternalInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ExternalInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ExternalInterface) return instance as ExternalInterface;
   final _type_id_handle = _smoke_ExternalInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
@@ -219,8 +219,8 @@ Pointer<Void> smoke_Structs_toFfi(Structs value) =>
   _smoke_Structs_copy_handle((value as Structs$Impl).handle);
 Structs smoke_Structs_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_Structs_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Structs;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Structs) return instance as Structs;
   final _copied_handle = _smoke_Structs_copy_handle(handle);
   final result = Structs$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -93,8 +93,8 @@ Pointer<Void> smoke_UseDartExternalTypes_toFfi(UseDartExternalTypes value) =>
   _smoke_UseDartExternalTypes_copy_handle((value as UseDartExternalTypes$Impl).handle);
 UseDartExternalTypes smoke_UseDartExternalTypes_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_UseDartExternalTypes_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as UseDartExternalTypes;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is UseDartExternalTypes) return instance as UseDartExternalTypes;
   final _copied_handle = _smoke_UseDartExternalTypes_copy_handle(handle);
   final result = UseDartExternalTypes$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -287,8 +287,8 @@ Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi(GenericTypesWithBasicTypes 
   _smoke_GenericTypesWithBasicTypes_copy_handle((value as GenericTypesWithBasicTypes$Impl).handle);
 GenericTypesWithBasicTypes smoke_GenericTypesWithBasicTypes_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_GenericTypesWithBasicTypes_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as GenericTypesWithBasicTypes;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is GenericTypesWithBasicTypes) return instance as GenericTypesWithBasicTypes;
   final _copied_handle = _smoke_GenericTypesWithBasicTypes_copy_handle(handle);
   final result = GenericTypesWithBasicTypes$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -401,8 +401,8 @@ Pointer<Void> smoke_GenericTypesWithCompoundTypes_toFfi(GenericTypesWithCompound
   _smoke_GenericTypesWithCompoundTypes_copy_handle((value as GenericTypesWithCompoundTypes$Impl).handle);
 GenericTypesWithCompoundTypes smoke_GenericTypesWithCompoundTypes_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_GenericTypesWithCompoundTypes_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as GenericTypesWithCompoundTypes;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is GenericTypesWithCompoundTypes) return instance as GenericTypesWithCompoundTypes;
   final _copied_handle = _smoke_GenericTypesWithCompoundTypes_copy_handle(handle);
   final result = GenericTypesWithCompoundTypes$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -139,8 +139,8 @@ Pointer<Void> smoke_GenericTypesWithGenericTypes_toFfi(GenericTypesWithGenericTy
   _smoke_GenericTypesWithGenericTypes_copy_handle((value as GenericTypesWithGenericTypes$Impl).handle);
 GenericTypesWithGenericTypes smoke_GenericTypesWithGenericTypes_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_GenericTypesWithGenericTypes_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as GenericTypesWithGenericTypes;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is GenericTypesWithGenericTypes) return instance as GenericTypesWithGenericTypes;
   final _copied_handle = _smoke_GenericTypesWithGenericTypes_copy_handle(handle);
   final result = GenericTypesWithGenericTypes$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -56,8 +56,8 @@ Pointer<Void> smoke_ChildClassFromClass_toFfi(ChildClassFromClass value) =>
   _smoke_ChildClassFromClass_copy_handle((value as ChildClassFromClass$Impl).handle);
 ChildClassFromClass smoke_ChildClassFromClass_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ChildClassFromClass_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ChildClassFromClass;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ChildClassFromClass) return instance as ChildClassFromClass;
   final _type_id_handle = _smoke_ChildClassFromClass_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -93,8 +93,8 @@ Pointer<Void> smoke_ChildClassFromInterface_toFfi(ChildClassFromInterface value)
   _smoke_ChildClassFromInterface_copy_handle((value as ChildClassFromInterface$Impl).handle);
 ChildClassFromInterface smoke_ChildClassFromInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ChildClassFromInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ChildClassFromInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ChildClassFromInterface) return instance as ChildClassFromInterface;
   final _type_id_handle = _smoke_ChildClassFromInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -131,8 +131,8 @@ Pointer<Void> smoke_ChildInterface_toFfi(ChildInterface value) {
 }
 ChildInterface smoke_ChildInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ChildInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ChildInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ChildInterface) return instance as ChildInterface;
   final _type_id_handle = _smoke_ChildInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -83,8 +83,8 @@ Pointer<Void> smoke_ChildWithParentClassReferences_toFfi(ChildWithParentClassRef
   _smoke_ChildWithParentClassReferences_copy_handle((value as ChildWithParentClassReferences$Impl).handle);
 ChildWithParentClassReferences smoke_ChildWithParentClassReferences_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ChildWithParentClassReferences_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ChildWithParentClassReferences;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ChildWithParentClassReferences) return instance as ChildWithParentClassReferences;
   final _type_id_handle = _smoke_ChildWithParentClassReferences_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -57,8 +57,8 @@ Pointer<Void> smoke_ParentClass_toFfi(ParentClass value) =>
   _smoke_ParentClass_copy_handle((value as ParentClass$Impl).handle);
 ParentClass smoke_ParentClass_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ParentClass_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ParentClass;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ParentClass) return instance as ParentClass;
   final _type_id_handle = _smoke_ParentClass_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -149,8 +149,8 @@ Pointer<Void> smoke_ParentInterface_toFfi(ParentInterface value) {
 }
 ParentInterface smoke_ParentInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ParentInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ParentInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ParentInterface) return instance as ParentInterface;
   final _type_id_handle = _smoke_ParentInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
@@ -66,8 +66,8 @@ Pointer<Void> smoke_SimpleClass_toFfi(SimpleClass value) =>
   _smoke_SimpleClass_copy_handle((value as SimpleClass$Impl).handle);
 SimpleClass smoke_SimpleClass_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_SimpleClass_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as SimpleClass;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is SimpleClass) return instance as SimpleClass;
   final _copied_handle = _smoke_SimpleClass_copy_handle(handle);
   final result = SimpleClass$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -132,8 +132,8 @@ Pointer<Void> smoke_SimpleInterface_toFfi(SimpleInterface value) {
 }
 SimpleInterface smoke_SimpleInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_SimpleInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as SimpleInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is SimpleInterface) return instance as SimpleInterface;
   final _type_id_handle = _smoke_SimpleInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -66,12 +66,9 @@ Pointer<Void> smoke_ClassWithInternalLambda_InternalLambda_toFfi(ClassWithIntern
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_ClassWithInternalLambda_InternalLambda_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_ClassWithInternalLambda_InternalLambda_get_raw_pointer(result)] = value;
   return result;
 }
 ClassWithInternalLambda_InternalLambda smoke_ClassWithInternalLambda_InternalLambda_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_ClassWithInternalLambda_InternalLambda_get_raw_pointer(handle)] as ClassWithInternalLambda_InternalLambda;
-  if (instance != null) return instance;
   final _impl = ClassWithInternalLambda_InternalLambda$Impl(_smoke_ClassWithInternalLambda_InternalLambda_copy_handle(handle));
   return (String p0) {
     final _result =_impl.internal_call(p0);
@@ -153,8 +150,8 @@ Pointer<Void> smoke_ClassWithInternalLambda_toFfi(ClassWithInternalLambda value)
   _smoke_ClassWithInternalLambda_copy_handle((value as ClassWithInternalLambda$Impl).handle);
 ClassWithInternalLambda smoke_ClassWithInternalLambda_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ClassWithInternalLambda_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ClassWithInternalLambda;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ClassWithInternalLambda) return instance as ClassWithInternalLambda;
   final _copied_handle = _smoke_ClassWithInternalLambda_copy_handle(handle);
   final result = ClassWithInternalLambda$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -64,12 +64,9 @@ Pointer<Void> smoke_Lambdas_Producer_toFfi(Lambdas_Producer value) {
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_Lambdas_Producer_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_Lambdas_Producer_get_raw_pointer(result)] = value;
   return result;
 }
 Lambdas_Producer smoke_Lambdas_Producer_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_Lambdas_Producer_get_raw_pointer(handle)] as Lambdas_Producer;
-  if (instance != null) return instance;
   final _impl = Lambdas_Producer$Impl(_smoke_Lambdas_Producer_copy_handle(handle));
   return () {
     final _result =_impl.call();
@@ -163,12 +160,9 @@ Pointer<Void> smoke_Lambdas_Confuser_toFfi(Lambdas_Confuser value) {
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_Lambdas_Confuser_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_Lambdas_Confuser_get_raw_pointer(result)] = value;
   return result;
 }
 Lambdas_Confuser smoke_Lambdas_Confuser_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_Lambdas_Confuser_get_raw_pointer(handle)] as Lambdas_Confuser;
-  if (instance != null) return instance;
   final _impl = Lambdas_Confuser$Impl(_smoke_Lambdas_Confuser_copy_handle(handle));
   return (String p0) {
     final _result =_impl.call(p0);
@@ -259,12 +253,9 @@ Pointer<Void> smoke_Lambdas_Consumer_toFfi(Lambdas_Consumer value) {
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_Lambdas_Consumer_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_Lambdas_Consumer_get_raw_pointer(result)] = value;
   return result;
 }
 Lambdas_Consumer smoke_Lambdas_Consumer_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_Lambdas_Consumer_get_raw_pointer(handle)] as Lambdas_Consumer;
-  if (instance != null) return instance;
   final _impl = Lambdas_Consumer$Impl(_smoke_Lambdas_Consumer_copy_handle(handle));
   return (String p0) {
     final _result =_impl.call(p0);
@@ -360,12 +351,9 @@ Pointer<Void> smoke_Lambdas_Indexer_toFfi(Lambdas_Indexer value) {
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Float, Pointer<Int32>)>(_Lambdas_Indexer_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_Lambdas_Indexer_get_raw_pointer(result)] = value;
   return result;
 }
 Lambdas_Indexer smoke_Lambdas_Indexer_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_Lambdas_Indexer_get_raw_pointer(handle)] as Lambdas_Indexer;
-  if (instance != null) return instance;
   final _impl = Lambdas_Indexer$Impl(_smoke_Lambdas_Indexer_copy_handle(handle));
   return (String p0, double p1) {
     final _result =_impl.call(p0, p1);
@@ -458,12 +446,9 @@ Pointer<Void> smoke_Lambdas_NullableConfuser_toFfi(Lambdas_NullableConfuser valu
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_Lambdas_NullableConfuser_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_Lambdas_NullableConfuser_get_raw_pointer(result)] = value;
   return result;
 }
 Lambdas_NullableConfuser smoke_Lambdas_NullableConfuser_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_Lambdas_NullableConfuser_get_raw_pointer(handle)] as Lambdas_NullableConfuser;
-  if (instance != null) return instance;
   final _impl = Lambdas_NullableConfuser$Impl(_smoke_Lambdas_NullableConfuser_copy_handle(handle));
   return (String p0) {
     final _result =_impl.call(p0);
@@ -560,8 +545,8 @@ Pointer<Void> smoke_Lambdas_toFfi(Lambdas value) =>
   _smoke_Lambdas_copy_handle((value as Lambdas$Impl).handle);
 Lambdas smoke_Lambdas_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_Lambdas_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Lambdas;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Lambdas) return instance as Lambdas;
   final _copied_handle = _smoke_Lambdas_copy_handle(handle);
   final result = Lambdas$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -66,12 +66,9 @@ Pointer<Void> smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(LambdasWithSt
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_LambdasWithStructuredTypes_ClassCallback_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer(result)] = value;
   return result;
 }
 LambdasWithStructuredTypes_ClassCallback smoke_LambdasWithStructuredTypes_ClassCallback_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_LambdasWithStructuredTypes_ClassCallback_get_raw_pointer(handle)] as LambdasWithStructuredTypes_ClassCallback;
-  if (instance != null) return instance;
   final _impl = LambdasWithStructuredTypes_ClassCallback$Impl(_smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle(handle));
   return (LambdasInterface p0) {
     final _result =_impl.call(p0);
@@ -162,12 +159,9 @@ Pointer<Void> smoke_LambdasWithStructuredTypes_StructCallback_toFfi(LambdasWithS
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_LambdasWithStructuredTypes_StructCallback_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer(result)] = value;
   return result;
 }
 LambdasWithStructuredTypes_StructCallback smoke_LambdasWithStructuredTypes_StructCallback_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_LambdasWithStructuredTypes_StructCallback_get_raw_pointer(handle)] as LambdasWithStructuredTypes_StructCallback;
-  if (instance != null) return instance;
   final _impl = LambdasWithStructuredTypes_StructCallback$Impl(_smoke_LambdasWithStructuredTypes_StructCallback_copy_handle(handle));
   return (LambdasDeclarationOrder_SomeStruct p0) {
     final _result =_impl.call(p0);
@@ -262,8 +256,8 @@ Pointer<Void> smoke_LambdasWithStructuredTypes_toFfi(LambdasWithStructuredTypes 
   _smoke_LambdasWithStructuredTypes_copy_handle((value as LambdasWithStructuredTypes$Impl).handle);
 LambdasWithStructuredTypes smoke_LambdasWithStructuredTypes_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_LambdasWithStructuredTypes_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as LambdasWithStructuredTypes;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is LambdasWithStructuredTypes) return instance as LambdasWithStructuredTypes;
   final _copied_handle = _smoke_LambdasWithStructuredTypes_copy_handle(handle);
   final result = LambdasWithStructuredTypes$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
@@ -54,12 +54,9 @@ Pointer<Void> smoke_StandaloneProducer_toFfi(StandaloneProducer value) {
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_StandaloneProducer_call_static, __lib.unknownError)
   );
-  __lib.reverseCache[_smoke_StandaloneProducer_get_raw_pointer(result)] = value;
   return result;
 }
 StandaloneProducer smoke_StandaloneProducer_fromFfi(Pointer<Void> handle) {
-  final instance = __lib.reverseCache[_smoke_StandaloneProducer_get_raw_pointer(handle)] as StandaloneProducer;
-  if (instance != null) return instance;
   final _impl = StandaloneProducer$Impl(_smoke_StandaloneProducer_copy_handle(handle));
   return () {
     final _result =_impl.call();

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -320,8 +320,8 @@ Pointer<Void> smoke_CalculatorListener_toFfi(CalculatorListener value) {
 }
 CalculatorListener smoke_CalculatorListener_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_CalculatorListener_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as CalculatorListener;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is CalculatorListener) return instance as CalculatorListener;
   final _type_id_handle = _smoke_CalculatorListener_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -565,8 +565,8 @@ Pointer<Void> smoke_ListenerWithProperties_toFfi(ListenerWithProperties value) {
 }
 ListenerWithProperties smoke_ListenerWithProperties_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ListenerWithProperties_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ListenerWithProperties;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ListenerWithProperties) return instance as ListenerWithProperties;
   final _type_id_handle = _smoke_ListenerWithProperties_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -404,8 +404,8 @@ Pointer<Void> smoke_ListenersWithReturnValues_toFfi(ListenersWithReturnValues va
 }
 ListenersWithReturnValues smoke_ListenersWithReturnValues_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_ListenersWithReturnValues_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as ListenersWithReturnValues;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is ListenersWithReturnValues) return instance as ListenersWithReturnValues;
   final _type_id_handle = _smoke_ListenersWithReturnValues_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -145,8 +145,8 @@ Pointer<Void> smoke_Locales_toFfi(Locales value) =>
   _smoke_Locales_copy_handle((value as Locales$Impl).handle);
 Locales smoke_Locales_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_Locales_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Locales;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Locales) return instance as Locales;
   final _copied_handle = _smoke_Locales_copy_handle(handle);
   final result = Locales$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -259,8 +259,8 @@ Pointer<Void> smoke_MethodOverloads_toFfi(MethodOverloads value) =>
   _smoke_MethodOverloads_copy_handle((value as MethodOverloads$Impl).handle);
 MethodOverloads smoke_MethodOverloads_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_MethodOverloads_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as MethodOverloads;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is MethodOverloads) return instance as MethodOverloads;
   final _copied_handle = _smoke_MethodOverloads_copy_handle(handle);
   final result = MethodOverloads$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -88,8 +88,8 @@ Pointer<Void> smoke_SpecialNames_toFfi(SpecialNames value) =>
   _smoke_SpecialNames_copy_handle((value as SpecialNames$Impl).handle);
 SpecialNames smoke_SpecialNames_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_SpecialNames_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as SpecialNames;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is SpecialNames) return instance as SpecialNames;
   final _copied_handle = _smoke_SpecialNames_copy_handle(handle);
   final result = SpecialNames$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -196,8 +196,8 @@ Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi(LevelOne_LevelTwo_LevelTh
   _smoke_LevelOne_LevelTwo_LevelThree_copy_handle((value as LevelOne_LevelTwo_LevelThree$Impl).handle);
 LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_LevelOne_LevelTwo_LevelThree_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as LevelOne_LevelTwo_LevelThree;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is LevelOne_LevelTwo_LevelThree) return instance as LevelOne_LevelTwo_LevelThree;
   final _copied_handle = _smoke_LevelOne_LevelTwo_LevelThree_copy_handle(handle);
   final result = LevelOne_LevelTwo_LevelThree$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;
@@ -241,8 +241,8 @@ Pointer<Void> smoke_LevelOne_LevelTwo_toFfi(LevelOne_LevelTwo value) =>
   _smoke_LevelOne_LevelTwo_copy_handle((value as LevelOne_LevelTwo$Impl).handle);
 LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_LevelOne_LevelTwo_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as LevelOne_LevelTwo;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is LevelOne_LevelTwo) return instance as LevelOne_LevelTwo;
   final _copied_handle = _smoke_LevelOne_LevelTwo_copy_handle(handle);
   final result = LevelOne_LevelTwo$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;
@@ -286,8 +286,8 @@ Pointer<Void> smoke_LevelOne_toFfi(LevelOne value) =>
   _smoke_LevelOne_copy_handle((value as LevelOne$Impl).handle);
 LevelOne smoke_LevelOne_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_LevelOne_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as LevelOne;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is LevelOne) return instance as LevelOne;
   final _copied_handle = _smoke_LevelOne_copy_handle(handle);
   final result = LevelOne$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -63,8 +63,8 @@ Pointer<Void> smoke_OuterClass_InnerClass_toFfi(OuterClass_InnerClass value) =>
   _smoke_OuterClass_InnerClass_copy_handle((value as OuterClass_InnerClass$Impl).handle);
 OuterClass_InnerClass smoke_OuterClass_InnerClass_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_OuterClass_InnerClass_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as OuterClass_InnerClass;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is OuterClass_InnerClass) return instance as OuterClass_InnerClass;
   final _copied_handle = _smoke_OuterClass_InnerClass_copy_handle(handle);
   final result = OuterClass_InnerClass$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;
@@ -175,8 +175,8 @@ Pointer<Void> smoke_OuterClass_InnerInterface_toFfi(OuterClass_InnerInterface va
 }
 OuterClass_InnerInterface smoke_OuterClass_InnerInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_OuterClass_InnerInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as OuterClass_InnerInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is OuterClass_InnerInterface) return instance as OuterClass_InnerInterface;
   final _type_id_handle = _smoke_OuterClass_InnerInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -238,8 +238,8 @@ Pointer<Void> smoke_OuterClass_toFfi(OuterClass value) =>
   _smoke_OuterClass_copy_handle((value as OuterClass$Impl).handle);
 OuterClass smoke_OuterClass_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_OuterClass_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as OuterClass;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is OuterClass) return instance as OuterClass;
   final _copied_handle = _smoke_OuterClass_copy_handle(handle);
   final result = OuterClass$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -69,8 +69,8 @@ Pointer<Void> smoke_OuterInterface_InnerClass_toFfi(OuterInterface_InnerClass va
   _smoke_OuterInterface_InnerClass_copy_handle((value as OuterInterface_InnerClass$Impl).handle);
 OuterInterface_InnerClass smoke_OuterInterface_InnerClass_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_OuterInterface_InnerClass_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as OuterInterface_InnerClass;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is OuterInterface_InnerClass) return instance as OuterInterface_InnerClass;
   final _copied_handle = _smoke_OuterInterface_InnerClass_copy_handle(handle);
   final result = OuterInterface_InnerClass$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;
@@ -181,8 +181,8 @@ Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi(OuterInterface_InnerInte
 }
 OuterInterface_InnerInterface smoke_OuterInterface_InnerInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_OuterInterface_InnerInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as OuterInterface_InnerInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is OuterInterface_InnerInterface) return instance as OuterInterface_InnerInterface;
   final _type_id_handle = _smoke_OuterInterface_InnerInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -284,8 +284,8 @@ Pointer<Void> smoke_OuterInterface_toFfi(OuterInterface value) {
 }
 OuterInterface smoke_OuterInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_OuterInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as OuterInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is OuterInterface) return instance as OuterInterface;
   final _type_id_handle = _smoke_OuterInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -205,8 +205,8 @@ Pointer<Void> smoke_OuterStruct_InnerClass_toFfi(OuterStruct_InnerClass value) =
   _smoke_OuterStruct_InnerClass_copy_handle((value as OuterStruct_InnerClass$Impl).handle);
 OuterStruct_InnerClass smoke_OuterStruct_InnerClass_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_OuterStruct_InnerClass_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as OuterStruct_InnerClass;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is OuterStruct_InnerClass) return instance as OuterStruct_InnerClass;
   final _copied_handle = _smoke_OuterStruct_InnerClass_copy_handle(handle);
   final result = OuterStruct_InnerClass$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;
@@ -314,8 +314,8 @@ Pointer<Void> smoke_OuterStruct_InnerInterface_toFfi(OuterStruct_InnerInterface 
 }
 OuterStruct_InnerInterface smoke_OuterStruct_InnerInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_OuterStruct_InnerInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as OuterStruct_InnerInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is OuterStruct_InnerInterface) return instance as OuterStruct_InnerInterface;
   final _type_id_handle = _smoke_OuterStruct_InnerInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -86,8 +86,8 @@ Pointer<Void> smoke_UseFreeTypes_toFfi(UseFreeTypes value) =>
   _smoke_UseFreeTypes_copy_handle((value as UseFreeTypes$Impl).handle);
 UseFreeTypes smoke_UseFreeTypes_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_UseFreeTypes_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as UseFreeTypes;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is UseFreeTypes) return instance as UseFreeTypes;
   final _copied_handle = _smoke_UseFreeTypes_copy_handle(handle);
   final result = UseFreeTypes$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -843,8 +843,8 @@ Pointer<Void> smoke_Nullable_toFfi(Nullable value) =>
   _smoke_Nullable_copy_handle((value as Nullable$Impl).handle);
 Nullable smoke_Nullable_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_Nullable_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Nullable;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Nullable) return instance as Nullable;
   final _copied_handle = _smoke_Nullable_copy_handle(handle);
   final result = Nullable$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
@@ -116,8 +116,8 @@ Pointer<Void> smoke_off_NestedPackages_toFfi(NestedPackages value) =>
   _smoke_off_NestedPackages_copy_handle((value as NestedPackages$Impl).handle);
 NestedPackages smoke_off_NestedPackages_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_off_NestedPackages_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as NestedPackages;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is NestedPackages) return instance as NestedPackages;
   final _copied_handle = _smoke_off_NestedPackages_copy_handle(handle);
   final result = NestedPackages$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -92,8 +92,8 @@ Pointer<Void> smoke_PlatformNamesInterface_toFfi(weeInterface value) =>
   _smoke_PlatformNamesInterface_copy_handle((value as weeInterface$Impl).handle);
 weeInterface smoke_PlatformNamesInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_PlatformNamesInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as weeInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is weeInterface) return instance as weeInterface;
   final _copied_handle = _smoke_PlatformNamesInterface_copy_handle(handle);
   final result = weeInterface$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -99,8 +99,8 @@ Pointer<Void> smoke_PlatformNamesListener_toFfi(weeListener value) {
 }
 weeListener smoke_PlatformNamesListener_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_PlatformNamesListener_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as weeListener;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is weeListener) return instance as weeListener;
   final _type_id_handle = _smoke_PlatformNamesListener_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
@@ -75,8 +75,8 @@ Pointer<Void> smoke_CachedProperties_toFfi(CachedProperties value) =>
   _smoke_CachedProperties_copy_handle((value as CachedProperties$Impl).handle);
 CachedProperties smoke_CachedProperties_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_CachedProperties_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as CachedProperties;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is CachedProperties) return instance as CachedProperties;
   final _copied_handle = _smoke_CachedProperties_copy_handle(handle);
   final result = CachedProperties$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -392,8 +392,8 @@ Pointer<Void> smoke_Properties_toFfi(Properties value) =>
   _smoke_Properties_copy_handle((value as Properties$Impl).handle);
 Properties smoke_Properties_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_Properties_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Properties;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Properties) return instance as Properties;
   final _copied_handle = _smoke_Properties_copy_handle(handle);
   final result = Properties$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -185,8 +185,8 @@ Pointer<Void> smoke_PropertiesInterface_toFfi(PropertiesInterface value) {
 }
 PropertiesInterface smoke_PropertiesInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_PropertiesInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as PropertiesInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is PropertiesInterface) return instance as PropertiesInterface;
   final _type_id_handle = _smoke_PropertiesInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -144,8 +144,8 @@ Pointer<Void> smoke_InheritFromSkipped_toFfi(InheritFromSkipped value) {
 }
 InheritFromSkipped smoke_InheritFromSkipped_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_InheritFromSkipped_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as InheritFromSkipped;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is InheritFromSkipped) return instance as InheritFromSkipped;
   final _type_id_handle = _smoke_InheritFromSkipped_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -64,8 +64,8 @@ Pointer<Void> smoke_SkipFunctions_toFfi(SkipFunctions value) =>
   _smoke_SkipFunctions_copy_handle((value as SkipFunctions$Impl).handle);
 SkipFunctions smoke_SkipFunctions_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_SkipFunctions_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as SkipFunctions;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is SkipFunctions) return instance as SkipFunctions;
   final _copied_handle = _smoke_SkipFunctions_copy_handle(handle);
   final result = SkipFunctions$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -240,8 +240,8 @@ Pointer<Void> smoke_SkipProxy_toFfi(SkipProxy value) {
 }
 SkipProxy smoke_SkipProxy_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_SkipProxy_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as SkipProxy;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is SkipProxy) return instance as SkipProxy;
   final _type_id_handle = _smoke_SkipProxy_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -168,8 +168,8 @@ Pointer<Void> smoke_SkipTypes_toFfi(SkipTypes value) =>
   _smoke_SkipTypes_copy_handle((value as SkipTypes$Impl).handle);
 SkipTypes smoke_SkipTypes_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_SkipTypes_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as SkipTypes;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is SkipTypes) return instance as SkipTypes;
   final _copied_handle = _smoke_SkipTypes_copy_handle(handle);
   final result = SkipTypes$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -816,8 +816,8 @@ Pointer<Void> smoke_Structs_toFfi(Structs value) =>
   _smoke_Structs_copy_handle((value as Structs$Impl).handle);
 Structs smoke_Structs_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_Structs_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as Structs;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is Structs) return instance as Structs;
   final _copied_handle = _smoke_Structs_copy_handle(handle);
   final result = Structs$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -268,8 +268,8 @@ Pointer<Void> smoke_TypeDefs_toFfi(TypeDefs value) =>
   _smoke_TypeDefs_copy_handle((value as TypeDefs$Impl).handle);
 TypeDefs smoke_TypeDefs_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_TypeDefs_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as TypeDefs;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is TypeDefs) return instance as TypeDefs;
   final _copied_handle = _smoke_TypeDefs_copy_handle(handle);
   final result = TypeDefs$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -54,8 +54,8 @@ Pointer<Void> smoke_InternalClass_toFfi(InternalClass value) =>
   _smoke_InternalClass_copy_handle((value as InternalClass$Impl).handle);
 InternalClass smoke_InternalClass_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_InternalClass_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as InternalClass;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is InternalClass) return instance as InternalClass;
   final _copied_handle = _smoke_InternalClass_copy_handle(handle);
   final result = InternalClass$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -76,8 +76,8 @@ Pointer<Void> smoke_InternalClassWithFunctions_toFfi(InternalClassWithFunctions 
   _smoke_InternalClassWithFunctions_copy_handle((value as InternalClassWithFunctions$Impl).handle);
 InternalClassWithFunctions smoke_InternalClassWithFunctions_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_InternalClassWithFunctions_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as InternalClassWithFunctions;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is InternalClassWithFunctions) return instance as InternalClassWithFunctions;
   final _copied_handle = _smoke_InternalClassWithFunctions_copy_handle(handle);
   final result = InternalClassWithFunctions$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -65,8 +65,8 @@ Pointer<Void> smoke_InternalClassWithStaticProperty_toFfi(InternalClassWithStati
   _smoke_InternalClassWithStaticProperty_copy_handle((value as InternalClassWithStaticProperty$Impl).handle);
 InternalClassWithStaticProperty smoke_InternalClassWithStaticProperty_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_InternalClassWithStaticProperty_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as InternalClassWithStaticProperty;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is InternalClassWithStaticProperty) return instance as InternalClassWithStaticProperty;
   final _copied_handle = _smoke_InternalClassWithStaticProperty_copy_handle(handle);
   final result = InternalClassWithStaticProperty$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -98,8 +98,8 @@ Pointer<Void> smoke_InternalInterface_toFfi(InternalInterface value) {
 }
 InternalInterface smoke_InternalInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_InternalInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as InternalInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is InternalInterface) return instance as InternalInterface;
   final _type_id_handle = _smoke_InternalInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -378,8 +378,8 @@ Pointer<Void> smoke_PublicClass_toFfi(PublicClass value) =>
   _smoke_PublicClass_copy_handle((value as PublicClass$Impl).handle);
 PublicClass smoke_PublicClass_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_PublicClass_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as PublicClass;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is PublicClass) return instance as PublicClass;
   final _copied_handle = _smoke_PublicClass_copy_handle(handle);
   final result = PublicClass$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
@@ -124,8 +124,8 @@ Pointer<Void> smoke_PublicInterface_toFfi(PublicInterface value) {
 }
 PublicInterface smoke_PublicInterface_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_PublicInterface_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as PublicInterface;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is PublicInterface) return instance as PublicInterface;
   final _type_id_handle = _smoke_PublicInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);

--- a/gluecodium/src/test/resources/stubs_smoke/classes/output/dart/lib/src/smoke/some_class.dart
+++ b/gluecodium/src/test/resources/stubs_smoke/classes/output/dart/lib/src/smoke/some_class.dart
@@ -122,8 +122,8 @@ Pointer<Void> smoke_SomeClass_toFfi(SomeClass value) =>
   _smoke_SomeClass_copy_handle((value as SomeClass$Impl).handle);
 SomeClass smoke_SomeClass_fromFfi(Pointer<Void> handle) {
   final raw_handle = _smoke_SomeClass_get_raw_pointer(handle);
-  final instance = __lib.reverseCache[raw_handle] as SomeClass;
-  if (instance != null) return instance;
+  final instance = __lib.reverseCache[raw_handle];
+  if (instance is SomeClass) return instance as SomeClass;
   final _copied_handle = _smoke_SomeClass_copy_handle(handle);
   final result = SomeClass$Impl(_copied_handle);
   __lib.reverseCache[raw_handle] = result;


### PR DESCRIPTION
In the current implementation, sending two native Dart objects (lambdas or interface implementations) to C++ and then
back again could sometimes cause a crash when the first object is destroyed in C++ but its Dart deleter is delayed by
the callback queue.

Updated related Dart templates to perform `instanceOf` checks before casting objects obtained from the reverse cache.
This properly treats the scenario as cache miss.

This is a temporary workaround. The full fix will be done in the scope of #606 later. As the issue does not arise in
practical scenarios, the full fix has a low priority.

Also restored Dart builds, without AddressSanitizer.

See: #606
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>