### PR TITLE
Fix typo in get_field_value() for Locale in JNI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed flaky crash for callbacks being sent from Dart to C++ and then back.
+  * Fixed compilation error for nullable Locale fields in Java.
 
 ## 8.6.1
 Release date: 2020-11-18

--- a/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsHeader.mustache
@@ -148,7 +148,7 @@ double get_field_value(
     JNIEnv* env,
     const JniReference< jobject >& object,
     const char* fieldName,
-    {{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Locale* > );
+    {{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Locale >* );
 
 JniReference< jobject > get_object_field_value( JNIEnv* env,
                                        const JniReference<jobject>& object,


### PR DESCRIPTION
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>