### PR TITLE
Delay exception throwing in JNI until the end of method scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 ### Bug fixes:
-  * Fixed flaky crash for callbacks being sent from Dart to C++ and then back.
+  * Fixed flaky crash in Dart for callbacks being sent from Dart to C++ and then back.
   * Fixed compilation error for nullable Locale fields in Java.
+  * Fixed runtime error for throwing methods with class/interface parameters in Java.
 
 ## 8.6.1
 Release date: 2020-11-18

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -264,11 +264,13 @@ feature(Errors cpp android swift dart SOURCES
     src/test/Errors.cpp
     src/test/ErrorsInInterface.cpp
     src/test/ErrorsInInterface.h
+    src/test/ErrorsWithNonTrivialType.cpp
 
     lime/hello/HelloWorldErrors.lime
     lime/test/Errors.lime
     lime/test/Errors2.lime
     lime/test/ErrorsInInterface.lime
+    lime/test/ErrorsWithNonTrivialType.lime
 )
 
 feature(Defaults cpp android swift dart SOURCES

--- a/examples/libhello/lime/test/ErrorsWithNonTrivialType.lime
+++ b/examples/libhello/lime/test/ErrorsWithNonTrivialType.lime
@@ -1,0 +1,35 @@
+# Copyright (C) 2016-2020 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+class ErrorsNonTrivial {
+    enum ErrorCode {
+        OK = 0,
+        FAILED = 1
+    }
+
+    exception Instantiation(ErrorCode)
+
+    interface Callback {
+        fun do_something()
+    }
+
+    constructor make(callback: Callback) throws Instantiation
+
+    static fun factory_make(callback: Callback): ErrorsNonTrivial throws Instantiation
+}

--- a/examples/libhello/src/test/ErrorsWithNonTrivialType.cpp
+++ b/examples/libhello/src/test/ErrorsWithNonTrivialType.cpp
@@ -1,0 +1,36 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2020 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/ErrorsNonTrivial.h"
+
+namespace test
+{
+::lorem_ipsum::test::Return<std::shared_ptr<ErrorsNonTrivial>, std::error_code>
+ErrorsNonTrivial::make(const std::shared_ptr<ErrorsNonTrivial::Callback>& callback)
+{
+    return make_error_code(ErrorsNonTrivial::ErrorCode::FAILED);
+}
+
+::lorem_ipsum::test::Return<std::shared_ptr<ErrorsNonTrivial>, std::error_code>
+ErrorsNonTrivial::factory_make(const std::shared_ptr<ErrorsNonTrivial::Callback>& callback)
+{
+    return make_error_code(ErrorsNonTrivial::ErrorCode::FAILED);
+}
+}

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/ErrorsTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/ErrorsTest.java
@@ -165,4 +165,18 @@ public class ErrorsTest {
 
     assertEquals("bar value", result);
   }
+
+  @Test
+  public void testCrashingConstructor() throws ErrorsNonTrivial.InstantiationException {
+    expectedException.expect(ErrorsNonTrivial.InstantiationException.class);
+
+    new ErrorsNonTrivial(() -> {});
+  }
+
+  @Test
+  public void testCrashingMethod() throws ErrorsNonTrivial.InstantiationException {
+    expectedException.expect(ErrorsNonTrivial.InstantiationException.class);
+
+    ErrorsNonTrivial.factoryMake(() -> {});
+  }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorSuite.kt
@@ -235,7 +235,8 @@ internal class JavaGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite 
             "JniWrapperCache",
             "JniCallJavaMethod"
         )
-        private val UTILS_FILES_HEADER_ONLY = listOf("JniTemplateMetainfo", "JniReference", "ArrayConversionUtils")
+        private val UTILS_FILES_HEADER_ONLY =
+            listOf("ArrayConversionUtils", "JniExceptionThrower", "JniReference", "JniTemplateMetainfo")
 
         private fun annotationFromOption(option: Pair<String, List<String>>?) =
             option?.let { JavaImport(option.second, option.first) }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniIncludeResolver.kt
@@ -84,4 +84,15 @@ internal class JniIncludeResolver(private val fileNameRules: JniFileNameRules) {
 
     fun collectConversionIncludes(limeStruct: LimeStruct) =
         limeStruct.fields.flatMap { getConversionIncludes(it.typeRef) }
+
+    fun collectExceptionIncludes(limeElement: LimeNamedElement): List<Include> {
+        val limeContainer = limeElement as? LimeContainer ?: return emptyList()
+        val allFunctions = limeContainer.functions +
+            ((limeContainer as? LimeContainerWithInheritance)?.inheritedFunctions ?: emptyList())
+        return listOfNotNull(exceptionThrowerInclude.takeIf { allFunctions.any { it.thrownType != null } })
+    }
+
+    companion object {
+        private val exceptionThrowerInclude = Include.createInternalInclude("JniExceptionThrower.h")
+    }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -83,7 +83,8 @@ internal class JniTemplates(
             is LimeStruct -> jniIncludeResolver.collectFunctionImplementationIncludes(limeElement)
             else -> jniIncludeResolver.collectImplementationIncludes(limeElement)
         } + Include.createInternalInclude("$fileName.h")
-        containerData["includes"] = implIncludes.distinct().sorted()
+        containerData["includes"] =
+            implIncludes.distinct().sorted() + jniIncludeResolver.collectExceptionIncludes(limeElement)
 
         val implFile = GeneratedFile(
             TemplateEngine.render("jni/Implementation", containerData, nameResolvers, predicates),

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -127,6 +127,9 @@ jint
 
 }}{{+jniMethodBody}}
 {
+{{#if thrownType}}
+    {{>common/InternalNamespace}}jni::JniExceptionThrower _throw_exception(_jenv);
+{{/if}}
 {{#parameters}}
 {{#unlessPredicate typeRef "isJniPrimitive"}}
     {{resolveName typeRef "C++"}} {{resolveName}} = {{>common/InternalNamespace}}jni::convert_from_jni(_jenv,
@@ -164,7 +167,7 @@ jint
         auto exceptionClass = {{>common/InternalNamespace}}jni::find_class(_jenv, "{{resolveName exception}}");
         auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "({{resolveName exception.errorType "signature"}})V");
         auto exception = {{>common/InternalNamespace}}jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
-        _jenv->Throw(static_cast<jthrowable>(exception.release()));{{#unless returnType.isVoid}}
+        _throw_exception.register_exception(std::move(exception));{{#unless returnType.isVoid}}
         return {{#ifPredicate "returnsOpaqueHandle"}}0{{/ifPredicate}}{{#unlessPredicate "returnsOpaqueHandle"}}{{!!
         }}{{#unlessPredicate returnType.typeRef "isJniPrimitive"}}nullptr{{/unlessPredicate}}{{!!
         }}{{#ifPredicate returnType.typeRef "isJniPrimitive"}}nativeCallResult.unsafe_value(){{/ifPredicate}}{{/unlessPredicate}};{{/unless}}

--- a/gluecodium/src/main/resources/templates/jni/utils/JniExceptionThrowerHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniExceptionThrowerHeader.mustache
@@ -1,0 +1,59 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{>java/CopyrightHeader}}
+
+#pragma once
+
+#include "JniReference.h"
+
+{{#internalNamespace}}
+namespace {{.}}
+{
+{{/internalNamespace}}
+namespace jni
+{
+    class JniExceptionThrower
+    {
+    public:
+        explicit JniExceptionThrower(JNIEnv* jni_env) : m_jni_env(jni_env)
+        {
+        }
+
+        ~JniExceptionThrower()
+        {
+            if (m_exception)
+            {
+                m_jni_env->Throw(static_cast<jthrowable>(m_exception.release()));
+            }
+        }
+
+        void register_exception(JniReference<jobject> exception)
+        {
+            m_exception = std::move(exception);
+        }
+    private:
+        JNIEnv* const m_jni_env;
+        JniReference<jobject> m_exception;
+    };
+}
+{{#internalNamespace}}
+}
+{{/internalNamespace}}

--- a/gluecodium/src/test/resources/smoke/constructors/output/android/jni/com_example_smoke_Constructors.cpp
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android/jni/com_example_smoke_Constructors.cpp
@@ -4,6 +4,7 @@
 #include "com_example_smoke_Constructors.h"
 #include "com_example_smoke_Constructors_ErrorEnum__Conversion.h"
 #include "com_example_smoke_Constructors__Conversion.h"
+#include "JniExceptionThrower.h"
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
@@ -58,6 +59,7 @@ Java_com_example_smoke_Constructors_create__Ljava_lang_String_2J(JNIEnv* _jenv, 
 jlong
 Java_com_example_smoke_Constructors_create__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
 {
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
             (::std::string*)nullptr);
@@ -70,7 +72,7 @@ Java_com_example_smoke_Constructors_create__Ljava_lang_String_2(JNIEnv* _jenv, j
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/Constructors$ConstructorExplodedException");
         auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Lcom/example/smoke/Constructors$ErrorEnum;)V");
         auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
-        _jenv->Throw(static_cast<jthrowable>(exception.release()));
+        _throw_exception.register_exception(std::move(exception));
         return 0;
     }
     auto result = nativeCallResult.unsafe_value();

--- a/gluecodium/src/test/resources/smoke/errors/output/android/jni/com_example_smoke_Errors.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/android/jni/com_example_smoke_Errors.cpp
@@ -6,6 +6,7 @@
 #include "com_example_smoke_Errors_InternalErrorCode__Conversion.h"
 #include "com_example_smoke_Errors__Conversion.h"
 #include "com_example_smoke_Payload__Conversion.h"
+#include "JniExceptionThrower.h"
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
@@ -14,6 +15,7 @@ extern "C" {
 void
 Java_com_example_smoke_Errors_methodWithErrors(JNIEnv* _jenv, jobject _jinstance)
 {
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
     auto nativeCallResult = ::smoke::Errors::method_with_errors();
     auto errorCode = nativeCallResult;
     if (errorCode)
@@ -23,12 +25,13 @@ Java_com_example_smoke_Errors_methodWithErrors(JNIEnv* _jenv, jobject _jinstance
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/Errors$InternalException");
         auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Lcom/example/smoke/Errors$InternalErrorCode;)V");
         auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
-        _jenv->Throw(static_cast<jthrowable>(exception.release()));
+        _throw_exception.register_exception(std::move(exception));
     }
 }
 void
 Java_com_example_smoke_Errors_methodWithExternalErrors(JNIEnv* _jenv, jobject _jinstance)
 {
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
     auto nativeCallResult = ::smoke::Errors::method_with_external_errors();
     auto errorCode = nativeCallResult;
     if (errorCode)
@@ -38,12 +41,13 @@ Java_com_example_smoke_Errors_methodWithExternalErrors(JNIEnv* _jenv, jobject _j
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/Errors$ExternalException");
         auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Lcom/example/smoke/Errors$ExternalErrors;)V");
         auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
-        _jenv->Throw(static_cast<jthrowable>(exception.release()));
+        _throw_exception.register_exception(std::move(exception));
     }
 }
 jstring
 Java_com_example_smoke_Errors_methodWithErrorsAndReturnValue(JNIEnv* _jenv, jobject _jinstance)
 {
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
     auto nativeCallResult = ::smoke::Errors::method_with_errors_and_return_value();
     auto errorCode = nativeCallResult.error();
     if (!nativeCallResult.has_value())
@@ -53,7 +57,7 @@ Java_com_example_smoke_Errors_methodWithErrorsAndReturnValue(JNIEnv* _jenv, jobj
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/Errors$InternalException");
         auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Lcom/example/smoke/Errors$InternalErrorCode;)V");
         auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
-        _jenv->Throw(static_cast<jthrowable>(exception.release()));
+        _throw_exception.register_exception(std::move(exception));
         return nullptr;
     }
     auto result = nativeCallResult.unsafe_value();
@@ -62,6 +66,7 @@ Java_com_example_smoke_Errors_methodWithErrorsAndReturnValue(JNIEnv* _jenv, jobj
 void
 Java_com_example_smoke_Errors_methodWithPayloadError(JNIEnv* _jenv, jobject _jinstance)
 {
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
     auto nativeCallResult = ::smoke::Errors::method_with_payload_error();
     if (!nativeCallResult.has_value())
     {
@@ -69,12 +74,13 @@ Java_com_example_smoke_Errors_methodWithPayloadError(JNIEnv* _jenv, jobject _jin
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/WithPayloadException");
         auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Lcom/example/smoke/Payload;)V");
         auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
-        _jenv->Throw(static_cast<jthrowable>(exception.release()));
+        _throw_exception.register_exception(std::move(exception));
     }
 }
 jstring
 Java_com_example_smoke_Errors_methodWithPayloadErrorAndReturnValue(JNIEnv* _jenv, jobject _jinstance)
 {
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
     auto nativeCallResult = ::smoke::Errors::method_with_payload_error_and_return_value();
     if (!nativeCallResult.has_value())
     {
@@ -82,7 +88,7 @@ Java_com_example_smoke_Errors_methodWithPayloadErrorAndReturnValue(JNIEnv* _jenv
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/WithPayloadException");
         auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Lcom/example/smoke/Payload;)V");
         auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
-        _jenv->Throw(static_cast<jthrowable>(exception.release()));
+        _throw_exception.register_exception(std::move(exception));
         return nullptr;
     }
     auto result = nativeCallResult.unsafe_value();

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID.cpp
@@ -5,6 +5,7 @@
 #include "com_example_namerules_NAME_RULES_DROID_EXAMPLE_ERROR_CODE_DROID__Conversion.h"
 #include "com_example_namerules_NAME_RULES_DROID_EXAMPLE_STRUCT_DROID__Conversion.h"
 #include "com_example_namerules_NAME_RULES_DROID__Conversion.h"
+#include "JniExceptionThrower.h"
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
@@ -26,6 +27,7 @@ Java_com_example_namerules_NAME_1RULES_1DROID_create(JNIEnv* _jenv, jobject _jin
 jdouble
 Java_com_example_namerules_NAME_1RULES_1DROID_some_1method(JNIEnv* _jenv, jobject _jinstance, jobject jsome_argument)
 {
+    ::jni::JniExceptionThrower _throw_exception(_jenv);
     ::namerules::NameRules::ExampleStruct some_argument = ::jni::convert_from_jni(_jenv,
             ::jni::make_non_releasing_ref(jsome_argument),
             (::namerules::NameRules::ExampleStruct*)nullptr);
@@ -44,7 +46,7 @@ Java_com_example_namerules_NAME_1RULES_1DROID_some_1method(JNIEnv* _jenv, jobjec
         auto exceptionClass = ::jni::find_class(_jenv, "com/example/namerules/NAME_RULES_DROID$example_x");
         auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Lcom/example/namerules/NAME_RULES_DROID$EXAMPLE_ERROR_CODE_DROID;)V");
         auto exception = ::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
-        _jenv->Throw(static_cast<jthrowable>(exception.release()));
+        _throw_exception.register_exception(std::move(exception));
         return nativeCallResult.unsafe_value();
     }
     auto result = nativeCallResult.unsafe_value();

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_StructsWithMethodsInterface_Vector3.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_StructsWithMethodsInterface_Vector3.cpp
@@ -4,6 +4,7 @@
 #include "com_example_smoke_StructsWithMethodsInterface_Vector3.h"
 #include "com_example_smoke_StructsWithMethodsInterface_Vector3__Conversion.h"
 #include "com_example_smoke_ValidationErrorCode__Conversion.h"
+#include "JniExceptionThrower.h"
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
@@ -54,6 +55,7 @@ Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_create__Ljava_la
 jobject
 Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_create__Lcom_example_smoke_StructsWithMethodsInterface_00024Vector3_2(JNIEnv* _jenv, jobject _jinstance, jobject jother)
 {
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
     ::smoke::StructsWithMethodsInterface::Vector3 other = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jother),
             (::smoke::StructsWithMethodsInterface::Vector3*)nullptr);
@@ -66,7 +68,7 @@ Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_create__Lcom_exa
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/ValidationException");
         auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Lcom/example/smoke/ValidationErrorCode;)V");
         auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
-        _jenv->Throw(static_cast<jthrowable>(exception.release()));
+        _throw_exception.register_exception(std::move(exception));
         return nullptr;
     }
     auto result = nativeCallResult.unsafe_value();

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Vector.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Vector.cpp
@@ -4,6 +4,7 @@
 #include "com_example_smoke_ValidationErrorCode__Conversion.h"
 #include "com_example_smoke_Vector.h"
 #include "com_example_smoke_Vector__Conversion.h"
+#include "JniExceptionThrower.h"
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniReference.h"
@@ -52,6 +53,7 @@ Java_com_example_smoke_Vector_create__DD(JNIEnv* _jenv, jobject _jinstance, jdou
 jobject
 Java_com_example_smoke_Vector_create__Lcom_example_smoke_Vector_2(JNIEnv* _jenv, jobject _jinstance, jobject jother)
 {
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
     ::smoke::Vector other = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jother),
             (::smoke::Vector*)nullptr);
@@ -64,7 +66,7 @@ Java_com_example_smoke_Vector_create__Lcom_example_smoke_Vector_2(JNIEnv* _jenv,
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/ValidationException");
         auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Lcom/example/smoke/ValidationErrorCode;)V");
         auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
-        _jenv->Throw(static_cast<jthrowable>(exception.release()));
+        _throw_exception.register_exception(std::move(exception));
         return nullptr;
     }
     auto result = nativeCallResult.unsafe_value();


### PR DESCRIPTION
Updated JNI template for functions throwing an exception to use
the new JniExceptionThrower class to delay throwing the
Java exception until the very end of the function scope.

This fixes the issue where a C++ proxy (for a Java interface
passed as a function parameter) tries to access JNI API but
there is a Java exception pending already.

Updated smoke tests. Added a functional test.

Resolves: #605
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
