### PR TITLE
Extract commmon generator functionality

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.common
+
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeTypeHelper
+
+/**
+ * Predicates used by `ifPredicate`/`unlessPredicate` template helpers in several generators.
+ */
+internal object CommonGeneratorPredicates {
+    fun hasImmutableFields(limeStruct: Any) =
+        when {
+            limeStruct !is LimeStruct -> false
+            limeStruct.attributes.have(LimeAttributeType.IMMUTABLE) -> true
+            else -> limeStruct.fields
+                .flatMap { LimeTypeHelper.getAllFieldTypes(it.typeRef.type) }
+                .any { it.attributes.have(LimeAttributeType.IMMUTABLE) }
+        }
+
+    fun hasTypeRepository(limeContainer: Any) =
+        when {
+            limeContainer !is LimeContainerWithInheritance -> false
+            limeContainer is LimeInterface -> true
+            limeContainer.visibility.isOpen -> true
+            else -> limeContainer.parent != null
+        }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/ReferenceMapBasedResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/ReferenceMapBasedResolver.kt
@@ -25,9 +25,7 @@ import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeParameter
 import com.here.gluecodium.model.lime.LimePath
 
-internal abstract class ReferenceMapNameResolver(
-    protected val limeReferenceMap: Map<String, LimeElement>
-) : NameResolver {
+internal abstract class ReferenceMapBasedResolver(protected val limeReferenceMap: Map<String, LimeElement>) {
 
     protected fun getParentElement(limeElement: LimeNamedElement): LimeNamedElement =
         getParentElement(limeElement.path, limeElement is LimeParameter)
@@ -42,4 +40,7 @@ internal abstract class ReferenceMapNameResolver(
                 "Failed to resolve parent for element $limePath"
             ))
     }
+
+    protected fun getTopElement(limeElement: LimeNamedElement) =
+        generateSequence(limeElement) { limeReferenceMap[it.path.parent.toString()] as? LimeNamedElement }.last()
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/Cpp2IncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/Cpp2IncludeResolver.kt
@@ -47,16 +47,15 @@ internal class Cpp2IncludeResolver(
     private val cppIncludeResolver = CppIncludeResolver(limeReferenceMap, nameRules, internalNamespace)
 
     val hashInclude = cppIncludeResolver.createInternalNamespaceInclude("Hash.h")
+    val typeRepositoryInclude = cppIncludeResolver.createInternalNamespaceInclude("TypeRepository.h")
+    val optionalInclude = cppIncludeResolver.createInternalNamespaceInclude("Optional.h")
 
     private val returnInclude = cppIncludeResolver.createInternalNamespaceInclude("Return.h")
     private val timePointHashInclude = cppIncludeResolver.createInternalNamespaceInclude("TimePointHash.h")
     private val vectorHashInclude = cppIncludeResolver.createInternalNamespaceInclude("VectorHash.h")
     private val unorderedMapHashInclude = cppIncludeResolver.createInternalNamespaceInclude("UnorderedMapHash.h")
     private val unorderedSetHashInclude = cppIncludeResolver.createInternalNamespaceInclude("UnorderedSetHash.h")
-    private val optionalInclude = cppIncludeResolver.createInternalNamespaceInclude("Optional.h")
     private val localeInclude = cppIncludeResolver.createInternalNamespaceInclude("Locale.h")
-
-    val typeRepositoryInclude = cppIncludeResolver.createInternalNamespaceInclude("TypeRepository.h")
 
     fun resolveIncludes(limeElement: LimeElement): List<Include> =
         when (limeElement) {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/Cpp2NameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/Cpp2NameResolver.kt
@@ -21,7 +21,8 @@ package com.here.gluecodium.generator.cpp
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
-import com.here.gluecodium.generator.common.ReferenceMapNameResolver
+import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.model.lime.LimeAttributeType.CPP
 import com.here.gluecodium.model.lime.LimeAttributeValueType.ACCESSORS
 import com.here.gluecodium.model.lime.LimeBasicType
@@ -60,7 +61,7 @@ internal class Cpp2NameResolver(
     private val cachingNameResolver: CppNameResolver,
     private val limeLogger: LimeLogger? = null,
     private val commentsProcessor: CommentsProcessor? = null
-) : ReferenceMapNameResolver(limeReferenceMap) {
+) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
     private val signatureResolver = LimeSignatureResolver(limeReferenceMap)
     private val limeToCppNames = buildPathMap()

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -21,8 +21,9 @@ package com.here.gluecodium.generator.dart
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.NameRules
-import com.here.gluecodium.generator.common.ReferenceMapNameResolver
+import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeBasicType
@@ -51,7 +52,7 @@ internal class DartNameResolver(
     private val nameRules: NameRules,
     private val limeLogger: LimeLogger,
     private val commentsProcessor: DartCommentsProcessor
-) : ReferenceMapNameResolver(limeReferenceMap) {
+) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
     private val joinInfix = nameRules.ruleSet.joinInfix ?: ""
     private val limeToDartNames = buildPathMap()

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppNameResolver.kt
@@ -20,7 +20,8 @@
 package com.here.gluecodium.generator.ffi
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
-import com.here.gluecodium.generator.common.ReferenceMapNameResolver
+import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.generator.cpp.CppLibraryIncludes
 import com.here.gluecodium.generator.cpp.CppNameResolver
 import com.here.gluecodium.generator.cpp.CppNameRules
@@ -50,7 +51,7 @@ internal class FfiCppNameResolver(
     nameRules: CppNameRules,
     rootNamespace: List<String>,
     internalNamespace: List<String>
-) : ReferenceMapNameResolver(limeReferenceMap) {
+) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
     private val cppNameResolver = CppNameResolver(rootNamespace, limeReferenceMap, nameRules)
     private val internalNamespace = internalNamespace.joinToString("::")

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
@@ -21,7 +21,8 @@ package com.here.gluecodium.generator.java
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
-import com.here.gluecodium.generator.common.ReferenceMapNameResolver
+import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeAttributeValueType.FUNCTION_NAME
 import com.here.gluecodium.model.lime.LimeBasicType
@@ -55,7 +56,7 @@ internal class JavaNameResolver(
     private val javaNameRules: JavaNameRules,
     private val limeLogger: LimeLogger,
     private val commentsProcessor: CommentsProcessor
-) : ReferenceMapNameResolver(limeReferenceMap) {
+) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
     private val valueResolver = JavaValueResolver(this)
     private val signatureResolver = JavaSignatureResolver(limeReferenceMap, javaNameRules)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
@@ -19,24 +19,20 @@
 
 package com.here.gluecodium.generator.jni
 
+import com.here.gluecodium.generator.common.CommonGeneratorPredicates
 import com.here.gluecodium.generator.cpp.Cpp2NameResolver
 import com.here.gluecodium.generator.java.JavaNameRules
 import com.here.gluecodium.generator.java.JavaSignatureResolver
-import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId.BOOLEAN
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId.VOID
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeContainer
-import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.CONVERTER_NAME
 import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeFunction
-import com.here.gluecodium.model.lime.LimeInterface
-import com.here.gluecodium.model.lime.LimeStruct
-import com.here.gluecodium.model.lime.LimeTypeHelper
 import com.here.gluecodium.model.lime.LimeTypeRef
 
 /**
@@ -59,23 +55,8 @@ internal class JniGeneratorPredicates(
         "hasCppSetter" to { limeField: Any ->
             limeField is LimeField && cppNameResolver.resolveSetterName(limeField) != null
         },
-        "hasImmutableFields" to { limeStruct: Any ->
-            when {
-                limeStruct !is LimeStruct -> false
-                limeStruct.attributes.have(LimeAttributeType.IMMUTABLE) -> true
-                else -> limeStruct.fields
-                    .flatMap { LimeTypeHelper.getAllFieldTypes(it.typeRef.type) }
-                    .any { it.attributes.have(LimeAttributeType.IMMUTABLE) }
-            }
-        },
-        "hasTypeRepository" to { limeContainer: Any ->
-            when {
-                limeContainer !is LimeContainerWithInheritance -> false
-                limeContainer is LimeInterface -> true
-                limeContainer.visibility.isOpen -> true
-                else -> limeContainer.parent != null
-            }
-        },
+        "hasImmutableFields" to CommonGeneratorPredicates::hasImmutableFields,
+        "hasTypeRepository" to CommonGeneratorPredicates::hasTypeRepository,
         "isJniPrimitive" to fun(limeTypeRef: Any): Boolean {
             if (limeTypeRef !is LimeTypeRef || limeTypeRef.isNullable) return false
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniNameResolver.kt
@@ -20,7 +20,8 @@
 package com.here.gluecodium.generator.jni
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
-import com.here.gluecodium.generator.common.ReferenceMapNameResolver
+import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.generator.java.JavaNameRules
 import com.here.gluecodium.model.lime.LimeAttributeType.CACHED
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
@@ -47,7 +48,7 @@ internal class JniNameResolver(
     limeReferenceMap: Map<String, LimeElement>,
     private val basePackages: List<String>,
     private val javaNameRules: JavaNameRules
-) : ReferenceMapNameResolver(limeReferenceMap) {
+) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
     override fun resolveName(element: Any): String =
         when (element) {


### PR DESCRIPTION
Removed NameResolver interface conformance from ReferenceMapNameResolver and renamed it to ReferenceMapBasedResolver.
This allows its reuse as a parent class for other resolvers that are not "name" resolvers.

Extracted common generator predicates to CommonGeneratorPredicates.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>