### PR TITLE
Extract GenericTypesCollector into a dedicated class

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/GenericTypesCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/GenericTypesCollector.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.common
+
+import com.here.gluecodium.common.LimeTypeRefsVisitor
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
+import com.here.gluecodium.model.lime.LimeGenericType
+import com.here.gluecodium.model.lime.LimeList
+import com.here.gluecodium.model.lime.LimeMap
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeSet
+import com.here.gluecodium.model.lime.LimeType
+import com.here.gluecodium.model.lime.LimeTypeRef
+
+internal class GenericTypesCollector(
+    private val sortingKeyMapper: (LimeGenericType) -> String,
+    private val platformAttributeType: LimeAttributeType
+) : LimeTypeRefsVisitor<List<LimeGenericType>>() {
+
+    fun getAllGenericTypes(allTypes: List<LimeType>) =
+        traverseTypes(allTypes).flatten()
+            .filterNot { it.attributes.have(platformAttributeType, SKIP) }
+            .associateBy(sortingKeyMapper)
+            .toSortedMap()
+            .values
+            .toList()
+
+    override fun visitTypeRef(parentElement: LimeNamedElement, limeTypeRef: LimeTypeRef?): List<LimeGenericType> {
+        val limeType = limeTypeRef?.type?.actualType as? LimeGenericType ?: return emptyList()
+        return listOf(limeType) + when (limeType) {
+            is LimeList -> visitTypeRef(parentElement, limeType.elementType)
+            is LimeSet -> visitTypeRef(parentElement, limeType.elementType)
+            is LimeMap -> visitTypeRef(parentElement, limeType.keyType) +
+                    visitTypeRef(parentElement, limeType.valueType)
+            else -> emptyList()
+        }
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -22,9 +22,9 @@ package com.here.gluecodium.generator.dart
 import com.here.gluecodium.Gluecodium
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
-import com.here.gluecodium.common.LimeTypeRefsVisitor
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.GeneratedFile.SourceSet.COMMON
+import com.here.gluecodium.generator.common.GenericTypesCollector
 import com.here.gluecodium.generator.common.LimeModelFilter
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.NameRules
@@ -51,17 +51,13 @@ import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeGenericType
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
-import com.here.gluecodium.model.lime.LimeList
-import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeProperty
-import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeHelper
-import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeTypesCollection
 import com.here.gluecodium.platform.common.GeneratorSuite
 import java.util.logging.Logger
@@ -124,11 +120,9 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
         val exportsCollector = mutableMapOf<List<String>, MutableList<DartExport>>()
         val typeRepositoriesCollector = mutableListOf<LimeContainerWithInheritance>()
 
-        val genericTypes = TypeRefsCollector.getAllTypeRefs(limeModel)
-            .map { it.type }
-            .filterIsInstance<LimeGenericType>()
-            .distinctBy { ffiNameResolver.resolveName(it) }
-            .sortedBy { ffiNameResolver.resolveName(it) }
+        val genericTypesCollector = GenericTypesCollector({ ffiNameResolver.resolveName(it) }, DART)
+        val genericTypes =
+            genericTypesCollector.getAllGenericTypes(dartFilteredElements.flatMap { LimeTypeHelper.getAllTypes(it) })
 
         val generatedFiles = dartFilteredElements.flatMap {
             listOfNotNull(generateDart(it, dartResolvers, dartNameResolver, importResolver,
@@ -459,35 +453,6 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
         limeFunction.parameters.map { it.typeRef } +
             limeFunction.returnType.typeRef +
             listOfNotNull(limeFunction.exception?.errorType)
-
-    private object TypeRefsCollector : LimeTypeRefsVisitor<List<LimeTypeRef>>() {
-        override fun visitTypeRef(
-            parentElement: LimeNamedElement,
-            limeTypeRef: LimeTypeRef?
-        ): List<LimeTypeRef> =
-            listOfNotNull(limeTypeRef) + when (val limeType = limeTypeRef?.type?.actualType) {
-                is LimeList -> visitTypeRef(parentElement, limeType.elementType)
-                is LimeSet -> visitTypeRef(parentElement, limeType.elementType)
-                is LimeMap -> visitTypeRef(parentElement, limeType.keyType) +
-                        visitTypeRef(parentElement, limeType.valueType)
-                else -> emptyList()
-            }
-
-        fun getAllTypeRefs(limeModel: LimeModel): List<LimeTypeRef> {
-            val allElements = limeModel.referenceMap.values
-                .filterIsInstance<LimeNamedElement>()
-                .filterNot { isSkipped(it, limeModel) }
-            return traverseModel(allElements).flatten()
-        }
-
-        private fun isSkipped(element: LimeNamedElement, limeModel: LimeModel) =
-            generateSequence(element) {
-                when {
-                    it.path.hasParent -> limeModel.referenceMap[it.path.parent.toString()] as? LimeNamedElement
-                    else -> null
-                }
-            }.any { it.attributes.have(DART, SKIP) }
-        }
 
     companion object {
         const val GENERATOR_NAME = "dart"

--- a/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
@@ -28,7 +28,6 @@ import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
 
 @RunWith(Parameterized::class)
-
 class SmokeTest(
     private val featureDirectory: File,
     generatorName: String,


### PR DESCRIPTION
CBridge generator and Dart generator each had a dedicated private class for collecting generic type references.
Extracted these into a single dedicated class GenericTypesCollector.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>