### PR TITLE
Fix Swift overloads resolution for platform names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed compilation issue for Swift function overloads with `@Swift(Name)` platform names.
+
 ## 8.6.2
 Release date: 2020-11-19
 ### Bug fixes:

--- a/examples/libhello/lime/test/MethodOverloads.lime
+++ b/examples/libhello/lime/test/MethodOverloads.lime
@@ -111,3 +111,11 @@ struct StructConstructorOverloads {
 
     constructor create(input1: String, input2: String)
 }
+
+@Java(Skip) @Dart(Skip)
+class SwiftMethodOverloads {
+    @Swift("three")
+    fun one(input: String)
+    @Swift("three")
+    fun two(input: List<String>)
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeNameResolver.kt
@@ -22,8 +22,9 @@ package com.here.gluecodium.generator.cbridge
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.generator.common.NameHelper
 import com.here.gluecodium.generator.common.NameResolver
-import com.here.gluecodium.generator.common.NameRules
 import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
+import com.here.gluecodium.generator.swift.SwiftNameRules
+import com.here.gluecodium.generator.swift.SwiftSignatureResolver
 import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
 import com.here.gluecodium.model.lime.LimeAttributeValueType.NAME
 import com.here.gluecodium.model.lime.LimeBasicType
@@ -40,18 +41,17 @@ import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeSet
-import com.here.gluecodium.model.lime.LimeSignatureResolver
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeRef
 
 internal class CBridgeNameResolver(
     limeReferenceMap: Map<String, LimeElement>,
-    private val nameRules: NameRules,
+    private val swiftNameRules: SwiftNameRules,
     private val internalPrefix: String
 ) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
-    private val signatureResolver = LimeSignatureResolver(limeReferenceMap)
+    private val signatureResolver = SwiftSignatureResolver(limeReferenceMap, swiftNameRules)
 
     override fun resolveName(element: Any): String =
         when (element) {
@@ -70,7 +70,7 @@ internal class CBridgeNameResolver(
             // TODO: review and remove after all tests are passing
             is TypeId -> resolveBasicType(element)
             is LimeTypeAlias -> resolveName(element.typeRef)
-            is LimeNamedElement -> nameRules.getName(element)
+            is LimeNamedElement -> swiftNameRules.getName(element)
             is LinkedHashMap<*, *> -> "" // TODO: remove
             else -> throw GluecodiumExecutionException("Unsupported element type ${element.javaClass.name}")
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -23,7 +23,6 @@ import com.here.gluecodium.generator.cbridge.CBridgeCollectionNameResolver
 import com.here.gluecodium.generator.common.modelbuilder.LimeTreeWalker
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeNamedElement
-import com.here.gluecodium.model.lime.LimeSignatureResolver
 import com.here.gluecodium.model.swift.SwiftClosure
 import com.here.gluecodium.model.swift.SwiftEnum
 import com.here.gluecodium.model.swift.SwiftFile
@@ -39,7 +38,7 @@ class SwiftGenerator(
 ) {
     val genericsGenerator = SwiftGenericsGenerator(internalPrefix)
     val builtinOptionalsGenerator = SwiftBuiltinOptionalsGenerator()
-    private val signatureResolver = LimeSignatureResolver(limeReferenceMap)
+    private val signatureResolver = SwiftSignatureResolver(limeReferenceMap, nameRules)
     private val nameResolver = SwiftNameResolver(limeReferenceMap, nameRules)
     private val cBridgeNameResolver = CBridgeCollectionNameResolver(internalPrefix ?: "")
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftSignatureResolver.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.swift
+
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeSignatureResolver
+
+class SwiftSignatureResolver(val limeReferenceMap: Map<String, LimeElement>, val nameRules: SwiftNameRules) :
+    LimeSignatureResolver(limeReferenceMap) {
+
+    override fun getFunctionName(limeFunction: LimeFunction) =
+        limeFunction.attributes.get(LimeAttributeType.SWIFT, LimeAttributeValueType.NAME, String::class.java)
+            ?: nameRules.getName(limeFunction)
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/input/MethodOverloads.lime
+++ b/gluecodium/src/test/resources/smoke/method_overloads/input/MethodOverloads.lime
@@ -62,3 +62,11 @@ class SpecialNames {
     fun createProxy()
     fun _upperCase()
 }
+
+@Java(Skip) @Dart(Skip)
+class SwiftMethodOverloads {
+    @Swift("three")
+    fun one(input: String)
+    @Swift("three")
+    fun two(input: List<String>)
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/include/smoke/cbridge_SwiftMethodOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/include/smoke/cbridge_SwiftMethodOverloads.h
@@ -1,0 +1,18 @@
+//
+//
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "cbridge/include/BaseHandle.h"
+#include "cbridge/include/Export.h"
+_GLUECODIUM_C_EXPORT void smoke_SwiftMethodOverloads_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_SwiftMethodOverloads_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_SwiftMethodOverloads_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_SwiftMethodOverloads_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
+_GLUECODIUM_C_EXPORT void smoke_SwiftMethodOverloads_remove_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_SwiftMethodOverloads_three_String(_baseRef _instance, _baseRef input);
+_GLUECODIUM_C_EXPORT void smoke_SwiftMethodOverloads_three__3String_4(_baseRef _instance, _baseRef input);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/src/smoke/cbridge_SwiftMethodOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/src/smoke/cbridge_SwiftMethodOverloads.cpp
@@ -1,0 +1,40 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_SwiftMethodOverloads.h"
+#include "cbridge/include/StringHandle.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
+#include "gluecodium/VectorHash.h"
+#include "smoke/SwiftMethodOverloads.h"
+#include <memory>
+#include <new>
+#include <string>
+#include <vector>
+void smoke_SwiftMethodOverloads_release_handle(_baseRef handle) {
+    delete get_pointer<::std::shared_ptr< ::smoke::SwiftMethodOverloads >>(handle);
+}
+_baseRef smoke_SwiftMethodOverloads_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr< ::smoke::SwiftMethodOverloads >>(handle)))
+        : 0;
+}
+const void* smoke_SwiftMethodOverloads_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::SwiftMethodOverloads >>(handle)->get())
+        : nullptr;
+}
+void smoke_SwiftMethodOverloads_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr< ::smoke::SwiftMethodOverloads >>(handle)->get(), swift_pointer);
+}
+void smoke_SwiftMethodOverloads_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::SwiftMethodOverloads >>(handle)->get());
+}
+void smoke_SwiftMethodOverloads_three_String(_baseRef _instance, _baseRef input) {
+    return get_pointer<::std::shared_ptr< ::smoke::SwiftMethodOverloads >>(_instance)->get()->one(Conversion<::std::string>::toCpp(input));
+}
+void smoke_SwiftMethodOverloads_three__3String_4(_baseRef _instance, _baseRef input) {
+    return get_pointer<::std::shared_ptr< ::smoke::SwiftMethodOverloads >>(_instance)->get()->two(Conversion<::std::vector< ::std::string >>::toCpp(input));
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SwiftMethodOverloads.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SwiftMethodOverloads.swift
@@ -1,0 +1,79 @@
+//
+//
+import Foundation
+public class SwiftMethodOverloads {
+    let c_instance : _baseRef
+    init(cSwiftMethodOverloads: _baseRef) {
+        guard cSwiftMethodOverloads != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cSwiftMethodOverloads
+    }
+    deinit {
+        smoke_SwiftMethodOverloads_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_SwiftMethodOverloads_release_handle(c_instance)
+    }
+    public func three(input: String) -> Void {
+        let c_input = moveToCType(input)
+        return moveFromCType(smoke_SwiftMethodOverloads_three_String(self.c_instance, c_input.ref))
+    }
+    public func three(input: [String]) -> Void {
+        let c_input = moveToCType(input)
+        return moveFromCType(smoke_SwiftMethodOverloads_three__3String_4(self.c_instance, c_input.ref))
+    }
+}
+internal func getRef(_ ref: SwiftMethodOverloads?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_SwiftMethodOverloads_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_SwiftMethodOverloads_release_handle)
+        : RefHolder(handle_copy)
+}
+extension SwiftMethodOverloads: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+internal func SwiftMethodOverloads_copyFromCType(_ handle: _baseRef) -> SwiftMethodOverloads {
+    if let swift_pointer = smoke_SwiftMethodOverloads_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SwiftMethodOverloads {
+        return re_constructed
+    }
+    let result = SwiftMethodOverloads(cSwiftMethodOverloads: smoke_SwiftMethodOverloads_copy_handle(handle))
+    smoke_SwiftMethodOverloads_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func SwiftMethodOverloads_moveFromCType(_ handle: _baseRef) -> SwiftMethodOverloads {
+    if let swift_pointer = smoke_SwiftMethodOverloads_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SwiftMethodOverloads {
+        smoke_SwiftMethodOverloads_release_handle(handle)
+        return re_constructed
+    }
+    let result = SwiftMethodOverloads(cSwiftMethodOverloads: handle)
+    smoke_SwiftMethodOverloads_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func SwiftMethodOverloads_copyFromCType(_ handle: _baseRef) -> SwiftMethodOverloads? {
+    guard handle != 0 else {
+        return nil
+    }
+    return SwiftMethodOverloads_moveFromCType(handle) as SwiftMethodOverloads
+}
+internal func SwiftMethodOverloads_moveFromCType(_ handle: _baseRef) -> SwiftMethodOverloads? {
+    guard handle != 0 else {
+        return nil
+    }
+    return SwiftMethodOverloads_moveFromCType(handle) as SwiftMethodOverloads
+}
+internal func copyToCType(_ swiftClass: SwiftMethodOverloads) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: SwiftMethodOverloads) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: SwiftMethodOverloads?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: SwiftMethodOverloads?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}


### PR DESCRIPTION
Added SwiftSignatureResolver class for resolving function overloads while taking Swift-specific platform names into
account. Previously Swift function overloads were resolved based on LIME names only.

Added smoke and functional tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>