### PR TITLE
Generalize GenericTypesCollector

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
@@ -22,8 +22,8 @@ package com.here.gluecodium.generator.cbridge
 import com.here.gluecodium.generator.cbridge.CBridgeNameRules.CBRIDGE_INTERNAL
 import com.here.gluecodium.generator.cbridge.CBridgeNameRules.CBRIDGE_PUBLIC
 import com.here.gluecodium.generator.common.GeneratedFile
-import com.here.gluecodium.generator.common.GenericTypesCollector
 import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.common.ReferredTypesCollector
 import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.generator.cpp.Cpp2IncludeResolver
 import com.here.gluecodium.generator.cpp.Cpp2NameResolver
@@ -37,6 +37,7 @@ import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
+import com.here.gluecodium.model.lime.LimeGenericType
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
@@ -90,8 +91,9 @@ internal class CBridgeGenerator(
     fun generateCollections(limeModel: List<LimeNamedElement>): List<GeneratedFile> {
         val allTypes = limeModel.flatMap { LimeTypeHelper.getAllTypes(it) }
         val allParentTypes = getAllParentTypes(allTypes)
-        val genericTypesCollector = GenericTypesCollector({ nameResolver.resolveName(it) }, LimeAttributeType.SWIFT)
-        val genericTypes = genericTypesCollector.getAllGenericTypes(allTypes + allParentTypes)
+        val referredTypesCollector = ReferredTypesCollector({ nameResolver.resolveName(it) }, LimeAttributeType.SWIFT)
+        val genericTypes =
+            referredTypesCollector.getAllReferredTypes(allTypes + allParentTypes).filterIsInstance<LimeGenericType>()
         val templateData = mutableMapOf<String, Any>(
             "lists" to genericTypes.filterIsInstance<LimeList>(),
             "maps" to genericTypes.filterIsInstance<LimeMap>(),

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorSuite.kt
@@ -24,10 +24,10 @@ import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.GeneratedFile.SourceSet.COMMON
-import com.here.gluecodium.generator.common.GenericTypesCollector
 import com.here.gluecodium.generator.common.LimeModelFilter
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.NameRules
+import com.here.gluecodium.generator.common.ReferredTypesCollector
 import com.here.gluecodium.generator.common.nameRuleSetFromConfig
 import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.generator.cpp.CppLibraryIncludes
@@ -120,9 +120,9 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
         val exportsCollector = mutableMapOf<List<String>, MutableList<DartExport>>()
         val typeRepositoriesCollector = mutableListOf<LimeContainerWithInheritance>()
 
-        val genericTypesCollector = GenericTypesCollector({ ffiNameResolver.resolveName(it) }, DART)
-        val genericTypes =
-            genericTypesCollector.getAllGenericTypes(dartFilteredElements.flatMap { LimeTypeHelper.getAllTypes(it) })
+        val collector = ReferredTypesCollector({ ffiNameResolver.resolveName(it) }, DART)
+        val allDeclaredTypes = dartFilteredElements.flatMap { LimeTypeHelper.getAllTypes(it) }
+        val genericTypes = collector.getAllReferredTypes(allDeclaredTypes).filterIsInstance<LimeGenericType>()
 
         val generatedFiles = dartFilteredElements.flatMap {
             listOfNotNull(generateDart(it, dartResolvers, dartNameResolver, importResolver,

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeTypeRefTargetValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeTypeRefTargetValidator.kt
@@ -34,25 +34,22 @@ import com.here.gluecodium.model.lime.LimeTypesCollection
  * * Referring to non-enum types from exception types.
  * * Referring to exception types from anywhere but the `throws` clause.
  */
-internal class LimeTypeRefTargetValidator(private val logger: LimeLogger) :
-    LimeTypeRefsVisitor<Boolean>() {
+internal class LimeTypeRefTargetValidator(private val logger: LimeLogger) : LimeTypeRefsVisitor<Boolean>() {
 
     fun validate(limeModel: LimeModel) = !traverseModel(limeModel).contains(false)
 
     override fun visitTypeRef(parentElement: LimeNamedElement, limeTypeRef: LimeTypeRef?): Boolean {
-        val referredType = limeTypeRef?.type?.let { it.actualType }
+        val referredType = limeTypeRef?.type?.actualType
         return when {
             referredType is LimeTypesCollection -> {
                 logger.error(
                     parentElement,
-                    "refers to `types` container ${referredType.fullName} " +
-                            "which cannot be used as a type itself."
+                    "refers to `types` container ${referredType.fullName} which cannot be used as a type itself."
                 )
                 false
             }
             referredType is LimeException &&
-                (parentElement !is LimeFunction ||
-                    parentElement.thrownType?.typeRef?.type !== referredType) -> {
+                    (parentElement !is LimeFunction || parentElement.thrownType?.typeRef?.type !== referredType) -> {
                 logger.error(
                     parentElement,
                     "refers to an exception type ${referredType.fullName} " +


### PR DESCRIPTION
Updated GenericTypesCollector to be able to output all "referred-to" types instead of just generic types, while
maintaining the same traversal logic. Renamed it correspondingly.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>