### PR TITLE
Add tests for Java overloads resolution for platform names

### DIFF
--- a/examples/libhello/lime/test/MethodOverloads.lime
+++ b/examples/libhello/lime/test/MethodOverloads.lime
@@ -119,3 +119,11 @@ class SwiftMethodOverloads {
     @Swift("three")
     fun two(input: List<String>)
 }
+
+@Swift(Skip) @Dart(Skip)
+class JavaMethodOverloads {
+    @Java("three")
+    fun one(input: String)
+    @Java("three")
+    fun two(input: List<String>)
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/input/MethodOverloads.lime
+++ b/gluecodium/src/test/resources/smoke/method_overloads/input/MethodOverloads.lime
@@ -70,3 +70,11 @@ class SwiftMethodOverloads {
     @Swift("three")
     fun two(input: List<String>)
 }
+
+@Swift(Skip) @Dart(Skip)
+class JavaMethodOverloads {
+    @Java("three")
+    fun one(input: String)
+    @Java("three")
+    fun two(input: List<String>)
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_JavaMethodOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_JavaMethodOverloads.cpp
@@ -1,0 +1,46 @@
+/*
+ *
+ */
+#include "com_example_smoke_JavaMethodOverloads.h"
+#include "com_example_smoke_JavaMethodOverloads__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+#include "JniWrapperCache.h"
+extern "C" {
+void
+Java_com_example_smoke_JavaMethodOverloads_three__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
+{
+    ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::std::string*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::JavaMethodOverloads>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->one(input);
+}
+void
+Java_com_example_smoke_JavaMethodOverloads_three__Ljava_util_List_2(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    ::std::vector< ::std::string > input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::std::vector< ::std::string >*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::JavaMethodOverloads>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->two(input);
+}
+JNIEXPORT void JNICALL
+Java_com_example_smoke_JavaMethodOverloads_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::JavaMethodOverloads>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_JavaMethodOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_JavaMethodOverloads.h
@@ -1,0 +1,15 @@
+/*
+ *
+ */
+#pragma once
+#include <jni.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+JNIEXPORT void JNICALL
+Java_com_example_smoke_JavaMethodOverloads_three__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_JavaMethodOverloads_three__Ljava_util_List_2(JNIEnv* _jenv, jobject _jinstance, jobject jinput);
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Added smoke and functional tests for resolving function overloads while taking Java-specific platform names into
account.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>