### PR TITLE
Resolve C++ typedefs in generated JNI code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed compilation issue in JNI for type aliases in combination with "external" types.
+
 ## 8.6.4
 Release date: 2020-11-26
 ### Bug fixes:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniCppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniCppNameResolver.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.jni
+
+import com.here.gluecodium.cli.GluecodiumExecutionException
+import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.cpp.Cpp2NameResolver
+import com.here.gluecodium.model.lime.LimeDirectTypeRef
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeReturnType
+import com.here.gluecodium.model.lime.LimeTypeAlias
+import com.here.gluecodium.model.lime.LimeTypeRef
+
+/**
+ * Auxiliary name resolver for the JNI generator. Resolves C++ names, while substituting type aliases with their actual
+ * types.
+ */
+internal class JniCppNameResolver(private val cppNameResolver: Cpp2NameResolver) : NameResolver {
+
+    override fun resolveName(element: Any): String =
+        when (element) {
+            is LimeReturnType -> resolveName(element.typeRef)
+            is LimeTypeRef ->
+                resolveElementName(LimeDirectTypeRef(element.type.actualType, isNullable = element.isNullable))
+            is LimeTypeAlias -> resolveElementName(element.actualType)
+            is LimeNamedElement -> resolveElementName(element)
+            else -> throw GluecodiumExecutionException("Unsupported element type ${element.javaClass.name}")
+        }
+
+    override fun resolveGetterName(element: Any) = cppNameResolver.resolveGetterName(element)
+    override fun resolveSetterName(element: Any) = cppNameResolver.resolveSetterName(element)
+    override fun resolveReferenceName(element: Any) = cppNameResolver.resolveReferenceName(element)
+
+    private fun resolveElementName(element: Any) = cppNameResolver.resolveName(element)
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniFullNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniFullNameResolver.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.jni
+
+import com.here.gluecodium.cli.GluecodiumExecutionException
+import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.cpp.CppNameResolver
+import com.here.gluecodium.model.lime.LimeType
+
+/**
+ * Auxiliary name resolver for the JNI generator. Resolves fully qualified names C++ only, while substituting type
+ * aliases with their actual types.
+ */
+internal class JniFullNameResolver(private val cachingNameResolver: CppNameResolver) : NameResolver {
+
+    override fun resolveName(element: Any): String =
+        when (element) {
+            is LimeType -> cachingNameResolver.getFullyQualifiedName(element.actualType)
+            else -> throw GluecodiumExecutionException("Unsupported element type ${element.javaClass.name}")
+        }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -23,7 +23,6 @@ import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.generator.cpp.Cpp2IncludeResolver
 import com.here.gluecodium.generator.cpp.Cpp2NameResolver
-import com.here.gluecodium.generator.cpp.CppFullNameResolver
 import com.here.gluecodium.generator.cpp.CppNameResolver
 import com.here.gluecodium.generator.cpp.CppNameRules
 import com.here.gluecodium.generator.java.JavaNameRules
@@ -54,8 +53,8 @@ internal class JniTemplates(
         "" to jniNameResolver,
         "signature" to JniTypeSignatureNameResolver(jniNameResolver),
         "mangled" to JniMangledNameResolver(jniNameResolver),
-        "C++" to cppNameResolver,
-        "C++ FQN" to CppFullNameResolver(cachingNameResolver)
+        "C++" to JniCppNameResolver(cppNameResolver),
+        "C++ FQN" to JniFullNameResolver(cachingNameResolver)
     )
     private val predicates = JniGeneratorPredicates(limeReferenceMap, javaNameRules, cppNameResolver).predicates
 

--- a/gluecodium/src/main/resources/templates/jni/CppProxyImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/CppProxyImplementation.mustache
@@ -92,12 +92,12 @@ namespace jni
         auto nErrorValue = convert_from_jni(
             jniEnv,
             jErrorValue,
-            ({{resolveName exception.errorType "C++ FQN"}}*)nullptr );
+            ({{resolveName exception.errorType "C++"}}*)nullptr );
 
 {{#instanceOf exception.errorType.type.actualType "LimeEnumeration"}}
         return ::std::error_code{nErrorValue};
 {{/instanceOf}}{{#notInstanceOf exception.errorType.type.actualType "LimeEnumeration"}}
-        return {{resolveName exception.errorType "C++ FQN"}}{nErrorValue};
+        return {{resolveName exception.errorType "C++"}}{nErrorValue};
 {{/notInstanceOf}}
     }
     else

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -157,7 +157,7 @@ jint
     auto errorCode = nativeCallResult{{#unless returnType.isVoid}}.error(){{/unless}};
     if ({{#unless returnType.isVoid}}!nativeCallResult.has_value(){{/unless}}{{#if returnType.isVoid}}errorCode{{/if}})
     {
-        auto nErrorValue = static_cast<{{resolveName exception.errorType "C++ FQN"}}>(errorCode.value());
+        auto nErrorValue = static_cast<{{resolveName exception.errorType "C++"}}>(errorCode.value());
         auto jErrorValue = {{>common/InternalNamespace}}jni::convert_to_jni(_jenv, nErrorValue);
 {{/instanceOf}}{{#notInstanceOf exception.errorType.type.actualType "LimeEnumeration"}}
     if (!nativeCallResult.has_value())
@@ -177,7 +177,7 @@ jint
 {{#unless thrownType}}    {{#unless returnType.isVoid}}auto result = {{/unless}}{{>cppMethodCall}}{{/unless}}{{!!
 }}{{#unless returnType.isVoid}}
     {{#ifPredicate "returnsOpaqueHandle"}}auto nSharedPtr = new (::std::nothrow) {{!!
-    }}::std::shared_ptr< {{resolveName returnType "C++ FQN"}} >(result);
+    }}::std::shared_ptr< {{resolveName returnType.typeRef.type "C++ FQN"}} >(result);
     if (nSharedPtr == nullptr)
     {
         auto exceptionClass = {{>common/InternalNamespace}}jni::find_class(_jenv, "java/lang/OutOfMemoryError");

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithBasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithBasicTypes.cpp
@@ -56,9 +56,9 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithSet(JNIEnv* _jenv, j
 jobject
 Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
 {
-    ::smoke::GenericTypesWithBasicTypes::BasicList input = ::gluecodium::jni::convert_from_jni(_jenv,
+    ::std::vector< ::std::string > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::GenericTypesWithBasicTypes::BasicList*)nullptr);
+            (::std::vector< ::std::string >*)nullptr);
     auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>*> (
         ::gluecodium::jni::get_field_value(
             _jenv,
@@ -71,9 +71,9 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias(JNIEnv
 jobject
 Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
 {
-    ::smoke::GenericTypesWithBasicTypes::BasicMap input = ::gluecodium::jni::convert_from_jni(_jenv,
+    ::std::unordered_map< ::std::string, ::std::string > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::GenericTypesWithBasicTypes::BasicMap*)nullptr);
+            (::std::unordered_map< ::std::string, ::std::string >*)nullptr);
     auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>*> (
         ::gluecodium::jni::get_field_value(
             _jenv,
@@ -86,9 +86,9 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias(JNIEnv*
 jobject
 Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
 {
-    ::smoke::GenericTypesWithBasicTypes::BasicSet input = ::gluecodium::jni::convert_from_jni(_jenv,
+    ::std::unordered_set< ::std::string > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::GenericTypesWithBasicTypes::BasicSet*)nullptr);
+            (::std::unordered_set< ::std::string >*)nullptr);
     auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::GenericTypesWithBasicTypes>*> (
         ::gluecodium::jni::get_field_value(
             _jenv,

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListenerImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListenerImplCppProxy.cpp
@@ -67,7 +67,7 @@ com_example_smoke_CalculatorListenerImpl_CppProxy::on_calculation_result_array( 
     }
 }
 void
-com_example_smoke_CalculatorListenerImpl_CppProxy::on_calculation_result_map( const ::smoke::CalculatorListener::NamedCalculationResults& ncalculationResults ) {
+com_example_smoke_CalculatorListenerImpl_CppProxy::on_calculation_result_map( const ::std::unordered_map< ::std::string, double >& ncalculationResults ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jcalculationResults = convert_to_jni( jniEnv, ncalculationResults );
     callJavaMethod<void>( "onCalculationResultMap", "(Ljava/util/Map;)V", jniEnv , jcalculationResults);

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListenerImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListenerImplCppProxy.h
@@ -2,7 +2,7 @@
  *
  */
 #pragma once
-#include "smoke/CalculatorListener.h"
+#include "smoke\CalculatorListener.h"
 #include "CppProxyBase.h"
 #include "JniReference.h"
 namespace gluecodium
@@ -18,7 +18,7 @@ public:
     void on_calculation_result_const( const double ncalculationResult ) const override;
     void on_calculation_result_struct( const ::smoke::CalculatorListener::ResultStruct& ncalculationResult ) override;
     void on_calculation_result_array( const ::std::vector< double >& ncalculationResult ) override;
-    void on_calculation_result_map( const ::smoke::CalculatorListener::NamedCalculationResults& ncalculationResults ) override;
+    void on_calculation_result_map( const ::std::unordered_map< ::std::string, double >& ncalculationResults ) override;
     void on_calculation_result_instance( const ::std::shared_ptr< ::smoke::CalculationResult >& ncalculationResult ) override;
 };
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithPropertiesImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithPropertiesImplCppProxy.cpp
@@ -145,7 +145,7 @@ com_example_smoke_ListenerWithPropertiesImpl_CppProxy::set_arrayed_message( cons
             "See the log for more information about the exception (including Java stack trace)." );
     }
 }
-::smoke::ListenerWithProperties::StringToDouble
+::std::unordered_map< ::std::string, double >
 com_example_smoke_ListenerWithPropertiesImpl_CppProxy::get_mapped_message(  ) const {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto result = callJavaMethod<jobject>( "getMappedMessage", "()Ljava/util/Map;", jniEnv  );
@@ -156,10 +156,10 @@ com_example_smoke_ListenerWithPropertiesImpl_CppProxy::get_mapped_message(  ) co
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::smoke::ListenerWithProperties::StringToDouble*)nullptr );
+    return convert_from_jni( jniEnv, result, (::std::unordered_map< ::std::string, double >*)nullptr );
 }
 void
-com_example_smoke_ListenerWithPropertiesImpl_CppProxy::set_mapped_message( const ::smoke::ListenerWithProperties::StringToDouble& nvalue ) {
+com_example_smoke_ListenerWithPropertiesImpl_CppProxy::set_mapped_message( const ::std::unordered_map< ::std::string, double >& nvalue ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jvalue = convert_to_jni( jniEnv, nvalue );
     callJavaMethod<void>( "setMappedMessage", "(Ljava/util/Map;)V", jniEnv , jvalue);

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenersWithReturnValuesImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenersWithReturnValuesImplCppProxy.cpp
@@ -80,7 +80,7 @@ com_example_smoke_ListenersWithReturnValuesImpl_CppProxy::fetch_data_array(  ) {
     }
     return convert_from_jni( jniEnv, result, (::std::vector< double >*)nullptr );
 }
-::smoke::ListenersWithReturnValues::StringToDouble
+::std::unordered_map< ::std::string, double >
 com_example_smoke_ListenersWithReturnValuesImpl_CppProxy::fetch_data_map(  ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto result = callJavaMethod<jobject>( "fetchDataMap", "()Ljava/util/Map;", jniEnv  );
@@ -91,7 +91,7 @@ com_example_smoke_ListenersWithReturnValuesImpl_CppProxy::fetch_data_map(  ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::smoke::ListenersWithReturnValues::StringToDouble*)nullptr );
+    return convert_from_jni( jniEnv, result, (::std::unordered_map< ::std::string, double >*)nullptr );
 }
 ::std::shared_ptr< ::smoke::CalculationResult >
 com_example_smoke_ListenersWithReturnValuesImpl_CppProxy::fetch_data_instance(  ) {

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_MethodOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_MethodOverloads.cpp
@@ -88,9 +88,9 @@ Java_com_example_smoke_MethodOverloads_isBoolean__ZBLjava_lang_String_2Lcom_exam
 jboolean
 Java_com_example_smoke_MethodOverloads_isBooleanStringArrayOverload(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
 {
-    ::smoke::MethodOverloads::StringArray input = ::gluecodium::jni::convert_from_jni(_jenv,
+    ::std::vector< ::std::string > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::MethodOverloads::StringArray*)nullptr);
+            (::std::vector< ::std::string >*)nullptr);
     auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
         ::gluecodium::jni::get_field_value(
             _jenv,
@@ -103,9 +103,9 @@ Java_com_example_smoke_MethodOverloads_isBooleanStringArrayOverload(JNIEnv* _jen
 jboolean
 Java_com_example_smoke_MethodOverloads_isBooleanIntArrayOverload(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
 {
-    ::smoke::MethodOverloads::IntArray input = ::gluecodium::jni::convert_from_jni(_jenv,
+    ::std::vector< int8_t > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::MethodOverloads::IntArray*)nullptr);
+            (::std::vector< int8_t >*)nullptr);
     auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
         ::gluecodium::jni::get_field_value(
             _jenv,
@@ -145,9 +145,9 @@ Java_com_example_smoke_MethodOverloads_isFloat__Ljava_lang_String_2(JNIEnv* _jen
 jboolean
 Java_com_example_smoke_MethodOverloads_isFloat__Ljava_util_List_2(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
 {
-    ::smoke::MethodOverloads::IntArray input = ::gluecodium::jni::convert_from_jni(_jenv,
+    ::std::vector< int8_t > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::MethodOverloads::IntArray*)nullptr);
+            (::std::vector< int8_t >*)nullptr);
     auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
         ::gluecodium::jni::get_field_value(
             _jenv,

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable.cpp
@@ -104,9 +104,9 @@ Java_com_example_smoke_Nullable_methodWithSomeEnum(JNIEnv* _jenv, jobject _jinst
 jobject
 Java_com_example_smoke_Nullable_methodWithSomeArray(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
 {
-    ::gluecodium::optional< ::smoke::Nullable::SomeArray > input = ::gluecodium::jni::convert_from_jni(_jenv,
+    ::gluecodium::optional< ::std::vector< ::std::string > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::gluecodium::optional< ::smoke::Nullable::SomeArray >*)nullptr);
+            (::gluecodium::optional< ::std::vector< ::std::string > >*)nullptr);
     auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Nullable>*> (
         ::gluecodium::jni::get_field_value(
             _jenv,
@@ -134,9 +134,9 @@ Java_com_example_smoke_Nullable_methodWithInlineArray(JNIEnv* _jenv, jobject _ji
 jobject
 Java_com_example_smoke_Nullable_methodWithSomeMap(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
 {
-    ::gluecodium::optional< ::smoke::Nullable::SomeMap > input = ::gluecodium::jni::convert_from_jni(_jenv,
+    ::gluecodium::optional< ::std::unordered_map< int64_t, ::std::string > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::gluecodium::optional< ::smoke::Nullable::SomeMap >*)nullptr);
+            (::gluecodium::optional< ::std::unordered_map< int64_t, ::std::string > >*)nullptr);
     auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Nullable>*> (
         ::gluecodium::jni::get_field_value(
             _jenv,
@@ -332,9 +332,9 @@ Java_com_example_smoke_Nullable_getArrayProperty(JNIEnv* _jenv, jobject _jinstan
 void
 Java_com_example_smoke_Nullable_setArrayProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
 {
-    ::gluecodium::optional< ::smoke::Nullable::SomeArray > value = ::gluecodium::jni::convert_from_jni(_jenv,
+    ::gluecodium::optional< ::std::vector< ::std::string > > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::gluecodium::optional< ::smoke::Nullable::SomeArray >*)nullptr);
+            (::gluecodium::optional< ::std::vector< ::std::string > >*)nullptr);
     auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Nullable>*> (
         ::gluecodium::jni::get_field_value(
             _jenv,
@@ -384,9 +384,9 @@ Java_com_example_smoke_Nullable_getMapProperty(JNIEnv* _jenv, jobject _jinstance
 void
 Java_com_example_smoke_Nullable_setMapProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
 {
-    ::gluecodium::optional< ::smoke::Nullable::SomeMap > value = ::gluecodium::jni::convert_from_jni(_jenv,
+    ::gluecodium::optional< ::std::unordered_map< int64_t, ::std::string > > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::gluecodium::optional< ::smoke::Nullable::SomeMap >*)nullptr);
+            (::gluecodium::optional< ::std::unordered_map< int64_t, ::std::string > >*)nullptr);
     auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Nullable>*> (
         ::gluecodium::jni::get_field_value(
             _jenv,

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable_NullableStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable_NullableStruct__Conversion.cpp
@@ -42,20 +42,20 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::N
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "enumField", "Lcom/example/smoke/Nullable$SomeEnum;"),
         (::gluecodium::optional< ::smoke::Nullable::SomeEnum >*)nullptr );
     _nout.enum_field = n_enum_field;
-    ::gluecodium::optional< ::smoke::Nullable::SomeArray > n_array_field = convert_from_jni(
+    ::gluecodium::optional< ::std::vector< ::std::string > > n_array_field = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "arrayField", "Ljava/util/List;"),
-        (::gluecodium::optional< ::smoke::Nullable::SomeArray >*)nullptr );
+        (::gluecodium::optional< ::std::vector< ::std::string > >*)nullptr );
     _nout.array_field = n_array_field;
     ::gluecodium::optional< ::std::vector< ::std::string > > n_inline_array_field = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "inlineArrayField", "Ljava/util/List;"),
         (::gluecodium::optional< ::std::vector< ::std::string > >*)nullptr );
     _nout.inline_array_field = n_inline_array_field;
-    ::gluecodium::optional< ::smoke::Nullable::SomeMap > n_map_field = convert_from_jni(
+    ::gluecodium::optional< ::std::unordered_map< int64_t, ::std::string > > n_map_field = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "mapField", "Ljava/util/Map;"),
-        (::gluecodium::optional< ::smoke::Nullable::SomeMap >*)nullptr );
+        (::gluecodium::optional< ::std::unordered_map< int64_t, ::std::string > >*)nullptr );
     _nout.map_field = n_map_field;
     ::std::shared_ptr< ::smoke::SomeInterface > n_instance_field = convert_from_jni(
         _jenv,

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android/jni/com_example_smoke_TypeDefs.cpp
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android/jni/com_example_smoke_TypeDefs.cpp
@@ -1,0 +1,96 @@
+/*
+ *
+ */
+#include "com_example_smoke_Point__Conversion.h"
+#include "com_example_smoke_TypeDefs.h"
+#include "com_example_smoke_TypeDefs_TestStruct__Conversion.h"
+#include "com_example_smoke_TypeDefs__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+#include "JniWrapperCache.h"
+extern "C" {
+jdouble
+Java_com_example_smoke_TypeDefs_methodWithPrimitiveTypeDef(JNIEnv* _jenv, jobject _jinstance, jdouble jinput)
+{
+    double input = jinput;
+    auto result = ::smoke::TypeDefs::method_with_primitive_type_def(input);
+    return result;
+}
+jobject
+Java_com_example_smoke_TypeDefs_methodWithComplexTypeDef(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    ::std::vector< ::smoke::TypeDefs::TestStruct > input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::std::vector< ::smoke::TypeDefs::TestStruct >*)nullptr);
+    auto result = ::smoke::TypeDefs::method_with_complex_type_def(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+jdouble
+Java_com_example_smoke_TypeDefs_returnNestedIntTypeDef(JNIEnv* _jenv, jobject _jinstance, jdouble jinput)
+{
+    double input = jinput;
+    auto result = ::smoke::TypeDefs::return_nested_int_type_def(input);
+    return result;
+}
+jobject
+Java_com_example_smoke_TypeDefs_returnTestStructTypeDef(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    ::smoke::TypeDefs::TestStruct input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::smoke::TypeDefs::TestStruct*)nullptr);
+    auto result = ::smoke::TypeDefs::return_test_struct_type_def(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+jobject
+Java_com_example_smoke_TypeDefs_returnNestedStructTypeDef(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    ::smoke::TypeDefs::TestStruct input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::smoke::TypeDefs::TestStruct*)nullptr);
+    auto result = ::smoke::TypeDefs::return_nested_struct_type_def(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+jobject
+Java_com_example_smoke_TypeDefs_returnTypeDefPointFromTypeCollection(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    ::smoke::Point input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::smoke::Point*)nullptr);
+    auto result = ::smoke::TypeDefs::return_type_def_point_from_type_collection(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+jobject
+Java_com_example_smoke_TypeDefs_getPrimitiveTypeProperty(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::TypeDefs>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->get_primitive_type_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+void
+Java_com_example_smoke_TypeDefs_setPrimitiveTypeProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
+{
+    ::std::vector< ::smoke::TypeDefs::PrimitiveTypeDef > value = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jvalue),
+            (::std::vector< ::smoke::TypeDefs::PrimitiveTypeDef >*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::TypeDefs>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->set_primitive_type_property(value);
+}
+JNIEXPORT void JNICALL
+Java_com_example_smoke_TypeDefs_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::TypeDefs>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+}


### PR DESCRIPTION
Updated JNI name resolvers and templates to always substitute an actual C++ type whenever a type-alias is used in IDL.
This improves error messages and debugging when mixing type-aliases and "external" types. Also potentially fixes a
compilation issue for such scenario.

Added/updated smoke tests.

Resolves: #641
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>