### PR TITLE
Move function overloads validation to individual generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed compilation issue for collections of nullable types in Swift.
+  * Fixed validation false positive for constructor overloads.
 
 ## 8.6.4
 Release date: 2020-11-26

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/PlatformSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/PlatformSignatureResolver.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.common
+
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeSignatureResolver
+
+internal open class PlatformSignatureResolver(
+    limeReferenceMap: Map<String, LimeElement>,
+    private val platformAttributeType: LimeAttributeType,
+    private val nameRules: NameRules
+) : LimeSignatureResolver(limeReferenceMap) {
+
+    override fun getAllContainerFunctions(limeContainer: LimeContainer) =
+        limeContainer.functions.filterNot { it.attributes.have(platformAttributeType, LimeAttributeValueType.SKIP) }
+
+    override fun getFunctionName(limeFunction: LimeFunction) =
+        limeFunction.attributes.get(platformAttributeType, LimeAttributeValueType.NAME, String::class.java)
+            ?: nameRules.getName(limeFunction)
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/Cpp2NameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/Cpp2NameResolver.kt
@@ -23,6 +23,7 @@ import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.generator.common.CommentsProcessor
 import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.common.PlatformSignatureResolver
 import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.model.lime.LimeAttributeType.CPP
 import com.here.gluecodium.model.lime.LimeAttributeValueType.ACCESSORS
@@ -45,7 +46,6 @@ import com.here.gluecodium.model.lime.LimeParameter
 import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeSet
-import com.here.gluecodium.model.lime.LimeSignatureResolver
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeValue
@@ -63,7 +63,7 @@ internal class Cpp2NameResolver(
     private val commentsProcessor: CommentsProcessor? = null
 ) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
-    private val signatureResolver = LimeSignatureResolver(limeReferenceMap)
+    private val signatureResolver = PlatformSignatureResolver(limeReferenceMap, CPP, cachingNameResolver.nameRules)
     private val limeToCppNames = buildPathMap()
 
     private val hashTypeName = (listOf("") + internalNamespace + "hash").joinToString("::")

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorSuite.kt
@@ -29,6 +29,7 @@ import com.here.gluecodium.generator.common.nameRuleSetFromConfig
 import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.generator.cpp.CppGeneratorPredicates.predicates
 import com.here.gluecodium.model.common.Include
+import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeType.EQUATABLE
 import com.here.gluecodium.model.lime.LimeConstant
 import com.here.gluecodium.model.lime.LimeContainer
@@ -49,6 +50,7 @@ import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeHelper
 import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeTypesCollection
+import com.here.gluecodium.validator.LimeOverloadsValidator
 import java.io.File
 import java.nio.file.Paths
 import java.util.logging.Logger
@@ -72,6 +74,14 @@ internal class CppGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
 
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
+
+        val overloadsValidator =
+            LimeOverloadsValidator(limeModel.referenceMap, LimeAttributeType.CPP, nameRules, limeLogger)
+        val validationResult = overloadsValidator.validate(limeModel.topElements)
+        if (!validationResult) {
+            throw GluecodiumExecutionException("Validation errors found, see log for details.")
+        }
+
         val cachingNameResolver = CppNameResolver(rootNamespace, limeModel.referenceMap, nameRules)
         val nameResolver = Cpp2NameResolver(
             limeModel.referenceMap,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
@@ -31,10 +31,10 @@ import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeTypesCollection
 import java.util.HashMap
 
-class CppNameResolver(
+internal class CppNameResolver(
     rootNamespace: List<String>,
     private val limeReferenceMap: Map<String, LimeElement>,
-    private val nameRules: CppNameRules
+    val nameRules: CppNameRules
 ) {
     private val rootNamespace: String = rootNamespace.joinToString("::")
     private val namesCache = HashMap<String, NamesCacheEntry>()

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaSignatureResolver.kt
@@ -19,18 +19,15 @@
 
 package com.here.gluecodium.generator.java
 
-import com.here.gluecodium.generator.common.NameRules
+import com.here.gluecodium.generator.common.PlatformSignatureResolver
+import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeElement
-import com.here.gluecodium.model.lime.LimeFunction
-import com.here.gluecodium.model.lime.LimeSignatureResolver
 import com.here.gluecodium.model.lime.LimeTypeRef
 
 internal class JavaSignatureResolver(
     limeReferenceMap: Map<String, LimeElement>,
-    private val nameRules: NameRules
-) : LimeSignatureResolver(limeReferenceMap) {
-
-    override fun getFunctionName(limeFunction: LimeFunction) = nameRules.getName(limeFunction)
+    nameRules: JavaNameRules
+) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.JAVA, nameRules) {
 
     override fun getArrayName(elementType: LimeTypeRef) = TYPE_ERASED_ARRAY
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftSignatureResolver.kt
@@ -19,18 +19,11 @@
 
 package com.here.gluecodium.generator.swift
 
+import com.here.gluecodium.generator.common.PlatformSignatureResolver
 import com.here.gluecodium.model.lime.LimeAttributeType
-import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeElement
-import com.here.gluecodium.model.lime.LimeFunction
-import com.here.gluecodium.model.lime.LimeSignatureResolver
 
 internal class SwiftSignatureResolver(
     limeReferenceMap: Map<String, LimeElement>,
-    private val nameRules: SwiftNameRules
-) : LimeSignatureResolver(limeReferenceMap) {
-
-    override fun getFunctionName(limeFunction: LimeFunction) =
-        limeFunction.attributes.get(LimeAttributeType.SWIFT, LimeAttributeValueType.NAME, String::class.java)
-            ?: nameRules.getName(limeFunction)
-}
+    nameRules: SwiftNameRules
+) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.SWIFT, nameRules)

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFunctionsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFunctionsValidator.kt
@@ -27,33 +27,21 @@ import com.here.gluecodium.model.lime.LimeException
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeModel
-import com.here.gluecodium.model.lime.LimeSignatureResolver
 
 internal class LimeFunctionsValidator(private val logger: LimeLogger) {
 
     fun validate(limeModel: LimeModel): Boolean {
-        val signatureResolver = LimeSignatureResolver(limeModel.referenceMap)
         val validationResults = limeModel.referenceMap.values
             .filterIsInstance<LimeFunction>()
-            .map { validateFunction(it, signatureResolver, limeModel.referenceMap) }
+            .map { validateFunction(it, limeModel.referenceMap) }
 
         return !validationResults.contains(false)
     }
 
-    private fun validateFunction(
-        limeFunction: LimeFunction,
-        signatureResolver: LimeSignatureResolver,
-        referenceMap: Map<String, LimeElement>
-    ): Boolean {
+    private fun validateFunction(limeFunction: LimeFunction, referenceMap: Map<String, LimeElement>): Boolean {
+
         var result = true
-        if (limeFunction.isConstructor && signatureResolver.hasConstructorSignatureClash(limeFunction)) {
-            logger.error(limeFunction, "constructor has conflicting overloads")
-            result = false
-        }
-        if (!limeFunction.isConstructor && signatureResolver.hasSignatureClash(limeFunction)) {
-            logger.error(limeFunction, "function has conflicting overloads")
-            result = false
-        }
+
         val thrownType = limeFunction.thrownType?.typeRef?.type?.actualType
         if (thrownType != null && thrownType !is LimeException) {
             logger.error(limeFunction, "function throws a non-exception type ${thrownType.fullName}")
@@ -66,6 +54,7 @@ internal class LimeFunctionsValidator(private val logger: LimeLogger) {
                 result = false
             }
         }
+
         return result
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeOverloadsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeOverloadsValidator.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016-2020 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.generator.common.NameRules
+import com.here.gluecodium.generator.common.PlatformSignatureResolver
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeSignatureResolver
+
+internal class LimeOverloadsValidator(
+    private val signatureResolver: LimeSignatureResolver,
+    private val logger: LimeLogger
+) {
+    constructor(
+        referenceMap: Map<String, LimeElement>,
+        platformAttributeType: LimeAttributeType,
+        nameRules: NameRules,
+        logger: LimeLogger
+    ) : this(PlatformSignatureResolver(referenceMap, platformAttributeType, nameRules), logger)
+
+    fun validate(limeModel: Collection<LimeElement>): Boolean {
+        val validationResults =
+            limeModel.filterIsInstance<LimeFunction>().map { validateFunction(it, signatureResolver) }
+        return !validationResults.contains(false)
+    }
+
+    private fun validateFunction(limeFunction: LimeFunction, signatureResolver: LimeSignatureResolver): Boolean {
+
+        var result = true
+
+        if (limeFunction.isConstructor && signatureResolver.hasConstructorSignatureClash(limeFunction)) {
+            logger.error(limeFunction, "constructor has conflicting overloads")
+            result = false
+        }
+        if (!limeFunction.isConstructor && signatureResolver.hasSignatureClash(limeFunction)) {
+            logger.error(limeFunction, "function has conflicting overloads")
+            result = false
+        }
+
+        return result
+    }
+}

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeOverloadsValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeOverloadsValidatorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 HERE Europe B.V.
+ * Copyright (C) 2016-2020 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ import com.here.gluecodium.model.lime.LimeBasicTypeRef
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeFunction
-import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeParameter
 import com.here.gluecodium.model.lime.LimePath
 import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
+import com.here.gluecodium.model.lime.LimeSignatureResolver
 import com.here.gluecodium.model.lime.LimeStruct
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
@@ -35,16 +35,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
-class LimeFunctionsValidatorTest(
+class LimeOverloadsValidatorTest(
     private val limeMethod1: LimeFunction,
     private val limeMethod2: LimeFunction,
     private val expectedResult: Boolean
 ) {
-
     private val allElements = mutableMapOf<String, LimeElement>()
-    private val limeModel = LimeModel(allElements, emptyList())
 
-    private val validator = LimeFunctionsValidator(mockk(relaxed = true))
+    private val validator = LimeOverloadsValidator(LimeSignatureResolver(allElements), mockk(relaxed = true))
 
     @Test
     fun validateInContainer() {
@@ -53,7 +51,7 @@ class LimeFunctionsValidatorTest(
         allElements[fooPath.toString()] =
             LimeClass(fooPath, functions = listOf(limeMethod1, limeMethod2))
 
-        assertEquals(expectedResult, validator.validate(limeModel))
+        assertEquals(expectedResult, validator.validate(allElements.values))
     }
 
     @Test
@@ -63,7 +61,7 @@ class LimeFunctionsValidatorTest(
         allElements[fooPath.toString()] =
             LimeStruct(fooPath, functions = listOf(limeMethod1, limeMethod2))
 
-        assertEquals(expectedResult, validator.validate(limeModel))
+        assertEquals(expectedResult, validator.validate(allElements.values))
     }
 
     companion object {

--- a/gluecodium/src/test/resources/smoke/method_overloads/input/MethodOverloads.lime
+++ b/gluecodium/src/test/resources/smoke/method_overloads/input/MethodOverloads.lime
@@ -85,3 +85,12 @@ interface SpecialNamesInterface {
     @Cpp(Const)
     fun dispatch(callback: Callback)
 }
+
+class SkippedOverloads {
+    @Dart(Skip)
+    constructor make()
+
+    @Swift(Skip)
+    @Java(Skip)
+    constructor make_for_dart()
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeSignatureResolver.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeSignatureResolver.kt
@@ -54,8 +54,7 @@ open class LimeSignatureResolver(private val referenceMap: Map<String, LimeEleme
     private fun getAllConstructorOverloads(limeFunction: LimeFunction): List<LimeFunction> {
         val parentElement = referenceMap[limeFunction.path.parent.toString()]
         return when (parentElement) {
-            is LimeContainer -> parentElement.functions.filter { it.isConstructor }
-            is LimeStruct -> parentElement.functions.filter { it.isConstructor }
+            is LimeContainer -> getAllContainerFunctions(parentElement).filter { it.isConstructor }
             else -> emptyList()
         }
     }
@@ -64,8 +63,10 @@ open class LimeSignatureResolver(private val referenceMap: Map<String, LimeEleme
         val parentContainer =
             (limeContainer as? LimeContainerWithInheritance)?.parent?.type as? LimeContainer
         val parentFunctions = parentContainer?.let { getAllFunctions(it) } ?: emptyList()
-        return parentFunctions + limeContainer.functions
+        return parentFunctions + getAllContainerFunctions(limeContainer)
     }
+
+    protected open fun getAllContainerFunctions(limeContainer: LimeContainer) = limeContainer.functions
 
     protected open fun getFunctionName(limeFunction: LimeFunction) = limeFunction.name
 
@@ -76,8 +77,7 @@ open class LimeSignatureResolver(private val referenceMap: Map<String, LimeEleme
 
     protected open fun getSetName(elementType: LimeTypeRef) = "[${getTypeName(elementType)}:]"
 
-    private fun computeSignature(limeFunction: LimeFunction) =
-        limeFunction.parameters.map { getTypeName(it.typeRef) }
+    private fun computeSignature(limeFunction: LimeFunction) = limeFunction.parameters.map { getTypeName(it.typeRef) }
 
     protected fun getTypeName(limeTypeRef: LimeTypeRef): String =
         when (val limeType = limeTypeRef.type) {


### PR DESCRIPTION
Extracted overloads validation functionality from
LimeFunctionsValidator into a separate LimeOverloadsValidator.

Updated LimeOverloadsValidator to be aware of platform names and
platforms skips.

Added overloads validation to C++, Java, and Swift generators
(Dart generator already had its own overloads validation).

Added a new use case to "method overloads" smoke test. The use
case fails with the "old" validation approach due to a
false positive.

Resolves: #635
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>