### PR TITLE
Resolve doc refs to functions as full names in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed compilation issue for collections of nullable types in Swift.
+  * Fixed documentation comment reference resolution for functions in Dart.
 
 ## 8.6.4
 Release date: 2020-11-26

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -212,16 +212,16 @@ internal class DartNameResolver(
             .toMutableMap()
 
         val functions = limeReferenceMap.values.filterIsInstance<LimeFunction>()
-        result += functions.associateBy({ it.path.withSuffix("").toString() }, { resolveName(it) })
+        result += functions.associateBy({ it.path.withSuffix("").toString() }, { resolveFullName(it) })
         result += functions.associateBy(
             { function -> function.path.withSuffix("").toString() + function.parameters
                 .joinToString(prefix = "(", postfix = ")", separator = ",") { it.typeRef.toString() } },
-            { resolveName(it) }
+            { resolveFullName(it) }
         )
 
         val properties = limeReferenceMap.values.filterIsInstance<LimeProperty>()
-        result += properties.associateBy({ it.fullName + ".get" }, { resolveName(it) })
-        result += properties.filter { it.setter != null }.associateBy({ it.fullName + ".set" }, { resolveName(it) })
+        result += properties.associateBy({ it.fullName + ".get" }, { resolveFullName(it) })
+        result += properties.filter { it.setter != null }.associateBy({ it.fullName + ".set" }, { resolveFullName(it) })
 
         return result
     }

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -34,7 +34,7 @@ class comments {
         // Not quite useful
         Useless,
         // Somewhat useful
-        Useful
+        USEFUL
     }
 
     // This is some very useful typedef.
@@ -157,7 +157,7 @@ class CommentsLinks {
     // * struct: [comments.SomeStruct]
     // * struct field: [comments.SomeStruct.someField]
     // * enum: [comments.SomeEnum]
-    // * enum item: [comments.SomeEnum.Useful]
+    // * enum item: [comments.SomeEnum.USEFUL]
     // * property: [comments.SomeProperty]
     // * property setter: [comments.SomeProperty.set]
     // * property getter: [comments.SomeProperty.get]
@@ -184,8 +184,8 @@ class CommentsLinks {
     // Not working for Swift:
     // * named comment: [Alternative name for the link, stripped for Swift][comments.VeryUseful]
     //
-    // @param[inputParameter] Sometimes takes [comments.SomeEnum.Useful]
-    // @return Sometimes returns [comments.SomeEnum.Useful]
+    // @param[inputParameter] Sometimes takes [comments.SomeEnum.USEFUL]
+    // @return Sometimes returns [comments.SomeEnum.USEFUL]
     // @throws May or may not throw [comments.SomethingWrong]
     fun random_method(inputParameter: comments.SomeEnum): comments.SomeEnum throws comments.SomethingWrong
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -5,9 +5,9 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-/// The nested types like [randomMethod2] don't need full name prefix, but it's
+/// The nested types like [CommentsLinks.randomMethod2] don't need full name prefix, but it's
 /// possible to references other interfaces like [CommentsInterface] or other members
-/// [someMethodWithAllComments].
+/// [Comments.someMethodWithAllComments].
 ///
 /// Weblinks are not modified like this [example1], [example2](http://www.example.com/2) or <https://www.example.com/3>.
 ///
@@ -25,11 +25,11 @@ abstract class CommentsLinks {
   /// * enum: [Comments_SomeEnum]
   /// * enum item: [Comments_SomeEnum.useful]
   /// * property: [Comments.isSomeProperty]
-  /// * property setter: [isSomeProperty]
-  /// * property getter: [isSomeProperty]
-  /// * method: [someMethodWithAllComments]
-  /// * method with signature: [oneParameterCommentOnly]
-  /// * method with signature with no spaces: [oneParameterCommentOnly]
+  /// * property setter: [Comments.isSomeProperty]
+  /// * property getter: [Comments.isSomeProperty]
+  /// * method: [Comments.someMethodWithAllComments]
+  /// * method with signature: [Comments.oneParameterCommentOnly]
+  /// * method with signature with no spaces: [Comments.oneParameterCommentOnly]
   /// * parameter: [CommentsLinks.randomMethod.inputParameter]
   /// * top level constant: [CommentsTypeCollection.typeCollectionConstant]
   /// * top level struct: [TypeCollectionStruct]
@@ -54,9 +54,9 @@ abstract class CommentsLinks {
   /// Throws [Comments_SomethingWrongException]. May or may not throw [Comments_SomethingWrongException]
   Comments_SomeEnum randomMethod(Comments_SomeEnum inputParameter);
   /// Links to method overloads:
-  /// * other one: [randomMethod]
-  /// * this one: [randomMethod2]
-  /// * ambiguous one: [randomMethod2]
+  /// * other one: [CommentsLinks.randomMethod]
+  /// * this one: [CommentsLinks.randomMethod2]
+  /// * ambiguous one: [CommentsLinks.randomMethod2]
   randomMethod2(String text, bool flag);
 }
 /// Links also work in:

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -29,13 +29,13 @@ abstract class DeprecationComments {
   /// This is some very useful method that measures the usefulness of its input.
   /// [input] Very useful input parameter
   /// Returns [bool]. Usefulness of the input
-  @Deprecated("Unfortunately, this method is deprecated.\nUse [someMethodWithAllComments] instead.")
+  @Deprecated("Unfortunately, this method is deprecated.\nUse [Comments.someMethodWithAllComments] instead.")
   bool someMethodWithAllComments(String input);
   /// Gets some very useful property.
-  @Deprecated("Unfortunately, this property's getter is deprecated.\nUse [isSomeProperty] instead.")
+  @Deprecated("Unfortunately, this property's getter is deprecated.\nUse [Comments.isSomeProperty] instead.")
   bool get isSomeProperty;
   /// Sets some very useful property.
-  @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [isSomeProperty] instead.")
+  @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [Comments.isSomeProperty] instead.")
   set isSomeProperty(bool value);
 }
 /// This is some very useful enum.
@@ -236,7 +236,7 @@ class DeprecationComments$Impl implements DeprecationComments {
     }
   }
   /// Gets some very useful property.
-  @Deprecated("Unfortunately, this property's getter is deprecated.\nUse [isSomeProperty] instead.")
+  @Deprecated("Unfortunately, this property's getter is deprecated.\nUse [Comments.isSomeProperty] instead.")
   bool get isSomeProperty {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_isSomeProperty_get'));
     final _handle = this.handle;
@@ -248,7 +248,7 @@ class DeprecationComments$Impl implements DeprecationComments {
     }
   }
   /// Sets some very useful property.
-  @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [isSomeProperty] instead.")
+  @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [Comments.isSomeProperty] instead.")
   set isSomeProperty(bool value) {
     final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationComments_isSomeProperty_set__Boolean'));
     final _value_handle = Boolean_toFfi(value);

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/CommentsLinks.lime
@@ -21,7 +21,7 @@ class CommentsLinks {
     // * struct: [comments.SomeStruct]
     // * struct field: [comments.SomeStruct.someField]
     // * enum: [comments.SomeEnum]
-    // * enum item: [comments.SomeEnum.Useful]
+    // * enum item: [comments.SomeEnum.USEFUL]
     // * property: [comments.SomeProperty]
     // * property setter: [comments.SomeProperty.set]
     // * property getter: [comments.SomeProperty.get]
@@ -47,8 +47,8 @@ class CommentsLinks {
     //
     // Not working for Swift:
     // * named comment: [Alternative name for the link, stripped for Swift][comments.VeryUseful]
-    // @param[inputParameter] Sometimes takes [comments.SomeEnum.Useful]
-    // @return Sometimes returns [comments.SomeEnum.Useful]
+    // @param[inputParameter] Sometimes takes [comments.SomeEnum.USEFUL]
+    // @return Sometimes returns [comments.SomeEnum.USEFUL]
     // @throws May or may not throw [comments.SomethingWrong]
     fun random_method(
         inputParameter: SomeEnum

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/comments.lime
@@ -11,7 +11,7 @@ class comments {
         // Not quite useful
         Useless,
         // Somewhat useful
-        Useful
+        USEFUL
     }
     // This is some very useful exception.
     exception SomethingWrong(SomeEnum)


### PR DESCRIPTION
Updated DartNameResolver to use full function names when resolving documentation references.

Resolves: #608
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>