### PR TITLE
Propagate `@Deprecated` attribute to property accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * `@Deprecated` attribute specified on a property in IDL is now propagated to that property's accessors (but only if
+    they lack their own attribute of this type).
+
 ## 8.6.8
 Release date: 2020-12-16
 ### Bug fixes:

--- a/gluecodium/src/test/resources/smoke/comments/input/DeprecationComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/DeprecationComments.lime
@@ -58,6 +58,10 @@ interface DeprecationComments {
         @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [comments.SomeProperty.set] instead.")
         set
     }
+    // Describes the property but not accessors.
+    // @get Gets the property but not accessors.
+    @Deprecated("Will be removed in v3.2.1.")
+    property PropertyButNotAccessors: String
 }
 
 @Deprecated("Unfortunately, this interface is deprecated.")

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/DeprecationComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/DeprecationComments.java
@@ -85,4 +85,18 @@ public interface DeprecationComments {
      */
     @Deprecated
     void setSomeProperty(final boolean value);
+    /**
+     * <p>Gets the property but not accessors.</p>
+     * @deprecated <p>Will be removed in v3.2.1.</p>
+     */
+    @Deprecated
+    @NonNull
+    String getPropertyButNotAccessors();
+    /**
+     *
+     * @deprecated <p>Will be removed in v3.2.1.</p>
+     * @param value <p>Describes the property but not accessors.</p>
+     */
+    @Deprecated
+    void setPropertyButNotAccessors(@NonNull final String value);
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationComments.h
@@ -77,6 +77,18 @@ public:
      * \param[in] value Some very useful property.
      */
     virtual void set_some_property( const ::smoke::DeprecationComments::Usefulness value ) = 0;
+    /**
+     * Gets the property but not accessors.
+     * \deprecated Will be removed in v3.2.1.
+     * \return Describes the property but not accessors.
+     */
+    virtual ::std::string get_property_but_not_accessors(  ) const = 0;
+    /**
+     *
+     * \deprecated Will be removed in v3.2.1.
+     * \param[in] value Describes the property but not accessors.
+     */
+    virtual void set_property_but_not_accessors( const ::std::string& value ) = 0;
 };
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::DeprecationComments::SomeEnum value ) noexcept;
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -12,11 +12,15 @@ abstract class DeprecationComments {
   factory DeprecationComments.fromLambdas({
     @required bool Function(String) lambda_someMethodWithAllComments,
     @required bool Function() lambda_isSomeProperty_get,
-    @required void Function(bool) lambda_isSomeProperty_set
+    @required void Function(bool) lambda_isSomeProperty_set,
+    @required String Function() lambda_propertyButNotAccessors_get,
+    @required void Function(String) lambda_propertyButNotAccessors_set
   }) => DeprecationComments$Lambdas(
     lambda_someMethodWithAllComments,
     lambda_isSomeProperty_get,
-    lambda_isSomeProperty_set
+    lambda_isSomeProperty_set,
+    lambda_propertyButNotAccessors_get,
+    lambda_propertyButNotAccessors_set
   );
   /// Destroys the underlying native object.
   ///
@@ -37,6 +41,11 @@ abstract class DeprecationComments {
   /// Sets some very useful property.
   @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [Comments.isSomeProperty] instead.")
   set isSomeProperty(bool value);
+  /// Gets the property but not accessors.
+  @Deprecated("Will be removed in v3.2.1.")
+  String get propertyButNotAccessors;
+  @Deprecated("Will be removed in v3.2.1.")
+  set propertyButNotAccessors(String value);
 }
 /// This is some very useful enum.
 @Deprecated("Unfortunately, this enum is deprecated. Use [Comments_SomeEnum] instead.")
@@ -177,8 +186,8 @@ final _smoke_DeprecationComments_release_handle = __lib.catchArgumentError(() =>
     void Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_release_handle'));
 final _smoke_DeprecationComments_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer),
-    Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer)
+    Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_DeprecationComments_create_proxy'));
 final _smoke_DeprecationComments_get_raw_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Pointer<Void> Function(Pointer<Void>),
@@ -192,14 +201,20 @@ class DeprecationComments$Lambdas implements DeprecationComments {
   bool Function(String) lambda_someMethodWithAllComments;
   bool Function() lambda_isSomeProperty_get;
   void Function(bool) lambda_isSomeProperty_set;
+  String Function() lambda_propertyButNotAccessors_get;
+  void Function(String) lambda_propertyButNotAccessors_set;
   DeprecationComments$Lambdas(
     bool Function(String) lambda_someMethodWithAllComments,
     bool Function() lambda_isSomeProperty_get,
-    void Function(bool) lambda_isSomeProperty_set
+    void Function(bool) lambda_isSomeProperty_set,
+    String Function() lambda_propertyButNotAccessors_get,
+    void Function(String) lambda_propertyButNotAccessors_set
   ) {
     this.lambda_someMethodWithAllComments = lambda_someMethodWithAllComments;
     this.lambda_isSomeProperty_get = lambda_isSomeProperty_get;
     this.lambda_isSomeProperty_set = lambda_isSomeProperty_set;
+    this.lambda_propertyButNotAccessors_get = lambda_propertyButNotAccessors_get;
+    this.lambda_propertyButNotAccessors_set = lambda_propertyButNotAccessors_set;
   }
   @override
   void release() {}
@@ -210,6 +225,10 @@ class DeprecationComments$Lambdas implements DeprecationComments {
   bool get isSomeProperty => lambda_isSomeProperty_get();
   @override
   set isSomeProperty(bool value) => lambda_isSomeProperty_set(value);
+  @override
+  String get propertyButNotAccessors => lambda_propertyButNotAccessors_get();
+  @override
+  set propertyButNotAccessors(String value) => lambda_propertyButNotAccessors_set(value);
 }
 class DeprecationComments$Impl implements DeprecationComments {
   @protected
@@ -261,6 +280,31 @@ class DeprecationComments$Impl implements DeprecationComments {
       (__result_handle);
     }
   }
+  /// Gets the property but not accessors.
+  @Deprecated("Will be removed in v3.2.1.")
+  String get propertyButNotAccessors {
+    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_propertyButNotAccessors_get'));
+    final _handle = this.handle;
+    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
+  }
+  @Deprecated("Will be removed in v3.2.1.")
+  set propertyButNotAccessors(String value) {
+    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_propertyButNotAccessors_set__String'));
+    final _value_handle = String_toFfi(value);
+    final _handle = this.handle;
+    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
+    String_releaseFfiHandle(_value_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
 }
 int _DeprecationComments_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
   bool _result_object = null;
@@ -285,6 +329,19 @@ int _DeprecationComments_isSomeProperty_set_static(int _token, int _value) {
   }
   return 0;
 }
+int _DeprecationComments_propertyButNotAccessors_get_static(int _token, Pointer<Pointer<Void>> _result) {
+  _result.value = String_toFfi((__lib.instanceCache[_token] as DeprecationComments).propertyButNotAccessors);
+  return 0;
+}
+int _DeprecationComments_propertyButNotAccessors_set_static(int _token, Pointer<Void> _value) {
+  try {
+    (__lib.instanceCache[_token] as DeprecationComments).propertyButNotAccessors =
+      String_fromFfi(_value);
+  } finally {
+    String_releaseFfiHandle(_value);
+  }
+  return 0;
+}
 Pointer<Void> smoke_DeprecationComments_toFfi(DeprecationComments value) {
   if (value is DeprecationComments$Impl) return _smoke_DeprecationComments_copy_handle(value.handle);
   final result = _smoke_DeprecationComments_create_proxy(
@@ -293,7 +350,9 @@ Pointer<Void> smoke_DeprecationComments_toFfi(DeprecationComments value) {
     __lib.uncacheObjectFfi,
     Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_DeprecationComments_someMethodWithAllComments_static, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_DeprecationComments_isSomeProperty_get_static, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Uint8)>(_DeprecationComments_isSomeProperty_set_static, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Uint8)>(_DeprecationComments_isSomeProperty_set_static, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_DeprecationComments_propertyButNotAccessors_get_static, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_DeprecationComments_propertyButNotAccessors_set_static, __lib.unknownError)
   );
   __lib.reverseCache[_smoke_DeprecationComments_get_raw_pointer(result)] = value;
   return result;

--- a/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/DeprecationComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/output/lime/smoke/DeprecationComments.lime
@@ -41,4 +41,13 @@ interface DeprecationComments {
         @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [comments.SomeProperty.set] instead.")
         set
     }
+    // Describes the property but not accessors.
+    // @get Gets the property but not accessors.
+    @Deprecated("Will be removed in v3.2.1.")
+    property PropertyButNotAccessors: String {
+        @Deprecated("Will be removed in v3.2.1.")
+        get
+        @Deprecated("Will be removed in v3.2.1.")
+        set
+    }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationComments.swift
@@ -13,6 +13,9 @@ public protocol DeprecationComments : AnyObject {
     @available(*, deprecated, message: "Unfortunately, this property is deprecated.
     Use `Comments.isSomeProperty` instead.")
     var isSomeProperty: DeprecationComments.Usefulness { get set }
+    /// Describes the property but not accessors.
+    @available(*, deprecated, message: "Will be removed in v3.2.1.")
+    var propertyButNotAccessors: String { get set }
     /// This is some very useful method that measures the usefulness of its input.
     /// - Parameter input: Very useful input parameter
     /// - Returns: Usefulness of the input
@@ -34,6 +37,17 @@ internal class _DeprecationComments: DeprecationComments {
         set {
             let c_value = moveToCType(newValue)
             return moveFromCType(smoke_DeprecationComments_isSomeProperty_set(self.c_instance, c_value.ref))
+        }
+    }
+    /// Describes the property but not accessors.
+    @available(*, deprecated, message: "Will be removed in v3.2.1.")
+    var propertyButNotAccessors: String {
+        get {
+            return moveFromCType(smoke_DeprecationComments_propertyButNotAccessors_get(self.c_instance))
+        }
+        set {
+            let c_value = moveToCType(newValue)
+            return moveFromCType(smoke_DeprecationComments_propertyButNotAccessors_set(self.c_instance, c_value.ref))
         }
     }
     let c_instance : _baseRef
@@ -138,6 +152,14 @@ internal func getRef(_ ref: DeprecationComments?, owning: Bool = true) -> RefHol
     functions.smoke_DeprecationComments_isSomeProperty_set = {(swift_class_pointer, value) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! DeprecationComments
         swift_class.isSomeProperty = moveFromCType(value)
+    }
+    functions.smoke_DeprecationComments_propertyButNotAccessors_get = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! DeprecationComments
+        return copyToCType(swift_class.propertyButNotAccessors).ref
+    }
+    functions.smoke_DeprecationComments_propertyButNotAccessors_set = {(swift_class_pointer, value) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! DeprecationComments
+        swift_class.propertyButNotAccessors = moveFromCType(value)
     }
     let proxy = smoke_DeprecationComments_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_DeprecationComments_release_handle) : RefHolder(proxy)

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -25,6 +25,7 @@ import com.here.gluecodium.antlr.LimedocParser
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeAttributes
+import com.here.gluecodium.model.lime.LimeComment
 import com.here.gluecodium.model.lime.LimeExternalDescriptor
 import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.CPP_TAG
 import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.GETTER_NAME_NAME
@@ -40,10 +41,16 @@ internal object AntlrLimeConverter {
 
     fun convertAnnotations(
         limePath: LimePath,
-        annotations: List<LimeParser.AnnotationContext>
+        annotations: List<LimeParser.AnnotationContext>,
+        parentAttributes: LimeAttributes? = null
     ): LimeAttributes {
         val attributes = LimeAttributes.Builder()
         annotations.forEach { convertAnnotation(it, attributes, limePath) }
+
+        parentAttributes
+            ?.get(LimeAttributeType.DEPRECATED, LimeAttributeValueType.MESSAGE, LimeComment::class.java)
+            ?.let { attributes.addAttributeIfAbsent(LimeAttributeType.DEPRECATED, LimeAttributeValueType.MESSAGE, it) }
+
         return attributes.build()
     }
 

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -284,6 +284,7 @@ internal class AntlrLimeModelBuilder(
         val propertyVisibility = currentVisibility
         val propertyIsStatic = ctx.Static() != null
         val propertyComment = structuredCommentsStack.peek().description
+        val propertyAttributes = AntlrLimeConverter.convertAnnotations(currentPath, ctx.annotation())
 
         val getter: LimeFunction
         val setter: LimeFunction?
@@ -293,6 +294,7 @@ internal class AntlrLimeModelBuilder(
             getter = LimeFunction(
                 path = getterPath,
                 comment = getComment("get", emptyList(), ctx).withExcluded(propertyComment.isExcluded),
+                attributes = AntlrLimeConverter.convertAnnotations(currentPath, emptyList(), propertyAttributes),
                 visibility = propertyVisibility,
                 returnType = LimeReturnType(propertyType, propertyComment),
                 isStatic = propertyIsStatic
@@ -300,6 +302,7 @@ internal class AntlrLimeModelBuilder(
             setter = LimeFunction(
                 path = currentPath.child("set"),
                 comment = getComment("set", emptyList(), ctx).withExcluded(propertyComment.isExcluded),
+                attributes = AntlrLimeConverter.convertAnnotations(currentPath, emptyList(), propertyAttributes),
                 visibility = propertyVisibility,
                 parameters = listOf(LimeParameter(
                     getterPath.child("value"),
@@ -310,7 +313,7 @@ internal class AntlrLimeModelBuilder(
             )
         } else {
             val getterAttributes =
-                AntlrLimeConverter.convertAnnotations(currentPath, getterContext.annotation())
+                AntlrLimeConverter.convertAnnotations(currentPath, getterContext.annotation(), propertyAttributes)
             val getterExternalDescriptor =
                 parseExternalDescriptor(getterContext.externalDescriptor(), getterContext.annotation())
             val getterComment = getComment("get", getterContext.docComment(), getterContext)
@@ -325,7 +328,7 @@ internal class AntlrLimeModelBuilder(
             )
             setter = ctx.setter()?.let {
                 val setterAttributes =
-                    AntlrLimeConverter.convertAnnotations(currentPath, it.annotation())
+                    AntlrLimeConverter.convertAnnotations(currentPath, it.annotation(), propertyAttributes)
                 val setterExternalDescriptor =
                     parseExternalDescriptor(it.externalDescriptor(), it.annotation())
                 val setterComment = getComment("set", it.docComment(), it)
@@ -349,7 +352,7 @@ internal class AntlrLimeModelBuilder(
             path = currentPath,
             visibility = propertyVisibility,
             comment = propertyComment,
-            attributes = AntlrLimeConverter.convertAnnotations(currentPath, ctx.annotation()),
+            attributes = propertyAttributes,
             typeRef = propertyType,
             getter = getter,
             setter = setter,

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributes.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributes.kt
@@ -135,6 +135,17 @@ class LimeAttributes private constructor(
             return this
         }
 
+        fun addAttributeIfAbsent(
+            attributeType: LimeAttributeType,
+            valueType: LimeAttributeValueType,
+            newValue: Any? = true
+        ): Builder {
+            if (attributes[attributeType]?.get(valueType) == null) {
+                addAttribute(attributeType, valueType, newValue)
+            }
+            return this
+        }
+
         fun build() = LimeAttributes(attributes)
     }
 }


### PR DESCRIPTION
Updated LIME model loader to propagate `@Deprecated` attribute from property itself to its accessors, but only if the
accessors lack a `@Deprecated` attribute of their own.

Added a smoke test use case for this.

Resolves: #668
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>