### PR TITLE
Add `@Dart(PositionalDefaults)` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Gluecodium project Release Notes
 
 ## Unreleased
+### Features:
+  * Added `@Dart(PositionalDefaults)` attribute for stucts. This attribute marks a struct to have a constructor with
+    optional positional parameters in Dart (only if the struct has at least one field with a default value).
 ### Bug fixes:
   * `@Deprecated` attribute specified on a property in IDL is now propagated to that property's accessors (but only if
     they lack their own attribute of this type).

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -522,6 +522,8 @@ access and cached in Java/Swift/Dart afterwards). Currently only supported for r
   * **Default**: marks a constructor as a "default" (nameless) in Dart.
   * **Skip**: marks an element to be skipped (not generated) in Dart. Can be applied to any element except for struct
   fields.
+  * **PositionalDefaults**: marks a struct to have a constructor with optional positional parameters in Dart. Can only
+  be applied to a struct that has at least one field with a default value.
   * **Attribute** **=** **"**_Annotation_**"**: marks an element to be marked with the given annotation in Dart
   generated code. _Annotation_ does not need to be prepended with `@`. _Annotation_ can contain parameters, e.g.
   `@Dart(Attribute="Deprecated(\"It's deprecated.\")")`. If some of the parameters are string literals, their enclosing

--- a/examples/libhello/CMakeLists.txt
+++ b/examples/libhello/CMakeLists.txt
@@ -279,6 +279,7 @@ feature(Defaults cpp android swift dart SOURCES
 
     lime/hello/HelloWorldDefaults.lime
     lime/test/Defaults.lime
+    lime/test/PositionalDefaults.lime
 )
 
 feature(Inheritance cpp android swift dart SOURCES

--- a/examples/libhello/lime/test/PositionalDefaults.lime
+++ b/examples/libhello/lime/test/PositionalDefaults.lime
@@ -1,0 +1,32 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct StructWithSomeDefaults {
+    intField: Int = 42
+    stringField: String
+}
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct StructWithAllDefaults {
+    intField: Int = 42
+    stringField: String = "\\Jonny \"Magic\" Smith\n"
+}

--- a/examples/platforms/dart/test/Defaults_test.dart
+++ b/examples/platforms/dart/test/Defaults_test.dart
@@ -74,4 +74,34 @@ void main() {
     expect(result.structField.enumField, DefaultsExternalEnum.oneValue);
     expect(result.setTypeField, {"foo", "bar"});
   });
+  _testSuite.test("Check StructWithSomeDefaults short ctor", () {
+    final result = StructWithSomeDefaults("foobar");
+
+    expect(result.intField, 42);
+    expect(result.stringField, "foobar");
+  });
+  _testSuite.test("Check StructWithSomeDefaults long ctor", () {
+    final result = StructWithSomeDefaults("foobar", 13);
+
+    expect(result.intField, 13);
+    expect(result.stringField, "foobar");
+  });
+  _testSuite.test("Check StructWithAllDefaults parameterless ctor", () {
+    final result = StructWithAllDefaults();
+
+    expect(result.intField, 42);
+    expect(result.stringField, "\\Jonny \"Magic\" Smith\n");
+  });
+  _testSuite.test("Check StructWithAllDefaults short ctor", () {
+    final result = StructWithAllDefaults(13);
+
+    expect(result.intField, 13);
+    expect(result.stringField, "\\Jonny \"Magic\" Smith\n");
+  });
+  _testSuite.test("Check StructWithAllDefaults long ctor", () {
+    final result = StructWithAllDefaults(13, "foobar");
+
+    expect(result.intField, 13);
+    expect(result.stringField, "foobar");
+  });
 }

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -127,13 +127,24 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName this "" "ref"}} value{{#
   try {
 {{#if external.dart.converter}}
     final result_internal = {{resolveName}}_internal{{#if constructors}}._{{/if}}(
-{{#fields}}      {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle){{#if iter.hasNext}}, {{/if}}
-{{/fields}}    );
+{{#fields}}
+{{>fromFfiFieldInit}}
+{{/fields}}
+    );
     return {{external.dart.converter}}.convertFromInternal(result_internal);
 {{/if}}{{#unless external.dart.converter}}
-    return {{resolveName this "" "ref"}}{{#if constructors}}._{{/if}}({{#fields}}
-      {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle){{#if iter.hasNext}}, {{/if}}
-    {{/fields}});
+    return {{resolveName this "" "ref"}}{{#if constructors}}._{{/if}}(
+{{#if attributes.dart.positionalDefaults initializedFields}}
+{{#each uninitializedFields initializedFields}}
+{{>fromFfiFieldInit}}
+{{/each}}
+{{/if}}{{!!
+}}{{#unless attributes.dart.positionalDefaults initializedFields}}
+{{#fields}}
+{{>fromFfiFieldInit}}
+{{/fields}}
+{{/unless}}
+    );
 {{/unless}}
   } finally {
 {{#fields}}
@@ -183,7 +194,16 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveN
   }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
 {{/fields}}
 {{/unless}}{{/resolveName}}{{/unless}}{{!!
-}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}_internal{{/if}}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
+}}{{#if attributes.dart.positionalDefaults initializedFields}}{{!!
+}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}_internal{{/if}}({{!!
+  }}{{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}, {{/uninitializedFields}}{{!!
+  }}[{{#initializedFields}}{{resolveName typeRef}} {{resolveName}} = {{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/initializedFields}}])
+    : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
+{{/if}}{{!!
+}}{{#unless attributes.dart.positionalDefaults initializedFields}}{{!!
+}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}_internal{{/if}}{{!!
+}}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
+{{/unless}}
 {{#if constructors}}  {{resolveName}}{{#if constructors}}._copy{{/if}}({{resolveName}} _other) : {{!!
 }}this._({{#fields}}_other.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{/if}}{{#unless constructors}}{{#if initializedFields}}
@@ -194,4 +214,8 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveN
 {{/if}}{{/unless}}{{/if}}
 {{#set isInClass=true}}{{#constants}}{{prefixPartial "dart/DartConstant" "  "}}
 {{/constants}}{{/set}}{{!!
-}}{{/dartFieldsAndConstants}}
+}}{{/dartFieldsAndConstants}}{{!!
+
+}}{{+fromFfiFieldInit}}{{!!
+}}      {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle){{#if iter.hasNext}}, {{/if}}
+{{/fromFfiFieldInit}}

--- a/gluecodium/src/test/resources/smoke/defaults/input/PositionalDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/PositionalDefaults.lime
@@ -1,0 +1,32 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct StructWithSomeDefaults {
+    intField: Int = 42
+    stringField: String
+}
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct StructWithAllDefaults {
+    intField: Int = 42
+    stringField: String = "\\Jonny \"Magic\" Smith\n"
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_all_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_all_defaults.dart
@@ -1,0 +1,82 @@
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+class StructWithAllDefaults {
+  int intField;
+  String stringField;
+  StructWithAllDefaults([int intField = 42, String stringField = "\\Jonny \"Magic\" Smith\n"])
+    : intField = intField, stringField = stringField;
+  StructWithAllDefaults.withDefaults()
+    : intField = 42, stringField = "\\Jonny \"Magic\" Smith\n";
+}
+// StructWithAllDefaults "private" section, not exported.
+final _smoke_StructWithAllDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int32, Pointer<Void>),
+    Pointer<Void> Function(int, Pointer<Void>)
+  >('library_smoke_StructWithAllDefaults_create_handle'));
+final _smoke_StructWithAllDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_StructWithAllDefaults_release_handle'));
+final _smoke_StructWithAllDefaults_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_StructWithAllDefaults_get_field_intField'));
+final _smoke_StructWithAllDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithAllDefaults_get_field_stringField'));
+Pointer<Void> smoke_StructWithAllDefaults_toFfi(StructWithAllDefaults value) {
+  final _intField_handle = (value.intField);
+  final _stringField_handle = String_toFfi(value.stringField);
+  final _result = _smoke_StructWithAllDefaults_create_handle(_intField_handle, _stringField_handle);
+  (_intField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  return _result;
+}
+StructWithAllDefaults smoke_StructWithAllDefaults_fromFfi(Pointer<Void> handle) {
+  final _intField_handle = _smoke_StructWithAllDefaults_get_field_intField(handle);
+  final _stringField_handle = _smoke_StructWithAllDefaults_get_field_stringField(handle);
+  try {
+    return StructWithAllDefaults(
+      (_intField_handle),
+      String_fromFfi(_stringField_handle)
+    );
+  } finally {
+    (_intField_handle);
+    String_releaseFfiHandle(_stringField_handle);
+  }
+}
+void smoke_StructWithAllDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithAllDefaults_release_handle(handle);
+// Nullable StructWithAllDefaults
+final _smoke_StructWithAllDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithAllDefaults_create_handle_nullable'));
+final _smoke_StructWithAllDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_StructWithAllDefaults_release_handle_nullable'));
+final _smoke_StructWithAllDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithAllDefaults_get_value_nullable'));
+Pointer<Void> smoke_StructWithAllDefaults_toFfi_nullable(StructWithAllDefaults value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_StructWithAllDefaults_toFfi(value);
+  final result = _smoke_StructWithAllDefaults_create_handle_nullable(_handle);
+  smoke_StructWithAllDefaults_releaseFfiHandle(_handle);
+  return result;
+}
+StructWithAllDefaults smoke_StructWithAllDefaults_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_StructWithAllDefaults_get_value_nullable(handle);
+  final result = smoke_StructWithAllDefaults_fromFfi(_handle);
+  smoke_StructWithAllDefaults_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_StructWithAllDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_StructWithAllDefaults_release_handle_nullable(handle);
+// End of StructWithAllDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_some_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_some_defaults.dart
@@ -1,0 +1,82 @@
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+class StructWithSomeDefaults {
+  int intField;
+  String stringField;
+  StructWithSomeDefaults(String stringField, [int intField = 42])
+    : intField = intField, stringField = stringField;
+  StructWithSomeDefaults.withDefaults(String stringField)
+    : intField = 42, stringField = stringField;
+}
+// StructWithSomeDefaults "private" section, not exported.
+final _smoke_StructWithSomeDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int32, Pointer<Void>),
+    Pointer<Void> Function(int, Pointer<Void>)
+  >('library_smoke_StructWithSomeDefaults_create_handle'));
+final _smoke_StructWithSomeDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_StructWithSomeDefaults_release_handle'));
+final _smoke_StructWithSomeDefaults_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_StructWithSomeDefaults_get_field_intField'));
+final _smoke_StructWithSomeDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithSomeDefaults_get_field_stringField'));
+Pointer<Void> smoke_StructWithSomeDefaults_toFfi(StructWithSomeDefaults value) {
+  final _intField_handle = (value.intField);
+  final _stringField_handle = String_toFfi(value.stringField);
+  final _result = _smoke_StructWithSomeDefaults_create_handle(_intField_handle, _stringField_handle);
+  (_intField_handle);
+  String_releaseFfiHandle(_stringField_handle);
+  return _result;
+}
+StructWithSomeDefaults smoke_StructWithSomeDefaults_fromFfi(Pointer<Void> handle) {
+  final _intField_handle = _smoke_StructWithSomeDefaults_get_field_intField(handle);
+  final _stringField_handle = _smoke_StructWithSomeDefaults_get_field_stringField(handle);
+  try {
+    return StructWithSomeDefaults(
+      String_fromFfi(_stringField_handle),
+      (_intField_handle)
+    );
+  } finally {
+    (_intField_handle);
+    String_releaseFfiHandle(_stringField_handle);
+  }
+}
+void smoke_StructWithSomeDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithSomeDefaults_release_handle(handle);
+// Nullable StructWithSomeDefaults
+final _smoke_StructWithSomeDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithSomeDefaults_create_handle_nullable'));
+final _smoke_StructWithSomeDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_StructWithSomeDefaults_release_handle_nullable'));
+final _smoke_StructWithSomeDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithSomeDefaults_get_value_nullable'));
+Pointer<Void> smoke_StructWithSomeDefaults_toFfi_nullable(StructWithSomeDefaults value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_StructWithSomeDefaults_toFfi(value);
+  final result = _smoke_StructWithSomeDefaults_create_handle_nullable(_handle);
+  smoke_StructWithSomeDefaults_releaseFfiHandle(_handle);
+  return result;
+}
+StructWithSomeDefaults smoke_StructWithSomeDefaults_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_StructWithSomeDefaults_get_value_nullable(handle);
+  final result = smoke_StructWithSomeDefaults_fromFfi(_handle);
+  smoke_StructWithSomeDefaults_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_StructWithSomeDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_StructWithSomeDefaults_release_handle_nullable(handle);
+// End of StructWithSomeDefaults "private" section.

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -148,6 +148,7 @@ internal object AntlrLimeConverter {
             "Label" -> LimeAttributeValueType.LABEL
             "ObjC" -> LimeAttributeValueType.OBJC
             "Message" -> LimeAttributeValueType.MESSAGE
+            "PositionalDefaults" -> LimeAttributeValueType.POSITIONAL_DEFAULTS
             "Ref" -> LimeAttributeValueType.REF
             "Skip" -> LimeAttributeValueType.SKIP
             "Weak" -> LimeAttributeValueType.WEAK

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
@@ -32,6 +32,7 @@ enum class LimeAttributeValueType(private val tag: String) {
     LABEL("Label"),
     OBJC("ObjC"),
     MESSAGE("Message"),
+    POSITIONAL_DEFAULTS("PositionalDefaults"),
     REF("Ref"),
     SKIP("Skip"),
     WEAK("Weak");


### PR DESCRIPTION
Added support for `@Dart(PositionalDefaults)` attribute for stucts. This attribute marks a struct to have a constructor
with optional positional parameters in Dart (only meaningful for a struct that has at least one field with a default
value).

Added smoke and functional tests.

Resolves: #594
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
