### PR TITLE
Fix flaky Android functional test

### DIFF
--- a/examples/libhello/lime/test/ListenerWithMaps.lime
+++ b/examples/libhello/lime/test/ListenerWithMaps.lime
@@ -28,6 +28,7 @@ types Forecast {
 class ForecastFactory {
     static fun createProvider(): ForecastProvider
     static fun createListener(): ForecastListener
+    static fun getLog(): String
 }
 
 class ForecastProvider {

--- a/examples/libhello/src/test/ListenerWithMaps.cpp
+++ b/examples/libhello/src/test/ListenerWithMaps.cpp
@@ -76,7 +76,7 @@ public:
                    << std::endl;
         }
 
-        s_log = s_log + stream.str();
+        s_log += stream.str();
     }
 };
 }

--- a/examples/libhello/src/test/ListenerWithMaps.cpp
+++ b/examples/libhello/src/test/ListenerWithMaps.cpp
@@ -32,7 +32,8 @@
 
 namespace
 {
-const ::test::CityDataMap data{{"Berlin", {-2, 26}}, {"Marrakesh", {8, 40}}, {"Madrid", {1, 33}}};
+const ::test::CityDataMap DATA{{"Berlin", {-2, 26}}, {"Marrakesh", {8, 40}}, {"Madrid", {1, 33}}};
+std::string s_log{};
 
 class MyForecastProvider : public ::test::ForecastProvider
 {
@@ -43,7 +44,7 @@ public:
     void
     inform( const ::std::shared_ptr<::test::ForecastListener >& listener )
     {
-        listener->on_forecast_data_provided( data );
+        listener->on_forecast_data_provided( DATA );
     }
 };
 
@@ -75,10 +76,10 @@ public:
                    << std::endl;
         }
 
-        ::hello::HelloWorldStaticLogger::append( stream.str( ) );
+        s_log = s_log + stream.str();
     }
 };
-}  // namespace
+}
 
 namespace test
 {
@@ -93,4 +94,9 @@ ForecastFactory::create_listener( )
 {
     return std::make_shared< MyForecastListener >( );
 }
-}  // namespace test
+
+std::string
+ForecastFactory::get_log() {
+    return s_log;
+}
+}

--- a/examples/platforms/android/app/src/test/java/com/here/android/test/ListenerWithMapsTest.java
+++ b/examples/platforms/android/app/src/test/java/com/here/android/test/ListenerWithMapsTest.java
@@ -25,10 +25,8 @@ import static org.junit.Assert.assertThat;
 import android.os.Build;
 import com.example.here.hello.BuildConfig;
 import com.here.android.RobolectricApplication;
-import com.here.android.hello.HelloWorldStaticLogger;
 import java.util.List;
 import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -72,16 +70,11 @@ public final class ListenerWithMapsTest {
   private static final String EXPECTED_DATA =
       "Berlin -> [-2, 26]\n" + "Madrid -> [1, 33]\n" + "Marrakesh -> [8, 40]\n";
 
-  @Before
-  public void setup() {
-    HelloWorldStaticLogger.clearLog();
-  }
-
   @Test
   public void checkNativeListener() {
     ForecastListener listener = ForecastFactory.createListener();
     PROVIDER.inform(listener);
-    assertThat(HelloWorldStaticLogger.getLog(), is(EXPECTED_DATA));
+    assertThat(ForecastFactory.getLog(), is(EXPECTED_DATA));
   }
 
   @Test

--- a/examples/platforms/ios/Tests/testTests/ListenersWithDictionaries.swift
+++ b/examples/platforms/ios/Tests/testTests/ListenersWithDictionaries.swift
@@ -27,13 +27,11 @@ class ListenersWithDictionaries: XCTestCase {
   let provider = ForecastFactory.createProvider()
 
   func testCheckNativeListener() {
-    HelloWorldStaticLogger.clearLog()
-
     let listener = ForecastFactory.createListener()
 
     provider.inform(listener: listener)
 
-    let log = HelloWorldStaticLogger.getLog()
+    let log = ForecastFactory.getLog()
     XCTAssertEqual(expectedData, log)
   }
 


### PR DESCRIPTION
Updated ListenerWithMapsTest.checkNativeListener() Android functional test to have its own "static log" instead of
relying on global singleton HelloWorldStaticLogger. This fixes the test's flakiness.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>