### PR TITLE
Don't run functional tests on .md file changes

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,38 +1,14 @@
-name: CI
+name: Functional tests
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - '*.md'
 
 jobs:
-  build:
-    name: Build and unit tests
-    runs-on: ubuntu-18.04
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            !*gluecodium*
-            !*lime-*
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Build and test :lime-runtime
-        run: ./gradlew :lime-runtime:build
-      - name: Build and test :lime-loader
-        run: ./gradlew :lime-loader:build
-      - name: Build and test :gluecodium
-        run: ./gradlew :gluecodium:build
-      - name: Build and test :gluecodium-gradle
-        run: ./gradlew :gluecodium-gradle:build
-
   cpp:
     name: C++
     runs-on: ubuntu-18.04

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,34 @@
+name: Unit tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build and unit tests
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            !*gluecodium*
+            !*lime-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build and test :lime-runtime
+        run: ./gradlew :lime-runtime:build
+      - name: Build and test :lime-loader
+        run: ./gradlew :lime-loader:build
+      - name: Build and test :gluecodium
+        run: ./gradlew :gluecodium:build
+      - name: Build and test :gluecodium-gradle
+        run: ./gradlew :gluecodium-gradle:build


### PR DESCRIPTION
Split "gluecodium.yml" workflow into two separate workflows for unit tests and for functional tests. Updated trigger
condition for function tests to not to trigger on *.md file changes. This avoids triggering functional test on
documentation or changelog changes.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>