### PR TITLE
Add Hashable conformance to generated Swift classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed referential equality in Dart for objects being sent from Dart to C++ and then back.
+  * Fixed `Hashable` protocol conformance for Swift classes that are not marked as `@Equatable`.
 
 ## 8.7.0
 Release date: 2021-01-11

--- a/functional-tests/functional/swift/Tests/RefEqualityTests.swift
+++ b/functional-tests/functional/swift/Tests/RefEqualityTests.swift
@@ -28,6 +28,7 @@ class RefEqualityTests: XCTestCase {
         let instance2 = DummyFactory.getDummyClassSingleton()
 
         XCTAssertTrue(instance1 === instance2)
+        XCTAssertTrue(instance1 == instance2)
     }
 
     func testRefInequalityPreservedForClass() {
@@ -35,6 +36,23 @@ class RefEqualityTests: XCTestCase {
         let instance2 = DummyFactory.createDummyClass()
 
         XCTAssertFalse(instance1 === instance2)
+        XCTAssertFalse(instance1 == instance2)
+    }
+
+    func testRefEqualityPreservedForClassInSet() {
+        let instance1 = DummyFactory.getDummyClassSingleton()
+        let instance2 = DummyFactory.getDummyClassSingleton()
+        let instanceSet: Set = [instance1, instance2]
+
+        XCTAssertEqual(instanceSet.count, 1)
+    }
+
+    func testRefInequalityPreservedForClassInSet() {
+        let instance1 = DummyFactory.getDummyClassSingleton()
+        let instance2 = DummyFactory.createDummyClass()
+        let instanceSet: Set = [instance1, instance2]
+
+        XCTAssertEqual(instanceSet.count, 2)
     }
 
     func testRefEqualityPreservedForInterface() {
@@ -56,6 +74,7 @@ class RefEqualityTests: XCTestCase {
         let instance2 = DummyClass.dummyClassRoundTrip(input: instance1)
 
         XCTAssertTrue(instance1 === instance2)
+        XCTAssertTrue(instance1 == instance2)
     }
 
     func testRefInequalityPreservedForClassConstructor() {
@@ -63,6 +82,7 @@ class RefEqualityTests: XCTestCase {
         let instance2 = DummyClass()
 
         XCTAssertFalse(instance1 === instance2)
+        XCTAssertFalse(instance1 == instance2)
     }
 
     func testRefEqualityPreservedForClassInList() {
@@ -71,6 +91,7 @@ class RefEqualityTests: XCTestCase {
         let result = DummyClass.dummyClassListRoundTrip(input: list)
 
         XCTAssertTrue(list.first === result.first)
+        XCTAssertTrue(list.first == result.first)
     }
 
     func testRefEqualityPreservedForChildClassAsParent() {
@@ -78,11 +99,14 @@ class RefEqualityTests: XCTestCase {
         let instance2 = DummyFactory.getDummyChildClassSingletonAsParent()
 
         XCTAssertTrue(instance1 === instance2)
+        XCTAssertTrue(instance1 == instance2)
     }
 
     static var allTests = [
         ("testRefEqualityPreservedForClass", testRefEqualityPreservedForClass),
         ("testRefInequalityPreservedForClass", testRefInequalityPreservedForClass),
+        ("testRefEqualityPreservedForClassInSet", testRefEqualityPreservedForClassInSet),
+        ("testRefInequalityPreservedForClassInSet", testRefInequalityPreservedForClassInSet),
         ("testRefEqualityPreservedForInterface", testRefEqualityPreservedForInterface),
         ("testRefInequalityPreservedForInterface", testRefInequalityPreservedForInterface),
         ("testRefEqualityPreservedForClassConstructor", testRefEqualityPreservedForClassConstructor),

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassConversion.mustache
@@ -62,7 +62,21 @@ extension {{>implName}}: Hashable {
         hasher.combine({{resolveName "CBridge"}}_hash(c_handle))
     }
 }
-{{/if}}
+{{/if}}{{!!
+}}{{#unless attributes.equatable attributes.pointerEquatable logic="and"}}
+{{#instanceOf this "LimeClass"}}{{#unlessPredicate "parentIsClass"}}
+
+extension {{>implName}}: Hashable {
+    public static func == (lhs: {{>implName}}, rhs: {{>implName}}) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
+{{/unlessPredicate}}{{/instanceOf}}
+{{/unless}}
 
 internal func {{resolveName this "mangled"}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
 {{#instanceOf this "LimeInterface"}}

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesClass.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesClass.swift
@@ -44,6 +44,14 @@ internal func getRef(_ ref: AttributesClass?, owning: Bool = true) -> RefHolder 
 extension AttributesClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension AttributesClass: Hashable {
+    public static func == (lhs: AttributesClass, rhs: AttributesClass) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func AttributesClass_copyFromCType(_ handle: _baseRef) -> AttributesClass {
     if let swift_pointer = smoke_AttributesClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesClass {

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithComments.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithComments.swift
@@ -58,6 +58,14 @@ internal func getRef(_ ref: AttributesWithComments?, owning: Bool = true) -> Ref
 extension AttributesWithComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension AttributesWithComments: Hashable {
+    public static func == (lhs: AttributesWithComments, rhs: AttributesWithComments) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func AttributesWithComments_copyFromCType(_ handle: _baseRef) -> AttributesWithComments {
     if let swift_pointer = smoke_AttributesWithComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesWithComments {

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithDeprecated.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithDeprecated.swift
@@ -59,6 +59,14 @@ internal func getRef(_ ref: AttributesWithDeprecated?, owning: Bool = true) -> R
 extension AttributesWithDeprecated: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension AttributesWithDeprecated: Hashable {
+    public static func == (lhs: AttributesWithDeprecated, rhs: AttributesWithDeprecated) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func AttributesWithDeprecated_copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated {
     if let swift_pointer = smoke_AttributesWithDeprecated_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesWithDeprecated {

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/MultipleAttributesSwift.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/MultipleAttributesSwift.swift
@@ -56,6 +56,14 @@ internal func getRef(_ ref: MultipleAttributesSwift?, owning: Bool = true) -> Re
 extension MultipleAttributesSwift: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension MultipleAttributesSwift: Hashable {
+    public static func == (lhs: MultipleAttributesSwift, rhs: MultipleAttributesSwift) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func MultipleAttributesSwift_copyFromCType(_ handle: _baseRef) -> MultipleAttributesSwift {
     if let swift_pointer = smoke_MultipleAttributesSwift_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MultipleAttributesSwift {

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/SpecialAttributes.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/SpecialAttributes.swift
@@ -34,6 +34,14 @@ internal func getRef(_ ref: SpecialAttributes?, owning: Bool = true) -> RefHolde
 extension SpecialAttributes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension SpecialAttributes: Hashable {
+    public static func == (lhs: SpecialAttributes, rhs: SpecialAttributes) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func SpecialAttributes_copyFromCType(_ handle: _baseRef) -> SpecialAttributes {
     if let swift_pointer = smoke_SpecialAttributes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SpecialAttributes {

--- a/gluecodium/src/test/resources/smoke/basic_types/output/swift/smoke/BasicTypes.swift
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/swift/smoke/BasicTypes.swift
@@ -74,6 +74,14 @@ internal func getRef(_ ref: BasicTypes?, owning: Bool = true) -> RefHolder {
 extension BasicTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension BasicTypes: Hashable {
+    public static func == (lhs: BasicTypes, rhs: BasicTypes) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func BasicTypes_copyFromCType(_ handle: _baseRef) -> BasicTypes {
     if let swift_pointer = smoke_BasicTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? BasicTypes {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -153,6 +153,14 @@ internal func getRef(_ ref: Comments?, owning: Bool = true) -> RefHolder {
 extension Comments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Comments: Hashable {
+    public static func == (lhs: Comments, rhs: Comments) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Comments_copyFromCType(_ handle: _baseRef) -> Comments {
     if let swift_pointer = smoke_Comments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Comments {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
@@ -102,6 +102,14 @@ internal func getRef(_ ref: CommentsLinks?, owning: Bool = true) -> RefHolder {
 extension CommentsLinks: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension CommentsLinks: Hashable {
+    public static func == (lhs: CommentsLinks, rhs: CommentsLinks) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func CommentsLinks_copyFromCType(_ handle: _baseRef) -> CommentsLinks {
     if let swift_pointer = smoke_CommentsLinks_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CommentsLinks {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
@@ -95,6 +95,14 @@ internal func getRef(_ ref: ExcludedComments?, owning: Bool = true) -> RefHolder
 extension ExcludedComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension ExcludedComments: Hashable {
+    public static func == (lhs: ExcludedComments, rhs: ExcludedComments) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func ExcludedComments_copyFromCType(_ handle: _baseRef) -> ExcludedComments {
     if let swift_pointer = smoke_ExcludedComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedComments {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
@@ -80,6 +80,14 @@ internal func getRef(_ ref: ExcludedCommentsOnly?, owning: Bool = true) -> RefHo
 extension ExcludedCommentsOnly: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension ExcludedCommentsOnly: Hashable {
+    public static func == (lhs: ExcludedCommentsOnly, rhs: ExcludedCommentsOnly) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func ExcludedCommentsOnly_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly {
     if let swift_pointer = smoke_ExcludedCommentsOnly_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedCommentsOnly {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/LongComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/LongComments.swift
@@ -37,6 +37,14 @@ internal func getRef(_ ref: LongComments?, owning: Bool = true) -> RefHolder {
 extension LongComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension LongComments: Hashable {
+    public static func == (lhs: LongComments, rhs: LongComments) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func LongComments_copyFromCType(_ handle: _baseRef) -> LongComments {
     if let swift_pointer = smoke_LongComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LongComments {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MultiLineComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MultiLineComments.swift
@@ -58,6 +58,14 @@ internal func getRef(_ ref: MultiLineComments?, owning: Bool = true) -> RefHolde
 extension MultiLineComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension MultiLineComments: Hashable {
+    public static func == (lhs: MultiLineComments, rhs: MultiLineComments) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func MultiLineComments_copyFromCType(_ handle: _baseRef) -> MultiLineComments {
     if let swift_pointer = smoke_MultiLineComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MultiLineComments {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
@@ -68,6 +68,14 @@ internal func getRef(_ ref: PlatformComments?, owning: Bool = true) -> RefHolder
 extension PlatformComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension PlatformComments: Hashable {
+    public static func == (lhs: PlatformComments, rhs: PlatformComments) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func PlatformComments_copyFromCType(_ handle: _baseRef) -> PlatformComments {
     if let swift_pointer = smoke_PlatformComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PlatformComments {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/UnicodeComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/UnicodeComments.swift
@@ -39,6 +39,14 @@ internal func getRef(_ ref: UnicodeComments?, owning: Bool = true) -> RefHolder 
 extension UnicodeComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension UnicodeComments: Hashable {
+    public static func == (lhs: UnicodeComments, rhs: UnicodeComments) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func UnicodeComments_copyFromCType(_ handle: _baseRef) -> UnicodeComments {
     if let swift_pointer = smoke_UnicodeComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UnicodeComments {

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/CollectionConstants.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/CollectionConstants.swift
@@ -30,6 +30,14 @@ internal func getRef(_ ref: CollectionConstants?, owning: Bool = true) -> RefHol
 extension CollectionConstants: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension CollectionConstants: Hashable {
+    public static func == (lhs: CollectionConstants, rhs: CollectionConstants) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func CollectionConstants_copyFromCType(_ handle: _baseRef) -> CollectionConstants {
     if let swift_pointer = smoke_CollectionConstants_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CollectionConstants {

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/ConstantsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/ConstantsInterface.swift
@@ -37,6 +37,14 @@ internal func getRef(_ ref: ConstantsInterface?, owning: Bool = true) -> RefHold
 extension ConstantsInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension ConstantsInterface: Hashable {
+    public static func == (lhs: ConstantsInterface, rhs: ConstantsInterface) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func ConstantsInterface_copyFromCType(_ handle: _baseRef) -> ConstantsInterface {
     if let swift_pointer = smoke_ConstantsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ConstantsInterface {

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/StructConstants.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/StructConstants.swift
@@ -49,6 +49,14 @@ internal func getRef(_ ref: StructConstants?, owning: Bool = true) -> RefHolder 
 extension StructConstants: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension StructConstants: Hashable {
+    public static func == (lhs: StructConstants, rhs: StructConstants) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func StructConstants_copyFromCType(_ handle: _baseRef) -> StructConstants {
     if let swift_pointer = smoke_StructConstants_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructConstants {

--- a/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/Constructors.swift
+++ b/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/Constructors.swift
@@ -101,6 +101,14 @@ internal func getRef(_ ref: Constructors?, owning: Bool = true) -> RefHolder {
 extension Constructors: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Constructors: Hashable {
+    public static func == (lhs: Constructors, rhs: Constructors) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Constructors_copyFromCType(_ handle: _baseRef) -> Constructors {
     if let swift_pointer = smoke_Constructors_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Constructors {

--- a/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/Dates.swift
+++ b/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/Dates.swift
@@ -51,6 +51,14 @@ internal func getRef(_ ref: Dates?, owning: Bool = true) -> RefHolder {
 extension Dates: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Dates: Hashable {
+    public static func == (lhs: Dates, rhs: Dates) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Dates_copyFromCType(_ handle: _baseRef) -> Dates {
     if let swift_pointer = smoke_Dates_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Dates {

--- a/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/DefaultValues.swift
+++ b/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/DefaultValues.swift
@@ -162,6 +162,14 @@ internal func getRef(_ ref: DefaultValues?, owning: Bool = true) -> RefHolder {
 extension DefaultValues: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension DefaultValues: Hashable {
+    public static func == (lhs: DefaultValues, rhs: DefaultValues) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func DefaultValues_copyFromCType(_ handle: _baseRef) -> DefaultValues {
     if let swift_pointer = smoke_DefaultValues_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DefaultValues {

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/Enums.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/Enums.swift
@@ -64,6 +64,14 @@ internal func getRef(_ ref: Enums?, owning: Bool = true) -> RefHolder {
 extension Enums: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Enums: Hashable {
+    public static func == (lhs: Enums, rhs: Enums) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Enums_copyFromCType(_ handle: _baseRef) -> Enums {
     if let swift_pointer = smoke_Enums_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Enums {

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumsInTypeCollectionInterface.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumsInTypeCollectionInterface.swift
@@ -30,6 +30,14 @@ internal func getRef(_ ref: EnumsInTypeCollectionInterface?, owning: Bool = true
 extension EnumsInTypeCollectionInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension EnumsInTypeCollectionInterface: Hashable {
+    public static func == (lhs: EnumsInTypeCollectionInterface, rhs: EnumsInTypeCollectionInterface) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func EnumsInTypeCollectionInterface_copyFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface {
     if let swift_pointer = smoke_EnumsInTypeCollectionInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EnumsInTypeCollectionInterface {

--- a/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/Errors.swift
+++ b/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/Errors.swift
@@ -71,6 +71,14 @@ internal func getRef(_ ref: Errors?, owning: Bool = true) -> RefHolder {
 extension Errors: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Errors: Hashable {
+    public static func == (lhs: Errors, rhs: Errors) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Errors_copyFromCType(_ handle: _baseRef) -> Errors {
     if let swift_pointer = smoke_Errors_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Errors {

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Class.swift
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Class.swift
@@ -60,6 +60,14 @@ internal func getRef(_ ref: Class?, owning: Bool = true) -> RefHolder {
 extension Class: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Class: Hashable {
+    public static func == (lhs: Class, rhs: Class) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Class_copyFromCType(_ handle: _baseRef) -> Class {
     if let swift_pointer = package_Class_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Class {

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Enums.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Enums.swift
@@ -38,6 +38,14 @@ internal func getRef(_ ref: Enums?, owning: Bool = true) -> RefHolder {
 extension Enums: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Enums: Hashable {
+    public static func == (lhs: Enums, rhs: Enums) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Enums_copyFromCType(_ handle: _baseRef) -> Enums {
     if let swift_pointer = smoke_Enums_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Enums {

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalClass.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalClass.swift
@@ -47,6 +47,14 @@ internal func getRef(_ ref: ExternalClass?, owning: Bool = true) -> RefHolder {
 extension ExternalClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension ExternalClass: Hashable {
+    public static func == (lhs: ExternalClass, rhs: ExternalClass) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func ExternalClass_copyFromCType(_ handle: _baseRef) -> ExternalClass {
     if let swift_pointer = smoke_ExternalClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExternalClass {

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Structs.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Structs.swift
@@ -59,6 +59,14 @@ internal func getRef(_ ref: Structs?, owning: Bool = true) -> RefHolder {
 extension Structs: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Structs: Hashable {
+    public static func == (lhs: Structs, rhs: Structs) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Structs_copyFromCType(_ handle: _baseRef) -> Structs {
     if let swift_pointer = smoke_Structs_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Structs {

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UseSwiftExternalTypes.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UseSwiftExternalTypes.swift
@@ -43,6 +43,14 @@ internal func getRef(_ ref: UseSwiftExternalTypes?, owning: Bool = true) -> RefH
 extension UseSwiftExternalTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension UseSwiftExternalTypes: Hashable {
+    public static func == (lhs: UseSwiftExternalTypes, rhs: UseSwiftExternalTypes) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func UseSwiftExternalTypes_copyFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes {
     if let swift_pointer = smoke_UseSwiftExternalTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UseSwiftExternalTypes {

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithBasicTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithBasicTypes.swift
@@ -95,6 +95,14 @@ internal func getRef(_ ref: GenericTypesWithBasicTypes?, owning: Bool = true) ->
 extension GenericTypesWithBasicTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension GenericTypesWithBasicTypes: Hashable {
+    public static func == (lhs: GenericTypesWithBasicTypes, rhs: GenericTypesWithBasicTypes) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func GenericTypesWithBasicTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes {
     if let swift_pointer = smoke_GenericTypesWithBasicTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithBasicTypes {

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithCompoundTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithCompoundTypes.swift
@@ -84,6 +84,14 @@ internal func getRef(_ ref: GenericTypesWithCompoundTypes?, owning: Bool = true)
 extension GenericTypesWithCompoundTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension GenericTypesWithCompoundTypes: Hashable {
+    public static func == (lhs: GenericTypesWithCompoundTypes, rhs: GenericTypesWithCompoundTypes) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func GenericTypesWithCompoundTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes {
     if let swift_pointer = smoke_GenericTypesWithCompoundTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithCompoundTypes {

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithGenericTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithGenericTypes.swift
@@ -54,6 +54,14 @@ internal func getRef(_ ref: GenericTypesWithGenericTypes?, owning: Bool = true) 
 extension GenericTypesWithGenericTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension GenericTypesWithGenericTypes: Hashable {
+    public static func == (lhs: GenericTypesWithGenericTypes, rhs: GenericTypesWithGenericTypes) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func GenericTypesWithGenericTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes {
     if let swift_pointer = smoke_GenericTypesWithGenericTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithGenericTypes {

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromInterface.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromInterface.swift
@@ -46,6 +46,14 @@ internal func getRef(_ ref: ChildClassFromInterface?, owning: Bool = true) -> Re
 extension ChildClassFromInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension ChildClassFromInterface: Hashable {
+    public static func == (lhs: ChildClassFromInterface, rhs: ChildClassFromInterface) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func ChildClassFromInterface_copyFromCType(_ handle: _baseRef) -> ChildClassFromInterface {
     if let swift_pointer = smoke_ChildClassFromInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromInterface {

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalParent.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalParent.swift
@@ -31,6 +31,14 @@ internal func getRef(_ ref: InternalParent?, owning: Bool = true) -> RefHolder {
 extension InternalParent: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension InternalParent: Hashable {
+    public static func == (lhs: InternalParent, rhs: InternalParent) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func InternalParent_copyFromCType(_ handle: _baseRef) -> InternalParent {
     if let swift_pointer = smoke_InternalParent_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalParent {

--- a/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleClass.swift
+++ b/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleClass.swift
@@ -33,6 +33,14 @@ internal func getRef(_ ref: SimpleClass?, owning: Bool = true) -> RefHolder {
 extension SimpleClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension SimpleClass: Hashable {
+    public static func == (lhs: SimpleClass, rhs: SimpleClass) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func SimpleClass_copyFromCType(_ handle: _baseRef) -> SimpleClass {
     if let swift_pointer = smoke_SimpleClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SimpleClass {

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
@@ -42,6 +42,14 @@ internal func getRef(_ ref: Lambdas?, owning: Bool = true) -> RefHolder {
 extension Lambdas: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Lambdas: Hashable {
+    public static func == (lhs: Lambdas, rhs: Lambdas) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Lambdas_copyFromCType(_ handle: _baseRef) -> Lambdas {
     if let swift_pointer = smoke_Lambdas_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Lambdas {

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
@@ -36,6 +36,14 @@ internal func getRef(_ ref: LambdasWithStructuredTypes?, owning: Bool = true) ->
 extension LambdasWithStructuredTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension LambdasWithStructuredTypes: Hashable {
+    public static func == (lhs: LambdasWithStructuredTypes, rhs: LambdasWithStructuredTypes) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func LambdasWithStructuredTypes_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes {
     if let swift_pointer = smoke_LambdasWithStructuredTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LambdasWithStructuredTypes {

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Calculator.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Calculator.swift
@@ -34,6 +34,14 @@ internal func getRef(_ ref: Calculator?, owning: Bool = true) -> RefHolder {
 extension Calculator: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Calculator: Hashable {
+    public static func == (lhs: Calculator, rhs: Calculator) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Calculator_copyFromCType(_ handle: _baseRef) -> Calculator {
     if let swift_pointer = smoke_Calculator_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Calculator {

--- a/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/Locales.swift
+++ b/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/Locales.swift
@@ -51,6 +51,14 @@ internal func getRef(_ ref: Locales?, owning: Bool = true) -> RefHolder {
 extension Locales: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Locales: Hashable {
+    public static func == (lhs: Locales, rhs: Locales) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Locales_copyFromCType(_ handle: _baseRef) -> Locales {
     if let swift_pointer = smoke_Locales_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Locales {

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/MethodOverloads.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/MethodOverloads.swift
@@ -82,6 +82,14 @@ internal func getRef(_ ref: MethodOverloads?, owning: Bool = true) -> RefHolder 
 extension MethodOverloads: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension MethodOverloads: Hashable {
+    public static func == (lhs: MethodOverloads, rhs: MethodOverloads) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func MethodOverloads_copyFromCType(_ handle: _baseRef) -> MethodOverloads {
     if let swift_pointer = smoke_MethodOverloads_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MethodOverloads {

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SpecialNames.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SpecialNames.swift
@@ -38,6 +38,14 @@ internal func getRef(_ ref: SpecialNames?, owning: Bool = true) -> RefHolder {
 extension SpecialNames: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension SpecialNames: Hashable {
+    public static func == (lhs: SpecialNames, rhs: SpecialNames) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func SpecialNames_copyFromCType(_ handle: _baseRef) -> SpecialNames {
     if let swift_pointer = smoke_SpecialNames_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SpecialNames {

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SwiftMethodOverloads.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SwiftMethodOverloads.swift
@@ -34,6 +34,14 @@ internal func getRef(_ ref: SwiftMethodOverloads?, owning: Bool = true) -> RefHo
 extension SwiftMethodOverloads: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension SwiftMethodOverloads: Hashable {
+    public static func == (lhs: SwiftMethodOverloads, rhs: SwiftMethodOverloads) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func SwiftMethodOverloads_copyFromCType(_ handle: _baseRef) -> SwiftMethodOverloads {
     if let swift_pointer = smoke_SwiftMethodOverloads_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SwiftMethodOverloads {

--- a/gluecodium/src/test/resources/smoke/name_rules/output/swift/namerules/INameRules.swift
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/swift/namerules/INameRules.swift
@@ -91,6 +91,14 @@ internal func getRef(_ ref: INameRules?, owning: Bool = true) -> RefHolder {
 extension INameRules: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension INameRules: Hashable {
+    public static func == (lhs: INameRules, rhs: INameRules) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func INameRules_copyFromCType(_ handle: _baseRef) -> INameRules {
     if let swift_pointer = namerules_INameRules_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? INameRules {

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/LevelOne.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/LevelOne.swift
@@ -72,6 +72,14 @@ internal func getRef(_ ref: LevelOne?, owning: Bool = true) -> RefHolder {
 extension LevelOne: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension LevelOne: Hashable {
+    public static func == (lhs: LevelOne, rhs: LevelOne) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func LevelOne_copyFromCType(_ handle: _baseRef) -> LevelOne {
     if let swift_pointer = smoke_LevelOne_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne {
@@ -127,6 +135,14 @@ internal func getRef(_ ref: LevelOne.LevelTwo?, owning: Bool = true) -> RefHolde
 extension LevelOne.LevelTwo: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension LevelOne.LevelTwo: Hashable {
+    public static func == (lhs: LevelOne.LevelTwo, rhs: LevelOne.LevelTwo) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func LevelOne_LevelTwo_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo {
     if let swift_pointer = smoke_LevelOne_LevelTwo_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne.LevelTwo {
@@ -181,6 +197,14 @@ internal func getRef(_ ref: LevelOne.LevelTwo.LevelThree?, owning: Bool = true) 
 }
 extension LevelOne.LevelTwo.LevelThree: NativeBase {
     var c_handle: _baseRef { return c_instance }
+}
+extension LevelOne.LevelTwo.LevelThree: Hashable {
+    public static func == (lhs: LevelOne.LevelTwo.LevelThree, rhs: LevelOne.LevelTwo.LevelThree) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
 }
 internal func LevelOne_LevelTwo_LevelThree_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree {
     if let swift_pointer = smoke_LevelOne_LevelTwo_LevelThree_get_swift_object_from_wrapper_cache(handle),

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/NestedReferences.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/NestedReferences.swift
@@ -40,6 +40,14 @@ internal func getRef(_ ref: NestedReferences?, owning: Bool = true) -> RefHolder
 extension NestedReferences: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension NestedReferences: Hashable {
+    public static func == (lhs: NestedReferences, rhs: NestedReferences) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func NestedReferences_copyFromCType(_ handle: _baseRef) -> NestedReferences {
     if let swift_pointer = smoke_NestedReferences_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? NestedReferences {

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClass.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClass.swift
@@ -67,6 +67,14 @@ internal func getRef(_ ref: OuterClass?, owning: Bool = true) -> RefHolder {
 extension OuterClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension OuterClass: Hashable {
+    public static func == (lhs: OuterClass, rhs: OuterClass) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func OuterClass_copyFromCType(_ handle: _baseRef) -> OuterClass {
     if let swift_pointer = smoke_OuterClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass {
@@ -121,6 +129,14 @@ internal func getRef(_ ref: OuterClass.InnerClass?, owning: Bool = true) -> RefH
 }
 extension OuterClass.InnerClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
+}
+extension OuterClass.InnerClass: Hashable {
+    public static func == (lhs: OuterClass.InnerClass, rhs: OuterClass.InnerClass) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
 }
 internal func OuterClass_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterClass.InnerClass {
     if let swift_pointer = smoke_OuterClass_InnerClass_get_swift_object_from_wrapper_cache(handle),

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterInterface.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterInterface.swift
@@ -160,6 +160,14 @@ internal func getRef(_ ref: InnerClass?, owning: Bool = true) -> RefHolder {
 extension InnerClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension InnerClass: Hashable {
+    public static func == (lhs: InnerClass, rhs: InnerClass) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func InnerClass_copyFromCType(_ handle: _baseRef) -> InnerClass {
     if let swift_pointer = smoke_OuterInterface_InnerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerClass {

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterStruct.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterStruct.swift
@@ -117,6 +117,14 @@ internal func getRef(_ ref: OuterStruct.InnerClass?, owning: Bool = true) -> Ref
 extension OuterStruct.InnerClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension OuterStruct.InnerClass: Hashable {
+    public static func == (lhs: OuterStruct.InnerClass, rhs: OuterStruct.InnerClass) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func OuterStruct_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass {
     if let swift_pointer = smoke_OuterStruct_InnerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterStruct.InnerClass {

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/UseFreeTypes.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/UseFreeTypes.swift
@@ -36,6 +36,14 @@ internal func getRef(_ ref: UseFreeTypes?, owning: Bool = true) -> RefHolder {
 extension UseFreeTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension UseFreeTypes: Hashable {
+    public static func == (lhs: UseFreeTypes, rhs: UseFreeTypes) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func UseFreeTypes_copyFromCType(_ handle: _baseRef) -> UseFreeTypes {
     if let swift_pointer = smoke_UseFreeTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UseFreeTypes {

--- a/gluecodium/src/test/resources/smoke/nullable/output/swift/smoke/Nullable.swift
+++ b/gluecodium/src/test/resources/smoke/nullable/output/swift/smoke/Nullable.swift
@@ -234,6 +234,14 @@ internal func getRef(_ ref: Nullable?, owning: Bool = true) -> RefHolder {
 extension Nullable: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Nullable: Hashable {
+    public static func == (lhs: Nullable, rhs: Nullable) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Nullable_copyFromCType(_ handle: _baseRef) -> Nullable {
     if let swift_pointer = smoke_Nullable_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Nullable {

--- a/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcClass.swift
+++ b/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcClass.swift
@@ -32,6 +32,14 @@ internal func getRef(_ ref: ObjcClass?, owning: Bool = true) -> RefHolder {
 extension ObjcClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension ObjcClass: Hashable {
+    public static func == (lhs: ObjcClass, rhs: ObjcClass) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func ObjcClass_copyFromCType(_ handle: _baseRef) -> ObjcClass {
     if let swift_pointer = smoke_ObjcClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcClass {

--- a/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcImplementerClass.swift
+++ b/gluecodium/src/test/resources/smoke/objc_interface/output/swift/smoke/ObjcImplementerClass.swift
@@ -32,6 +32,14 @@ internal func getRef(_ ref: ObjcImplementerClass?, owning: Bool = true) -> RefHo
 extension ObjcImplementerClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension ObjcImplementerClass: Hashable {
+    public static func == (lhs: ObjcImplementerClass, rhs: ObjcImplementerClass) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func ObjcImplementerClass_copyFromCType(_ handle: _baseRef) -> ObjcImplementerClass {
     if let swift_pointer = smoke_ObjcImplementerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ObjcImplementerClass {

--- a/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazInterface.swift
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazInterface.swift
@@ -51,6 +51,14 @@ internal func getRef(_ ref: bazInterface?, owning: Bool = true) -> RefHolder {
 extension bazInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension bazInterface: Hashable {
+    public static func == (lhs: bazInterface, rhs: bazInterface) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func bazInterface_copyFromCType(_ handle: _baseRef) -> bazInterface {
     if let swift_pointer = smoke_bazInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? bazInterface {

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/CachedProperties.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/CachedProperties.swift
@@ -32,6 +32,14 @@ internal func getRef(_ ref: CachedProperties?, owning: Bool = true) -> RefHolder
 extension CachedProperties: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension CachedProperties: Hashable {
+    public static func == (lhs: CachedProperties, rhs: CachedProperties) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func CachedProperties_copyFromCType(_ handle: _baseRef) -> CachedProperties {
     if let swift_pointer = smoke_CachedProperties_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CachedProperties {

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/Properties.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/Properties.swift
@@ -121,6 +121,14 @@ internal func getRef(_ ref: Properties?, owning: Bool = true) -> RefHolder {
 extension Properties: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Properties: Hashable {
+    public static func == (lhs: Properties, rhs: Properties) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Properties_copyFromCType(_ handle: _baseRef) -> Properties {
     if let swift_pointer = smoke_Properties_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Properties {

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipFunctions.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipFunctions.swift
@@ -34,6 +34,14 @@ internal func getRef(_ ref: SkipFunctions?, owning: Bool = true) -> RefHolder {
 extension SkipFunctions: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension SkipFunctions: Hashable {
+    public static func == (lhs: SkipFunctions, rhs: SkipFunctions) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func SkipFunctions_copyFromCType(_ handle: _baseRef) -> SkipFunctions {
     if let swift_pointer = smoke_SkipFunctions_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipFunctions {

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTypes.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTypes.swift
@@ -44,6 +44,14 @@ internal func getRef(_ ref: SkipTypes?, owning: Bool = true) -> RefHolder {
 extension SkipTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension SkipTypes: Hashable {
+    public static func == (lhs: SkipTypes, rhs: SkipTypes) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func SkipTypes_copyFromCType(_ handle: _baseRef) -> SkipTypes {
     if let swift_pointer = smoke_SkipTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipTypes {

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/Structs.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/Structs.swift
@@ -165,6 +165,14 @@ internal func getRef(_ ref: Structs?, owning: Bool = true) -> RefHolder {
 extension Structs: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension Structs: Hashable {
+    public static func == (lhs: Structs, rhs: Structs) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func Structs_copyFromCType(_ handle: _baseRef) -> Structs {
     if let swift_pointer = smoke_Structs_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Structs {

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithConstantsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithConstantsInterface.swift
@@ -43,6 +43,14 @@ internal func getRef(_ ref: StructsWithConstantsInterface?, owning: Bool = true)
 extension StructsWithConstantsInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension StructsWithConstantsInterface: Hashable {
+    public static func == (lhs: StructsWithConstantsInterface, rhs: StructsWithConstantsInterface) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func StructsWithConstantsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface {
     if let swift_pointer = smoke_StructsWithConstantsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructsWithConstantsInterface {

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithMethodsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithMethodsInterface.swift
@@ -90,6 +90,14 @@ internal func getRef(_ ref: StructsWithMethodsInterface?, owning: Bool = true) -
 extension StructsWithMethodsInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension StructsWithMethodsInterface: Hashable {
+    public static func == (lhs: StructsWithMethodsInterface, rhs: StructsWithMethodsInterface) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func StructsWithMethodsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface {
     if let swift_pointer = smoke_StructsWithMethodsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructsWithMethodsInterface {

--- a/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/TypeDefs.swift
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/TypeDefs.swift
@@ -83,6 +83,14 @@ internal func getRef(_ ref: TypeDefs?, owning: Bool = true) -> RefHolder {
 extension TypeDefs: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension TypeDefs: Hashable {
+    public static func == (lhs: TypeDefs, rhs: TypeDefs) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func TypeDefs_copyFromCType(_ handle: _baseRef) -> TypeDefs {
     if let swift_pointer = smoke_TypeDefs_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? TypeDefs {

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalClass.swift
@@ -29,6 +29,14 @@ internal func getRef(_ ref: InternalClass?, owning: Bool = true) -> RefHolder {
 extension InternalClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension InternalClass: Hashable {
+    public static func == (lhs: InternalClass, rhs: InternalClass) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func InternalClass_copyFromCType(_ handle: _baseRef) -> InternalClass {
     if let swift_pointer = smoke_InternalClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalClass {

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicClass.swift
@@ -89,6 +89,14 @@ internal func getRef(_ ref: PublicClass?, owning: Bool = true) -> RefHolder {
 extension PublicClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
+extension PublicClass: Hashable {
+    public static func == (lhs: PublicClass, rhs: PublicClass) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
 internal func PublicClass_copyFromCType(_ handle: _baseRef) -> PublicClass {
     if let swift_pointer = smoke_PublicClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PublicClass {


### PR DESCRIPTION
Updated SwiftClassConversion template to add Hashable protocol conformance to classes that are not marked as
`@Equatable`. The hashing key is based on the value of the native handle. This restores the functionality of the
deprecated `@PointerEquatable` attribute.

Updated smoke tests. Added functional tests.

Resolves: #693
