### PR TITLE
Add `@Skip` attribute support to C++ generator

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -397,6 +397,12 @@ feature(SkipAttribute android swift dart SOURCES
     input/src/cpp/Skip.cpp
 )
 
+feature(SkipTags cpp SOURCES
+    input/lime/SkipTags.lime
+
+    input/src/cpp/SkipTags.cpp
+)
+
 # This feature is intended for Swift only.
 feature(Extensions swift SOURCES
     input/lime/Extensions.lime
@@ -445,6 +451,7 @@ apigen_generate(TARGET functional
         DART_LIBRARY_NAME "functional"
         DART_NAMERULES "${CMAKE_CURRENT_SOURCE_DIR}/../config/dart.properties"
         COPYRIGHT_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/../config/COPYRIGHT"
+        TAGS "Lite"
         VERBOSE)
 apigen_target_include_directories(functional)
 apigen_target_sources(functional)

--- a/functional-tests/functional/input/lime/SkipTags.lime
+++ b/functional-tests/functional/input/lime/SkipTags.lime
@@ -15,41 +15,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-package smoke
+package test
 
 class SkipTagsOnly {
     @Skip(Lite)
     static fun skipUnquoted()
-    @Skip(Lite, Pro)
-    static fun skipUnquotedList()
     @Skip("Lite")
-    static fun skipQuoted()
-    @Skip("Lite", "Pro")
-    static fun skipQuotedList()
-    @Skip(Tag = "Lite")
-    static fun skipTagged()
-    @Skip(Tag = ["Lite", "Pro"])
-    static fun skipTaggedList()
-    @Skip(Lite, "Pro")
-    static fun skipMixedList()
-}
-
-class SkipPlatforms {
-    @Skip(Java)
-    static fun notInJava(input: String): String
-    @Skip(Swift)
-    static fun notInSwift(input: Boolean): Boolean
-    @Skip(Dart)
-    static fun notInDart(input: Float): Float
-}
-
-class SkipMixed {
-    @Skip(Java, Lite)
-    static fun notInJava(input: String): String
-    @Skip(Swift, Lite)
-    static fun notInSwift(input: Boolean): Boolean
-    @Skip(Dart, Lite)
-    static fun notInDart(input: Float): Float
+    static property skipQuoted: String
 }
 
 types SkipTypesTags {

--- a/functional-tests/functional/input/src/cpp/SkipTags.cpp
+++ b/functional-tests/functional/input/src/cpp/SkipTags.cpp
@@ -1,0 +1,30 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/SkipTypesTags.h"
+
+namespace test
+{
+// Should fail if such type is already defined.
+struct SkipMe {};
+
+// Should fail if such type is already defined.
+enum SkipMeToo {};
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -20,6 +20,7 @@
 package com.here.gluecodium.cli
 
 import com.here.gluecodium.Gluecodium
+import com.here.gluecodium.common.CaseInsensitiveSet
 import com.here.gluecodium.generator.common.GeneratorSuite
 import com.natpryce.konfig.Configuration
 import com.natpryce.konfig.ConfigurationProperties
@@ -193,7 +194,7 @@ object OptionReader {
         getStringValue("libraryname")?.let { options.libraryName = it }
         getStringValue("dartlookuperrormessage")?.let { options.dartLookupErrorMessage = it }
         getStringListValue("werror")?.let { options.werror = it.toSet() }
-        getStringListValue("tag")?.let { options.tags = it.toSet() }
+        getStringListValue("tag")?.let { options.tags = CaseInsensitiveSet(it) }
         options.generateStubs = getFlagValue("stubs")
 
         options.cppNameRules = readConfigFile(getStringValue("cppnamerules"), options.cppNameRules)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
@@ -20,6 +20,8 @@
 package com.here.gluecodium.generator.common
 
 import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeType.SKIP
+import com.here.gluecodium.model.lime.LimeAttributeValueType.TAG
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeInterface
@@ -54,6 +56,13 @@ internal object CommonGeneratorPredicates {
             else -> limeStruct.fields
                 .flatMap { LimeTypeHelper.getAllFieldTypes(it.typeRef.type) }
                 .any { it.attributes.have(LimeAttributeType.IMMUTABLE) }
+        }
+
+    fun hasSkipTags(limeElement: LimeNamedElement, tags: Set<String>) =
+        when (val skipTags = limeElement.attributes.get(SKIP, TAG, Any::class.java)) {
+            is String -> tags.contains(skipTags)
+            is List<*> -> skipTags.filterIsInstance<String>().intersect(tags).isNotEmpty()
+            else -> false
         }
 
     fun hasTypeRepository(limeContainer: Any) =

--- a/gluecodium/src/test/resources/smoke/skip/input/commandlineoptions.txt
+++ b/gluecodium/src/test/resources/smoke/skip/input/commandlineoptions.txt
@@ -1,0 +1,6 @@
+-input $INPUT_FOLDER
+-auxinput $AUX_FOLDER
+-intnamespace gluecodium
+-javanonnullannotation android.support.annotation.NonNull
+-javanullableannotation android.support.annotation.Nullables
+-tag lite

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipTagsOnly.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipTagsOnly.h
@@ -1,0 +1,13 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT SkipTagsOnly {
+public:
+    SkipTagsOnly();
+    virtual ~SkipTagsOnly() = 0;
+};
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipTypesTags.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipTypesTags.h
@@ -1,0 +1,9 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+namespace smoke {
+_GLUECODIUM_CPP_EXPORT extern const bool PLACE_HOLDER;
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/CaseInsensitiveMap.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/CaseInsensitiveMap.kt
@@ -22,7 +22,7 @@ package com.here.gluecodium.common
 import java.util.function.BiFunction
 import java.util.function.Function
 
-class CaseInsensitiveMap<V> : HashMap<String, V>() {
+class CaseInsensitiveMap<V : Any /* mark as non-nullable */> : HashMap<String, V>() {
     override fun compute(key: String, remappingFunction: BiFunction<in String, in V?, out V?>) =
         super.compute(key.toLowerCase(), remappingFunction)
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/CaseInsensitiveSet.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/CaseInsensitiveSet.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.common
+
+class CaseInsensitiveSet(elements: Collection<String> = emptySet()) :
+    HashSet<String>(elements.map { it.toLowerCase() }) {
+
+    override fun add(element: String) = super.add(element.toLowerCase())
+
+    override fun addAll(elements: Collection<String>) = super.addAll(elements.map { it.toLowerCase() })
+
+    override fun remove(element: String) = super.remove(element.toLowerCase())
+
+    override fun removeAll(elements: Collection<String>) = super.removeAll(elements.map { it.toLowerCase() })
+
+    override fun retainAll(elements: Collection<String>) = super.retainAll(elements.map { it.toLowerCase() })
+
+    override fun contains(element: String) = super.contains(element.toLowerCase())
+
+    override fun containsAll(elements: Collection<String>) = super.containsAll(elements.map { it.toLowerCase() })
+}


### PR DESCRIPTION
Add model filtering by `@Skip()` attribute base on command-line tags to C++ generator. To facilitate this, added new
implementation for a set of strings, CaseInsensitiveSet. Using this set for tags comparison ensures the comparison is
case-insensitive without explicitly using toLowerCase() anywhere outside of this set's implementation.

Added smoke and functional tests. The functional tests are compilation tests that should fail compilation unless the
types are properly skipped.

See: #702
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>