### PR TITLE
Add `@Skip` attribute support to Java generator

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -397,7 +397,7 @@ feature(SkipAttribute android swift dart SOURCES
     input/src/cpp/Skip.cpp
 )
 
-feature(SkipTags cpp SOURCES
+feature(SkipTags cpp android SOURCES
     input/lime/SkipTags.lime
 
     input/src/cpp/SkipTags.cpp

--- a/functional-tests/functional/input/src/android/SkipMe.java
+++ b/functional-tests/functional/input/src/android/SkipMe.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+// Should fail if such type is already defined.
+class SkipMe {}

--- a/functional-tests/functional/input/src/android/SkipMeToo.java
+++ b/functional-tests/functional/input/src/android/SkipMeToo.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+// Should fail if such type is already defined.
+enum SkipMeToo {
+  ;
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorSuite.kt
@@ -23,6 +23,7 @@ import com.here.gluecodium.Gluecodium
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.generator.androidmanifest.AndroidManifestGenerator
+import com.here.gluecodium.generator.common.CommonGeneratorPredicates
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.GeneratorSuite
 import com.here.gluecodium.generator.common.LimeModelFilter
@@ -67,6 +68,7 @@ internal class JavaGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite 
     private val nullableAnnotation = annotationFromOption(options.javaNullableAnnotation)
     private val basePackages = if (options.javaPackages.isNotEmpty()) options.javaPackages else listOf("com", "example")
     private val internalPackageList = basePackages + internalPackage
+    private val customTags = options.tags
 
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
         val cachingNameResolver = CppNameResolver(rootNamespace, limeModel.referenceMap, cppNameRules)
@@ -144,11 +146,12 @@ internal class JavaGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite 
         }
 
     private fun shouldRetainElement(limeElement: LimeNamedElement) =
-        when {
-            limeElement is LimeFunction || limeElement is LimeProperty -> true
-            limeElement.attributes.have(JAVA, SKIP) -> false
-            else -> true
-        }
+        !CommonGeneratorPredicates.hasSkipTags(limeElement, customTags) &&
+            when {
+                limeElement is LimeFunction || limeElement is LimeProperty -> true
+                limeElement.attributes.have(JAVA, SKIP) -> false
+                else -> true
+            }
 
     private fun generateJavaFiles(
         limeElement: LimeNamedElement,

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipTagsOnly.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipTagsOnly.java
@@ -1,0 +1,20 @@
+/*
+ *
+ */
+package com.example.smoke;
+import com.example.NativeBase;
+public final class SkipTagsOnly extends NativeBase {
+    /**
+     * For internal use only.
+     * @exclude
+     */
+    protected SkipTagsOnly(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+    private static native void disposeNativeHandle(long nativeHandle);
+}


### PR DESCRIPTION
Added model filtering by `@Skip()` attribute base on command-line tags to Java generator.

Added smoke and functional tests.

See: #702
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>