### PR TITLE
Add `@Skip` attribute support to Swift generator

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -397,7 +397,7 @@ feature(SkipAttribute android swift dart SOURCES
     input/src/cpp/Skip.cpp
 )
 
-feature(SkipTags cpp android SOURCES
+feature(SkipTags cpp android swift SOURCES
     input/lime/SkipTags.lime
 
     input/src/cpp/SkipTags.cpp
@@ -496,7 +496,9 @@ elseif(FUNCTIONAL_GLUECODIUM_GENERATOR STREQUAL swift)
         "${CMAKE_CURRENT_SOURCE_DIR}/input/src/swift/ColorConverter.swift"
         "${CMAKE_CURRENT_SOURCE_DIR}/input/src/swift/PseudoColor.swift"
         "${CMAKE_CURRENT_SOURCE_DIR}/input/src/swift/Season.swift"
-        "${CMAKE_CURRENT_SOURCE_DIR}/input/src/swift/SeasonConverter.swift")
+        "${CMAKE_CURRENT_SOURCE_DIR}/input/src/swift/SeasonConverter.swift"
+        "${CMAKE_CURRENT_SOURCE_DIR}/input/src/swift/SkipMe.swift"
+        "${CMAKE_CURRENT_SOURCE_DIR}/input/src/swift/SkipMeToo.swift")
 
     apigen_swift_build(functional)
     apigen_swift_framework_info_plist(functional)

--- a/functional-tests/functional/input/src/swift/SkipMe.swift
+++ b/functional-tests/functional/input/src/swift/SkipMe.swift
@@ -1,0 +1,22 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+// Should fail if such type is already defined.
+internal class SkipMe {}

--- a/functional-tests/functional/input/src/swift/SkipMeToo.swift
+++ b/functional-tests/functional/input/src/swift/SkipMeToo.swift
@@ -1,0 +1,22 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+// Should fail if such type is already defined.
+internal enum SkipMeToo {}

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTagsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTagsOnly.swift
@@ -1,0 +1,79 @@
+//
+//
+import Foundation
+public class SkipTagsOnly {
+    let c_instance : _baseRef
+    init(cSkipTagsOnly: _baseRef) {
+        guard cSkipTagsOnly != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cSkipTagsOnly
+    }
+    deinit {
+        smoke_SkipTagsOnly_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_SkipTagsOnly_release_handle(c_instance)
+    }
+}
+internal func getRef(_ ref: SkipTagsOnly?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_SkipTagsOnly_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_SkipTagsOnly_release_handle)
+        : RefHolder(handle_copy)
+}
+extension SkipTagsOnly: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+extension SkipTagsOnly: Hashable {
+    public static func == (lhs: SkipTagsOnly, rhs: SkipTagsOnly) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
+internal func SkipTagsOnly_copyFromCType(_ handle: _baseRef) -> SkipTagsOnly {
+    if let swift_pointer = smoke_SkipTagsOnly_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipTagsOnly {
+        return re_constructed
+    }
+    let result = SkipTagsOnly(cSkipTagsOnly: smoke_SkipTagsOnly_copy_handle(handle))
+    smoke_SkipTagsOnly_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func SkipTagsOnly_moveFromCType(_ handle: _baseRef) -> SkipTagsOnly {
+    if let swift_pointer = smoke_SkipTagsOnly_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipTagsOnly {
+        smoke_SkipTagsOnly_release_handle(handle)
+        return re_constructed
+    }
+    let result = SkipTagsOnly(cSkipTagsOnly: handle)
+    smoke_SkipTagsOnly_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func SkipTagsOnly_copyFromCType(_ handle: _baseRef) -> SkipTagsOnly? {
+    guard handle != 0 else {
+        return nil
+    }
+    return SkipTagsOnly_moveFromCType(handle) as SkipTagsOnly
+}
+internal func SkipTagsOnly_moveFromCType(_ handle: _baseRef) -> SkipTagsOnly? {
+    guard handle != 0 else {
+        return nil
+    }
+    return SkipTagsOnly_moveFromCType(handle) as SkipTagsOnly
+}
+internal func copyToCType(_ swiftClass: SkipTagsOnly) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: SkipTagsOnly) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: SkipTagsOnly?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: SkipTagsOnly?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTypesTags.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTypesTags.swift
@@ -1,0 +1,6 @@
+//
+//
+import Foundation
+public struct SkipTypesTags {
+    public static let placeHolder: Bool = true
+}


### PR DESCRIPTION
Added model filtering by `@Skip()` attribute base on command-line tags to Swift generator.

Added smoke and functional tests.

See: #702
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>