### PR TITLE
Add `@Skip` attribute support to Dart generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added `@Skip("Tag1", "Tag2"...)` attribute for skipping elements based on presence of user-defined custom tags.
+
 ## 8.7.1
 Release date: 2021-01-18
 ### Bug fixes:

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -390,16 +390,11 @@ feature(Visibility dart SOURCES
     input/src/cpp/Visibility.cpp
 )
 
-# Not supported for C++
-feature(SkipAttribute android swift dart SOURCES
+feature(SkipAttribute cpp android swift dart SOURCES
     input/lime/Skip.lime
-
-    input/src/cpp/Skip.cpp
-)
-
-feature(SkipTags cpp android swift SOURCES
     input/lime/SkipTags.lime
 
+    input/src/cpp/Skip.cpp
     input/src/cpp/SkipTags.cpp
 )
 
@@ -512,6 +507,14 @@ elseif(FUNCTIONAL_GLUECODIUM_GENERATOR STREQUAL dart)
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/input/src/dart/season_converter.dart"
         "${CMAKE_CURRENT_BINARY_DIR}/functional/dart/dart/lib/src/season_converter.dart"
+        COPYONLY)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/input/src/dart/skip_me.dart"
+        "${CMAKE_CURRENT_BINARY_DIR}/functional/dart/dart/lib/src/skip_me.dart"
+        COPYONLY)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/input/src/dart/skip_me_too.dart"
+        "${CMAKE_CURRENT_BINARY_DIR}/functional/dart/dart/lib/src/skip_me_too.dart"
         COPYONLY)
 
     # Install the shared library for Dart

--- a/functional-tests/functional/input/src/dart/skip_me.dart
+++ b/functional-tests/functional/input/src/dart/skip_me.dart
@@ -1,0 +1,22 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+/// Should fail if such type is already defined.
+class SkipMe {}

--- a/functional-tests/functional/input/src/dart/skip_me_too.dart
+++ b/functional-tests/functional/input/src/dart/skip_me_too.dart
@@ -1,0 +1,24 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+/// Should fail if such type is already defined.
+enum SkipMeToo {
+  dummy
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipTagsOnly.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipTagsOnly.h
@@ -1,0 +1,11 @@
+/*
+ *
+ */
+#pragma once
+#include <jni.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipTagsOnly.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipTagsOnly.h
@@ -1,0 +1,16 @@
+//
+//
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "cbridge/include/BaseHandle.h"
+#include "cbridge/include/Export.h"
+_GLUECODIUM_C_EXPORT void smoke_SkipTagsOnly_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_SkipTagsOnly_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_SkipTagsOnly_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_SkipTagsOnly_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
+_GLUECODIUM_C_EXPORT void smoke_SkipTagsOnly_remove_swift_object_from_wrapper_cache(_baseRef handle);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipTypesTags.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipTypesTags.h
@@ -1,0 +1,11 @@
+//
+//
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "cbridge/include/BaseHandle.h"
+#include "cbridge/include/Export.h"
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipTagsOnly.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipTagsOnly.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "Export.h"
+#include "OpaqueHandle.h"
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipTagsOnly_copy_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void library_smoke_SkipTagsOnly_release_handle(FfiOpaqueHandle handle);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipTypesTags.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipTypesTags.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "Export.h"
+#include "OpaqueHandle.h"
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
@@ -1,0 +1,55 @@
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+abstract class SkipTagsOnly {
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+}
+// SkipTagsOnly "private" section, not exported.
+final _smoke_SkipTagsOnly_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SkipTagsOnly_copy_handle'));
+final _smoke_SkipTagsOnly_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SkipTagsOnly_release_handle'));
+class SkipTagsOnly$Impl implements SkipTagsOnly {
+  @protected
+  Pointer<Void> handle;
+  SkipTagsOnly$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.uncacheObject(this);
+    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
+    _smoke_SkipTagsOnly_release_handle(handle);
+    handle = null;
+  }
+}
+Pointer<Void> smoke_SkipTagsOnly_toFfi(SkipTagsOnly value) =>
+  _smoke_SkipTagsOnly_copy_handle((value as SkipTagsOnly$Impl).handle);
+SkipTagsOnly smoke_SkipTagsOnly_fromFfi(Pointer<Void> handle) {
+  final isolateId = __lib.LibraryContext.isolateId;
+  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final instance = __lib.instanceCache[token] as SkipTagsOnly;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_SkipTagsOnly_copy_handle(handle);
+  final result = SkipTagsOnly$Impl(_copied_handle);
+  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  return result;
+}
+void smoke_SkipTagsOnly_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_SkipTagsOnly_release_handle(handle);
+Pointer<Void> smoke_SkipTagsOnly_toFfi_nullable(SkipTagsOnly value) =>
+  value != null ? smoke_SkipTagsOnly_toFfi(value) : Pointer<Void>.fromAddress(0);
+SkipTagsOnly smoke_SkipTagsOnly_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_SkipTagsOnly_fromFfi(handle) : null;
+void smoke_SkipTagsOnly_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_SkipTagsOnly_release_handle(handle);
+// End of SkipTagsOnly "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types_tags.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types_tags.dart
@@ -1,0 +1,5 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+final bool placeHolder = true;


### PR DESCRIPTION
Added model filtering by @Skip() attribute base on command-line tags to Dart generator.

Added smoke and functional tests. Also added missing CBridge and JNI smoke test reference files.

Resolves: #702
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>