### PR TITLE
Compute enumerator implicit values dynamically in LIME model

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -393,9 +393,11 @@ feature(Visibility dart SOURCES
 feature(SkipAttribute cpp android swift dart SOURCES
     input/lime/Skip.lime
     input/lime/SkipTags.lime
+    input/lime/SkipEnumerator.lime
 
     input/src/cpp/Skip.cpp
     input/src/cpp/SkipTags.cpp
+    input/src/cpp/SkipEnumerator.cpp
 )
 
 # This feature is intended for Swift only.

--- a/functional-tests/functional/android/app/src/test/java/com/here/android/test/SkipEnumeratorTest.java
+++ b/functional-tests/functional/android/app/src/test/java/com/here/android/test/SkipEnumeratorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+import static junit.framework.Assert.assertEquals;
+
+import android.os.Build;
+import com.here.android.RobolectricApplication;
+import com.here.gluecodium.test.functional.BuildConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(
+    sdk = Build.VERSION_CODES.M,
+    application = RobolectricApplication.class,
+    constants = BuildConfig.class)
+public final class SkipEnumeratorTest {
+  @Test
+  public void autoTagRoundTrip() {
+    SkipEnumeratorAutoTag value = SkipEnumeratorAutoTag.THREE;
+
+    SkipEnumeratorAutoTag result = UseSkipEnumerator.autoTagRoundTrip(value);
+
+    assertEquals(value, result);
+  }
+
+  @Test
+  public void explicitTagRoundTrip() {
+    SkipEnumeratorExplicitTag value = SkipEnumeratorExplicitTag.THREE;
+
+    SkipEnumeratorExplicitTag result = UseSkipEnumerator.explicitTagRoundTrip(value);
+
+    assertEquals(value, result);
+  }
+}

--- a/functional-tests/functional/dart/main.dart
+++ b/functional-tests/functional/dart/main.dart
@@ -51,6 +51,7 @@ import "test/Properties_test.dart" as PropertiesTests;
 import "test/RefEquality_test.dart" as RefEqualityTests;
 import "test/Sets_test.dart" as SetsTests;
 import "test/SimpleEquality_test.dart" as SimpleEqualityTests;
+import "test/SkipEnumerator_test.dart" as SkipEnumeratorTests;
 import "test/StaticBooleanMethods_test.dart" as StaticBooleanMethodsTests;
 import "test/StaticFloatDoubleMethods_test.dart" as StaticFloatDoubleMethodsTests;
 import "test/StaticIntMethods_test.dart" as StaticIntMethodsTests;
@@ -92,6 +93,7 @@ final _allTests = [
   RefEqualityTests.main,
   SetsTests.main,
   SimpleEqualityTests.main,
+  SkipEnumeratorTests.main,
   StaticBooleanMethodsTests.main,
   StaticFloatDoubleMethodsTests.main,
   StaticIntMethodsTests.main,

--- a/functional-tests/functional/dart/test/SkipEnumerator_test.dart
+++ b/functional-tests/functional/dart/test/SkipEnumerator_test.dart
@@ -1,0 +1,42 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:functional/test.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("SkipEnumerator");
+
+void main() {
+  _testSuite.test("AutoTagRoundTrip", () {
+    final value = SkipEnumeratorAutoTag.three;
+
+    final result = UseSkipEnumerator.autoTagRoundTrip(value);
+
+    expect(result, value);
+  });
+  _testSuite.test("ExplicitTagRoundTrip", () {
+    final value = SkipEnumeratorExplicitTag.three;
+
+    final result = UseSkipEnumerator.explicitTagRoundTrip(value);
+
+    expect(result, value);
+  });
+}

--- a/functional-tests/functional/input/lime/SkipEnumerator.lime
+++ b/functional-tests/functional/input/lime/SkipEnumerator.lime
@@ -1,0 +1,38 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+enum SkipEnumeratorAutoTag {
+    ONE,
+    @Skip(Lite)
+    TWO,
+    THREE
+}
+
+enum SkipEnumeratorExplicitTag {
+    ZERO,
+    ONE = 3,
+    @Skip(Lite)
+    TWO = 7,
+    THREE
+}
+
+class UseSkipEnumerator {
+    static fun autoTagRoundTrip(input: SkipEnumeratorAutoTag): SkipEnumeratorAutoTag
+    static fun explicitTagRoundTrip(input: SkipEnumeratorExplicitTag): SkipEnumeratorExplicitTag
+}

--- a/functional-tests/functional/input/src/cpp/SkipEnumerator.cpp
+++ b/functional-tests/functional/input/src/cpp/SkipEnumerator.cpp
@@ -1,0 +1,36 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/SkipEnumeratorAutoTag.h"
+#include "test/SkipEnumeratorAutoTag.h"
+#include "test/UseSkipEnumerator.h"
+
+namespace test
+{
+SkipEnumeratorAutoTag
+UseSkipEnumerator::auto_tag_round_trip(const SkipEnumeratorAutoTag input) {
+    return input;
+}
+
+SkipEnumeratorExplicitTag
+UseSkipEnumerator::explicit_tag_round_trip(const SkipEnumeratorExplicitTag input) {
+    return input;
+}
+}

--- a/functional-tests/functional/swift/Tests/SkipEnumeratorTests.swift
+++ b/functional-tests/functional/swift/Tests/SkipEnumeratorTests.swift
@@ -1,0 +1,45 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import functional
+
+class SkipEnumeratorTests: XCTestCase {
+    func testAutoTagRoundTrip() {
+        let value = SkipEnumeratorAutoTag.three
+
+        let result = UseSkipEnumerator.autoTagRoundTrip(input: value)
+
+        XCTAssertEqual(result, value)
+    }
+
+    func testExplicitTagRoundTrip() {
+        let value = SkipEnumeratorExplicitTag.three
+
+        let result = UseSkipEnumerator.explicitTagRoundTrip(input: value)
+
+        XCTAssertEqual(result, value)
+    }
+
+    static var allTests = [
+        ("testAutoTagRoundTrip", testAutoTagRoundTrip),
+        ("testExplicitTagRoundTrip", testExplicitTagRoundTrip)
+    ]
+}

--- a/functional-tests/functional/swift/main.swift
+++ b/functional-tests/functional/swift/main.swift
@@ -60,6 +60,7 @@ let allTests = [
     testCase(SerializationTests.allTests),
     testCase(SetTypeTests.allTests),
     testCase(SimpleEqualityTests.allTests),
+    testCase(SkipEnumeratorTests.allTests),
     testCase(StaticBooleanMethodsTests.allTests),
     testCase(StaticByteArrayMethodsTests.allTests),
     testCase(StaticFloatDoubleMethodsTests.allTests),

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/LimeModelFilter.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/LimeModelFilter.kt
@@ -22,6 +22,7 @@ package com.here.gluecodium.generator.common
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeEnumeration
+import com.here.gluecodium.model.lime.LimeEnumerator
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeStruct
@@ -113,12 +114,25 @@ class LimeModelFilter(private val predicate: (LimeNamedElement) -> Boolean) {
         ) }
 
     private fun filterEnum(limeEnum: LimeEnumeration) =
-        limeEnum.run { LimeEnumeration(
-            path = path,
-            visibility = visibility,
-            comment = comment,
-            attributes = attributes,
-            external = external,
-            enumerators = enumerators.filter(predicate)
-        ) }
+        limeEnum.run {
+            val filteredEnumerators = enumerators.filter(predicate)
+            val relinkedEnumerators = filteredEnumerators.mapIndexed { idx, it ->
+                LimeEnumerator(
+                    path = it.path,
+                    comment = it.comment,
+                    attributes = it.attributes,
+                    explicitValue = it.explicitValue,
+                    previous = filteredEnumerators.getOrNull(idx - 1)
+                )
+            }
+
+            LimeEnumeration(
+                path = path,
+                visibility = visibility,
+                comment = comment,
+                attributes = attributes,
+                external = external,
+                enumerators = relinkedEnumerators
+            )
+        }
 }

--- a/gluecodium/src/test/resources/smoke/skip/input/SkipEnumerator.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipEnumerator.lime
@@ -1,0 +1,33 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+enum SkipEnumeratorAutoTag {
+    ONE,
+    @Skip(Lite)
+    TWO,
+    THREE
+}
+
+enum SkipEnumeratorExplicitTag {
+    ZERO,
+    ONE = 3,
+    @Skip(Lite)
+    TWO = 7,
+    THREE
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipEnumeratorAutoTag.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipEnumeratorAutoTag.java
@@ -1,0 +1,12 @@
+/*
+ *
+ */
+package com.example.smoke;
+public enum SkipEnumeratorAutoTag {
+    ONE(0),
+    THREE(1);
+    public final int value;
+    SkipEnumeratorAutoTag(final int value) {
+        this.value = value;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipEnumeratorExplicitTag.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipEnumeratorExplicitTag.java
@@ -1,0 +1,13 @@
+/*
+ *
+ */
+package com.example.smoke;
+public enum SkipEnumeratorExplicitTag {
+    ZERO(0),
+    ONE(3),
+    THREE(4);
+    public final int value;
+    SkipEnumeratorExplicitTag(final int value) {
+        this.value = value;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipEnumeratorAutoTag.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipEnumeratorAutoTag.h
@@ -1,0 +1,13 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include <cstdint>
+namespace smoke {
+enum class SkipEnumeratorAutoTag {
+    ONE,
+    THREE
+};
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipEnumeratorExplicitTag.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipEnumeratorExplicitTag.h
@@ -1,0 +1,14 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include <cstdint>
+namespace smoke {
+enum class SkipEnumeratorExplicitTag {
+    ZERO,
+    ONE = 3,
+    THREE
+};
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_auto_tag.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_auto_tag.dart
@@ -1,0 +1,63 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+enum SkipEnumeratorAutoTag {
+    one,
+    three
+}
+// SkipEnumeratorAutoTag "private" section, not exported.
+int smoke_SkipEnumeratorAutoTag_toFfi(SkipEnumeratorAutoTag value) {
+  switch (value) {
+  case SkipEnumeratorAutoTag.one:
+    return 0;
+  break;
+  case SkipEnumeratorAutoTag.three:
+    return 1;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for SkipEnumeratorAutoTag enum.");
+  }
+}
+SkipEnumeratorAutoTag smoke_SkipEnumeratorAutoTag_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return SkipEnumeratorAutoTag.one;
+  break;
+  case 1:
+    return SkipEnumeratorAutoTag.three;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for SkipEnumeratorAutoTag enum.");
+  }
+}
+void smoke_SkipEnumeratorAutoTag_releaseFfiHandle(int handle) {}
+final _smoke_SkipEnumeratorAutoTag_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_SkipEnumeratorAutoTag_create_handle_nullable'));
+final _smoke_SkipEnumeratorAutoTag_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SkipEnumeratorAutoTag_release_handle_nullable'));
+final _smoke_SkipEnumeratorAutoTag_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_SkipEnumeratorAutoTag_get_value_nullable'));
+Pointer<Void> smoke_SkipEnumeratorAutoTag_toFfi_nullable(SkipEnumeratorAutoTag value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_SkipEnumeratorAutoTag_toFfi(value);
+  final result = _smoke_SkipEnumeratorAutoTag_create_handle_nullable(_handle);
+  smoke_SkipEnumeratorAutoTag_releaseFfiHandle(_handle);
+  return result;
+}
+SkipEnumeratorAutoTag smoke_SkipEnumeratorAutoTag_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_SkipEnumeratorAutoTag_get_value_nullable(handle);
+  final result = smoke_SkipEnumeratorAutoTag_fromFfi(_handle);
+  smoke_SkipEnumeratorAutoTag_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_SkipEnumeratorAutoTag_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_SkipEnumeratorAutoTag_release_handle_nullable(handle);
+// End of SkipEnumeratorAutoTag "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_explicit_tag.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_explicit_tag.dart
@@ -1,0 +1,70 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+enum SkipEnumeratorExplicitTag {
+    zero,
+    one,
+    three
+}
+// SkipEnumeratorExplicitTag "private" section, not exported.
+int smoke_SkipEnumeratorExplicitTag_toFfi(SkipEnumeratorExplicitTag value) {
+  switch (value) {
+  case SkipEnumeratorExplicitTag.zero:
+    return 0;
+  break;
+  case SkipEnumeratorExplicitTag.one:
+    return 3;
+  break;
+  case SkipEnumeratorExplicitTag.three:
+    return 4;
+  break;
+  default:
+    throw StateError("Invalid enum value $value for SkipEnumeratorExplicitTag enum.");
+  }
+}
+SkipEnumeratorExplicitTag smoke_SkipEnumeratorExplicitTag_fromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return SkipEnumeratorExplicitTag.zero;
+  break;
+  case 3:
+    return SkipEnumeratorExplicitTag.one;
+  break;
+  case 4:
+    return SkipEnumeratorExplicitTag.three;
+  break;
+  default:
+    throw StateError("Invalid numeric value $handle for SkipEnumeratorExplicitTag enum.");
+  }
+}
+void smoke_SkipEnumeratorExplicitTag_releaseFfiHandle(int handle) {}
+final _smoke_SkipEnumeratorExplicitTag_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_SkipEnumeratorExplicitTag_create_handle_nullable'));
+final _smoke_SkipEnumeratorExplicitTag_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SkipEnumeratorExplicitTag_release_handle_nullable'));
+final _smoke_SkipEnumeratorExplicitTag_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_SkipEnumeratorExplicitTag_get_value_nullable'));
+Pointer<Void> smoke_SkipEnumeratorExplicitTag_toFfi_nullable(SkipEnumeratorExplicitTag value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_SkipEnumeratorExplicitTag_toFfi(value);
+  final result = _smoke_SkipEnumeratorExplicitTag_create_handle_nullable(_handle);
+  smoke_SkipEnumeratorExplicitTag_releaseFfiHandle(_handle);
+  return result;
+}
+SkipEnumeratorExplicitTag smoke_SkipEnumeratorExplicitTag_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_SkipEnumeratorExplicitTag_get_value_nullable(handle);
+  final result = smoke_SkipEnumeratorExplicitTag_fromFfi(_handle);
+  smoke_SkipEnumeratorExplicitTag_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_SkipEnumeratorExplicitTag_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_SkipEnumeratorExplicitTag_release_handle_nullable(handle);
+// End of SkipEnumeratorExplicitTag "private" section.

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -435,19 +435,13 @@ internal class AntlrLimeModelBuilder(
     }
 
     override fun exitEnumerator(ctx: LimeParser.EnumeratorContext) {
-        val siblings =
-            parentContext?.previousResults?.filterIsInstance<LimeEnumerator>() ?: emptyList()
-        val computedValue = siblings.lastOrNull()
-            ?.let { it.value as? LimeValue.Literal }
-            ?.value?.toIntOrNull()
-            ?.let { LimeValue.Literal(LimeBasicTypeRef.INT, (it + 1).toString()) }
-            ?: LimeValue.ZERO
+        val siblings = parentContext?.previousResults?.filterIsInstance<LimeEnumerator>() ?: emptyList()
         val limeElement = LimeEnumerator(
             path = currentPath,
             comment = parseStructuredComment(ctx.docComment(), ctx).description,
             attributes = AntlrLimeConverter.convertAnnotations(currentPath, ctx.annotation()),
-            computedValue = computedValue,
-            explicitValue = ctx.literalConstant()?.let { convertLiteralConstant(LimeBasicTypeRef.INT, it) }
+            explicitValue = ctx.literalConstant()?.let { convertLiteralConstant(LimeBasicTypeRef.INT, it) },
+            previous = siblings.lastOrNull()
         )
 
         storeResultAndPopStacks(limeElement)

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeEnumerator.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeEnumerator.kt
@@ -23,8 +23,14 @@ class LimeEnumerator(
     path: LimePath,
     comment: LimeComment = LimeComment(),
     attributes: LimeAttributes? = null,
-    computedValue: LimeValue = LimeValue.ZERO,
-    val explicitValue: LimeValue? = null
+    val explicitValue: LimeValue? = null,
+    private val previous: LimeEnumerator? = null
 ) : LimeNamedElement(path = path, comment = comment, attributes = attributes) {
-    val value = explicitValue ?: computedValue
+    val value
+        get() = explicitValue ?: computeValue()
+
+    private fun computeValue(): LimeValue =
+        previous?.value?.toString()?.toIntOrNull()?.let {
+            LimeValue.Literal(LimeBasicTypeRef.INT, (it + 1).toString())
+        } ?: LimeValue.ZERO
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeValue.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeValue.kt
@@ -70,16 +70,6 @@ sealed class LimeValue(val typeRef: LimeTypeRef) : LimeElement() {
         }
 
         override fun toString() = value.toString()
-
-        companion object {
-            val FLOAT_NAN = Special(LimeBasicTypeRef.FLOAT, ValueId.NAN)
-            val FLOAT_INFINITY = Special(LimeBasicTypeRef.FLOAT, ValueId.INFINITY)
-            val FLOAT_NEGATIVE_INFINITY = Special(LimeBasicTypeRef.FLOAT, ValueId.NEGATIVE_INFINITY)
-            val DOUBLE_NAN = Special(LimeBasicTypeRef.DOUBLE, ValueId.NAN)
-            val DOUBLE_INFINITY = Special(LimeBasicTypeRef.DOUBLE, ValueId.INFINITY)
-            val DOUBLE_NEGATIVE_INFINITY =
-                Special(LimeBasicTypeRef.DOUBLE, ValueId.NEGATIVE_INFINITY)
-        }
     }
 
     class Null(type: LimeTypeRef) : LimeValue(type) {


### PR DESCRIPTION
Updated LimeEnumerator to keep track of its preceding sibling inside to the same enumeration and to use this sibling to
dynamically compute an implicit value when necessary.

Previous implementation pre-computed all enumerator implicit values at the moment of model loading. However, this
approach works incorrectly in Java and Dart if some of the enumerators are skipped.

See: #703
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>