### PR TITLE
Add validation against "diamond" inheritance

### DIFF
--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -147,8 +147,9 @@ immediately after the package declaration.
 
 #### Container-type elements
 
-* Syntax: (**class** | **interface** | **types**) *ElementName*\[**:** *ParentName*\] **{**
+* Syntax: (**class** | **interface** | **types**) *ElementName*\[**:** *parent-types-list*\] **{**
 *child-elements-declarations...* **}**
+* where *parent-types-list* is a comma-separated list of parent types, see `Inheritance` below.
 * Example: `class SomeImportantProcessor { ... }`
 * Example: `interface ProcessorDelegate: GenericDelegate { ... }`
 * Description: declares a container-type language element:
@@ -161,20 +162,22 @@ class, interface, or struct. `types` declaration can be only placed at file leve
 
 #### Inheritance
 
-Classes and interfaces support inheritance (optionally, see *ParentName* in the syntax above).
-There are some restrictions on inheritance:
-* multiple inheritance is not supported.
+Classes and interfaces support inheritance (optionally, see *parent-types-list* in the syntax above). Multiple
+inheritance is supported. There are some rules and restrictions for inheritance:
+* a class or an interface can inherit from any number of interfaces.
+* a class can inherit from at most one class.
 * an interface cannot inherit from a class.
-* an class can only inherit from another ("parent") class if the parent class has "open" visibility
+* a class can only inherit from another ("parent") class if the parent class has "open" visibility
 (see `Visibility` above).
 * a class or an interface with "public" visibility cannot inherit from a class or an interface with
 "internal" visibility (see `Visibility` above).
+* "diamond" inheritance is not supported (i.e. when two classes/interfaces B and C inherit from A, and class/interface D
+inherits from both B and C).
 
 Contrary to the usual practice encountered in programming languages, in LimeIDL it is not necessary
 to (re)declare functions and properties of parent class/interface in the child class. An IDL
 declaration describes an API and parent's functions and properties are already part of child's API
-due to inheritance. Gluecodium generators will also generate all necessary code for the child class
-automatically.
+due to inheritance. Gluecodium will also generate all necessary code for the child class automatically.
 
 ### Child element declarations
 

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeInheritanceValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeInheritanceValidatorTest.kt
@@ -54,8 +54,10 @@ class LimeInheritanceValidatorTest {
         assertTrue(validator.validate(limeModel))
     }
 
+    // Class
+
     @Test
-    fun validateWithClassWithNoParent() {
+    fun validateClassWithNoParent() {
         allElements[""] = LimeClass(EMPTY_PATH)
 
         assertTrue(validator.validate(limeModel))
@@ -119,6 +121,23 @@ class LimeInheritanceValidatorTest {
     }
 
     @Test
+    fun validateClassWithDiamondInheritance() {
+        val rootInterface = LimeInterface(fooPath)
+        val anotherInterface =
+            LimeInterface(LimePath(emptyList(), listOf("bar")), parents = listOf(LimeDirectTypeRef(rootInterface)))
+        val yetAnotherInterface =
+            LimeInterface(LimePath(emptyList(), listOf("fizz")), parents = listOf(LimeDirectTypeRef(rootInterface)))
+        allElements[""] = LimeClass(
+            EMPTY_PATH,
+            parents = listOf(LimeDirectTypeRef(anotherInterface), LimeDirectTypeRef(yetAnotherInterface))
+        )
+
+        assertFalse(validator.validate(limeModel))
+    }
+
+    // Interface
+
+    @Test
     fun validateInterfaceWithNoParent() {
         allElements[""] = LimeInterface(EMPTY_PATH)
 
@@ -162,5 +181,20 @@ class LimeInheritanceValidatorTest {
         allElements[""] = LimeInterface(EMPTY_PATH, parents = listOf(LimeDirectTypeRef(anotherInterface)))
 
         assertTrue(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateInterfaceWithDiamondInheritance() {
+        val rootInterface = LimeInterface(fooPath)
+        val anotherInterface =
+            LimeInterface(LimePath(emptyList(), listOf("bar")), parents = listOf(LimeDirectTypeRef(rootInterface)))
+        val yetAnotherInterface =
+            LimeInterface(LimePath(emptyList(), listOf("fizz")), parents = listOf(LimeDirectTypeRef(rootInterface)))
+        allElements[""] = LimeInterface(
+            EMPTY_PATH,
+            parents = listOf(LimeDirectTypeRef(anotherInterface), LimeDirectTypeRef(yetAnotherInterface))
+        )
+
+        assertFalse(validator.validate(limeModel))
     }
 }


### PR DESCRIPTION
Added validation against "diamond" inheritance to LimeInheritanceValidator. Added unit tests. Updated LIME IDL
documentation to mention support of multiple inheritance, including the restriction of "diamond" inheritance being
unsupported.

See: #723
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>