### PR TITLE
Add support for multiple inheritance to C++ generator

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -259,6 +259,11 @@ feature(Inheritance cpp android swift dart SOURCES
     input/lime/InterfaceWithLambda.lime
 )
 
+feature(MultipleInheritance cpp SOURCES
+    input/src/cpp/MultipleInheritance.cpp
+    input/lime/MultipleInheritance.lime
+)
+
 feature(Serialization android swift SOURCES
     input/lime/Serialization.lime
 )

--- a/functional-tests/functional/input/lime/MultipleInheritance.lime
+++ b/functional-tests/functional/input/lime/MultipleInheritance.lime
@@ -1,0 +1,60 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+interface ParentInterfaceOne {
+    fun parentFunctionOne()
+    property parentPropertyOne: String
+}
+
+interface ParentInterfaceTwo {
+    fun parentFunctionTwo()
+    property parentPropertyTwo: String
+}
+
+open class ParentClass {
+    fun parentFunction()
+    property parentProperty: String
+}
+
+class ClassWithMixedParents: ParentClass, ParentInterfaceOne {
+    fun childFunction()
+    property childProperty: String
+}
+
+class ClassWithInterfaceParents: ParentInterfaceOne, ParentInterfaceTwo {
+    fun childFunction()
+    property childProperty: String
+}
+
+class ClassWithAllParents: ParentClass, ParentInterfaceOne, ParentInterfaceTwo {
+    fun childFunction()
+    property childProperty: String
+}
+
+interface InterfaceWithAllParents: ParentInterfaceOne, ParentInterfaceTwo {
+    fun childFunction()
+    property childProperty: String
+}
+
+class MultipleInheritanceFactory {
+    static fun getClassWithMixedParents(): ClassWithMixedParents
+    static fun getClassWithInterfaceParents(): ClassWithInterfaceParents
+    static fun getClassWithAllParents(): ClassWithAllParents
+    static fun getInterfaceWithAllParents(): InterfaceWithAllParents
+}

--- a/functional-tests/functional/input/src/cpp/MultipleInheritance.cpp
+++ b/functional-tests/functional/input/src/cpp/MultipleInheritance.cpp
@@ -1,0 +1,129 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/ParentInterfaceOne.h"
+#include "test/ParentInterfaceOne.h"
+#include "test/ParentClass.h"
+#include "test/ClassWithMixedParents.h"
+#include "test/ClassWithInterfaceParents.h"
+#include "test/ClassWithAllParents.h"
+#include "test/InterfaceWithAllParents.h"
+#include "test/MultipleInheritanceFactory.h"
+
+#include <memory>
+
+namespace
+{
+class ClassWithMixedParentsImpl: public test::ClassWithMixedParents
+{
+public:
+    ClassWithMixedParentsImpl( ) = default;
+    ~ClassWithMixedParentsImpl( ) = default;
+
+    void child_function() override {}
+    std::string get_child_property() const override { return {}; }
+    void set_child_property(const std::string& value) override {}
+    void parent_function() override {}
+    std::string get_parent_property() const override { return {}; }
+    void set_parent_property(const std::string& value) override {}
+    void parent_function_one() override {}
+    std::string get_parent_property_one() const override { return {}; }
+    void set_parent_property_one(const std::string& value) override {}
+};
+
+class ClassWithInterfaceParentsImpl: public test::ClassWithInterfaceParents
+{
+public:
+    ClassWithInterfaceParentsImpl( ) = default;
+    ~ClassWithInterfaceParentsImpl( ) = default;
+
+    void child_function() override {}
+    std::string get_child_property() const override { return {}; }
+    void set_child_property(const std::string& value) override {}
+    void parent_function_one() override {}
+    std::string get_parent_property_one() const override { return {}; }
+    void set_parent_property_one(const std::string& value) override {}
+    void parent_function_two() override {}
+    std::string get_parent_property_two() const override { return {}; }
+    void set_parent_property_two(const std::string& value) override {}
+};
+
+class ClassWithAllParentsImpl: public test::ClassWithAllParents
+{
+public:
+    ClassWithAllParentsImpl( ) = default;
+    ~ClassWithAllParentsImpl( ) = default;
+
+    void child_function() override {}
+    std::string get_child_property() const override { return {}; }
+    void set_child_property(const std::string& value) override {}
+    void parent_function() override {}
+    std::string get_parent_property() const override { return {}; }
+    void set_parent_property(const std::string& value) override {}
+    void parent_function_one() override {}
+    std::string get_parent_property_one() const override { return {}; }
+    void set_parent_property_one(const std::string& value) override {}
+    void parent_function_two() override {}
+    std::string get_parent_property_two() const override { return {}; }
+    void set_parent_property_two(const std::string& value) override {}
+};
+
+class InterfaceWithAllParentsImpl: public test::InterfaceWithAllParents
+{
+public:
+    InterfaceWithAllParentsImpl( ) = default;
+    ~InterfaceWithAllParentsImpl( ) = default;
+
+    void child_function() override {}
+    std::string get_child_property() const override { return {}; }
+    void set_child_property(const std::string& value) override {}
+    void parent_function_one() override {}
+    std::string get_parent_property_one() const override { return {}; }
+    void set_parent_property_one(const std::string& value) override {}
+    void parent_function_two() override {}
+    std::string get_parent_property_two() const override { return {}; }
+    void set_parent_property_two(const std::string& value) override {}
+};
+
+}
+
+namespace test
+{
+std::shared_ptr<ClassWithMixedParents>
+MultipleInheritanceFactory::get_class_with_mixed_parents() {
+    return std::make_shared<ClassWithMixedParentsImpl>();
+}
+
+std::shared_ptr<ClassWithInterfaceParents>
+MultipleInheritanceFactory::get_class_with_interface_parents() {
+    return std::make_shared<ClassWithInterfaceParentsImpl>();
+}
+
+std::shared_ptr<ClassWithAllParents>
+MultipleInheritanceFactory::get_class_with_all_parents() {
+    return std::make_shared<ClassWithAllParentsImpl>();
+}
+
+std::shared_ptr<InterfaceWithAllParents>
+MultipleInheritanceFactory::get_interface_with_all_parents() {
+    return std::make_shared<InterfaceWithAllParentsImpl>();
+}
+
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
@@ -61,6 +61,6 @@ internal object CommonGeneratorPredicates {
             limeContainer !is LimeContainerWithInheritance -> false
             limeContainer is LimeInterface -> true
             limeContainer.visibility.isOpen -> true
-            else -> limeContainer.parent != null
+            else -> limeContainer.parents.isNotEmpty()
         }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorSuite.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorSuite.kt
@@ -157,10 +157,8 @@ internal class CppGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
             return emptyList()
         }
 
-        val typeRegisteredClasses =
-            allTypes.filterIsInstance<LimeContainerWithInheritance>()
-                .filter { it.external?.cpp == null && it.parent == null &&
-                    (it is LimeInterface || it.visibility.isOpen) }
+        val typeRegisteredClasses = allTypes.filterIsInstance<LimeContainerWithInheritance>()
+            .filter { it.external?.cpp == null && it.parents.isEmpty() && (it is LimeInterface || it.visibility.isOpen) }
         val allTypeRefs = collectTypeRefs(allTypes)
         val forwardDeclaredTypes = allTypeRefs.map { it.type }
             .filterIsInstance<LimeContainerWithInheritance>()
@@ -218,8 +216,8 @@ internal class CppGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
         errorEnums: Set<LimeType>,
         typeRegisteredClasses: List<LimeContainerWithInheritance>
     ): List<Include> {
-        val parentIncludes = (rootElement as? LimeContainerWithInheritance)?.parent
-            ?.let { includeResolver.resolveIncludes(it.type) } ?: emptyList()
+        val parentIncludes = (rootElement as? LimeContainerWithInheritance)?.parents
+            ?.flatMap { includeResolver.resolveIncludes(it.type) } ?: emptyList()
         val additionalIncludes = (parentIncludes + exportInclude).toMutableList()
         if (allTypes.any { it is LimeEnumeration }) {
             additionalIncludes += CppLibraryIncludes.INT_TYPES

--- a/gluecodium/src/main/resources/templates/cpp/CppClass.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppClass.mustache
@@ -20,7 +20,8 @@
   !}}
 {{#unless external.cpp}}{{!!
 }}{{>cpp/CppDocComment}}
-class {{>cpp/CppExportMacro}}{{>cpp/CppAttributesInline}}{{resolveName}}{{#if parent}}: public {{resolveName parent.type "FQN"}}{{/if}} {
+class {{>cpp/CppExportMacro}}{{>cpp/CppAttributesInline}}{{resolveName}}{{!!
+}}{{#if parents}}: {{#parents}}public {{resolveName this.type "FQN"}}{{#if iter.hasNext}}, {{/if}}{{/parents}}{{/if}} {
 public:
     {{resolveName}}();
     virtual ~{{resolveName}}() = 0;

--- a/gluecodium/src/main/resources/templates/cpp/CppClassImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppClassImpl.mustache
@@ -20,12 +20,12 @@
   !}}
 {{#unless external.cpp}}
 {{#parentName}}{{.}}::{{/parentName}}{{resolveName}}::{{resolveName}}() {
-{{#if parent}}
+{{#if parents}}
     {{>common/InternalNamespace}}get_type_repository().add_type(this, "{{#namespace}}{{.}}_{{/namespace}}{{resolveName}}");
 {{/if}}
 }
 {{#parentName}}{{.}}::{{/parentName}}{{resolveName}}::~{{resolveName}}() {
-{{#if parent}}
+{{#if parents}}
     {{>common/InternalNamespace}}get_type_repository().remove_type(this);
 {{/if}}
 }

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/ClassWithAllParents.h
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/ClassWithAllParents.h
@@ -1,0 +1,21 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/ParentClass.h"
+#include "smoke/ParentInterfaceOne.h"
+#include "smoke/ParentInterfaceTwo.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT ClassWithAllParents: public ::smoke::ParentClass, public ::smoke::ParentInterfaceOne, public ::smoke::ParentInterfaceTwo {
+public:
+    ClassWithAllParents();
+    virtual ~ClassWithAllParents() = 0;
+public:
+    virtual void child_function(  ) = 0;
+    virtual ::std::string get_child_property(  ) const = 0;
+    virtual void set_child_property( const ::std::string& value ) = 0;
+};
+}

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/ClassWithInterfaceParents.h
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/ClassWithInterfaceParents.h
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/ParentInterfaceOne.h"
+#include "smoke/ParentInterfaceTwo.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT ClassWithInterfaceParents: public ::smoke::ParentInterfaceOne, public ::smoke::ParentInterfaceTwo {
+public:
+    ClassWithInterfaceParents();
+    virtual ~ClassWithInterfaceParents() = 0;
+public:
+    virtual void child_function(  ) = 0;
+    virtual ::std::string get_child_property(  ) const = 0;
+    virtual void set_child_property( const ::std::string& value ) = 0;
+};
+}

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/ClassWithMixedParents.h
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/ClassWithMixedParents.h
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/ParentClass.h"
+#include "smoke/ParentInterfaceOne.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT ClassWithMixedParents: public ::smoke::ParentClass, public ::smoke::ParentInterfaceOne {
+public:
+    ClassWithMixedParents();
+    virtual ~ClassWithMixedParents() = 0;
+public:
+    virtual void child_function(  ) = 0;
+    virtual ::std::string get_child_property(  ) const = 0;
+    virtual void set_child_property( const ::std::string& value ) = 0;
+};
+}

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/InterfaceWithAllParents.h
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/InterfaceWithAllParents.h
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/ParentInterfaceOne.h"
+#include "smoke/ParentInterfaceTwo.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT InterfaceWithAllParents: public ::smoke::ParentInterfaceOne, public ::smoke::ParentInterfaceTwo {
+public:
+    InterfaceWithAllParents();
+    virtual ~InterfaceWithAllParents() = 0;
+public:
+    virtual void child_function(  ) = 0;
+    virtual ::std::string get_child_property(  ) const = 0;
+    virtual void set_child_property( const ::std::string& value ) = 0;
+};
+}


### PR DESCRIPTION
Added support for multiple inheritance to CppGeneratorSuite and C++ templates.

Added smoke tests. Added functional compilation tests.

See: #723
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
