### PR TITLE
Add "internal prefix" to all conversion functions in Swift 

### DIFF
--- a/gluecodium/src/main/resources/templates/swift/ConversionPrefixFrom.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ConversionPrefixFrom.mustache
@@ -18,8 +18,6 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#typeRef.type.actualType}}{{#instanceOf this "LimeInterface"}}{{resolveName typeRef "mangled"}}{{/instanceOf}}{{!!
-}}{{#instanceOf this "LimeClass"}}{{resolveName typeRef "mangled"}}{{/instanceOf}}{{!!
-}}{{#instanceOf this "LimeList"}}{{internalPrefix}}{{/instanceOf}}{{!!
-}}{{#instanceOf this "LimeSet"}}{{internalPrefix}}{{/instanceOf}}{{!!
-}}{{#instanceOf this "LimeMap"}}{{internalPrefix}}{{/instanceOf}}{{/typeRef.type.actualType}}
+{{#typeRef.type.actualType}}{{#notInstanceOf this "LimeBasicType"}}{{internalPrefix}}{{/notInstanceOf}}{{!!
+}}{{#instanceOf this "LimeInterface"}}{{resolveName typeRef "mangled"}}{{/instanceOf}}{{!!
+}}{{#instanceOf this "LimeClass"}}{{resolveName typeRef "mangled"}}{{/instanceOf}}{{/typeRef.type.actualType}}

--- a/gluecodium/src/main/resources/templates/swift/ConversionPrefixTo.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ConversionPrefixTo.mustache
@@ -18,6 +18,4 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#typeRef.type.actualType}}{{#instanceOf this "LimeList"}}{{internalPrefix}}{{/instanceOf}}{{!!
-}}{{#instanceOf this "LimeSet"}}{{internalPrefix}}{{/instanceOf}}{{!!
-}}{{#instanceOf this "LimeMap"}}{{internalPrefix}}{{/instanceOf}}{{/typeRef.type.actualType}}
+{{#typeRef.type.actualType}}{{#notInstanceOf this "LimeBasicType"}}{{internalPrefix}}{{/notInstanceOf}}{{/typeRef.type.actualType}}

--- a/gluecodium/src/main/resources/templates/swift/GetReference.mustache
+++ b/gluecodium/src/main/resources/templates/swift/GetReference.mustache
@@ -69,7 +69,7 @@ internal func getRef(_ ref: {{resolveName this "" "ref"}}?, owning: Bool = true{
 {{/class}}{{/set}}
 {{#ifPredicate "hasWeakSupport"}}
 
-internal func weakToCType(_ swiftClass: {{resolveName}}?) -> RefHolder {
+internal func {{internalPrefix}}weakToCType(_ swiftClass: {{resolveName}}?) -> RefHolder {
     return getRef(swiftClass, owning: true, isWeak: true)
 }
 {{/ifPredicate}}{{!!
@@ -103,13 +103,15 @@ internal func weakToCType(_ swiftClass: {{resolveName}}?) -> RefHolder {
             try {{include delegateToCall}}
             return {{resolveName function "CBridge"}}_result(has_value: true, error_value: 0)
         } catch let error as {{resolveName exception "" "ref"}} {
-            return {{resolveName function "CBridge"}}_result(has_value: false, error_value: copyToCType(error).ref){{/if}}{{!!
+            return {{resolveName function "CBridge"}}_result(has_value: false, error_value: {{!!
+            }}{{#set typeRef=exception.errorType}}{{>swift/ConversionPrefixTo}}{{/set}}copyToCType(error).ref){{/if}}{{!!
         }}{{#unless returnType.isVoid}}
             let call_result = try {{include delegateToCall}}
             {{#set delegateToCall="callResult" returnPrefix="let result_handle ="}}{{>swiftReturn}}{{/set}}
             return {{resolveName function "CBridge"}}_result(has_value: true, .init(returned_value: result_handle))
         } catch let error as {{resolveName exception "" "ref"}} {
-            return {{resolveName function "CBridge"}}_result(has_value: false, .init(error_value: copyToCType(error).ref)){{/unless}}
+            return {{resolveName function "CBridge"}}_result(has_value: false, .init(error_value: {{!!
+            }}{{#set typeRef=exception.errorType}}{{>swift/ConversionPrefixTo}}{{/set}}copyToCType(error).ref)){{/unless}}
         } catch {
             fatalError("Unexpected error: \(error)")
         }{{/if}}{{!!

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassConversion.mustache
@@ -78,7 +78,7 @@ extension {{>implName}}: Hashable {
 {{/unlessPredicate}}{{/instanceOf}}
 {{/unless}}
 
-internal func {{resolveName this "mangled"}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
+internal func {{internalPrefix}}{{resolveName "mangled"}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
 {{#instanceOf this "LimeInterface"}}
     if let swift_pointer = {{resolveName "CBridge"}}_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? {{resolveName this "" "ref"}} {
@@ -103,7 +103,7 @@ internal func {{resolveName this "mangled"}}copyFromCType(_ handle: _baseRef) ->
 {{/unlessPredicate}}
 }
 
-internal func {{resolveName "mangled"}}moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
+internal func {{internalPrefix}}{{resolveName "mangled"}}moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
 {{#instanceOf this "LimeInterface"}}
     if let swift_pointer = {{resolveName "CBridge"}}_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? {{resolveName this "" "ref"}} {
@@ -130,32 +130,32 @@ internal func {{resolveName "mangled"}}moveFromCType(_ handle: _baseRef) -> {{re
 {{/unlessPredicate}}
 }
 
-internal func {{resolveName "mangled"}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
+internal func {{internalPrefix}}{{resolveName "mangled"}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
     guard handle != 0 else {
         return nil
     }
-    return {{resolveName "mangled"}}moveFromCType(handle) as {{resolveName this "" "ref"}}
+    return {{internalPrefix}}{{resolveName "mangled"}}moveFromCType(handle) as {{resolveName this "" "ref"}}
 }
-internal func {{resolveName "mangled"}}moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
+internal func {{internalPrefix}}{{resolveName "mangled"}}moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
     guard handle != 0 else {
         return nil
     }
-    return {{resolveName "mangled"}}moveFromCType(handle) as {{resolveName this "" "ref"}}
+    return {{internalPrefix}}{{resolveName "mangled"}}moveFromCType(handle) as {{resolveName this "" "ref"}}
 }
 
-internal func copyToCType(_ swiftClass: {{resolveName this "" "ref"}}) -> RefHolder {
+internal func {{internalPrefix}}copyToCType(_ swiftClass: {{resolveName this "" "ref"}}) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
 
-internal func moveToCType(_ swiftClass: {{resolveName this "" "ref"}}) -> RefHolder {
+internal func {{internalPrefix}}moveToCType(_ swiftClass: {{resolveName this "" "ref"}}) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
 
-internal func copyToCType(_ swiftClass: {{resolveName this "" "ref"}}?) -> RefHolder {
+internal func {{internalPrefix}}copyToCType(_ swiftClass: {{resolveName this "" "ref"}}?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
 
-internal func moveToCType(_ swiftClass: {{resolveName this "" "ref"}}?) -> RefHolder {
+internal func {{internalPrefix}}moveToCType(_ swiftClass: {{resolveName this "" "ref"}}?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
 

--- a/gluecodium/src/main/resources/templates/swift/SwiftEnumConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftEnumConversion.mustache
@@ -18,17 +18,18 @@
   ! License-Filename: LICENSE
   !
   !}}
-internal func copyToCType(_ swiftEnum{{#if external.swift.converter}}_ext{{/if}}: {{resolveName this "" "ref"}}) -> PrimitiveHolder<UInt32> {
+internal func {{internalPrefix}}copyToCType(_ swiftEnum{{#if external.swift.converter}}_ext{{/if}}: {{resolveName this "" "ref"}}) -> PrimitiveHolder<UInt32> {
 {{#if external.swift.converter}}
     let swiftEnum = {{external.swift.converter}}.convertToInternal(swiftEnum_ext)
 {{/if}}
     return PrimitiveHolder({{#ifPredicate "skipDeclaration"}}UInt32({{/ifPredicate}}swiftEnum.rawValue{{#ifPredicate "skipDeclaration"}}){{/ifPredicate}})
 }
-internal func moveToCType(_ swiftEnum: {{resolveName this "" "ref"}}) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+
+internal func {{internalPrefix}}moveToCType(_ swiftEnum: {{resolveName this "" "ref"}}) -> PrimitiveHolder<UInt32> {
+    return {{internalPrefix}}copyToCType(swiftEnum)
 }
 
-internal func copyToCType(_ swiftEnum{{#if external.swift.converter}}_ext{{/if}}: {{resolveName this "" "ref"}}?) -> RefHolder {
+internal func {{internalPrefix}}copyToCType(_ swiftEnum{{#if external.swift.converter}}_ext{{/if}}: {{resolveName this "" "ref"}}?) -> RefHolder {
 {{#ifPredicate "skipDeclaration"}}
     if let rawValue = swiftEnum?.rawValue {
         return copyToCType(UInt32(rawValue) as UInt32?)
@@ -45,7 +46,8 @@ internal func copyToCType(_ swiftEnum{{#if external.swift.converter}}_ext{{/if}}
     return copyToCType(swiftEnum?.rawValue)
 {{/unlessPredicate}}
 }
-internal func moveToCType(_ swiftEnum{{#if external.swift.converter}}_ext{{/if}}: {{resolveName this "" "ref"}}?) -> RefHolder {
+
+internal func {{internalPrefix}}moveToCType(_ swiftEnum{{#if external.swift.converter}}_ext{{/if}}: {{resolveName this "" "ref"}}?) -> RefHolder {
 {{#ifPredicate "skipDeclaration"}}
     if let rawValue = swiftEnum?.rawValue {
         return moveToCType(UInt32(rawValue) as UInt32?)
@@ -63,18 +65,19 @@ internal func moveToCType(_ swiftEnum{{#if external.swift.converter}}_ext{{/if}}
 {{/unlessPredicate}}
 }
 
-internal func copyFromCType(_ cValue: UInt32) -> {{resolveName this "" "ref"}} {
+internal func {{internalPrefix}}copyFromCType(_ cValue: UInt32) -> {{resolveName this "" "ref"}} {
 {{#if external.swift.converter}}
     return {{external.swift.converter}}.convertFromInternal({{resolveName this "" "ref"}}_internal(rawValue: cValue)!)
 {{/if}}{{#unless external.swift.converter}}
     return {{resolveName this "" "ref"}}(rawValue: {{#ifPredicate "skipDeclaration"}}UInt({{/ifPredicate}}cValue{{#ifPredicate "skipDeclaration"}}){{/ifPredicate}})!
 {{/unless}}
 }
-internal func moveFromCType(_ cValue: UInt32) -> {{resolveName this "" "ref"}} {
-    return copyFromCType(cValue)
+
+internal func {{internalPrefix}}moveFromCType(_ cValue: UInt32) -> {{resolveName this "" "ref"}} {
+    return {{internalPrefix}}copyFromCType(cValue)
 }
 
-internal func copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
+internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
     guard handle != 0 else {
         return nil
     }
@@ -84,9 +87,10 @@ internal func copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}
     return {{resolveName this "" "ref"}}(rawValue: {{#ifPredicate "skipDeclaration"}}UInt({{/ifPredicate}}uint32_t_value_get(handle){{#ifPredicate "skipDeclaration"}}){{/ifPredicate}})!
 {{/unless}}
 }
-internal func moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
+
+internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return {{internalPrefix}}copyFromCType(handle)
 }

--- a/gluecodium/src/main/resources/templates/swift/SwiftFunctionBody.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftFunctionBody.mustache
@@ -20,7 +20,7 @@
   !}}
 {
 {{#unless isStatic}}{{#if selfIsStruct}}
-    let c_self_handle = moveToCType(self)
+    let c_self_handle = {{internalPrefix}}moveToCType(self)
 {{/if}}{{/unless}}
 {{#parameters}}
     let c_{{resolveName}} = {{>swift/ConversionPrefixTo}}{{!!
@@ -29,7 +29,7 @@
 {{#if thrownType}}
     let RESULT = {{>delegateCall}}
     if (!RESULT.has_value) {
-        throw moveFromCType(RESULT.error_value) as {{resolveName exception "" "ref"}}
+        throw {{#set typeRef=exception.errorType}}{{>swift/ConversionPrefixFrom}}{{/set}}moveFromCType(RESULT.error_value) as {{resolveName exception "" "ref"}}
     }{{#unless returnType.isVoid}} else {
         return {{#unless isConstructor}}{{#returnType}}{{>swift/ConversionPrefixFrom}}{{/returnType}}{{/unless}}moveFromCType(RESULT.returned_value)
     }{{/unless}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftLambdaConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftLambdaConversion.mustache
@@ -18,10 +18,11 @@
   ! License-Filename: LICENSE
   !
   !}}
-internal func copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
-    return moveFromCType({{resolveName "CBridge"}}_copy_handle(handle))
+internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
+    return {{internalPrefix}}moveFromCType({{resolveName "CBridge"}}_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
+
+internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
     let refHolder = RefHolder(ref: handle, release: {{resolveName "CBridge"}}_release_handle)
     return { ({{#parameters}}p{{iter.position}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
     }} -> {{resolveName returnType}} in
@@ -30,17 +31,18 @@ internal func moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}
     }
 }
 
-internal func copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
+internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as {{resolveName this "" "ref"}}
+    return {{internalPrefix}}copyFromCType(handle) as {{resolveName this "" "ref"}}
 }
-internal func moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
+
+internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as {{resolveName this "" "ref"}}
+    return {{internalPrefix}}moveFromCType(handle) as {{resolveName this "" "ref"}}
 }
 
 internal func createFunctionalTable(_ swiftType: @escaping {{resolveName this "" "ref"}}) -> {{resolveName "CBridge"}}_FunctionTable {
@@ -67,16 +69,17 @@ internal func createFunctionalTable(_ swiftType: @escaping {{resolveName this ""
     return functions
 }
 
-internal func copyToCType(_ swiftType: @escaping {{resolveName this "" "ref"}}) -> RefHolder {
+internal func {{internalPrefix}}copyToCType(_ swiftType: @escaping {{resolveName this "" "ref"}}) -> RefHolder {
     let handle = {{resolveName "CBridge"}}_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping {{resolveName this "" "ref"}}) -> RefHolder {
+
+internal func {{internalPrefix}}moveToCType(_ swiftType: @escaping {{resolveName this "" "ref"}}) -> RefHolder {
     let handle = {{resolveName "CBridge"}}_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: {{resolveName "CBridge"}}_release_handle)
 }
 
-internal func copyToCType(_ swiftType: {{resolveName this "" "ref"}}?) -> RefHolder {
+internal func {{internalPrefix}}copyToCType(_ swiftType: {{resolveName this "" "ref"}}?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -84,7 +87,8 @@ internal func copyToCType(_ swiftType: {{resolveName this "" "ref"}}?) -> RefHol
     let handle = {{resolveName "CBridge"}}_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: {{resolveName this "" "ref"}}?) -> RefHolder {
+
+internal func {{internalPrefix}}moveToCType(_ swiftType: {{resolveName this "" "ref"}}?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }

--- a/gluecodium/src/main/resources/templates/swift/SwiftStructConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftStructConversion.mustache
@@ -19,21 +19,21 @@
   !
   !}}
 {{#if fields}}
-internal func copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
+internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
 {{#if external.swift.converter}}
     return {{external.swift.converter}}.convertFromInternal({{resolveName this "" "ref"}}_internal(cHandle: handle))
 {{/if}}{{#unless external.swift.converter}}
     return {{resolveName this "" "ref"}}(cHandle: handle){{#ifPredicate "skipDeclaration"}}!{{/ifPredicate}}
 {{/unless}}
 }
-internal func moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
+internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
     defer {
         {{resolveName "CBridge"}}_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return {{internalPrefix}}copyFromCType(handle)
 }
 
-internal func copyToCType(_ swiftType{{#if external.swift.converter}}_ext{{/if}}: {{resolveName this "" "ref"}}) -> RefHolder {
+internal func {{internalPrefix}}copyToCType(_ swiftType{{#if external.swift.converter}}_ext{{/if}}: {{resolveName this "" "ref"}}) -> RefHolder {
 {{#if external.swift.converter}}
     let swiftType = {{external.swift.converter}}.convertToInternal(swiftType_ext)
 {{/if}}
@@ -42,13 +42,13 @@ internal func copyToCType(_ swiftType{{#if external.swift.converter}}_ext{{/if}}
 {{/fields}}
     return RefHolder({{resolveName "CBridge"}}_create_handle({{#fields}}c_{{resolveName}}.ref{{#if iter.hasNext}}, {{/if}}{{/fields}}))
 }
-internal func moveToCType(_ swiftType: {{resolveName this "" "ref"}}) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: {{resolveName "CBridge"}}_release_handle)
+internal func {{internalPrefix}}moveToCType(_ swiftType: {{resolveName this "" "ref"}}) -> RefHolder {
+    return RefHolder(ref: {{internalPrefix}}copyToCType(swiftType).ref, release: {{resolveName "CBridge"}}_release_handle)
 }
 {{!!
 Optionals
 }}
-internal func copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
+internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
     guard handle != 0 else {
         return nil
     }
@@ -59,14 +59,14 @@ internal func copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}
     return {{resolveName this "" "ref"}}(cHandle: unwrappedHandle){{#ifPredicate "skipDeclaration"}}!{{/ifPredicate}} as {{resolveName this "" "ref"}}
 {{/unless}}
 }
-internal func moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
+internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
     defer {
         {{resolveName "CBridge"}}_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return {{internalPrefix}}copyFromCType(handle)
 }
 
-internal func copyToCType(_ swiftType{{#if external.swift.converter}}_ext{{/if}}: {{resolveName this "" "ref"}}?) -> RefHolder {
+internal func {{internalPrefix}}copyToCType(_ swiftType{{#if external.swift.converter}}_ext{{/if}}: {{resolveName this "" "ref"}}?) -> RefHolder {
     guard let swiftType{{#if external.swift.converter}}_ext{{/if}} = swiftType{{#if external.swift.converter}}_ext{{/if}} else {
         return RefHolder(0)
     }
@@ -78,8 +78,8 @@ internal func copyToCType(_ swiftType{{#if external.swift.converter}}_ext{{/if}}
 {{/fields}}
     return RefHolder({{resolveName "CBridge"}}_create_optional_handle({{#fields}}c_{{resolveName}}.ref{{#if iter.hasNext}}, {{/if}}{{/fields}}))
 }
-internal func moveToCType(_ swiftType: {{resolveName this "" "ref"}}?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: {{resolveName "CBridge"}}_release_optional_handle)
+internal func {{internalPrefix}}moveToCType(_ swiftType: {{resolveName this "" "ref"}}?) -> RefHolder {
+    return RefHolder(ref: {{internalPrefix}}copyToCType(swiftType).ref, release: {{resolveName "CBridge"}}_release_optional_handle)
 }
 
 {{/if}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftStructDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftStructDefinition.mustache
@@ -87,7 +87,7 @@
         guard _result_handle != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
-        let _result: {{resolveName struct "" "ref"}} = moveFromCType(_result_handle)
+        let _result: {{resolveName struct "" "ref"}} = {{internalPrefix}}moveFromCType(_result_handle)
 {{#fields}}
         self.{{resolveName}} = _result.{{resolveName}}
 {{/fields}}

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesClass.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesClass.swift
@@ -52,7 +52,7 @@ extension AttributesClass: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func AttributesClass_copyFromCType(_ handle: _baseRef) -> AttributesClass {
+internal func foobar_AttributesClass_copyFromCType(_ handle: _baseRef) -> AttributesClass {
     if let swift_pointer = smoke_AttributesClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesClass {
         return re_constructed
@@ -61,7 +61,7 @@ internal func AttributesClass_copyFromCType(_ handle: _baseRef) -> AttributesCla
     smoke_AttributesClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func AttributesClass_moveFromCType(_ handle: _baseRef) -> AttributesClass {
+internal func foobar_AttributesClass_moveFromCType(_ handle: _baseRef) -> AttributesClass {
     if let swift_pointer = smoke_AttributesClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesClass {
         smoke_AttributesClass_release_handle(handle)
@@ -71,27 +71,27 @@ internal func AttributesClass_moveFromCType(_ handle: _baseRef) -> AttributesCla
     smoke_AttributesClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func AttributesClass_copyFromCType(_ handle: _baseRef) -> AttributesClass? {
+internal func foobar_AttributesClass_copyFromCType(_ handle: _baseRef) -> AttributesClass? {
     guard handle != 0 else {
         return nil
     }
-    return AttributesClass_moveFromCType(handle) as AttributesClass
+    return foobar_AttributesClass_moveFromCType(handle) as AttributesClass
 }
-internal func AttributesClass_moveFromCType(_ handle: _baseRef) -> AttributesClass? {
+internal func foobar_AttributesClass_moveFromCType(_ handle: _baseRef) -> AttributesClass? {
     guard handle != 0 else {
         return nil
     }
-    return AttributesClass_moveFromCType(handle) as AttributesClass
+    return foobar_AttributesClass_moveFromCType(handle) as AttributesClass
 }
-internal func copyToCType(_ swiftClass: AttributesClass) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: AttributesClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: AttributesClass) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: AttributesClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: AttributesClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: AttributesClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: AttributesClass?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: AttributesClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesEnum.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesEnum.swift
@@ -6,33 +6,33 @@ public enum AttributesEnum : UInt32, CaseIterable, Codable {
     @OnEnumerator
     case nope
 }
-internal func copyToCType(_ swiftEnum: AttributesEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: AttributesEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: AttributesEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: AttributesEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: AttributesEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: AttributesEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: AttributesEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: AttributesEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> AttributesEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> AttributesEnum {
     return AttributesEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> AttributesEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> AttributesEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> AttributesEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AttributesEnum? {
     guard handle != 0 else {
         return nil
     }
     return AttributesEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> AttributesEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AttributesEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesInterface.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesInterface.swift
@@ -78,7 +78,7 @@ internal func getRef(_ ref: AttributesInterface?, owning: Bool = true) -> RefHol
 extension _AttributesInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func AttributesInterface_copyFromCType(_ handle: _baseRef) -> AttributesInterface {
+internal func foobar_AttributesInterface_copyFromCType(_ handle: _baseRef) -> AttributesInterface {
     if let swift_pointer = smoke_AttributesInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesInterface {
         return re_constructed
@@ -94,7 +94,7 @@ internal func AttributesInterface_copyFromCType(_ handle: _baseRef) -> Attribute
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func AttributesInterface_moveFromCType(_ handle: _baseRef) -> AttributesInterface {
+internal func foobar_AttributesInterface_moveFromCType(_ handle: _baseRef) -> AttributesInterface {
     if let swift_pointer = smoke_AttributesInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesInterface {
         smoke_AttributesInterface_release_handle(handle)
@@ -112,27 +112,27 @@ internal func AttributesInterface_moveFromCType(_ handle: _baseRef) -> Attribute
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func AttributesInterface_copyFromCType(_ handle: _baseRef) -> AttributesInterface? {
+internal func foobar_AttributesInterface_copyFromCType(_ handle: _baseRef) -> AttributesInterface? {
     guard handle != 0 else {
         return nil
     }
-    return AttributesInterface_moveFromCType(handle) as AttributesInterface
+    return foobar_AttributesInterface_moveFromCType(handle) as AttributesInterface
 }
-internal func AttributesInterface_moveFromCType(_ handle: _baseRef) -> AttributesInterface? {
+internal func foobar_AttributesInterface_moveFromCType(_ handle: _baseRef) -> AttributesInterface? {
     guard handle != 0 else {
         return nil
     }
-    return AttributesInterface_moveFromCType(handle) as AttributesInterface
+    return foobar_AttributesInterface_moveFromCType(handle) as AttributesInterface
 }
-internal func copyToCType(_ swiftClass: AttributesInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: AttributesInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: AttributesInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: AttributesInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: AttributesInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: AttributesInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: AttributesInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: AttributesInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesLambda.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesLambda.swift
@@ -3,26 +3,26 @@
 import Foundation
 @OnLambda
 public typealias AttributesLambda = () -> Void
-internal func copyFromCType(_ handle: _baseRef) -> AttributesLambda {
-    return moveFromCType(smoke_AttributesLambda_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AttributesLambda {
+    return foobar_moveFromCType(smoke_AttributesLambda_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> AttributesLambda {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AttributesLambda {
     let refHolder = RefHolder(ref: handle, release: smoke_AttributesLambda_release_handle)
     return { () -> Void in
         return moveFromCType(smoke_AttributesLambda_call(refHolder.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> AttributesLambda? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AttributesLambda? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as AttributesLambda
+    return foobar_copyFromCType(handle) as AttributesLambda
 }
-internal func moveFromCType(_ handle: _baseRef) -> AttributesLambda? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AttributesLambda? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as AttributesLambda
+    return foobar_moveFromCType(handle) as AttributesLambda
 }
 internal func createFunctionalTable(_ swiftType: @escaping AttributesLambda) -> smoke_AttributesLambda_FunctionTable {
     class smoke_AttributesLambda_Holder {
@@ -44,22 +44,22 @@ internal func createFunctionalTable(_ swiftType: @escaping AttributesLambda) -> 
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping AttributesLambda) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping AttributesLambda) -> RefHolder {
     let handle = smoke_AttributesLambda_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping AttributesLambda) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping AttributesLambda) -> RefHolder {
     let handle = smoke_AttributesLambda_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_AttributesLambda_release_handle)
 }
-internal func copyToCType(_ swiftType: AttributesLambda?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: AttributesLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_AttributesLambda_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: AttributesLambda?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: AttributesLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesStruct.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesStruct.swift
@@ -15,48 +15,47 @@ public struct AttributesStruct {
     }
     @OnFunctionInStruct
     public func veryFun(@OnParameterInStruct param: String) -> Void {
-        let c_self_handle = moveToCType(self)
+        let c_self_handle = foobar_moveToCType(self)
         let c_param = moveToCType(param)
         return moveFromCType(smoke_AttributesStruct_veryFun(c_self_handle.ref, c_param.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> AttributesStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AttributesStruct {
     return AttributesStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> AttributesStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AttributesStruct {
     defer {
         smoke_AttributesStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: AttributesStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: AttributesStruct) -> RefHolder {
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_AttributesStruct_create_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: AttributesStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_AttributesStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: AttributesStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AttributesStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> AttributesStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AttributesStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_AttributesStruct_unwrap_optional_handle(handle)
     return AttributesStruct(cHandle: unwrappedHandle) as AttributesStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> AttributesStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AttributesStruct? {
     defer {
         smoke_AttributesStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: AttributesStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: AttributesStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_AttributesStruct_create_optional_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: AttributesStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_AttributesStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: AttributesStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AttributesStruct_release_optional_handle)
 }
-

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithComments.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithComments.swift
@@ -66,7 +66,7 @@ extension AttributesWithComments: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func AttributesWithComments_copyFromCType(_ handle: _baseRef) -> AttributesWithComments {
+internal func foobar_AttributesWithComments_copyFromCType(_ handle: _baseRef) -> AttributesWithComments {
     if let swift_pointer = smoke_AttributesWithComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesWithComments {
         return re_constructed
@@ -75,7 +75,7 @@ internal func AttributesWithComments_copyFromCType(_ handle: _baseRef) -> Attrib
     smoke_AttributesWithComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func AttributesWithComments_moveFromCType(_ handle: _baseRef) -> AttributesWithComments {
+internal func foobar_AttributesWithComments_moveFromCType(_ handle: _baseRef) -> AttributesWithComments {
     if let swift_pointer = smoke_AttributesWithComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesWithComments {
         smoke_AttributesWithComments_release_handle(handle)
@@ -85,66 +85,66 @@ internal func AttributesWithComments_moveFromCType(_ handle: _baseRef) -> Attrib
     smoke_AttributesWithComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func AttributesWithComments_copyFromCType(_ handle: _baseRef) -> AttributesWithComments? {
+internal func foobar_AttributesWithComments_copyFromCType(_ handle: _baseRef) -> AttributesWithComments? {
     guard handle != 0 else {
         return nil
     }
-    return AttributesWithComments_moveFromCType(handle) as AttributesWithComments
+    return foobar_AttributesWithComments_moveFromCType(handle) as AttributesWithComments
 }
-internal func AttributesWithComments_moveFromCType(_ handle: _baseRef) -> AttributesWithComments? {
+internal func foobar_AttributesWithComments_moveFromCType(_ handle: _baseRef) -> AttributesWithComments? {
     guard handle != 0 else {
         return nil
     }
-    return AttributesWithComments_moveFromCType(handle) as AttributesWithComments
+    return foobar_AttributesWithComments_moveFromCType(handle) as AttributesWithComments
 }
-internal func copyToCType(_ swiftClass: AttributesWithComments) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: AttributesWithComments) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: AttributesWithComments) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: AttributesWithComments) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: AttributesWithComments?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: AttributesWithComments?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: AttributesWithComments?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: AttributesWithComments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> AttributesWithComments.SomeStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AttributesWithComments.SomeStruct {
     return AttributesWithComments.SomeStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> AttributesWithComments.SomeStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AttributesWithComments.SomeStruct {
     defer {
         smoke_AttributesWithComments_SomeStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: AttributesWithComments.SomeStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: AttributesWithComments.SomeStruct) -> RefHolder {
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_AttributesWithComments_SomeStruct_create_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: AttributesWithComments.SomeStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_AttributesWithComments_SomeStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: AttributesWithComments.SomeStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AttributesWithComments_SomeStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> AttributesWithComments.SomeStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AttributesWithComments.SomeStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_AttributesWithComments_SomeStruct_unwrap_optional_handle(handle)
     return AttributesWithComments.SomeStruct(cHandle: unwrappedHandle) as AttributesWithComments.SomeStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> AttributesWithComments.SomeStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AttributesWithComments.SomeStruct? {
     defer {
         smoke_AttributesWithComments_SomeStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: AttributesWithComments.SomeStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: AttributesWithComments.SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_AttributesWithComments_SomeStruct_create_optional_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: AttributesWithComments.SomeStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_AttributesWithComments_SomeStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: AttributesWithComments.SomeStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AttributesWithComments_SomeStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithDeprecated.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithDeprecated.swift
@@ -67,7 +67,7 @@ extension AttributesWithDeprecated: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func AttributesWithDeprecated_copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated {
+internal func foobar_AttributesWithDeprecated_copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated {
     if let swift_pointer = smoke_AttributesWithDeprecated_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesWithDeprecated {
         return re_constructed
@@ -76,7 +76,7 @@ internal func AttributesWithDeprecated_copyFromCType(_ handle: _baseRef) -> Attr
     smoke_AttributesWithDeprecated_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func AttributesWithDeprecated_moveFromCType(_ handle: _baseRef) -> AttributesWithDeprecated {
+internal func foobar_AttributesWithDeprecated_moveFromCType(_ handle: _baseRef) -> AttributesWithDeprecated {
     if let swift_pointer = smoke_AttributesWithDeprecated_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AttributesWithDeprecated {
         smoke_AttributesWithDeprecated_release_handle(handle)
@@ -86,66 +86,66 @@ internal func AttributesWithDeprecated_moveFromCType(_ handle: _baseRef) -> Attr
     smoke_AttributesWithDeprecated_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func AttributesWithDeprecated_copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated? {
+internal func foobar_AttributesWithDeprecated_copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated? {
     guard handle != 0 else {
         return nil
     }
-    return AttributesWithDeprecated_moveFromCType(handle) as AttributesWithDeprecated
+    return foobar_AttributesWithDeprecated_moveFromCType(handle) as AttributesWithDeprecated
 }
-internal func AttributesWithDeprecated_moveFromCType(_ handle: _baseRef) -> AttributesWithDeprecated? {
+internal func foobar_AttributesWithDeprecated_moveFromCType(_ handle: _baseRef) -> AttributesWithDeprecated? {
     guard handle != 0 else {
         return nil
     }
-    return AttributesWithDeprecated_moveFromCType(handle) as AttributesWithDeprecated
+    return foobar_AttributesWithDeprecated_moveFromCType(handle) as AttributesWithDeprecated
 }
-internal func copyToCType(_ swiftClass: AttributesWithDeprecated) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: AttributesWithDeprecated) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: AttributesWithDeprecated) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: AttributesWithDeprecated) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: AttributesWithDeprecated?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: AttributesWithDeprecated?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: AttributesWithDeprecated?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: AttributesWithDeprecated?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated.SomeStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated.SomeStruct {
     return AttributesWithDeprecated.SomeStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> AttributesWithDeprecated.SomeStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AttributesWithDeprecated.SomeStruct {
     defer {
         smoke_AttributesWithDeprecated_SomeStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: AttributesWithDeprecated.SomeStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: AttributesWithDeprecated.SomeStruct) -> RefHolder {
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_AttributesWithDeprecated_SomeStruct_create_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: AttributesWithDeprecated.SomeStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_AttributesWithDeprecated_SomeStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: AttributesWithDeprecated.SomeStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AttributesWithDeprecated_SomeStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated.SomeStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AttributesWithDeprecated.SomeStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_AttributesWithDeprecated_SomeStruct_unwrap_optional_handle(handle)
     return AttributesWithDeprecated.SomeStruct(cHandle: unwrappedHandle) as AttributesWithDeprecated.SomeStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> AttributesWithDeprecated.SomeStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AttributesWithDeprecated.SomeStruct? {
     defer {
         smoke_AttributesWithDeprecated_SomeStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: AttributesWithDeprecated.SomeStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: AttributesWithDeprecated.SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_AttributesWithDeprecated_SomeStruct_create_optional_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: AttributesWithDeprecated.SomeStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_AttributesWithDeprecated_SomeStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: AttributesWithDeprecated.SomeStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AttributesWithDeprecated_SomeStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/MultipleAttributesSwift.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/MultipleAttributesSwift.swift
@@ -64,7 +64,7 @@ extension MultipleAttributesSwift: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func MultipleAttributesSwift_copyFromCType(_ handle: _baseRef) -> MultipleAttributesSwift {
+internal func foobar_MultipleAttributesSwift_copyFromCType(_ handle: _baseRef) -> MultipleAttributesSwift {
     if let swift_pointer = smoke_MultipleAttributesSwift_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MultipleAttributesSwift {
         return re_constructed
@@ -73,7 +73,7 @@ internal func MultipleAttributesSwift_copyFromCType(_ handle: _baseRef) -> Multi
     smoke_MultipleAttributesSwift_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func MultipleAttributesSwift_moveFromCType(_ handle: _baseRef) -> MultipleAttributesSwift {
+internal func foobar_MultipleAttributesSwift_moveFromCType(_ handle: _baseRef) -> MultipleAttributesSwift {
     if let swift_pointer = smoke_MultipleAttributesSwift_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MultipleAttributesSwift {
         smoke_MultipleAttributesSwift_release_handle(handle)
@@ -83,27 +83,27 @@ internal func MultipleAttributesSwift_moveFromCType(_ handle: _baseRef) -> Multi
     smoke_MultipleAttributesSwift_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func MultipleAttributesSwift_copyFromCType(_ handle: _baseRef) -> MultipleAttributesSwift? {
+internal func foobar_MultipleAttributesSwift_copyFromCType(_ handle: _baseRef) -> MultipleAttributesSwift? {
     guard handle != 0 else {
         return nil
     }
-    return MultipleAttributesSwift_moveFromCType(handle) as MultipleAttributesSwift
+    return foobar_MultipleAttributesSwift_moveFromCType(handle) as MultipleAttributesSwift
 }
-internal func MultipleAttributesSwift_moveFromCType(_ handle: _baseRef) -> MultipleAttributesSwift? {
+internal func foobar_MultipleAttributesSwift_moveFromCType(_ handle: _baseRef) -> MultipleAttributesSwift? {
     guard handle != 0 else {
         return nil
     }
-    return MultipleAttributesSwift_moveFromCType(handle) as MultipleAttributesSwift
+    return foobar_MultipleAttributesSwift_moveFromCType(handle) as MultipleAttributesSwift
 }
-internal func copyToCType(_ swiftClass: MultipleAttributesSwift) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: MultipleAttributesSwift) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: MultipleAttributesSwift) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: MultipleAttributesSwift) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: MultipleAttributesSwift?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: MultipleAttributesSwift?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: MultipleAttributesSwift?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: MultipleAttributesSwift?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/SpecialAttributes.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/SpecialAttributes.swift
@@ -42,7 +42,7 @@ extension SpecialAttributes: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func SpecialAttributes_copyFromCType(_ handle: _baseRef) -> SpecialAttributes {
+internal func foobar_SpecialAttributes_copyFromCType(_ handle: _baseRef) -> SpecialAttributes {
     if let swift_pointer = smoke_SpecialAttributes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SpecialAttributes {
         return re_constructed
@@ -51,7 +51,7 @@ internal func SpecialAttributes_copyFromCType(_ handle: _baseRef) -> SpecialAttr
     smoke_SpecialAttributes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func SpecialAttributes_moveFromCType(_ handle: _baseRef) -> SpecialAttributes {
+internal func foobar_SpecialAttributes_moveFromCType(_ handle: _baseRef) -> SpecialAttributes {
     if let swift_pointer = smoke_SpecialAttributes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SpecialAttributes {
         smoke_SpecialAttributes_release_handle(handle)
@@ -61,27 +61,27 @@ internal func SpecialAttributes_moveFromCType(_ handle: _baseRef) -> SpecialAttr
     smoke_SpecialAttributes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func SpecialAttributes_copyFromCType(_ handle: _baseRef) -> SpecialAttributes? {
+internal func foobar_SpecialAttributes_copyFromCType(_ handle: _baseRef) -> SpecialAttributes? {
     guard handle != 0 else {
         return nil
     }
-    return SpecialAttributes_moveFromCType(handle) as SpecialAttributes
+    return foobar_SpecialAttributes_moveFromCType(handle) as SpecialAttributes
 }
-internal func SpecialAttributes_moveFromCType(_ handle: _baseRef) -> SpecialAttributes? {
+internal func foobar_SpecialAttributes_moveFromCType(_ handle: _baseRef) -> SpecialAttributes? {
     guard handle != 0 else {
         return nil
     }
-    return SpecialAttributes_moveFromCType(handle) as SpecialAttributes
+    return foobar_SpecialAttributes_moveFromCType(handle) as SpecialAttributes
 }
-internal func copyToCType(_ swiftClass: SpecialAttributes) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: SpecialAttributes) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: SpecialAttributes) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: SpecialAttributes) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: SpecialAttributes?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: SpecialAttributes?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: SpecialAttributes?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: SpecialAttributes?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/swift/smoke/BasicTypes.swift
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/swift/smoke/BasicTypes.swift
@@ -82,7 +82,7 @@ extension BasicTypes: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func BasicTypes_copyFromCType(_ handle: _baseRef) -> BasicTypes {
+internal func foobar_BasicTypes_copyFromCType(_ handle: _baseRef) -> BasicTypes {
     if let swift_pointer = smoke_BasicTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? BasicTypes {
         return re_constructed
@@ -91,7 +91,7 @@ internal func BasicTypes_copyFromCType(_ handle: _baseRef) -> BasicTypes {
     smoke_BasicTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func BasicTypes_moveFromCType(_ handle: _baseRef) -> BasicTypes {
+internal func foobar_BasicTypes_moveFromCType(_ handle: _baseRef) -> BasicTypes {
     if let swift_pointer = smoke_BasicTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? BasicTypes {
         smoke_BasicTypes_release_handle(handle)
@@ -101,27 +101,27 @@ internal func BasicTypes_moveFromCType(_ handle: _baseRef) -> BasicTypes {
     smoke_BasicTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func BasicTypes_copyFromCType(_ handle: _baseRef) -> BasicTypes? {
+internal func foobar_BasicTypes_copyFromCType(_ handle: _baseRef) -> BasicTypes? {
     guard handle != 0 else {
         return nil
     }
-    return BasicTypes_moveFromCType(handle) as BasicTypes
+    return foobar_BasicTypes_moveFromCType(handle) as BasicTypes
 }
-internal func BasicTypes_moveFromCType(_ handle: _baseRef) -> BasicTypes? {
+internal func foobar_BasicTypes_moveFromCType(_ handle: _baseRef) -> BasicTypes? {
     guard handle != 0 else {
         return nil
     }
-    return BasicTypes_moveFromCType(handle) as BasicTypes
+    return foobar_BasicTypes_moveFromCType(handle) as BasicTypes
 }
-internal func copyToCType(_ swiftClass: BasicTypes) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: BasicTypes) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: BasicTypes) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: BasicTypes) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: BasicTypes?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: BasicTypes?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: BasicTypes?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: BasicTypes?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -68,7 +68,7 @@ public class Comments {
         let c_inputParameter = moveToCType(inputParameter)
         let RESULT = smoke_Comments_someMethodWithAllComments(self.c_instance, c_inputParameter.ref)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as Comments.SomethingWrongError
+            throw foobar_moveFromCType(RESULT.error_value) as Comments.SomethingWrongError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
@@ -161,7 +161,7 @@ extension Comments: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Comments_copyFromCType(_ handle: _baseRef) -> Comments {
+internal func foobar_Comments_copyFromCType(_ handle: _baseRef) -> Comments {
     if let swift_pointer = smoke_Comments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Comments {
         return re_constructed
@@ -170,7 +170,7 @@ internal func Comments_copyFromCType(_ handle: _baseRef) -> Comments {
     smoke_Comments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Comments_moveFromCType(_ handle: _baseRef) -> Comments {
+internal func foobar_Comments_moveFromCType(_ handle: _baseRef) -> Comments {
     if let swift_pointer = smoke_Comments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Comments {
         smoke_Comments_release_handle(handle)
@@ -180,50 +180,50 @@ internal func Comments_moveFromCType(_ handle: _baseRef) -> Comments {
     smoke_Comments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Comments_copyFromCType(_ handle: _baseRef) -> Comments? {
+internal func foobar_Comments_copyFromCType(_ handle: _baseRef) -> Comments? {
     guard handle != 0 else {
         return nil
     }
-    return Comments_moveFromCType(handle) as Comments
+    return foobar_Comments_moveFromCType(handle) as Comments
 }
-internal func Comments_moveFromCType(_ handle: _baseRef) -> Comments? {
+internal func foobar_Comments_moveFromCType(_ handle: _baseRef) -> Comments? {
     guard handle != 0 else {
         return nil
     }
-    return Comments_moveFromCType(handle) as Comments
+    return foobar_Comments_moveFromCType(handle) as Comments
 }
-internal func copyToCType(_ swiftClass: Comments) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Comments) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Comments) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Comments) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Comments?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Comments?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Comments?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Comments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
-    return moveFromCType(smoke_Comments_SomeLambda_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
+    return foobar_moveFromCType(smoke_Comments_SomeLambda_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
     let refHolder = RefHolder(ref: handle, release: smoke_Comments_SomeLambda_release_handle)
     return { (p0: String, p1: Int32) -> Double in
         return moveFromCType(smoke_Comments_SomeLambda_call(refHolder.ref, moveToCType(p0).ref, moveToCType(p1).ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as Comments.SomeLambda
+    return foobar_copyFromCType(handle) as Comments.SomeLambda
 }
-internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeLambda? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Comments.SomeLambda? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as Comments.SomeLambda
+    return foobar_moveFromCType(handle) as Comments.SomeLambda
 }
 internal func createFunctionalTable(_ swiftType: @escaping Comments.SomeLambda) -> smoke_Comments_SomeLambda_FunctionTable {
     class smoke_Comments_SomeLambda_Holder {
@@ -245,59 +245,59 @@ internal func createFunctionalTable(_ swiftType: @escaping Comments.SomeLambda) 
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping Comments.SomeLambda) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping Comments.SomeLambda) -> RefHolder {
     let handle = smoke_Comments_SomeLambda_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping Comments.SomeLambda) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping Comments.SomeLambda) -> RefHolder {
     let handle = smoke_Comments_SomeLambda_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Comments_SomeLambda_release_handle)
 }
-internal func copyToCType(_ swiftType: Comments.SomeLambda?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Comments.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_Comments_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: Comments.SomeLambda?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: Comments.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_Comments_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Comments_SomeLambda_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Comments.SomeStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Comments.SomeStruct {
     return Comments.SomeStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Comments.SomeStruct {
     defer {
         smoke_Comments_SomeStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Comments.SomeStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Comments.SomeStruct) -> RefHolder {
     let c_someField = moveToCType(swiftType.someField)
     let c_nullableField = moveToCType(swiftType.nullableField)
     return RefHolder(smoke_Comments_SomeStruct_create_handle(c_someField.ref, c_nullableField.ref))
 }
-internal func moveToCType(_ swiftType: Comments.SomeStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Comments_SomeStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Comments.SomeStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Comments_SomeStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Comments.SomeStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Comments.SomeStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Comments_SomeStruct_unwrap_optional_handle(handle)
     return Comments.SomeStruct(cHandle: unwrappedHandle) as Comments.SomeStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Comments.SomeStruct? {
     defer {
         smoke_Comments_SomeStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Comments.SomeStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Comments.SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -305,38 +305,38 @@ internal func copyToCType(_ swiftType: Comments.SomeStruct?) -> RefHolder {
     let c_nullableField = moveToCType(swiftType.nullableField)
     return RefHolder(smoke_Comments_SomeStruct_create_optional_handle(c_someField.ref, c_nullableField.ref))
 }
-internal func moveToCType(_ swiftType: Comments.SomeStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Comments_SomeStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Comments.SomeStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Comments_SomeStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: Comments.SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Comments.SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Comments.SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Comments.SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Comments.SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Comments.SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Comments.SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Comments.SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Comments.SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Comments.SomeEnum {
     return Comments.SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Comments.SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Comments.SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Comments.SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Comments.SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return Comments.SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Comments.SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 extension Comments.SomeEnum : Error {
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsInterface.swift
@@ -215,7 +215,7 @@ internal func getRef(_ ref: CommentsInterface?, owning: Bool = true) -> RefHolde
 extension _CommentsInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func CommentsInterface_copyFromCType(_ handle: _baseRef) -> CommentsInterface {
+internal func foobar_CommentsInterface_copyFromCType(_ handle: _baseRef) -> CommentsInterface {
     if let swift_pointer = smoke_CommentsInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CommentsInterface {
         return re_constructed
@@ -231,7 +231,7 @@ internal func CommentsInterface_copyFromCType(_ handle: _baseRef) -> CommentsInt
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func CommentsInterface_moveFromCType(_ handle: _baseRef) -> CommentsInterface {
+internal func foobar_CommentsInterface_moveFromCType(_ handle: _baseRef) -> CommentsInterface {
     if let swift_pointer = smoke_CommentsInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CommentsInterface {
         smoke_CommentsInterface_release_handle(handle)
@@ -249,96 +249,96 @@ internal func CommentsInterface_moveFromCType(_ handle: _baseRef) -> CommentsInt
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func CommentsInterface_copyFromCType(_ handle: _baseRef) -> CommentsInterface? {
+internal func foobar_CommentsInterface_copyFromCType(_ handle: _baseRef) -> CommentsInterface? {
     guard handle != 0 else {
         return nil
     }
-    return CommentsInterface_moveFromCType(handle) as CommentsInterface
+    return foobar_CommentsInterface_moveFromCType(handle) as CommentsInterface
 }
-internal func CommentsInterface_moveFromCType(_ handle: _baseRef) -> CommentsInterface? {
+internal func foobar_CommentsInterface_moveFromCType(_ handle: _baseRef) -> CommentsInterface? {
     guard handle != 0 else {
         return nil
     }
-    return CommentsInterface_moveFromCType(handle) as CommentsInterface
+    return foobar_CommentsInterface_moveFromCType(handle) as CommentsInterface
 }
-internal func copyToCType(_ swiftClass: CommentsInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: CommentsInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: CommentsInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: CommentsInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: CommentsInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: CommentsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: CommentsInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: CommentsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeStruct {
     return SomeStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeStruct {
     defer {
         smoke_CommentsInterface_SomeStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SomeStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SomeStruct) -> RefHolder {
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_CommentsInterface_SomeStruct_create_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: SomeStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_CommentsInterface_SomeStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: SomeStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_CommentsInterface_SomeStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_CommentsInterface_SomeStruct_unwrap_optional_handle(handle)
     return SomeStruct(cHandle: unwrappedHandle) as SomeStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeStruct? {
     defer {
         smoke_CommentsInterface_SomeStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SomeStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_CommentsInterface_SomeStruct_create_optional_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: SomeStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_CommentsInterface_SomeStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: SomeStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_CommentsInterface_SomeStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> SomeEnum {
     return SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
@@ -31,7 +31,7 @@ public class CommentsLinks {
             self.randomField = randomField
         }
         internal init(cHandle: _baseRef) {
-            randomField = moveFromCType(smoke_CommentsLinks_RandomStruct_randomField_get(cHandle))
+            randomField = foobar_moveFromCType(smoke_CommentsLinks_RandomStruct_randomField_get(cHandle))
         }
     }
     /// Link types:
@@ -69,12 +69,12 @@ public class CommentsLinks {
     /// - Returns: Sometimes returns `Comments.SomeEnum.useful`
     /// - Throws: `Comments.SomethingWrongError` May or may not throw `Comments.SomethingWrongError`
     public func randomMethod(inputParameter: Comments.SomeEnum) throws -> Comments.SomeEnum {
-        let c_inputParameter = moveToCType(inputParameter)
+        let c_inputParameter = foobar_moveToCType(inputParameter)
         let RESULT = smoke_CommentsLinks_randomMethod_SomeEnum(self.c_instance, c_inputParameter.ref)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as Comments.SomethingWrongError
+            throw foobar_moveFromCType(RESULT.error_value) as Comments.SomethingWrongError
         } else {
-            return moveFromCType(RESULT.returned_value)
+            return foobar_moveFromCType(RESULT.returned_value)
         }
     }
     /// Links to method overloads:
@@ -110,7 +110,7 @@ extension CommentsLinks: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func CommentsLinks_copyFromCType(_ handle: _baseRef) -> CommentsLinks {
+internal func foobar_CommentsLinks_copyFromCType(_ handle: _baseRef) -> CommentsLinks {
     if let swift_pointer = smoke_CommentsLinks_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CommentsLinks {
         return re_constructed
@@ -119,7 +119,7 @@ internal func CommentsLinks_copyFromCType(_ handle: _baseRef) -> CommentsLinks {
     smoke_CommentsLinks_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func CommentsLinks_moveFromCType(_ handle: _baseRef) -> CommentsLinks {
+internal func foobar_CommentsLinks_moveFromCType(_ handle: _baseRef) -> CommentsLinks {
     if let swift_pointer = smoke_CommentsLinks_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CommentsLinks {
         smoke_CommentsLinks_release_handle(handle)
@@ -129,66 +129,66 @@ internal func CommentsLinks_moveFromCType(_ handle: _baseRef) -> CommentsLinks {
     smoke_CommentsLinks_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func CommentsLinks_copyFromCType(_ handle: _baseRef) -> CommentsLinks? {
+internal func foobar_CommentsLinks_copyFromCType(_ handle: _baseRef) -> CommentsLinks? {
     guard handle != 0 else {
         return nil
     }
-    return CommentsLinks_moveFromCType(handle) as CommentsLinks
+    return foobar_CommentsLinks_moveFromCType(handle) as CommentsLinks
 }
-internal func CommentsLinks_moveFromCType(_ handle: _baseRef) -> CommentsLinks? {
+internal func foobar_CommentsLinks_moveFromCType(_ handle: _baseRef) -> CommentsLinks? {
     guard handle != 0 else {
         return nil
     }
-    return CommentsLinks_moveFromCType(handle) as CommentsLinks
+    return foobar_CommentsLinks_moveFromCType(handle) as CommentsLinks
 }
-internal func copyToCType(_ swiftClass: CommentsLinks) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: CommentsLinks) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: CommentsLinks) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: CommentsLinks) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: CommentsLinks?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: CommentsLinks?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: CommentsLinks?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: CommentsLinks?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> CommentsLinks.RandomStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> CommentsLinks.RandomStruct {
     return CommentsLinks.RandomStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> CommentsLinks.RandomStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> CommentsLinks.RandomStruct {
     defer {
         smoke_CommentsLinks_RandomStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: CommentsLinks.RandomStruct) -> RefHolder {
-    let c_randomField = moveToCType(swiftType.randomField)
+internal func foobar_copyToCType(_ swiftType: CommentsLinks.RandomStruct) -> RefHolder {
+    let c_randomField = foobar_moveToCType(swiftType.randomField)
     return RefHolder(smoke_CommentsLinks_RandomStruct_create_handle(c_randomField.ref))
 }
-internal func moveToCType(_ swiftType: CommentsLinks.RandomStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_CommentsLinks_RandomStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: CommentsLinks.RandomStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_CommentsLinks_RandomStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> CommentsLinks.RandomStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> CommentsLinks.RandomStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_CommentsLinks_RandomStruct_unwrap_optional_handle(handle)
     return CommentsLinks.RandomStruct(cHandle: unwrappedHandle) as CommentsLinks.RandomStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> CommentsLinks.RandomStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> CommentsLinks.RandomStruct? {
     defer {
         smoke_CommentsLinks_RandomStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: CommentsLinks.RandomStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: CommentsLinks.RandomStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_randomField = moveToCType(swiftType.randomField)
+    let c_randomField = foobar_moveToCType(swiftType.randomField)
     return RefHolder(smoke_CommentsLinks_RandomStruct_create_optional_handle(c_randomField.ref))
 }
-internal func moveToCType(_ swiftType: CommentsLinks.RandomStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_CommentsLinks_RandomStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: CommentsLinks.RandomStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_CommentsLinks_RandomStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecatedWithNoMessage.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecatedWithNoMessage.swift
@@ -11,42 +11,42 @@ public struct DeprecatedWithNoMessage {
         field = moveFromCType(smoke_DeprecatedWithNoMessage_field_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> DeprecatedWithNoMessage {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> DeprecatedWithNoMessage {
     return DeprecatedWithNoMessage(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> DeprecatedWithNoMessage {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> DeprecatedWithNoMessage {
     defer {
         smoke_DeprecatedWithNoMessage_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: DeprecatedWithNoMessage) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: DeprecatedWithNoMessage) -> RefHolder {
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_DeprecatedWithNoMessage_create_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: DeprecatedWithNoMessage) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DeprecatedWithNoMessage_release_handle)
+internal func foobar_moveToCType(_ swiftType: DeprecatedWithNoMessage) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_DeprecatedWithNoMessage_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> DeprecatedWithNoMessage? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> DeprecatedWithNoMessage? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_DeprecatedWithNoMessage_unwrap_optional_handle(handle)
     return DeprecatedWithNoMessage(cHandle: unwrappedHandle) as DeprecatedWithNoMessage
 }
-internal func moveFromCType(_ handle: _baseRef) -> DeprecatedWithNoMessage? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> DeprecatedWithNoMessage? {
     defer {
         smoke_DeprecatedWithNoMessage_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: DeprecatedWithNoMessage?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: DeprecatedWithNoMessage?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_DeprecatedWithNoMessage_create_optional_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: DeprecatedWithNoMessage?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DeprecatedWithNoMessage_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: DeprecatedWithNoMessage?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_DeprecatedWithNoMessage_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationComments.swift
@@ -167,7 +167,7 @@ internal func getRef(_ ref: DeprecationComments?, owning: Bool = true) -> RefHol
 extension _DeprecationComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func DeprecationComments_copyFromCType(_ handle: _baseRef) -> DeprecationComments {
+internal func foobar_DeprecationComments_copyFromCType(_ handle: _baseRef) -> DeprecationComments {
     if let swift_pointer = smoke_DeprecationComments_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DeprecationComments {
         return re_constructed
@@ -183,7 +183,7 @@ internal func DeprecationComments_copyFromCType(_ handle: _baseRef) -> Deprecati
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func DeprecationComments_moveFromCType(_ handle: _baseRef) -> DeprecationComments {
+internal func foobar_DeprecationComments_moveFromCType(_ handle: _baseRef) -> DeprecationComments {
     if let swift_pointer = smoke_DeprecationComments_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DeprecationComments {
         smoke_DeprecationComments_release_handle(handle)
@@ -201,98 +201,98 @@ internal func DeprecationComments_moveFromCType(_ handle: _baseRef) -> Deprecati
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func DeprecationComments_copyFromCType(_ handle: _baseRef) -> DeprecationComments? {
+internal func foobar_DeprecationComments_copyFromCType(_ handle: _baseRef) -> DeprecationComments? {
     guard handle != 0 else {
         return nil
     }
-    return DeprecationComments_moveFromCType(handle) as DeprecationComments
+    return foobar_DeprecationComments_moveFromCType(handle) as DeprecationComments
 }
-internal func DeprecationComments_moveFromCType(_ handle: _baseRef) -> DeprecationComments? {
+internal func foobar_DeprecationComments_moveFromCType(_ handle: _baseRef) -> DeprecationComments? {
     guard handle != 0 else {
         return nil
     }
-    return DeprecationComments_moveFromCType(handle) as DeprecationComments
+    return foobar_DeprecationComments_moveFromCType(handle) as DeprecationComments
 }
-internal func copyToCType(_ swiftClass: DeprecationComments) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: DeprecationComments) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: DeprecationComments) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: DeprecationComments) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: DeprecationComments?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: DeprecationComments?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: DeprecationComments?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: DeprecationComments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeStruct {
     return SomeStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeStruct {
     defer {
         smoke_DeprecationComments_SomeStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SomeStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SomeStruct) -> RefHolder {
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_DeprecationComments_SomeStruct_create_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: SomeStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DeprecationComments_SomeStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: SomeStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_DeprecationComments_SomeStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_DeprecationComments_SomeStruct_unwrap_optional_handle(handle)
     return SomeStruct(cHandle: unwrappedHandle) as SomeStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeStruct? {
     defer {
         smoke_DeprecationComments_SomeStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SomeStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_DeprecationComments_SomeStruct_create_optional_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: SomeStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DeprecationComments_SomeStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: SomeStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_DeprecationComments_SomeStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> SomeEnum {
     return SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 extension SomeEnum : Error {
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationCommentsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationCommentsOnly.swift
@@ -128,7 +128,7 @@ internal func getRef(_ ref: DeprecationCommentsOnly?, owning: Bool = true) -> Re
 extension _DeprecationCommentsOnly: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func DeprecationCommentsOnly_copyFromCType(_ handle: _baseRef) -> DeprecationCommentsOnly {
+internal func foobar_DeprecationCommentsOnly_copyFromCType(_ handle: _baseRef) -> DeprecationCommentsOnly {
     if let swift_pointer = smoke_DeprecationCommentsOnly_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DeprecationCommentsOnly {
         return re_constructed
@@ -144,7 +144,7 @@ internal func DeprecationCommentsOnly_copyFromCType(_ handle: _baseRef) -> Depre
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func DeprecationCommentsOnly_moveFromCType(_ handle: _baseRef) -> DeprecationCommentsOnly {
+internal func foobar_DeprecationCommentsOnly_moveFromCType(_ handle: _baseRef) -> DeprecationCommentsOnly {
     if let swift_pointer = smoke_DeprecationCommentsOnly_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DeprecationCommentsOnly {
         smoke_DeprecationCommentsOnly_release_handle(handle)
@@ -162,96 +162,96 @@ internal func DeprecationCommentsOnly_moveFromCType(_ handle: _baseRef) -> Depre
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func DeprecationCommentsOnly_copyFromCType(_ handle: _baseRef) -> DeprecationCommentsOnly? {
+internal func foobar_DeprecationCommentsOnly_copyFromCType(_ handle: _baseRef) -> DeprecationCommentsOnly? {
     guard handle != 0 else {
         return nil
     }
-    return DeprecationCommentsOnly_moveFromCType(handle) as DeprecationCommentsOnly
+    return foobar_DeprecationCommentsOnly_moveFromCType(handle) as DeprecationCommentsOnly
 }
-internal func DeprecationCommentsOnly_moveFromCType(_ handle: _baseRef) -> DeprecationCommentsOnly? {
+internal func foobar_DeprecationCommentsOnly_moveFromCType(_ handle: _baseRef) -> DeprecationCommentsOnly? {
     guard handle != 0 else {
         return nil
     }
-    return DeprecationCommentsOnly_moveFromCType(handle) as DeprecationCommentsOnly
+    return foobar_DeprecationCommentsOnly_moveFromCType(handle) as DeprecationCommentsOnly
 }
-internal func copyToCType(_ swiftClass: DeprecationCommentsOnly) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: DeprecationCommentsOnly) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: DeprecationCommentsOnly) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: DeprecationCommentsOnly) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: DeprecationCommentsOnly?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: DeprecationCommentsOnly?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: DeprecationCommentsOnly?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: DeprecationCommentsOnly?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeStruct {
     return SomeStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeStruct {
     defer {
         smoke_DeprecationCommentsOnly_SomeStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SomeStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SomeStruct) -> RefHolder {
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_DeprecationCommentsOnly_SomeStruct_create_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: SomeStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DeprecationCommentsOnly_SomeStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: SomeStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_DeprecationCommentsOnly_SomeStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_DeprecationCommentsOnly_SomeStruct_unwrap_optional_handle(handle)
     return SomeStruct(cHandle: unwrappedHandle) as SomeStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeStruct? {
     defer {
         smoke_DeprecationCommentsOnly_SomeStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SomeStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_DeprecationCommentsOnly_SomeStruct_create_optional_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: SomeStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DeprecationCommentsOnly_SomeStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: SomeStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_DeprecationCommentsOnly_SomeStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> SomeEnum {
     return SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
@@ -72,7 +72,7 @@ public class ExcludedComments {
         let c_inputParameter = moveToCType(inputParameter)
         let RESULT = smoke_ExcludedComments_someMethodWithAllComments(self.c_instance, c_inputParameter.ref)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as ExcludedComments.SomethingWrongError
+            throw foobar_moveFromCType(RESULT.error_value) as ExcludedComments.SomethingWrongError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
@@ -103,7 +103,7 @@ extension ExcludedComments: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func ExcludedComments_copyFromCType(_ handle: _baseRef) -> ExcludedComments {
+internal func foobar_ExcludedComments_copyFromCType(_ handle: _baseRef) -> ExcludedComments {
     if let swift_pointer = smoke_ExcludedComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedComments {
         return re_constructed
@@ -112,7 +112,7 @@ internal func ExcludedComments_copyFromCType(_ handle: _baseRef) -> ExcludedComm
     smoke_ExcludedComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func ExcludedComments_moveFromCType(_ handle: _baseRef) -> ExcludedComments {
+internal func foobar_ExcludedComments_moveFromCType(_ handle: _baseRef) -> ExcludedComments {
     if let swift_pointer = smoke_ExcludedComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedComments {
         smoke_ExcludedComments_release_handle(handle)
@@ -122,50 +122,50 @@ internal func ExcludedComments_moveFromCType(_ handle: _baseRef) -> ExcludedComm
     smoke_ExcludedComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func ExcludedComments_copyFromCType(_ handle: _baseRef) -> ExcludedComments? {
+internal func foobar_ExcludedComments_copyFromCType(_ handle: _baseRef) -> ExcludedComments? {
     guard handle != 0 else {
         return nil
     }
-    return ExcludedComments_moveFromCType(handle) as ExcludedComments
+    return foobar_ExcludedComments_moveFromCType(handle) as ExcludedComments
 }
-internal func ExcludedComments_moveFromCType(_ handle: _baseRef) -> ExcludedComments? {
+internal func foobar_ExcludedComments_moveFromCType(_ handle: _baseRef) -> ExcludedComments? {
     guard handle != 0 else {
         return nil
     }
-    return ExcludedComments_moveFromCType(handle) as ExcludedComments
+    return foobar_ExcludedComments_moveFromCType(handle) as ExcludedComments
 }
-internal func copyToCType(_ swiftClass: ExcludedComments) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ExcludedComments) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ExcludedComments) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ExcludedComments) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ExcludedComments?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ExcludedComments?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ExcludedComments?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ExcludedComments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda {
-    return moveFromCType(smoke_ExcludedComments_SomeLambda_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda {
+    return foobar_moveFromCType(smoke_ExcludedComments_SomeLambda_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda {
     let refHolder = RefHolder(ref: handle, release: smoke_ExcludedComments_SomeLambda_release_handle)
     return { (p0: String, p1: Int32) -> Double in
         return moveFromCType(smoke_ExcludedComments_SomeLambda_call(refHolder.ref, moveToCType(p0).ref, moveToCType(p1).ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as ExcludedComments.SomeLambda
+    return foobar_copyFromCType(handle) as ExcludedComments.SomeLambda
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as ExcludedComments.SomeLambda
+    return foobar_moveFromCType(handle) as ExcludedComments.SomeLambda
 }
 internal func createFunctionalTable(_ swiftType: @escaping ExcludedComments.SomeLambda) -> smoke_ExcludedComments_SomeLambda_FunctionTable {
     class smoke_ExcludedComments_SomeLambda_Holder {
@@ -187,96 +187,96 @@ internal func createFunctionalTable(_ swiftType: @escaping ExcludedComments.Some
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping ExcludedComments.SomeLambda) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping ExcludedComments.SomeLambda) -> RefHolder {
     let handle = smoke_ExcludedComments_SomeLambda_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping ExcludedComments.SomeLambda) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping ExcludedComments.SomeLambda) -> RefHolder {
     let handle = smoke_ExcludedComments_SomeLambda_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_ExcludedComments_SomeLambda_release_handle)
 }
-internal func copyToCType(_ swiftType: ExcludedComments.SomeLambda?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ExcludedComments.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_ExcludedComments_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: ExcludedComments.SomeLambda?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: ExcludedComments.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_ExcludedComments_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_ExcludedComments_SomeLambda_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct {
     return ExcludedComments.SomeStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct {
     defer {
         smoke_ExcludedComments_SomeStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ExcludedComments.SomeStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ExcludedComments.SomeStruct) -> RefHolder {
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_ExcludedComments_SomeStruct_create_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: ExcludedComments.SomeStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ExcludedComments_SomeStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: ExcludedComments.SomeStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_ExcludedComments_SomeStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_ExcludedComments_SomeStruct_unwrap_optional_handle(handle)
     return ExcludedComments.SomeStruct(cHandle: unwrappedHandle) as ExcludedComments.SomeStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct? {
     defer {
         smoke_ExcludedComments_SomeStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ExcludedComments.SomeStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ExcludedComments.SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_ExcludedComments_SomeStruct_create_optional_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: ExcludedComments.SomeStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ExcludedComments_SomeStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: ExcludedComments.SomeStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_ExcludedComments_SomeStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: ExcludedComments.SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: ExcludedComments.SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ExcludedComments.SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: ExcludedComments.SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: ExcludedComments.SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: ExcludedComments.SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ExcludedComments.SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: ExcludedComments.SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> ExcludedComments.SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> ExcludedComments.SomeEnum {
     return ExcludedComments.SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> ExcludedComments.SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> ExcludedComments.SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return ExcludedComments.SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 extension ExcludedComments.SomeEnum : Error {
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsInterface.swift
@@ -46,7 +46,7 @@ internal func getRef(_ ref: ExcludedCommentsInterface?, owning: Bool = true) -> 
 extension _ExcludedCommentsInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func ExcludedCommentsInterface_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsInterface {
+internal func foobar_ExcludedCommentsInterface_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsInterface {
     if let swift_pointer = smoke_ExcludedCommentsInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedCommentsInterface {
         return re_constructed
@@ -62,7 +62,7 @@ internal func ExcludedCommentsInterface_copyFromCType(_ handle: _baseRef) -> Exc
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ExcludedCommentsInterface_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsInterface {
+internal func foobar_ExcludedCommentsInterface_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsInterface {
     if let swift_pointer = smoke_ExcludedCommentsInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedCommentsInterface {
         smoke_ExcludedCommentsInterface_release_handle(handle)
@@ -80,27 +80,27 @@ internal func ExcludedCommentsInterface_moveFromCType(_ handle: _baseRef) -> Exc
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ExcludedCommentsInterface_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsInterface? {
+internal func foobar_ExcludedCommentsInterface_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ExcludedCommentsInterface_moveFromCType(handle) as ExcludedCommentsInterface
+    return foobar_ExcludedCommentsInterface_moveFromCType(handle) as ExcludedCommentsInterface
 }
-internal func ExcludedCommentsInterface_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsInterface? {
+internal func foobar_ExcludedCommentsInterface_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ExcludedCommentsInterface_moveFromCType(handle) as ExcludedCommentsInterface
+    return foobar_ExcludedCommentsInterface_moveFromCType(handle) as ExcludedCommentsInterface
 }
-internal func copyToCType(_ swiftClass: ExcludedCommentsInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ExcludedCommentsInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ExcludedCommentsInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ExcludedCommentsInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ExcludedCommentsInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ExcludedCommentsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ExcludedCommentsInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ExcludedCommentsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
@@ -57,7 +57,7 @@ public class ExcludedCommentsOnly {
         let c_inputParameter = moveToCType(inputParameter)
         let RESULT = smoke_ExcludedCommentsOnly_someMethodWithAllComments(self.c_instance, c_inputParameter.ref)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as ExcludedCommentsOnly.SomethingWrongError
+            throw foobar_moveFromCType(RESULT.error_value) as ExcludedCommentsOnly.SomethingWrongError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
@@ -88,7 +88,7 @@ extension ExcludedCommentsOnly: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func ExcludedCommentsOnly_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly {
+internal func foobar_ExcludedCommentsOnly_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly {
     if let swift_pointer = smoke_ExcludedCommentsOnly_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedCommentsOnly {
         return re_constructed
@@ -97,7 +97,7 @@ internal func ExcludedCommentsOnly_copyFromCType(_ handle: _baseRef) -> Excluded
     smoke_ExcludedCommentsOnly_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func ExcludedCommentsOnly_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly {
+internal func foobar_ExcludedCommentsOnly_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly {
     if let swift_pointer = smoke_ExcludedCommentsOnly_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExcludedCommentsOnly {
         smoke_ExcludedCommentsOnly_release_handle(handle)
@@ -107,50 +107,50 @@ internal func ExcludedCommentsOnly_moveFromCType(_ handle: _baseRef) -> Excluded
     smoke_ExcludedCommentsOnly_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func ExcludedCommentsOnly_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly? {
+internal func foobar_ExcludedCommentsOnly_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly? {
     guard handle != 0 else {
         return nil
     }
-    return ExcludedCommentsOnly_moveFromCType(handle) as ExcludedCommentsOnly
+    return foobar_ExcludedCommentsOnly_moveFromCType(handle) as ExcludedCommentsOnly
 }
-internal func ExcludedCommentsOnly_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly? {
+internal func foobar_ExcludedCommentsOnly_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly? {
     guard handle != 0 else {
         return nil
     }
-    return ExcludedCommentsOnly_moveFromCType(handle) as ExcludedCommentsOnly
+    return foobar_ExcludedCommentsOnly_moveFromCType(handle) as ExcludedCommentsOnly
 }
-internal func copyToCType(_ swiftClass: ExcludedCommentsOnly) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ExcludedCommentsOnly) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ExcludedCommentsOnly) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ExcludedCommentsOnly) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ExcludedCommentsOnly?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ExcludedCommentsOnly?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ExcludedCommentsOnly?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ExcludedCommentsOnly?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda {
-    return moveFromCType(smoke_ExcludedCommentsOnly_SomeLambda_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda {
+    return foobar_moveFromCType(smoke_ExcludedCommentsOnly_SomeLambda_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda {
     let refHolder = RefHolder(ref: handle, release: smoke_ExcludedCommentsOnly_SomeLambda_release_handle)
     return { (p0: String, p1: Int32) -> Double in
         return moveFromCType(smoke_ExcludedCommentsOnly_SomeLambda_call(refHolder.ref, moveToCType(p0).ref, moveToCType(p1).ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as ExcludedCommentsOnly.SomeLambda
+    return foobar_copyFromCType(handle) as ExcludedCommentsOnly.SomeLambda
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as ExcludedCommentsOnly.SomeLambda
+    return foobar_moveFromCType(handle) as ExcludedCommentsOnly.SomeLambda
 }
 internal func createFunctionalTable(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> smoke_ExcludedCommentsOnly_SomeLambda_FunctionTable {
     class smoke_ExcludedCommentsOnly_SomeLambda_Holder {
@@ -172,96 +172,96 @@ internal func createFunctionalTable(_ swiftType: @escaping ExcludedCommentsOnly.
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> RefHolder {
     let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> RefHolder {
     let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_ExcludedCommentsOnly_SomeLambda_release_handle)
 }
-internal func copyToCType(_ swiftType: ExcludedCommentsOnly.SomeLambda?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ExcludedCommentsOnly.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: ExcludedCommentsOnly.SomeLambda?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: ExcludedCommentsOnly.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_ExcludedCommentsOnly_SomeLambda_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct {
     return ExcludedCommentsOnly.SomeStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct {
     defer {
         smoke_ExcludedCommentsOnly_SomeStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ExcludedCommentsOnly.SomeStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ExcludedCommentsOnly.SomeStruct) -> RefHolder {
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_ExcludedCommentsOnly_SomeStruct_create_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: ExcludedCommentsOnly.SomeStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ExcludedCommentsOnly_SomeStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: ExcludedCommentsOnly.SomeStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_ExcludedCommentsOnly_SomeStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_ExcludedCommentsOnly_SomeStruct_unwrap_optional_handle(handle)
     return ExcludedCommentsOnly.SomeStruct(cHandle: unwrappedHandle) as ExcludedCommentsOnly.SomeStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct? {
     defer {
         smoke_ExcludedCommentsOnly_SomeStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ExcludedCommentsOnly.SomeStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ExcludedCommentsOnly.SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_ExcludedCommentsOnly_SomeStruct_create_optional_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: ExcludedCommentsOnly.SomeStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ExcludedCommentsOnly_SomeStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: ExcludedCommentsOnly.SomeStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_ExcludedCommentsOnly_SomeStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: ExcludedCommentsOnly.SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: ExcludedCommentsOnly.SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ExcludedCommentsOnly.SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: ExcludedCommentsOnly.SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: ExcludedCommentsOnly.SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: ExcludedCommentsOnly.SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ExcludedCommentsOnly.SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: ExcludedCommentsOnly.SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> ExcludedCommentsOnly.SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> ExcludedCommentsOnly.SomeEnum {
     return ExcludedCommentsOnly.SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> ExcludedCommentsOnly.SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> ExcludedCommentsOnly.SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return ExcludedCommentsOnly.SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 extension ExcludedCommentsOnly.SomeEnum : Error {
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/LongComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/LongComments.swift
@@ -45,7 +45,7 @@ extension LongComments: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func LongComments_copyFromCType(_ handle: _baseRef) -> LongComments {
+internal func foobar_LongComments_copyFromCType(_ handle: _baseRef) -> LongComments {
     if let swift_pointer = smoke_LongComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LongComments {
         return re_constructed
@@ -54,7 +54,7 @@ internal func LongComments_copyFromCType(_ handle: _baseRef) -> LongComments {
     smoke_LongComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func LongComments_moveFromCType(_ handle: _baseRef) -> LongComments {
+internal func foobar_LongComments_moveFromCType(_ handle: _baseRef) -> LongComments {
     if let swift_pointer = smoke_LongComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LongComments {
         smoke_LongComments_release_handle(handle)
@@ -64,27 +64,27 @@ internal func LongComments_moveFromCType(_ handle: _baseRef) -> LongComments {
     smoke_LongComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func LongComments_copyFromCType(_ handle: _baseRef) -> LongComments? {
+internal func foobar_LongComments_copyFromCType(_ handle: _baseRef) -> LongComments? {
     guard handle != 0 else {
         return nil
     }
-    return LongComments_moveFromCType(handle) as LongComments
+    return foobar_LongComments_moveFromCType(handle) as LongComments
 }
-internal func LongComments_moveFromCType(_ handle: _baseRef) -> LongComments? {
+internal func foobar_LongComments_moveFromCType(_ handle: _baseRef) -> LongComments? {
     guard handle != 0 else {
         return nil
     }
-    return LongComments_moveFromCType(handle) as LongComments
+    return foobar_LongComments_moveFromCType(handle) as LongComments
 }
-internal func copyToCType(_ swiftClass: LongComments) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: LongComments) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: LongComments) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: LongComments) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: LongComments?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: LongComments?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: LongComments?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: LongComments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MultiLineComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MultiLineComments.swift
@@ -66,7 +66,7 @@ extension MultiLineComments: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func MultiLineComments_copyFromCType(_ handle: _baseRef) -> MultiLineComments {
+internal func foobar_MultiLineComments_copyFromCType(_ handle: _baseRef) -> MultiLineComments {
     if let swift_pointer = smoke_MultiLineComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MultiLineComments {
         return re_constructed
@@ -75,7 +75,7 @@ internal func MultiLineComments_copyFromCType(_ handle: _baseRef) -> MultiLineCo
     smoke_MultiLineComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func MultiLineComments_moveFromCType(_ handle: _baseRef) -> MultiLineComments {
+internal func foobar_MultiLineComments_moveFromCType(_ handle: _baseRef) -> MultiLineComments {
     if let swift_pointer = smoke_MultiLineComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MultiLineComments {
         smoke_MultiLineComments_release_handle(handle)
@@ -85,27 +85,27 @@ internal func MultiLineComments_moveFromCType(_ handle: _baseRef) -> MultiLineCo
     smoke_MultiLineComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func MultiLineComments_copyFromCType(_ handle: _baseRef) -> MultiLineComments? {
+internal func foobar_MultiLineComments_copyFromCType(_ handle: _baseRef) -> MultiLineComments? {
     guard handle != 0 else {
         return nil
     }
-    return MultiLineComments_moveFromCType(handle) as MultiLineComments
+    return foobar_MultiLineComments_moveFromCType(handle) as MultiLineComments
 }
-internal func MultiLineComments_moveFromCType(_ handle: _baseRef) -> MultiLineComments? {
+internal func foobar_MultiLineComments_moveFromCType(_ handle: _baseRef) -> MultiLineComments? {
     guard handle != 0 else {
         return nil
     }
-    return MultiLineComments_moveFromCType(handle) as MultiLineComments
+    return foobar_MultiLineComments_moveFromCType(handle) as MultiLineComments
 }
-internal func copyToCType(_ swiftClass: MultiLineComments) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: MultiLineComments) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: MultiLineComments) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: MultiLineComments) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: MultiLineComments?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: MultiLineComments?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: MultiLineComments?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: MultiLineComments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
@@ -45,7 +45,7 @@ public class PlatformComments {
         let c_input = moveToCType(input)
         let RESULT = smoke_PlatformComments_someMethodWithAllComments(self.c_instance, c_input.ref)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as PlatformComments.SomethingWrongError
+            throw foobar_moveFromCType(RESULT.error_value) as PlatformComments.SomethingWrongError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
@@ -76,7 +76,7 @@ extension PlatformComments: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func PlatformComments_copyFromCType(_ handle: _baseRef) -> PlatformComments {
+internal func foobar_PlatformComments_copyFromCType(_ handle: _baseRef) -> PlatformComments {
     if let swift_pointer = smoke_PlatformComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PlatformComments {
         return re_constructed
@@ -85,7 +85,7 @@ internal func PlatformComments_copyFromCType(_ handle: _baseRef) -> PlatformComm
     smoke_PlatformComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func PlatformComments_moveFromCType(_ handle: _baseRef) -> PlatformComments {
+internal func foobar_PlatformComments_moveFromCType(_ handle: _baseRef) -> PlatformComments {
     if let swift_pointer = smoke_PlatformComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PlatformComments {
         smoke_PlatformComments_release_handle(handle)
@@ -95,98 +95,98 @@ internal func PlatformComments_moveFromCType(_ handle: _baseRef) -> PlatformComm
     smoke_PlatformComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func PlatformComments_copyFromCType(_ handle: _baseRef) -> PlatformComments? {
+internal func foobar_PlatformComments_copyFromCType(_ handle: _baseRef) -> PlatformComments? {
     guard handle != 0 else {
         return nil
     }
-    return PlatformComments_moveFromCType(handle) as PlatformComments
+    return foobar_PlatformComments_moveFromCType(handle) as PlatformComments
 }
-internal func PlatformComments_moveFromCType(_ handle: _baseRef) -> PlatformComments? {
+internal func foobar_PlatformComments_moveFromCType(_ handle: _baseRef) -> PlatformComments? {
     guard handle != 0 else {
         return nil
     }
-    return PlatformComments_moveFromCType(handle) as PlatformComments
+    return foobar_PlatformComments_moveFromCType(handle) as PlatformComments
 }
-internal func copyToCType(_ swiftClass: PlatformComments) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: PlatformComments) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: PlatformComments) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: PlatformComments) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: PlatformComments?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: PlatformComments?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: PlatformComments?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: PlatformComments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> PlatformComments.Something {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> PlatformComments.Something {
     return PlatformComments.Something(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> PlatformComments.Something {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> PlatformComments.Something {
     defer {
         smoke_PlatformComments_Something_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: PlatformComments.Something) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: PlatformComments.Something) -> RefHolder {
     let c_nothing = moveToCType(swiftType.nothing)
     return RefHolder(smoke_PlatformComments_Something_create_handle(c_nothing.ref))
 }
-internal func moveToCType(_ swiftType: PlatformComments.Something) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PlatformComments_Something_release_handle)
+internal func foobar_moveToCType(_ swiftType: PlatformComments.Something) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PlatformComments_Something_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> PlatformComments.Something? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> PlatformComments.Something? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_PlatformComments_Something_unwrap_optional_handle(handle)
     return PlatformComments.Something(cHandle: unwrappedHandle) as PlatformComments.Something
 }
-internal func moveFromCType(_ handle: _baseRef) -> PlatformComments.Something? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> PlatformComments.Something? {
     defer {
         smoke_PlatformComments_Something_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: PlatformComments.Something?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: PlatformComments.Something?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_nothing = moveToCType(swiftType.nothing)
     return RefHolder(smoke_PlatformComments_Something_create_optional_handle(c_nothing.ref))
 }
-internal func moveToCType(_ swiftType: PlatformComments.Something?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PlatformComments_Something_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: PlatformComments.Something?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PlatformComments_Something_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: PlatformComments.SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: PlatformComments.SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: PlatformComments.SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: PlatformComments.SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: PlatformComments.SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: PlatformComments.SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: PlatformComments.SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: PlatformComments.SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> PlatformComments.SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> PlatformComments.SomeEnum {
     return PlatformComments.SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> PlatformComments.SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> PlatformComments.SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> PlatformComments.SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> PlatformComments.SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return PlatformComments.SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> PlatformComments.SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> PlatformComments.SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 extension PlatformComments.SomeEnum : Error {
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/UnicodeComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/UnicodeComments.swift
@@ -21,7 +21,7 @@ public class UnicodeComments {
         let c_input = moveToCType(input)
         let RESULT = smoke_UnicodeComments_someMethodWithAllComments(self.c_instance, c_input.ref)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as Comments.SomethingWrongError
+            throw foobar_moveFromCType(RESULT.error_value) as Comments.SomethingWrongError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
@@ -47,7 +47,7 @@ extension UnicodeComments: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func UnicodeComments_copyFromCType(_ handle: _baseRef) -> UnicodeComments {
+internal func foobar_UnicodeComments_copyFromCType(_ handle: _baseRef) -> UnicodeComments {
     if let swift_pointer = smoke_UnicodeComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UnicodeComments {
         return re_constructed
@@ -56,7 +56,7 @@ internal func UnicodeComments_copyFromCType(_ handle: _baseRef) -> UnicodeCommen
     smoke_UnicodeComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func UnicodeComments_moveFromCType(_ handle: _baseRef) -> UnicodeComments {
+internal func foobar_UnicodeComments_moveFromCType(_ handle: _baseRef) -> UnicodeComments {
     if let swift_pointer = smoke_UnicodeComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UnicodeComments {
         smoke_UnicodeComments_release_handle(handle)
@@ -66,27 +66,27 @@ internal func UnicodeComments_moveFromCType(_ handle: _baseRef) -> UnicodeCommen
     smoke_UnicodeComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func UnicodeComments_copyFromCType(_ handle: _baseRef) -> UnicodeComments? {
+internal func foobar_UnicodeComments_copyFromCType(_ handle: _baseRef) -> UnicodeComments? {
     guard handle != 0 else {
         return nil
     }
-    return UnicodeComments_moveFromCType(handle) as UnicodeComments
+    return foobar_UnicodeComments_moveFromCType(handle) as UnicodeComments
 }
-internal func UnicodeComments_moveFromCType(_ handle: _baseRef) -> UnicodeComments? {
+internal func foobar_UnicodeComments_moveFromCType(_ handle: _baseRef) -> UnicodeComments? {
     guard handle != 0 else {
         return nil
     }
-    return UnicodeComments_moveFromCType(handle) as UnicodeComments
+    return foobar_UnicodeComments_moveFromCType(handle) as UnicodeComments
 }
-internal func copyToCType(_ swiftClass: UnicodeComments) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: UnicodeComments) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: UnicodeComments) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: UnicodeComments) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: UnicodeComments?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: UnicodeComments?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: UnicodeComments?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: UnicodeComments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/CollectionConstants.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/CollectionConstants.swift
@@ -38,7 +38,7 @@ extension CollectionConstants: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func CollectionConstants_copyFromCType(_ handle: _baseRef) -> CollectionConstants {
+internal func foobar_CollectionConstants_copyFromCType(_ handle: _baseRef) -> CollectionConstants {
     if let swift_pointer = smoke_CollectionConstants_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CollectionConstants {
         return re_constructed
@@ -47,7 +47,7 @@ internal func CollectionConstants_copyFromCType(_ handle: _baseRef) -> Collectio
     smoke_CollectionConstants_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func CollectionConstants_moveFromCType(_ handle: _baseRef) -> CollectionConstants {
+internal func foobar_CollectionConstants_moveFromCType(_ handle: _baseRef) -> CollectionConstants {
     if let swift_pointer = smoke_CollectionConstants_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CollectionConstants {
         smoke_CollectionConstants_release_handle(handle)
@@ -57,27 +57,27 @@ internal func CollectionConstants_moveFromCType(_ handle: _baseRef) -> Collectio
     smoke_CollectionConstants_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func CollectionConstants_copyFromCType(_ handle: _baseRef) -> CollectionConstants? {
+internal func foobar_CollectionConstants_copyFromCType(_ handle: _baseRef) -> CollectionConstants? {
     guard handle != 0 else {
         return nil
     }
-    return CollectionConstants_moveFromCType(handle) as CollectionConstants
+    return foobar_CollectionConstants_moveFromCType(handle) as CollectionConstants
 }
-internal func CollectionConstants_moveFromCType(_ handle: _baseRef) -> CollectionConstants? {
+internal func foobar_CollectionConstants_moveFromCType(_ handle: _baseRef) -> CollectionConstants? {
     guard handle != 0 else {
         return nil
     }
-    return CollectionConstants_moveFromCType(handle) as CollectionConstants
+    return foobar_CollectionConstants_moveFromCType(handle) as CollectionConstants
 }
-internal func copyToCType(_ swiftClass: CollectionConstants) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: CollectionConstants) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: CollectionConstants) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: CollectionConstants) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: CollectionConstants?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: CollectionConstants?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: CollectionConstants?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: CollectionConstants?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/Constants.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/Constants.swift
@@ -1,40 +1,39 @@
 //
 //
-
 import Foundation
 public enum StateEnum : UInt32, CaseIterable, Codable {
     case off
     case on
 }
-internal func copyToCType(_ swiftEnum: StateEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: StateEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: StateEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: StateEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: StateEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: StateEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: StateEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: StateEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> StateEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> StateEnum {
     return StateEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> StateEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> StateEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> StateEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StateEnum? {
     guard handle != 0 else {
         return nil
     }
     return StateEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> StateEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StateEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 public struct Constants {
     public static let boolConstant: Bool = true

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/ConstantsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/ConstantsInterface.swift
@@ -45,7 +45,7 @@ extension ConstantsInterface: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func ConstantsInterface_copyFromCType(_ handle: _baseRef) -> ConstantsInterface {
+internal func foobar_ConstantsInterface_copyFromCType(_ handle: _baseRef) -> ConstantsInterface {
     if let swift_pointer = smoke_ConstantsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ConstantsInterface {
         return re_constructed
@@ -54,7 +54,7 @@ internal func ConstantsInterface_copyFromCType(_ handle: _baseRef) -> ConstantsI
     smoke_ConstantsInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func ConstantsInterface_moveFromCType(_ handle: _baseRef) -> ConstantsInterface {
+internal func foobar_ConstantsInterface_moveFromCType(_ handle: _baseRef) -> ConstantsInterface {
     if let swift_pointer = smoke_ConstantsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ConstantsInterface {
         smoke_ConstantsInterface_release_handle(handle)
@@ -64,57 +64,57 @@ internal func ConstantsInterface_moveFromCType(_ handle: _baseRef) -> ConstantsI
     smoke_ConstantsInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func ConstantsInterface_copyFromCType(_ handle: _baseRef) -> ConstantsInterface? {
+internal func foobar_ConstantsInterface_copyFromCType(_ handle: _baseRef) -> ConstantsInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ConstantsInterface_moveFromCType(handle) as ConstantsInterface
+    return foobar_ConstantsInterface_moveFromCType(handle) as ConstantsInterface
 }
-internal func ConstantsInterface_moveFromCType(_ handle: _baseRef) -> ConstantsInterface? {
+internal func foobar_ConstantsInterface_moveFromCType(_ handle: _baseRef) -> ConstantsInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ConstantsInterface_moveFromCType(handle) as ConstantsInterface
+    return foobar_ConstantsInterface_moveFromCType(handle) as ConstantsInterface
 }
-internal func copyToCType(_ swiftClass: ConstantsInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ConstantsInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ConstantsInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ConstantsInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ConstantsInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ConstantsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ConstantsInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ConstantsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftEnum: ConstantsInterface.StateEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: ConstantsInterface.StateEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ConstantsInterface.StateEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: ConstantsInterface.StateEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: ConstantsInterface.StateEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: ConstantsInterface.StateEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ConstantsInterface.StateEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: ConstantsInterface.StateEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> ConstantsInterface.StateEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> ConstantsInterface.StateEnum {
     return ConstantsInterface.StateEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> ConstantsInterface.StateEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> ConstantsInterface.StateEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ConstantsInterface.StateEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ConstantsInterface.StateEnum? {
     guard handle != 0 else {
         return nil
     }
     return ConstantsInterface.StateEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> ConstantsInterface.StateEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ConstantsInterface.StateEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/StructConstants.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/StructConstants.swift
@@ -33,7 +33,7 @@ public class StructConstants {
             self.structField = structField
         }
         internal init(cHandle: _baseRef) {
-            structField = moveFromCType(smoke_StructConstants_NestingStruct_structField_get(cHandle))
+            structField = foobar_moveFromCType(smoke_StructConstants_NestingStruct_structField_get(cHandle))
         }
     }
 }
@@ -57,7 +57,7 @@ extension StructConstants: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func StructConstants_copyFromCType(_ handle: _baseRef) -> StructConstants {
+internal func foobar_StructConstants_copyFromCType(_ handle: _baseRef) -> StructConstants {
     if let swift_pointer = smoke_StructConstants_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructConstants {
         return re_constructed
@@ -66,7 +66,7 @@ internal func StructConstants_copyFromCType(_ handle: _baseRef) -> StructConstan
     smoke_StructConstants_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func StructConstants_moveFromCType(_ handle: _baseRef) -> StructConstants {
+internal func foobar_StructConstants_moveFromCType(_ handle: _baseRef) -> StructConstants {
     if let swift_pointer = smoke_StructConstants_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructConstants {
         smoke_StructConstants_release_handle(handle)
@@ -76,61 +76,61 @@ internal func StructConstants_moveFromCType(_ handle: _baseRef) -> StructConstan
     smoke_StructConstants_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func StructConstants_copyFromCType(_ handle: _baseRef) -> StructConstants? {
+internal func foobar_StructConstants_copyFromCType(_ handle: _baseRef) -> StructConstants? {
     guard handle != 0 else {
         return nil
     }
-    return StructConstants_moveFromCType(handle) as StructConstants
+    return foobar_StructConstants_moveFromCType(handle) as StructConstants
 }
-internal func StructConstants_moveFromCType(_ handle: _baseRef) -> StructConstants? {
+internal func foobar_StructConstants_moveFromCType(_ handle: _baseRef) -> StructConstants? {
     guard handle != 0 else {
         return nil
     }
-    return StructConstants_moveFromCType(handle) as StructConstants
+    return foobar_StructConstants_moveFromCType(handle) as StructConstants
 }
-internal func copyToCType(_ swiftClass: StructConstants) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: StructConstants) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: StructConstants) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: StructConstants) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: StructConstants?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: StructConstants?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: StructConstants?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: StructConstants?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructConstants.SomeStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructConstants.SomeStruct {
     return StructConstants.SomeStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructConstants.SomeStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructConstants.SomeStruct {
     defer {
         smoke_StructConstants_SomeStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructConstants.SomeStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: StructConstants.SomeStruct) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     let c_floatField = moveToCType(swiftType.floatField)
     return RefHolder(smoke_StructConstants_SomeStruct_create_handle(c_stringField.ref, c_floatField.ref))
 }
-internal func moveToCType(_ swiftType: StructConstants.SomeStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructConstants_SomeStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: StructConstants.SomeStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructConstants_SomeStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructConstants.SomeStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructConstants.SomeStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_StructConstants_SomeStruct_unwrap_optional_handle(handle)
     return StructConstants.SomeStruct(cHandle: unwrappedHandle) as StructConstants.SomeStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructConstants.SomeStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructConstants.SomeStruct? {
     defer {
         smoke_StructConstants_SomeStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructConstants.SomeStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: StructConstants.SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -138,45 +138,45 @@ internal func copyToCType(_ swiftType: StructConstants.SomeStruct?) -> RefHolder
     let c_floatField = moveToCType(swiftType.floatField)
     return RefHolder(smoke_StructConstants_SomeStruct_create_optional_handle(c_stringField.ref, c_floatField.ref))
 }
-internal func moveToCType(_ swiftType: StructConstants.SomeStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructConstants_SomeStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: StructConstants.SomeStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructConstants_SomeStruct_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructConstants.NestingStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructConstants.NestingStruct {
     return StructConstants.NestingStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructConstants.NestingStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructConstants.NestingStruct {
     defer {
         smoke_StructConstants_NestingStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructConstants.NestingStruct) -> RefHolder {
-    let c_structField = moveToCType(swiftType.structField)
+internal func foobar_copyToCType(_ swiftType: StructConstants.NestingStruct) -> RefHolder {
+    let c_structField = foobar_moveToCType(swiftType.structField)
     return RefHolder(smoke_StructConstants_NestingStruct_create_handle(c_structField.ref))
 }
-internal func moveToCType(_ swiftType: StructConstants.NestingStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructConstants_NestingStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: StructConstants.NestingStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructConstants_NestingStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructConstants.NestingStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructConstants.NestingStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_StructConstants_NestingStruct_unwrap_optional_handle(handle)
     return StructConstants.NestingStruct(cHandle: unwrappedHandle) as StructConstants.NestingStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructConstants.NestingStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructConstants.NestingStruct? {
     defer {
         smoke_StructConstants_NestingStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructConstants.NestingStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: StructConstants.NestingStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_structField = moveToCType(swiftType.structField)
+    let c_structField = foobar_moveToCType(swiftType.structField)
     return RefHolder(smoke_StructConstants_NestingStruct_create_optional_handle(c_structField.ref))
 }
-internal func moveToCType(_ swiftType: StructConstants.NestingStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructConstants_NestingStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: StructConstants.NestingStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructConstants_NestingStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/ChildConstructors.swift
+++ b/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/ChildConstructors.swift
@@ -19,7 +19,7 @@ public class ChildConstructors: Constructors {
         return moveFromCType(smoke_ChildConstructors_create_())
     }
     private static func create(other: Constructors) -> _baseRef {
-        let c_other = moveToCType(other)
+        let c_other = foobar_moveToCType(other)
         return moveFromCType(smoke_ChildConstructors_create_Constructors(c_other.ref))
     }
 }
@@ -37,7 +37,7 @@ internal func getRef(_ ref: ChildConstructors?, owning: Bool = true) -> RefHolde
         ? RefHolder(ref: handle_copy, release: smoke_ChildConstructors_release_handle)
         : RefHolder(handle_copy)
 }
-internal func ChildConstructors_copyFromCType(_ handle: _baseRef) -> ChildConstructors {
+internal func foobar_ChildConstructors_copyFromCType(_ handle: _baseRef) -> ChildConstructors {
     if let swift_pointer = smoke_ChildConstructors_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildConstructors {
         return re_constructed
@@ -49,7 +49,7 @@ internal func ChildConstructors_copyFromCType(_ handle: _baseRef) -> ChildConstr
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ChildConstructors_moveFromCType(_ handle: _baseRef) -> ChildConstructors {
+internal func foobar_ChildConstructors_moveFromCType(_ handle: _baseRef) -> ChildConstructors {
     if let swift_pointer = smoke_ChildConstructors_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildConstructors {
         smoke_ChildConstructors_release_handle(handle)
@@ -62,27 +62,27 @@ internal func ChildConstructors_moveFromCType(_ handle: _baseRef) -> ChildConstr
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ChildConstructors_copyFromCType(_ handle: _baseRef) -> ChildConstructors? {
+internal func foobar_ChildConstructors_copyFromCType(_ handle: _baseRef) -> ChildConstructors? {
     guard handle != 0 else {
         return nil
     }
-    return ChildConstructors_moveFromCType(handle) as ChildConstructors
+    return foobar_ChildConstructors_moveFromCType(handle) as ChildConstructors
 }
-internal func ChildConstructors_moveFromCType(_ handle: _baseRef) -> ChildConstructors? {
+internal func foobar_ChildConstructors_moveFromCType(_ handle: _baseRef) -> ChildConstructors? {
     guard handle != 0 else {
         return nil
     }
-    return ChildConstructors_moveFromCType(handle) as ChildConstructors
+    return foobar_ChildConstructors_moveFromCType(handle) as ChildConstructors
 }
-internal func copyToCType(_ swiftClass: ChildConstructors) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ChildConstructors) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ChildConstructors) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ChildConstructors) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ChildConstructors?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ChildConstructors?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ChildConstructors?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ChildConstructors?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/Constructors.swift
+++ b/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/Constructors.swift
@@ -62,7 +62,7 @@ public class Constructors {
         return moveFromCType(smoke_Constructors_create_())
     }
     private static func create(other: Constructors) -> _baseRef {
-        let c_other = moveToCType(other)
+        let c_other = foobar_moveToCType(other)
         return moveFromCType(smoke_Constructors_create_Constructors(c_other.ref))
     }
     private static func create(foo: String, bar: UInt64) -> _baseRef {
@@ -74,7 +74,7 @@ public class Constructors {
         let c_input = moveToCType(input)
         let RESULT = smoke_Constructors_create_String(c_input.ref)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as Constructors.ConstructorExplodedError
+            throw foobar_moveFromCType(RESULT.error_value) as Constructors.ConstructorExplodedError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
@@ -109,7 +109,7 @@ extension Constructors: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Constructors_copyFromCType(_ handle: _baseRef) -> Constructors {
+internal func foobar_Constructors_copyFromCType(_ handle: _baseRef) -> Constructors {
     if let swift_pointer = smoke_Constructors_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Constructors {
         return re_constructed
@@ -121,7 +121,7 @@ internal func Constructors_copyFromCType(_ handle: _baseRef) -> Constructors {
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func Constructors_moveFromCType(_ handle: _baseRef) -> Constructors {
+internal func foobar_Constructors_moveFromCType(_ handle: _baseRef) -> Constructors {
     if let swift_pointer = smoke_Constructors_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Constructors {
         smoke_Constructors_release_handle(handle)
@@ -134,59 +134,59 @@ internal func Constructors_moveFromCType(_ handle: _baseRef) -> Constructors {
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func Constructors_copyFromCType(_ handle: _baseRef) -> Constructors? {
+internal func foobar_Constructors_copyFromCType(_ handle: _baseRef) -> Constructors? {
     guard handle != 0 else {
         return nil
     }
-    return Constructors_moveFromCType(handle) as Constructors
+    return foobar_Constructors_moveFromCType(handle) as Constructors
 }
-internal func Constructors_moveFromCType(_ handle: _baseRef) -> Constructors? {
+internal func foobar_Constructors_moveFromCType(_ handle: _baseRef) -> Constructors? {
     guard handle != 0 else {
         return nil
     }
-    return Constructors_moveFromCType(handle) as Constructors
+    return foobar_Constructors_moveFromCType(handle) as Constructors
 }
-internal func copyToCType(_ swiftClass: Constructors) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Constructors) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Constructors) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Constructors) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Constructors?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Constructors?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Constructors?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Constructors?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftEnum: Constructors.ErrorEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Constructors.ErrorEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Constructors.ErrorEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Constructors.ErrorEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Constructors.ErrorEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Constructors.ErrorEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Constructors.ErrorEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Constructors.ErrorEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Constructors.ErrorEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Constructors.ErrorEnum {
     return Constructors.ErrorEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Constructors.ErrorEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Constructors.ErrorEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Constructors.ErrorEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Constructors.ErrorEnum? {
     guard handle != 0 else {
         return nil
     }
     return Constructors.ErrorEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Constructors.ErrorEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Constructors.ErrorEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 extension Constructors.ErrorEnum : Error {
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/Dates.swift
+++ b/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/Dates.swift
@@ -59,7 +59,7 @@ extension Dates: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Dates_copyFromCType(_ handle: _baseRef) -> Dates {
+internal func foobar_Dates_copyFromCType(_ handle: _baseRef) -> Dates {
     if let swift_pointer = smoke_Dates_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Dates {
         return re_constructed
@@ -68,7 +68,7 @@ internal func Dates_copyFromCType(_ handle: _baseRef) -> Dates {
     smoke_Dates_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Dates_moveFromCType(_ handle: _baseRef) -> Dates {
+internal func foobar_Dates_moveFromCType(_ handle: _baseRef) -> Dates {
     if let swift_pointer = smoke_Dates_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Dates {
         smoke_Dates_release_handle(handle)
@@ -78,66 +78,66 @@ internal func Dates_moveFromCType(_ handle: _baseRef) -> Dates {
     smoke_Dates_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Dates_copyFromCType(_ handle: _baseRef) -> Dates? {
+internal func foobar_Dates_copyFromCType(_ handle: _baseRef) -> Dates? {
     guard handle != 0 else {
         return nil
     }
-    return Dates_moveFromCType(handle) as Dates
+    return foobar_Dates_moveFromCType(handle) as Dates
 }
-internal func Dates_moveFromCType(_ handle: _baseRef) -> Dates? {
+internal func foobar_Dates_moveFromCType(_ handle: _baseRef) -> Dates? {
     guard handle != 0 else {
         return nil
     }
-    return Dates_moveFromCType(handle) as Dates
+    return foobar_Dates_moveFromCType(handle) as Dates
 }
-internal func copyToCType(_ swiftClass: Dates) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Dates) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Dates) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Dates) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Dates?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Dates?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Dates?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Dates?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Dates.DateStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Dates.DateStruct {
     return Dates.DateStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Dates.DateStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Dates.DateStruct {
     defer {
         smoke_Dates_DateStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Dates.DateStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Dates.DateStruct) -> RefHolder {
     let c_dateField = moveToCType(swiftType.dateField)
     return RefHolder(smoke_Dates_DateStruct_create_handle(c_dateField.ref))
 }
-internal func moveToCType(_ swiftType: Dates.DateStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Dates_DateStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Dates.DateStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Dates_DateStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Dates.DateStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Dates.DateStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Dates_DateStruct_unwrap_optional_handle(handle)
     return Dates.DateStruct(cHandle: unwrappedHandle) as Dates.DateStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Dates.DateStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Dates.DateStruct? {
     defer {
         smoke_Dates_DateStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Dates.DateStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Dates.DateStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_dateField = moveToCType(swiftType.dateField)
     return RefHolder(smoke_Dates_DateStruct_create_optional_handle(c_dateField.ref))
 }
-internal func moveToCType(_ swiftType: Dates.DateStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Dates_DateStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Dates.DateStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Dates_DateStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/Enums.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/Enums.swift
@@ -30,26 +30,26 @@ public class Enums {
             self.message = message
         }
         internal init(cHandle: _baseRef) {
-            type = moveFromCType(smoke_Enums_ErrorStruct_type_get(cHandle))
+            type = foobar_moveFromCType(smoke_Enums_ErrorStruct_type_get(cHandle))
             message = moveFromCType(smoke_Enums_ErrorStruct_message_get(cHandle))
         }
     }
     public static func methodWithEnumeration(input: Enums.SimpleEnum) -> Enums.SimpleEnum {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_Enums_methodWithEnumeration(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_Enums_methodWithEnumeration(c_input.ref))
     }
     public static func flipEnumValue(input: Enums.InternalErrorCode) -> Enums.InternalErrorCode {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_Enums_flipEnumValue(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_Enums_flipEnumValue(c_input.ref))
     }
     public static func extractEnumFromStruct(input: Enums.ErrorStruct) -> Enums.InternalErrorCode {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_Enums_extractEnumFromStruct(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_Enums_extractEnumFromStruct(c_input.ref))
     }
     public static func createStructWithEnumInside(type: Enums.InternalErrorCode, message: String) -> Enums.ErrorStruct {
-        let c_type = moveToCType(type)
+        let c_type = foobar_moveToCType(type)
         let c_message = moveToCType(message)
-        return moveFromCType(smoke_Enums_createStructWithEnumInside(c_type.ref, c_message.ref))
+        return foobar_moveFromCType(smoke_Enums_createStructWithEnumInside(c_type.ref, c_message.ref))
     }
 }
 internal func getRef(_ ref: Enums?, owning: Bool = true) -> RefHolder {
@@ -72,7 +72,7 @@ extension Enums: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Enums_copyFromCType(_ handle: _baseRef) -> Enums {
+internal func foobar_Enums_copyFromCType(_ handle: _baseRef) -> Enums {
     if let swift_pointer = smoke_Enums_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Enums {
         return re_constructed
@@ -81,7 +81,7 @@ internal func Enums_copyFromCType(_ handle: _baseRef) -> Enums {
     smoke_Enums_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Enums_moveFromCType(_ handle: _baseRef) -> Enums {
+internal func foobar_Enums_moveFromCType(_ handle: _baseRef) -> Enums {
     if let swift_pointer = smoke_Enums_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Enums {
         smoke_Enums_release_handle(handle)
@@ -91,128 +91,128 @@ internal func Enums_moveFromCType(_ handle: _baseRef) -> Enums {
     smoke_Enums_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Enums_copyFromCType(_ handle: _baseRef) -> Enums? {
+internal func foobar_Enums_copyFromCType(_ handle: _baseRef) -> Enums? {
     guard handle != 0 else {
         return nil
     }
-    return Enums_moveFromCType(handle) as Enums
+    return foobar_Enums_moveFromCType(handle) as Enums
 }
-internal func Enums_moveFromCType(_ handle: _baseRef) -> Enums? {
+internal func foobar_Enums_moveFromCType(_ handle: _baseRef) -> Enums? {
     guard handle != 0 else {
         return nil
     }
-    return Enums_moveFromCType(handle) as Enums
+    return foobar_Enums_moveFromCType(handle) as Enums
 }
-internal func copyToCType(_ swiftClass: Enums) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Enums) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Enums) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Enums) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Enums?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Enums?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Enums?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Enums?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Enums.ErrorStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Enums.ErrorStruct {
     return Enums.ErrorStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Enums.ErrorStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Enums.ErrorStruct {
     defer {
         smoke_Enums_ErrorStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Enums.ErrorStruct) -> RefHolder {
-    let c_type = moveToCType(swiftType.type)
+internal func foobar_copyToCType(_ swiftType: Enums.ErrorStruct) -> RefHolder {
+    let c_type = foobar_moveToCType(swiftType.type)
     let c_message = moveToCType(swiftType.message)
     return RefHolder(smoke_Enums_ErrorStruct_create_handle(c_type.ref, c_message.ref))
 }
-internal func moveToCType(_ swiftType: Enums.ErrorStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Enums_ErrorStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Enums.ErrorStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Enums_ErrorStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Enums.ErrorStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Enums.ErrorStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Enums_ErrorStruct_unwrap_optional_handle(handle)
     return Enums.ErrorStruct(cHandle: unwrappedHandle) as Enums.ErrorStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Enums.ErrorStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Enums.ErrorStruct? {
     defer {
         smoke_Enums_ErrorStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Enums.ErrorStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Enums.ErrorStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_type = moveToCType(swiftType.type)
+    let c_type = foobar_moveToCType(swiftType.type)
     let c_message = moveToCType(swiftType.message)
     return RefHolder(smoke_Enums_ErrorStruct_create_optional_handle(c_type.ref, c_message.ref))
 }
-internal func moveToCType(_ swiftType: Enums.ErrorStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Enums_ErrorStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Enums.ErrorStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Enums_ErrorStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: Enums.SimpleEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Enums.SimpleEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Enums.SimpleEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Enums.SimpleEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Enums.SimpleEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Enums.SimpleEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Enums.SimpleEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Enums.SimpleEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Enums.SimpleEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Enums.SimpleEnum {
     return Enums.SimpleEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Enums.SimpleEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Enums.SimpleEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Enums.SimpleEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Enums.SimpleEnum? {
     guard handle != 0 else {
         return nil
     }
     return Enums.SimpleEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Enums.SimpleEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Enums.SimpleEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftEnum: Enums.InternalErrorCode) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Enums.InternalErrorCode) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Enums.InternalErrorCode) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Enums.InternalErrorCode) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Enums.InternalErrorCode?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Enums.InternalErrorCode?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Enums.InternalErrorCode?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Enums.InternalErrorCode?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Enums.InternalErrorCode {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Enums.InternalErrorCode {
     return Enums.InternalErrorCode(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Enums.InternalErrorCode {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Enums.InternalErrorCode {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Enums.InternalErrorCode? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Enums.InternalErrorCode? {
     guard handle != 0 else {
         return nil
     }
     return Enums.InternalErrorCode(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Enums.InternalErrorCode? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Enums.InternalErrorCode? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumsInTypeCollection.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumsInTypeCollection.swift
@@ -1,38 +1,37 @@
 //
 //
-
 import Foundation
 public enum TCEnum : UInt32, CaseIterable, Codable {
     case first
     case second
 }
-internal func copyToCType(_ swiftEnum: TCEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: TCEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: TCEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: TCEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: TCEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: TCEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: TCEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: TCEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> TCEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> TCEnum {
     return TCEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> TCEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> TCEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> TCEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> TCEnum? {
     guard handle != 0 else {
         return nil
     }
     return TCEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> TCEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> TCEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumsInTypeCollectionInterface.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumsInTypeCollectionInterface.swift
@@ -14,8 +14,8 @@ public class EnumsInTypeCollectionInterface {
         smoke_EnumsInTypeCollectionInterface_release_handle(c_instance)
     }
     public static func flipEnumValue(input: TCEnum) -> TCEnum {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_EnumsInTypeCollectionInterface_flipEnumValue(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_EnumsInTypeCollectionInterface_flipEnumValue(c_input.ref))
     }
 }
 internal func getRef(_ ref: EnumsInTypeCollectionInterface?, owning: Bool = true) -> RefHolder {
@@ -38,7 +38,7 @@ extension EnumsInTypeCollectionInterface: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func EnumsInTypeCollectionInterface_copyFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface {
+internal func foobar_EnumsInTypeCollectionInterface_copyFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface {
     if let swift_pointer = smoke_EnumsInTypeCollectionInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EnumsInTypeCollectionInterface {
         return re_constructed
@@ -47,7 +47,7 @@ internal func EnumsInTypeCollectionInterface_copyFromCType(_ handle: _baseRef) -
     smoke_EnumsInTypeCollectionInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func EnumsInTypeCollectionInterface_moveFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface {
+internal func foobar_EnumsInTypeCollectionInterface_moveFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface {
     if let swift_pointer = smoke_EnumsInTypeCollectionInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EnumsInTypeCollectionInterface {
         smoke_EnumsInTypeCollectionInterface_release_handle(handle)
@@ -57,27 +57,27 @@ internal func EnumsInTypeCollectionInterface_moveFromCType(_ handle: _baseRef) -
     smoke_EnumsInTypeCollectionInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func EnumsInTypeCollectionInterface_copyFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface? {
+internal func foobar_EnumsInTypeCollectionInterface_copyFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface? {
     guard handle != 0 else {
         return nil
     }
-    return EnumsInTypeCollectionInterface_moveFromCType(handle) as EnumsInTypeCollectionInterface
+    return foobar_EnumsInTypeCollectionInterface_moveFromCType(handle) as EnumsInTypeCollectionInterface
 }
-internal func EnumsInTypeCollectionInterface_moveFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface? {
+internal func foobar_EnumsInTypeCollectionInterface_moveFromCType(_ handle: _baseRef) -> EnumsInTypeCollectionInterface? {
     guard handle != 0 else {
         return nil
     }
-    return EnumsInTypeCollectionInterface_moveFromCType(handle) as EnumsInTypeCollectionInterface
+    return foobar_EnumsInTypeCollectionInterface_moveFromCType(handle) as EnumsInTypeCollectionInterface
 }
-internal func copyToCType(_ swiftClass: EnumsInTypeCollectionInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: EnumsInTypeCollectionInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: EnumsInTypeCollectionInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: EnumsInTypeCollectionInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: EnumsInTypeCollectionInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: EnumsInTypeCollectionInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: EnumsInTypeCollectionInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: EnumsInTypeCollectionInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/Equatable.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/Equatable.swift
@@ -6,35 +6,35 @@ public enum SomeEnum : UInt32, CaseIterable, Codable {
     case foo
     case bar
 }
-internal func copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> SomeEnum {
     return SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 public struct EquatableStruct: Hashable {
     public var boolField: Bool
@@ -66,51 +66,51 @@ public struct EquatableStruct: Hashable {
         floatField = moveFromCType(smoke_Equatable_EquatableStruct_floatField_get(cHandle))
         doubleField = moveFromCType(smoke_Equatable_EquatableStruct_doubleField_get(cHandle))
         stringField = moveFromCType(smoke_Equatable_EquatableStruct_stringField_get(cHandle))
-        structField = moveFromCType(smoke_Equatable_EquatableStruct_structField_get(cHandle))
-        enumField = moveFromCType(smoke_Equatable_EquatableStruct_enumField_get(cHandle))
+        structField = foobar_moveFromCType(smoke_Equatable_EquatableStruct_structField_get(cHandle))
+        enumField = foobar_moveFromCType(smoke_Equatable_EquatableStruct_enumField_get(cHandle))
         arrayField = foobar_moveFromCType(smoke_Equatable_EquatableStruct_arrayField_get(cHandle))
         mapField = foobar_moveFromCType(smoke_Equatable_EquatableStruct_mapField_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> EquatableStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> EquatableStruct {
     return EquatableStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> EquatableStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> EquatableStruct {
     defer {
         smoke_Equatable_EquatableStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: EquatableStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: EquatableStruct) -> RefHolder {
     let c_boolField = moveToCType(swiftType.boolField)
     let c_intField = moveToCType(swiftType.intField)
     let c_longField = moveToCType(swiftType.longField)
     let c_floatField = moveToCType(swiftType.floatField)
     let c_doubleField = moveToCType(swiftType.doubleField)
     let c_stringField = moveToCType(swiftType.stringField)
-    let c_structField = moveToCType(swiftType.structField)
-    let c_enumField = moveToCType(swiftType.enumField)
+    let c_structField = foobar_moveToCType(swiftType.structField)
+    let c_enumField = foobar_moveToCType(swiftType.enumField)
     let c_arrayField = foobar_moveToCType(swiftType.arrayField)
     let c_mapField = foobar_moveToCType(swiftType.mapField)
     return RefHolder(smoke_Equatable_EquatableStruct_create_handle(c_boolField.ref, c_intField.ref, c_longField.ref, c_floatField.ref, c_doubleField.ref, c_stringField.ref, c_structField.ref, c_enumField.ref, c_arrayField.ref, c_mapField.ref))
 }
-internal func moveToCType(_ swiftType: EquatableStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Equatable_EquatableStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: EquatableStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Equatable_EquatableStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> EquatableStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> EquatableStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Equatable_EquatableStruct_unwrap_optional_handle(handle)
     return EquatableStruct(cHandle: unwrappedHandle) as EquatableStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> EquatableStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> EquatableStruct? {
     defer {
         smoke_Equatable_EquatableStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: EquatableStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: EquatableStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -120,14 +120,14 @@ internal func copyToCType(_ swiftType: EquatableStruct?) -> RefHolder {
     let c_floatField = moveToCType(swiftType.floatField)
     let c_doubleField = moveToCType(swiftType.doubleField)
     let c_stringField = moveToCType(swiftType.stringField)
-    let c_structField = moveToCType(swiftType.structField)
-    let c_enumField = moveToCType(swiftType.enumField)
+    let c_structField = foobar_moveToCType(swiftType.structField)
+    let c_enumField = foobar_moveToCType(swiftType.enumField)
     let c_arrayField = foobar_moveToCType(swiftType.arrayField)
     let c_mapField = foobar_moveToCType(swiftType.mapField)
     return RefHolder(smoke_Equatable_EquatableStruct_create_optional_handle(c_boolField.ref, c_intField.ref, c_longField.ref, c_floatField.ref, c_doubleField.ref, c_stringField.ref, c_structField.ref, c_enumField.ref, c_arrayField.ref, c_mapField.ref))
 }
-internal func moveToCType(_ swiftType: EquatableStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Equatable_EquatableStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: EquatableStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Equatable_EquatableStruct_release_optional_handle)
 }
 public struct EquatableNullableStruct: Hashable {
     public var boolField: Bool?
@@ -156,50 +156,50 @@ public struct EquatableNullableStruct: Hashable {
         uintField = moveFromCType(smoke_Equatable_EquatableNullableStruct_uintField_get(cHandle))
         floatField = moveFromCType(smoke_Equatable_EquatableNullableStruct_floatField_get(cHandle))
         stringField = moveFromCType(smoke_Equatable_EquatableNullableStruct_stringField_get(cHandle))
-        structField = moveFromCType(smoke_Equatable_EquatableNullableStruct_structField_get(cHandle))
-        enumField = moveFromCType(smoke_Equatable_EquatableNullableStruct_enumField_get(cHandle))
+        structField = foobar_moveFromCType(smoke_Equatable_EquatableNullableStruct_structField_get(cHandle))
+        enumField = foobar_moveFromCType(smoke_Equatable_EquatableNullableStruct_enumField_get(cHandle))
         arrayField = foobar_moveFromCType(smoke_Equatable_EquatableNullableStruct_arrayField_get(cHandle))
         mapField = foobar_moveFromCType(smoke_Equatable_EquatableNullableStruct_mapField_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> EquatableNullableStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> EquatableNullableStruct {
     return EquatableNullableStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> EquatableNullableStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> EquatableNullableStruct {
     defer {
         smoke_Equatable_EquatableNullableStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: EquatableNullableStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: EquatableNullableStruct) -> RefHolder {
     let c_boolField = moveToCType(swiftType.boolField)
     let c_intField = moveToCType(swiftType.intField)
     let c_uintField = moveToCType(swiftType.uintField)
     let c_floatField = moveToCType(swiftType.floatField)
     let c_stringField = moveToCType(swiftType.stringField)
-    let c_structField = moveToCType(swiftType.structField)
-    let c_enumField = moveToCType(swiftType.enumField)
+    let c_structField = foobar_moveToCType(swiftType.structField)
+    let c_enumField = foobar_moveToCType(swiftType.enumField)
     let c_arrayField = foobar_moveToCType(swiftType.arrayField)
     let c_mapField = foobar_moveToCType(swiftType.mapField)
     return RefHolder(smoke_Equatable_EquatableNullableStruct_create_handle(c_boolField.ref, c_intField.ref, c_uintField.ref, c_floatField.ref, c_stringField.ref, c_structField.ref, c_enumField.ref, c_arrayField.ref, c_mapField.ref))
 }
-internal func moveToCType(_ swiftType: EquatableNullableStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Equatable_EquatableNullableStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: EquatableNullableStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Equatable_EquatableNullableStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> EquatableNullableStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> EquatableNullableStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Equatable_EquatableNullableStruct_unwrap_optional_handle(handle)
     return EquatableNullableStruct(cHandle: unwrappedHandle) as EquatableNullableStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> EquatableNullableStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> EquatableNullableStruct? {
     defer {
         smoke_Equatable_EquatableNullableStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: EquatableNullableStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: EquatableNullableStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -208,14 +208,14 @@ internal func copyToCType(_ swiftType: EquatableNullableStruct?) -> RefHolder {
     let c_uintField = moveToCType(swiftType.uintField)
     let c_floatField = moveToCType(swiftType.floatField)
     let c_stringField = moveToCType(swiftType.stringField)
-    let c_structField = moveToCType(swiftType.structField)
-    let c_enumField = moveToCType(swiftType.enumField)
+    let c_structField = foobar_moveToCType(swiftType.structField)
+    let c_enumField = foobar_moveToCType(swiftType.enumField)
     let c_arrayField = foobar_moveToCType(swiftType.arrayField)
     let c_mapField = foobar_moveToCType(swiftType.mapField)
     return RefHolder(smoke_Equatable_EquatableNullableStruct_create_optional_handle(c_boolField.ref, c_intField.ref, c_uintField.ref, c_floatField.ref, c_stringField.ref, c_structField.ref, c_enumField.ref, c_arrayField.ref, c_mapField.ref))
 }
-internal func moveToCType(_ swiftType: EquatableNullableStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Equatable_EquatableNullableStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: EquatableNullableStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Equatable_EquatableNullableStruct_release_optional_handle)
 }
 public struct NestedEquatableStruct: Hashable {
     public var fooField: String
@@ -226,42 +226,42 @@ public struct NestedEquatableStruct: Hashable {
         fooField = moveFromCType(smoke_Equatable_NestedEquatableStruct_fooField_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> NestedEquatableStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> NestedEquatableStruct {
     return NestedEquatableStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> NestedEquatableStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> NestedEquatableStruct {
     defer {
         smoke_Equatable_NestedEquatableStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: NestedEquatableStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: NestedEquatableStruct) -> RefHolder {
     let c_fooField = moveToCType(swiftType.fooField)
     return RefHolder(smoke_Equatable_NestedEquatableStruct_create_handle(c_fooField.ref))
 }
-internal func moveToCType(_ swiftType: NestedEquatableStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Equatable_NestedEquatableStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: NestedEquatableStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Equatable_NestedEquatableStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> NestedEquatableStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> NestedEquatableStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Equatable_NestedEquatableStruct_unwrap_optional_handle(handle)
     return NestedEquatableStruct(cHandle: unwrappedHandle) as NestedEquatableStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> NestedEquatableStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> NestedEquatableStruct? {
     defer {
         smoke_Equatable_NestedEquatableStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: NestedEquatableStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: NestedEquatableStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_fooField = moveToCType(swiftType.fooField)
     return RefHolder(smoke_Equatable_NestedEquatableStruct_create_optional_handle(c_fooField.ref))
 }
-internal func moveToCType(_ swiftType: NestedEquatableStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Equatable_NestedEquatableStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: NestedEquatableStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Equatable_NestedEquatableStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableClass.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableClass.swift
@@ -27,8 +27,8 @@ public class EquatableClass {
         internal init(cHandle: _baseRef) {
             intField = moveFromCType(smoke_EquatableClass_EquatableStruct_intField_get(cHandle))
             stringField = moveFromCType(smoke_EquatableClass_EquatableStruct_stringField_get(cHandle))
-            nestedEquatableInstance = EquatableClass_moveFromCType(smoke_EquatableClass_EquatableStruct_nestedEquatableInstance_get(cHandle))
-            nestedPointerEquatableInstance = PointerEquatableClass_moveFromCType(smoke_EquatableClass_EquatableStruct_nestedPointerEquatableInstance_get(cHandle))
+            nestedEquatableInstance = foobar_EquatableClass_moveFromCType(smoke_EquatableClass_EquatableStruct_nestedEquatableInstance_get(cHandle))
+            nestedPointerEquatableInstance = foobar_PointerEquatableClass_moveFromCType(smoke_EquatableClass_EquatableStruct_nestedPointerEquatableInstance_get(cHandle))
         }
     }
 }
@@ -52,7 +52,7 @@ extension EquatableClass: Hashable {
         hasher.combine(smoke_EquatableClass_hash(c_handle))
     }
 }
-internal func EquatableClass_copyFromCType(_ handle: _baseRef) -> EquatableClass {
+internal func foobar_EquatableClass_copyFromCType(_ handle: _baseRef) -> EquatableClass {
     if let swift_pointer = smoke_EquatableClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableClass {
         return re_constructed
@@ -61,7 +61,7 @@ internal func EquatableClass_copyFromCType(_ handle: _baseRef) -> EquatableClass
     smoke_EquatableClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func EquatableClass_moveFromCType(_ handle: _baseRef) -> EquatableClass {
+internal func foobar_EquatableClass_moveFromCType(_ handle: _baseRef) -> EquatableClass {
     if let swift_pointer = smoke_EquatableClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableClass {
         smoke_EquatableClass_release_handle(handle)
@@ -71,72 +71,72 @@ internal func EquatableClass_moveFromCType(_ handle: _baseRef) -> EquatableClass
     smoke_EquatableClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func EquatableClass_copyFromCType(_ handle: _baseRef) -> EquatableClass? {
+internal func foobar_EquatableClass_copyFromCType(_ handle: _baseRef) -> EquatableClass? {
     guard handle != 0 else {
         return nil
     }
-    return EquatableClass_moveFromCType(handle) as EquatableClass
+    return foobar_EquatableClass_moveFromCType(handle) as EquatableClass
 }
-internal func EquatableClass_moveFromCType(_ handle: _baseRef) -> EquatableClass? {
+internal func foobar_EquatableClass_moveFromCType(_ handle: _baseRef) -> EquatableClass? {
     guard handle != 0 else {
         return nil
     }
-    return EquatableClass_moveFromCType(handle) as EquatableClass
+    return foobar_EquatableClass_moveFromCType(handle) as EquatableClass
 }
-internal func copyToCType(_ swiftClass: EquatableClass) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: EquatableClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: EquatableClass) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: EquatableClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: EquatableClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: EquatableClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: EquatableClass?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: EquatableClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> EquatableClass.EquatableStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> EquatableClass.EquatableStruct {
     return EquatableClass.EquatableStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> EquatableClass.EquatableStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> EquatableClass.EquatableStruct {
     defer {
         smoke_EquatableClass_EquatableStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: EquatableClass.EquatableStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: EquatableClass.EquatableStruct) -> RefHolder {
     let c_intField = moveToCType(swiftType.intField)
     let c_stringField = moveToCType(swiftType.stringField)
-    let c_nestedEquatableInstance = moveToCType(swiftType.nestedEquatableInstance)
-    let c_nestedPointerEquatableInstance = moveToCType(swiftType.nestedPointerEquatableInstance)
+    let c_nestedEquatableInstance = foobar_moveToCType(swiftType.nestedEquatableInstance)
+    let c_nestedPointerEquatableInstance = foobar_moveToCType(swiftType.nestedPointerEquatableInstance)
     return RefHolder(smoke_EquatableClass_EquatableStruct_create_handle(c_intField.ref, c_stringField.ref, c_nestedEquatableInstance.ref, c_nestedPointerEquatableInstance.ref))
 }
-internal func moveToCType(_ swiftType: EquatableClass.EquatableStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_EquatableClass_EquatableStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: EquatableClass.EquatableStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_EquatableClass_EquatableStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> EquatableClass.EquatableStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> EquatableClass.EquatableStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_EquatableClass_EquatableStruct_unwrap_optional_handle(handle)
     return EquatableClass.EquatableStruct(cHandle: unwrappedHandle) as EquatableClass.EquatableStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> EquatableClass.EquatableStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> EquatableClass.EquatableStruct? {
     defer {
         smoke_EquatableClass_EquatableStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: EquatableClass.EquatableStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: EquatableClass.EquatableStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_intField = moveToCType(swiftType.intField)
     let c_stringField = moveToCType(swiftType.stringField)
-    let c_nestedEquatableInstance = moveToCType(swiftType.nestedEquatableInstance)
-    let c_nestedPointerEquatableInstance = moveToCType(swiftType.nestedPointerEquatableInstance)
+    let c_nestedEquatableInstance = foobar_moveToCType(swiftType.nestedEquatableInstance)
+    let c_nestedPointerEquatableInstance = foobar_moveToCType(swiftType.nestedPointerEquatableInstance)
     return RefHolder(smoke_EquatableClass_EquatableStruct_create_optional_handle(c_intField.ref, c_stringField.ref, c_nestedEquatableInstance.ref, c_nestedPointerEquatableInstance.ref))
 }
-internal func moveToCType(_ swiftType: EquatableClass.EquatableStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_EquatableClass_EquatableStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: EquatableClass.EquatableStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_EquatableClass_EquatableStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableInterface.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableInterface.swift
@@ -57,7 +57,7 @@ extension _EquatableInterface: Hashable {
         hasher.combine(smoke_EquatableInterface_hash(c_handle))
     }
 }
-internal func EquatableInterface_copyFromCType(_ handle: _baseRef) -> EquatableInterface {
+internal func foobar_EquatableInterface_copyFromCType(_ handle: _baseRef) -> EquatableInterface {
     if let swift_pointer = smoke_EquatableInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableInterface {
         return re_constructed
@@ -73,7 +73,7 @@ internal func EquatableInterface_copyFromCType(_ handle: _baseRef) -> EquatableI
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func EquatableInterface_moveFromCType(_ handle: _baseRef) -> EquatableInterface {
+internal func foobar_EquatableInterface_moveFromCType(_ handle: _baseRef) -> EquatableInterface {
     if let swift_pointer = smoke_EquatableInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EquatableInterface {
         smoke_EquatableInterface_release_handle(handle)
@@ -91,27 +91,27 @@ internal func EquatableInterface_moveFromCType(_ handle: _baseRef) -> EquatableI
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func EquatableInterface_copyFromCType(_ handle: _baseRef) -> EquatableInterface? {
+internal func foobar_EquatableInterface_copyFromCType(_ handle: _baseRef) -> EquatableInterface? {
     guard handle != 0 else {
         return nil
     }
-    return EquatableInterface_moveFromCType(handle) as EquatableInterface
+    return foobar_EquatableInterface_moveFromCType(handle) as EquatableInterface
 }
-internal func EquatableInterface_moveFromCType(_ handle: _baseRef) -> EquatableInterface? {
+internal func foobar_EquatableInterface_moveFromCType(_ handle: _baseRef) -> EquatableInterface? {
     guard handle != 0 else {
         return nil
     }
-    return EquatableInterface_moveFromCType(handle) as EquatableInterface
+    return foobar_EquatableInterface_moveFromCType(handle) as EquatableInterface
 }
-internal func copyToCType(_ swiftClass: EquatableInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: EquatableInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: EquatableInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: EquatableInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: EquatableInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: EquatableInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: EquatableInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: EquatableInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/PointerEquatableClass.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/PointerEquatableClass.swift
@@ -34,7 +34,7 @@ extension PointerEquatableClass: Hashable {
         hasher.combine(smoke_PointerEquatableClass_hash(c_handle))
     }
 }
-internal func PointerEquatableClass_copyFromCType(_ handle: _baseRef) -> PointerEquatableClass {
+internal func foobar_PointerEquatableClass_copyFromCType(_ handle: _baseRef) -> PointerEquatableClass {
     if let swift_pointer = smoke_PointerEquatableClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PointerEquatableClass {
         return re_constructed
@@ -43,7 +43,7 @@ internal func PointerEquatableClass_copyFromCType(_ handle: _baseRef) -> Pointer
     smoke_PointerEquatableClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func PointerEquatableClass_moveFromCType(_ handle: _baseRef) -> PointerEquatableClass {
+internal func foobar_PointerEquatableClass_moveFromCType(_ handle: _baseRef) -> PointerEquatableClass {
     if let swift_pointer = smoke_PointerEquatableClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PointerEquatableClass {
         smoke_PointerEquatableClass_release_handle(handle)
@@ -53,27 +53,27 @@ internal func PointerEquatableClass_moveFromCType(_ handle: _baseRef) -> Pointer
     smoke_PointerEquatableClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func PointerEquatableClass_copyFromCType(_ handle: _baseRef) -> PointerEquatableClass? {
+internal func foobar_PointerEquatableClass_copyFromCType(_ handle: _baseRef) -> PointerEquatableClass? {
     guard handle != 0 else {
         return nil
     }
-    return PointerEquatableClass_moveFromCType(handle) as PointerEquatableClass
+    return foobar_PointerEquatableClass_moveFromCType(handle) as PointerEquatableClass
 }
-internal func PointerEquatableClass_moveFromCType(_ handle: _baseRef) -> PointerEquatableClass? {
+internal func foobar_PointerEquatableClass_moveFromCType(_ handle: _baseRef) -> PointerEquatableClass? {
     guard handle != 0 else {
         return nil
     }
-    return PointerEquatableClass_moveFromCType(handle) as PointerEquatableClass
+    return foobar_PointerEquatableClass_moveFromCType(handle) as PointerEquatableClass
 }
-internal func copyToCType(_ swiftClass: PointerEquatableClass) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: PointerEquatableClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: PointerEquatableClass) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: PointerEquatableClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: PointerEquatableClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: PointerEquatableClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: PointerEquatableClass?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: PointerEquatableClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/SimpleEquatableStruct.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/SimpleEquatableStruct.swift
@@ -13,10 +13,10 @@ public struct SimpleEquatableStruct: Hashable {
         self.nullableInterfaceField = nullableInterfaceField
     }
     internal init(cHandle: _baseRef) {
-        classField = NonEquatableClass_moveFromCType(smoke_SimpleEquatableStruct_classField_get(cHandle))
-        interfaceField = NonEquatableInterface_moveFromCType(smoke_SimpleEquatableStruct_interfaceField_get(cHandle))
-        nullableClassField = NonEquatableClass_moveFromCType(smoke_SimpleEquatableStruct_nullableClassField_get(cHandle))
-        nullableInterfaceField = NonEquatableInterface_moveFromCType(smoke_SimpleEquatableStruct_nullableInterfaceField_get(cHandle))
+        classField = foobar_NonEquatableClass_moveFromCType(smoke_SimpleEquatableStruct_classField_get(cHandle))
+        interfaceField = foobar_NonEquatableInterface_moveFromCType(smoke_SimpleEquatableStruct_interfaceField_get(cHandle))
+        nullableClassField = foobar_NonEquatableClass_moveFromCType(smoke_SimpleEquatableStruct_nullableClassField_get(cHandle))
+        nullableInterfaceField = foobar_NonEquatableInterface_moveFromCType(smoke_SimpleEquatableStruct_nullableInterfaceField_get(cHandle))
     }
     public static func == (lhs: SimpleEquatableStruct, rhs: SimpleEquatableStruct) -> Bool {
         return
@@ -32,48 +32,48 @@ public struct SimpleEquatableStruct: Hashable {
         hasher.combine(nullableInterfaceField != nil ? Unmanaged<AnyObject>.passUnretained(nullableInterfaceField!).toOpaque().hashValue : 0)
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> SimpleEquatableStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SimpleEquatableStruct {
     return SimpleEquatableStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> SimpleEquatableStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SimpleEquatableStruct {
     defer {
         smoke_SimpleEquatableStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SimpleEquatableStruct) -> RefHolder {
-    let c_classField = moveToCType(swiftType.classField)
-    let c_interfaceField = moveToCType(swiftType.interfaceField)
-    let c_nullableClassField = moveToCType(swiftType.nullableClassField)
-    let c_nullableInterfaceField = moveToCType(swiftType.nullableInterfaceField)
+internal func foobar_copyToCType(_ swiftType: SimpleEquatableStruct) -> RefHolder {
+    let c_classField = foobar_moveToCType(swiftType.classField)
+    let c_interfaceField = foobar_moveToCType(swiftType.interfaceField)
+    let c_nullableClassField = foobar_moveToCType(swiftType.nullableClassField)
+    let c_nullableInterfaceField = foobar_moveToCType(swiftType.nullableInterfaceField)
     return RefHolder(smoke_SimpleEquatableStruct_create_handle(c_classField.ref, c_interfaceField.ref, c_nullableClassField.ref, c_nullableInterfaceField.ref))
 }
-internal func moveToCType(_ swiftType: SimpleEquatableStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_SimpleEquatableStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: SimpleEquatableStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_SimpleEquatableStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SimpleEquatableStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SimpleEquatableStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_SimpleEquatableStruct_unwrap_optional_handle(handle)
     return SimpleEquatableStruct(cHandle: unwrappedHandle) as SimpleEquatableStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> SimpleEquatableStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SimpleEquatableStruct? {
     defer {
         smoke_SimpleEquatableStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SimpleEquatableStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SimpleEquatableStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_classField = moveToCType(swiftType.classField)
-    let c_interfaceField = moveToCType(swiftType.interfaceField)
-    let c_nullableClassField = moveToCType(swiftType.nullableClassField)
-    let c_nullableInterfaceField = moveToCType(swiftType.nullableInterfaceField)
+    let c_classField = foobar_moveToCType(swiftType.classField)
+    let c_interfaceField = foobar_moveToCType(swiftType.interfaceField)
+    let c_nullableClassField = foobar_moveToCType(swiftType.nullableClassField)
+    let c_nullableInterfaceField = foobar_moveToCType(swiftType.nullableInterfaceField)
     return RefHolder(smoke_SimpleEquatableStruct_create_optional_handle(c_classField.ref, c_interfaceField.ref, c_nullableClassField.ref, c_nullableInterfaceField.ref))
 }
-internal func moveToCType(_ swiftType: SimpleEquatableStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_SimpleEquatableStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: SimpleEquatableStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_SimpleEquatableStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/Errors.swift
+++ b/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/Errors.swift
@@ -27,19 +27,19 @@ public class Errors {
     public static func methodWithErrors() throws -> Void {
         let RESULT = smoke_Errors_methodWithErrors()
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as Errors.InternalError
+            throw foobar_moveFromCType(RESULT.error_value) as Errors.InternalError
         }
     }
     public static func methodWithExternalErrors() throws -> Void {
         let RESULT = smoke_Errors_methodWithExternalErrors()
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as Errors.ExternalError
+            throw foobar_moveFromCType(RESULT.error_value) as Errors.ExternalError
         }
     }
     public static func methodWithErrorsAndReturnValue() throws -> String {
         let RESULT = smoke_Errors_methodWithErrorsAndReturnValue()
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as Errors.InternalError
+            throw foobar_moveFromCType(RESULT.error_value) as Errors.InternalError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
@@ -47,13 +47,13 @@ public class Errors {
     public static func methodWithPayloadError() throws -> Void {
         let RESULT = smoke_Errors_methodWithPayloadError()
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as WithPayloadError
+            throw foobar_moveFromCType(RESULT.error_value) as WithPayloadError
         }
     }
     public static func methodWithPayloadErrorAndReturnValue() throws -> String {
         let RESULT = smoke_Errors_methodWithPayloadErrorAndReturnValue()
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as WithPayloadError
+            throw foobar_moveFromCType(RESULT.error_value) as WithPayloadError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
@@ -79,7 +79,7 @@ extension Errors: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Errors_copyFromCType(_ handle: _baseRef) -> Errors {
+internal func foobar_Errors_copyFromCType(_ handle: _baseRef) -> Errors {
     if let swift_pointer = smoke_Errors_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Errors {
         return re_constructed
@@ -88,7 +88,7 @@ internal func Errors_copyFromCType(_ handle: _baseRef) -> Errors {
     smoke_Errors_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Errors_moveFromCType(_ handle: _baseRef) -> Errors {
+internal func foobar_Errors_moveFromCType(_ handle: _baseRef) -> Errors {
     if let swift_pointer = smoke_Errors_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Errors {
         smoke_Errors_release_handle(handle)
@@ -98,89 +98,89 @@ internal func Errors_moveFromCType(_ handle: _baseRef) -> Errors {
     smoke_Errors_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Errors_copyFromCType(_ handle: _baseRef) -> Errors? {
+internal func foobar_Errors_copyFromCType(_ handle: _baseRef) -> Errors? {
     guard handle != 0 else {
         return nil
     }
-    return Errors_moveFromCType(handle) as Errors
+    return foobar_Errors_moveFromCType(handle) as Errors
 }
-internal func Errors_moveFromCType(_ handle: _baseRef) -> Errors? {
+internal func foobar_Errors_moveFromCType(_ handle: _baseRef) -> Errors? {
     guard handle != 0 else {
         return nil
     }
-    return Errors_moveFromCType(handle) as Errors
+    return foobar_Errors_moveFromCType(handle) as Errors
 }
-internal func copyToCType(_ swiftClass: Errors) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Errors) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Errors) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Errors) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Errors?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Errors?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Errors?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Errors?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftEnum: Errors.InternalErrorCode) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Errors.InternalErrorCode) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Errors.InternalErrorCode) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Errors.InternalErrorCode) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Errors.InternalErrorCode?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Errors.InternalErrorCode?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Errors.InternalErrorCode?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Errors.InternalErrorCode?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Errors.InternalErrorCode {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Errors.InternalErrorCode {
     return Errors.InternalErrorCode(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Errors.InternalErrorCode {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Errors.InternalErrorCode {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Errors.InternalErrorCode? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Errors.InternalErrorCode? {
     guard handle != 0 else {
         return nil
     }
     return Errors.InternalErrorCode(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Errors.InternalErrorCode? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Errors.InternalErrorCode? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftEnum: Errors.ExternalErrors) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Errors.ExternalErrors) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Errors.ExternalErrors) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Errors.ExternalErrors) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Errors.ExternalErrors?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Errors.ExternalErrors?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Errors.ExternalErrors?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Errors.ExternalErrors?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Errors.ExternalErrors {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Errors.ExternalErrors {
     return Errors.ExternalErrors(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Errors.ExternalErrors {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Errors.ExternalErrors {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Errors.ExternalErrors? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Errors.ExternalErrors? {
     guard handle != 0 else {
         return nil
     }
     return Errors.ExternalErrors(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Errors.ExternalErrors? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Errors.ExternalErrors? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 extension Errors.InternalErrorCode : Error {
 }

--- a/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/ErrorsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/ErrorsInterface.swift
@@ -24,19 +24,19 @@ internal class _ErrorsInterface: ErrorsInterface {
     public func methodWithErrors() throws -> Void {
         let RESULT = smoke_ErrorsInterface_methodWithErrors(self.c_instance)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as InternalError
+            throw foobar_moveFromCType(RESULT.error_value) as InternalError
         }
     }
     public func methodWithExternalErrors() throws -> Void {
         let RESULT = smoke_ErrorsInterface_methodWithExternalErrors(self.c_instance)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as ErrorsInterface.ExternalError
+            throw foobar_moveFromCType(RESULT.error_value) as ErrorsInterface.ExternalError
         }
     }
     public func methodWithErrorsAndReturnValue() throws -> String {
         let RESULT = smoke_ErrorsInterface_methodWithErrorsAndReturnValue(self.c_instance)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as InternalError
+            throw foobar_moveFromCType(RESULT.error_value) as InternalError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
@@ -44,13 +44,13 @@ internal class _ErrorsInterface: ErrorsInterface {
     public static func methodWithPayloadError() throws -> Void {
         let RESULT = smoke_ErrorsInterface_methodWithPayloadError()
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as WithPayloadError
+            throw foobar_moveFromCType(RESULT.error_value) as WithPayloadError
         }
     }
     public static func methodWithPayloadErrorAndReturnValue() throws -> String {
         let RESULT = smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue()
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as WithPayloadError
+            throw foobar_moveFromCType(RESULT.error_value) as WithPayloadError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
@@ -93,7 +93,7 @@ internal func getRef(_ ref: ErrorsInterface?, owning: Bool = true) -> RefHolder 
             try swift_class.methodWithErrors()
             return smoke_ErrorsInterface_methodWithErrors_result(has_value: true, error_value: 0)
         } catch let error as InternalError {
-            return smoke_ErrorsInterface_methodWithErrors_result(has_value: false, error_value: copyToCType(error).ref)
+            return smoke_ErrorsInterface_methodWithErrors_result(has_value: false, error_value: foobar_copyToCType(error).ref)
         } catch {
             fatalError("Unexpected error: \(error)")
         }
@@ -104,7 +104,7 @@ internal func getRef(_ ref: ErrorsInterface?, owning: Bool = true) -> RefHolder 
             try swift_class.methodWithExternalErrors()
             return smoke_ErrorsInterface_methodWithExternalErrors_result(has_value: true, error_value: 0)
         } catch let error as ErrorsInterface.ExternalError {
-            return smoke_ErrorsInterface_methodWithExternalErrors_result(has_value: false, error_value: copyToCType(error).ref)
+            return smoke_ErrorsInterface_methodWithExternalErrors_result(has_value: false, error_value: foobar_copyToCType(error).ref)
         } catch {
             fatalError("Unexpected error: \(error)")
         }
@@ -116,7 +116,7 @@ internal func getRef(_ ref: ErrorsInterface?, owning: Bool = true) -> RefHolder 
             let result_handle = copyToCType(call_result).ref
             return smoke_ErrorsInterface_methodWithErrorsAndReturnValue_result(has_value: true, .init(returned_value: result_handle))
         } catch let error as InternalError {
-            return smoke_ErrorsInterface_methodWithErrorsAndReturnValue_result(has_value: false, .init(error_value: copyToCType(error).ref))
+            return smoke_ErrorsInterface_methodWithErrorsAndReturnValue_result(has_value: false, .init(error_value: foobar_copyToCType(error).ref))
         } catch {
             fatalError("Unexpected error: \(error)")
         }
@@ -127,7 +127,7 @@ internal func getRef(_ ref: ErrorsInterface?, owning: Bool = true) -> RefHolder 
             try swift_class.methodWithPayloadError()
             return smoke_ErrorsInterface_methodWithPayloadError_result(has_value: true, error_value: 0)
         } catch let error as WithPayloadError {
-            return smoke_ErrorsInterface_methodWithPayloadError_result(has_value: false, error_value: copyToCType(error).ref)
+            return smoke_ErrorsInterface_methodWithPayloadError_result(has_value: false, error_value: foobar_copyToCType(error).ref)
         } catch {
             fatalError("Unexpected error: \(error)")
         }
@@ -139,7 +139,7 @@ internal func getRef(_ ref: ErrorsInterface?, owning: Bool = true) -> RefHolder 
             let result_handle = copyToCType(call_result).ref
             return smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_result(has_value: true, .init(returned_value: result_handle))
         } catch let error as WithPayloadError {
-            return smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_result(has_value: false, .init(error_value: copyToCType(error).ref))
+            return smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_result(has_value: false, .init(error_value: foobar_copyToCType(error).ref))
         } catch {
             fatalError("Unexpected error: \(error)")
         }
@@ -150,7 +150,7 @@ internal func getRef(_ ref: ErrorsInterface?, owning: Bool = true) -> RefHolder 
 extension _ErrorsInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func ErrorsInterface_copyFromCType(_ handle: _baseRef) -> ErrorsInterface {
+internal func foobar_ErrorsInterface_copyFromCType(_ handle: _baseRef) -> ErrorsInterface {
     if let swift_pointer = smoke_ErrorsInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ErrorsInterface {
         return re_constructed
@@ -166,7 +166,7 @@ internal func ErrorsInterface_copyFromCType(_ handle: _baseRef) -> ErrorsInterfa
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ErrorsInterface_moveFromCType(_ handle: _baseRef) -> ErrorsInterface {
+internal func foobar_ErrorsInterface_moveFromCType(_ handle: _baseRef) -> ErrorsInterface {
     if let swift_pointer = smoke_ErrorsInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ErrorsInterface {
         smoke_ErrorsInterface_release_handle(handle)
@@ -184,89 +184,89 @@ internal func ErrorsInterface_moveFromCType(_ handle: _baseRef) -> ErrorsInterfa
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ErrorsInterface_copyFromCType(_ handle: _baseRef) -> ErrorsInterface? {
+internal func foobar_ErrorsInterface_copyFromCType(_ handle: _baseRef) -> ErrorsInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ErrorsInterface_moveFromCType(handle) as ErrorsInterface
+    return foobar_ErrorsInterface_moveFromCType(handle) as ErrorsInterface
 }
-internal func ErrorsInterface_moveFromCType(_ handle: _baseRef) -> ErrorsInterface? {
+internal func foobar_ErrorsInterface_moveFromCType(_ handle: _baseRef) -> ErrorsInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ErrorsInterface_moveFromCType(handle) as ErrorsInterface
+    return foobar_ErrorsInterface_moveFromCType(handle) as ErrorsInterface
 }
-internal func copyToCType(_ swiftClass: ErrorsInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ErrorsInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ErrorsInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ErrorsInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ErrorsInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ErrorsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ErrorsInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ErrorsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftEnum: InternalError) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: InternalError) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: InternalError) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: InternalError) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: InternalError?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: InternalError?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: InternalError?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: InternalError?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> InternalError {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> InternalError {
     return InternalError(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> InternalError {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> InternalError {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> InternalError? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> InternalError? {
     guard handle != 0 else {
         return nil
     }
     return InternalError(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> InternalError? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> InternalError? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftEnum: ExternalErrors) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: ExternalErrors) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ExternalErrors) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: ExternalErrors) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: ExternalErrors?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: ExternalErrors?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ExternalErrors?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: ExternalErrors?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> ExternalErrors {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> ExternalErrors {
     return ExternalErrors(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> ExternalErrors {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> ExternalErrors {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExternalErrors? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExternalErrors? {
     guard handle != 0 else {
         return nil
     }
     return ExternalErrors(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExternalErrors? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExternalErrors? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 extension InternalError : Error {
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Class.swift
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Class.swift
@@ -12,10 +12,10 @@ public class Class: Interface {
     }
     public var property: Enum {
         get {
-            return moveFromCType(package_Class_property_get(self.c_instance))
+            return foobar_moveFromCType(package_Class_property_get(self.c_instance))
         }
         set {
-            let c_value = moveToCType(newValue)
+            let c_value = foobar_moveToCType(newValue)
             return moveFromCType(package_Class_property_set(self.c_instance, c_value.ref))
         }
     }
@@ -37,9 +37,9 @@ public class Class: Interface {
         let c_double = foobar_moveToCType(double)
         let RESULT = package_Class_fun(self.c_instance, c_double.ref)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as ExceptionError
+            throw foobar_moveFromCType(RESULT.error_value) as ExceptionError
         } else {
-            return moveFromCType(RESULT.returned_value)
+            return foobar_moveFromCType(RESULT.returned_value)
         }
     }
 }
@@ -68,7 +68,7 @@ extension Class: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Class_copyFromCType(_ handle: _baseRef) -> Class {
+internal func foobar_Class_copyFromCType(_ handle: _baseRef) -> Class {
     if let swift_pointer = package_Class_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Class {
         return re_constructed
@@ -80,7 +80,7 @@ internal func Class_copyFromCType(_ handle: _baseRef) -> Class {
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func Class_moveFromCType(_ handle: _baseRef) -> Class {
+internal func foobar_Class_moveFromCType(_ handle: _baseRef) -> Class {
     if let swift_pointer = package_Class_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Class {
         package_Class_release_handle(handle)
@@ -93,27 +93,27 @@ internal func Class_moveFromCType(_ handle: _baseRef) -> Class {
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func Class_copyFromCType(_ handle: _baseRef) -> Class? {
+internal func foobar_Class_copyFromCType(_ handle: _baseRef) -> Class? {
     guard handle != 0 else {
         return nil
     }
-    return Class_moveFromCType(handle) as Class
+    return foobar_Class_moveFromCType(handle) as Class
 }
-internal func Class_moveFromCType(_ handle: _baseRef) -> Class? {
+internal func foobar_Class_moveFromCType(_ handle: _baseRef) -> Class? {
     guard handle != 0 else {
         return nil
     }
-    return Class_moveFromCType(handle) as Class
+    return foobar_Class_moveFromCType(handle) as Class
 }
-internal func copyToCType(_ swiftClass: Class) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Class) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Class) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Class) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Class?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Class?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Class?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Class?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Interface.swift
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Interface.swift
@@ -44,7 +44,7 @@ internal func getRef(_ ref: Interface?, owning: Bool = true) -> RefHolder {
 extension _Interface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func Interface_copyFromCType(_ handle: _baseRef) -> Interface {
+internal func foobar_Interface_copyFromCType(_ handle: _baseRef) -> Interface {
     if let swift_pointer = package_Interface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Interface {
         return re_constructed
@@ -60,7 +60,7 @@ internal func Interface_copyFromCType(_ handle: _baseRef) -> Interface {
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func Interface_moveFromCType(_ handle: _baseRef) -> Interface {
+internal func foobar_Interface_moveFromCType(_ handle: _baseRef) -> Interface {
     if let swift_pointer = package_Interface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Interface {
         package_Interface_release_handle(handle)
@@ -78,27 +78,27 @@ internal func Interface_moveFromCType(_ handle: _baseRef) -> Interface {
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func Interface_copyFromCType(_ handle: _baseRef) -> Interface? {
+internal func foobar_Interface_copyFromCType(_ handle: _baseRef) -> Interface? {
     guard handle != 0 else {
         return nil
     }
-    return Interface_moveFromCType(handle) as Interface
+    return foobar_Interface_moveFromCType(handle) as Interface
 }
-internal func Interface_moveFromCType(_ handle: _baseRef) -> Interface? {
+internal func foobar_Interface_moveFromCType(_ handle: _baseRef) -> Interface? {
     guard handle != 0 else {
         return nil
     }
-    return Interface_moveFromCType(handle) as Interface
+    return foobar_Interface_moveFromCType(handle) as Interface
 }
-internal func copyToCType(_ swiftClass: Interface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Interface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Interface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Interface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Interface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Interface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Interface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Interface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Types.swift
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Types.swift
@@ -6,35 +6,35 @@ public typealias ExceptionError = Enum
 public enum Enum : UInt32, CaseIterable, Codable {
     case naN
 }
-internal func copyToCType(_ swiftEnum: Enum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Enum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Enum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Enum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Enum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Enum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Enum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Enum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Enum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Enum {
     return Enum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Enum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Enum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Enum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Enum? {
     guard handle != 0 else {
         return nil
     }
     return Enum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Enum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Enum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 public struct Struct {
     public var null: Enum
@@ -42,47 +42,47 @@ public struct Struct {
         self.null = null
     }
     internal init(cHandle: _baseRef) {
-        null = moveFromCType(package_Types_Struct_null_get(cHandle))
+        null = foobar_moveFromCType(package_Types_Struct_null_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Struct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Struct {
     return Struct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Struct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Struct {
     defer {
         package_Types_Struct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Struct) -> RefHolder {
-    let c_null = moveToCType(swiftType.null)
+internal func foobar_copyToCType(_ swiftType: Struct) -> RefHolder {
+    let c_null = foobar_moveToCType(swiftType.null)
     return RefHolder(package_Types_Struct_create_handle(c_null.ref))
 }
-internal func moveToCType(_ swiftType: Struct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: package_Types_Struct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Struct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: package_Types_Struct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Struct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Struct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = package_Types_Struct_unwrap_optional_handle(handle)
     return Struct(cHandle: unwrappedHandle) as Struct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Struct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Struct? {
     defer {
         package_Types_Struct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Struct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Struct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_null = moveToCType(swiftType.null)
+    let c_null = foobar_moveToCType(swiftType.null)
     return RefHolder(package_Types_Struct_create_optional_handle(c_null.ref))
 }
-internal func moveToCType(_ swiftType: Struct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: package_Types_Struct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Struct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: package_Types_Struct_release_optional_handle)
 }
 public struct Types {
     public static let const: Enum = Enum.naN

--- a/gluecodium/src/test/resources/smoke/extensions/output/swift/smoke/Extensions__extension.swift
+++ b/gluecodium/src/test/resources/smoke/extensions/output/swift/smoke/Extensions__extension.swift
@@ -18,72 +18,72 @@ extension Extensions {
         }
     }
 }
-internal func copyToCType(_ swiftEnum: Extensions.FooEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Extensions.FooEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Extensions.FooEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Extensions.FooEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Extensions.FooEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Extensions.FooEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Extensions.FooEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Extensions.FooEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Extensions.FooEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Extensions.FooEnum {
     return Extensions.FooEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Extensions.FooEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Extensions.FooEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Extensions.FooEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Extensions.FooEnum? {
     guard handle != 0 else {
         return nil
     }
     return Extensions.FooEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Extensions.FooEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Extensions.FooEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Extensions.FooStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Extensions.FooStruct {
     return Extensions.FooStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Extensions.FooStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Extensions.FooStruct {
     defer {
         smoke_Extensions_FooStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Extensions.FooStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Extensions.FooStruct) -> RefHolder {
     let c_fooField = moveToCType(swiftType.fooField)
     return RefHolder(smoke_Extensions_FooStruct_create_handle(c_fooField.ref))
 }
-internal func moveToCType(_ swiftType: Extensions.FooStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Extensions_FooStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Extensions.FooStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Extensions_FooStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Extensions.FooStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Extensions.FooStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Extensions_FooStruct_unwrap_optional_handle(handle)
     return Extensions.FooStruct(cHandle: unwrappedHandle) as Extensions.FooStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Extensions.FooStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Extensions.FooStruct? {
     defer {
         smoke_Extensions_FooStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Extensions.FooStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Extensions.FooStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_fooField = moveToCType(swiftType.fooField)
     return RefHolder(smoke_Extensions_FooStruct_create_optional_handle(c_fooField.ref))
 }
-internal func moveToCType(_ swiftType: Extensions.FooStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Extensions_FooStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Extensions.FooStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Extensions_FooStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/Collections.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/Collections.swift
@@ -5,7 +5,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [DateInterval] {
     var result: [DateInterval] = []
     let count = foobar_ArrayOf_smoke_DateInterval_count(handle)
     for idx in 0..<count {
-        result.append(copyFromCType(foobar_ArrayOf_smoke_DateInterval_get(handle, idx)))
+        result.append(foobar_copyFromCType(foobar_ArrayOf_smoke_DateInterval_get(handle, idx)))
     }
     return result
 }
@@ -18,7 +18,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [DateInterval] {
 internal func foobar_copyToCType(_ swiftArray: [DateInterval]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_DateInterval_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
+        let value = foobar_moveToCType(item)
         foobar_ArrayOf_smoke_DateInterval_append(handle, value.ref)
     }
     return RefHolder(handle)
@@ -33,7 +33,7 @@ internal func foobar_copyToCType(_ swiftArray: [DateInterval]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf_smoke_DateInterval_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_DateInterval_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_DateInterval_append(handle, moveToCType(item).ref)
+        foobar_ArrayOf_smoke_DateInterval_append(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/Dictionaries.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/Dictionaries.swift
@@ -3,8 +3,8 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [URLCredential.Persist
     var swiftDict: [URLCredential.Persistence: DateInterval] = [:]
     let iterator_handle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator(handle)
     while foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_is_valid(handle, iterator_handle) {
-        swiftDict[moveFromCType(foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_key(iterator_handle))] =
-            moveFromCType(foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_value(iterator_handle)) as DateInterval
+        swiftDict[foobar_moveFromCType(foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_key(iterator_handle))] =
+            foobar_moveFromCType(foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_value(iterator_handle)) as DateInterval
         foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_increment(iterator_handle)
     }
     foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_release_handle(iterator_handle)
@@ -19,8 +19,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [URLCredential.Persist
 internal func foobar_copyToCType(_ swiftDict: [URLCredential.Persistence: DateInterval]) -> RefHolder {
     let c_handle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_create_handle()
     for (key, value) in swiftDict {
-        let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_key = foobar_moveToCType(key)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_put(c_handle, c_key.ref, c_value.ref)
     }
     return RefHolder(c_handle)
@@ -48,8 +48,8 @@ internal func foobar_copyToCType(_ swiftDict: [URLCredential.Persistence: DateIn
     let optionalHandle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_create_optional_handle()
     let handle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_unwrap_optional_handle(optionalHandle)
     for (key, value) in swiftDict {
-        let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_key = foobar_moveToCType(key)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_put(handle, c_key.ref, c_value.ref)
     }
     return RefHolder(optionalHandle)

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/Sets.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/Sets.swift
@@ -5,7 +5,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> Set<URLCredential.Pers
     var result: Set<URLCredential.Persistence> = []
     let iterator_handle = foobar_SetOf_smoke_URLCredential_1Persistence_iterator(handle)
     while foobar_SetOf_smoke_URLCredential_1Persistence_iterator_is_valid(handle, iterator_handle) {
-        result.insert(copyFromCType(foobar_SetOf_smoke_URLCredential_1Persistence_iterator_get(iterator_handle)))
+        result.insert(foobar_copyFromCType(foobar_SetOf_smoke_URLCredential_1Persistence_iterator_get(iterator_handle)))
         foobar_SetOf_smoke_URLCredential_1Persistence_iterator_increment(iterator_handle)
     }
     foobar_SetOf_smoke_URLCredential_1Persistence_iterator_release_handle(iterator_handle)
@@ -20,7 +20,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<URLCredential.Pers
 internal func foobar_copyToCType(_ swiftSet: Set<URLCredential.Persistence>) -> RefHolder {
     let handle = foobar_SetOf_smoke_URLCredential_1Persistence_create_handle()
     for item in swiftSet {
-        foobar_SetOf_smoke_URLCredential_1Persistence_insert(handle, moveToCType(item).ref)
+        foobar_SetOf_smoke_URLCredential_1Persistence_insert(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(handle)
 }
@@ -34,7 +34,7 @@ internal func foobar_copyToCType(_ swiftSet: Set<URLCredential.Persistence>?) ->
     let optionalHandle = foobar_SetOf_smoke_URLCredential_1Persistence_create_optional_handle()
     let handle = foobar_SetOf_smoke_URLCredential_1Persistence_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf_smoke_URLCredential_1Persistence_insert(handle, moveToCType(item).ref)
+        foobar_SetOf_smoke_URLCredential_1Persistence_insert(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/DateInterval.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/DateInterval.swift
@@ -6,37 +6,37 @@ extension DateInterval {
         self.init(start: moveFromCType(smoke_DateInterval_start_get(cHandle)), end: moveFromCType(smoke_DateInterval_end_get(cHandle)))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> DateInterval {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> DateInterval {
     return DateInterval(cHandle: handle)!
 }
-internal func moveFromCType(_ handle: _baseRef) -> DateInterval {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> DateInterval {
     defer {
         smoke_DateInterval_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: DateInterval) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: DateInterval) -> RefHolder {
     let c_start = moveToCType(swiftType.start)
     let c_end = moveToCType(swiftType.end)
     return RefHolder(smoke_DateInterval_create_handle(c_start.ref, c_end.ref))
 }
-internal func moveToCType(_ swiftType: DateInterval) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DateInterval_release_handle)
+internal func foobar_moveToCType(_ swiftType: DateInterval) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_DateInterval_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> DateInterval? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> DateInterval? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_DateInterval_unwrap_optional_handle(handle)
     return DateInterval(cHandle: unwrappedHandle)! as DateInterval
 }
-internal func moveFromCType(_ handle: _baseRef) -> DateInterval? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> DateInterval? {
     defer {
         smoke_DateInterval_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: DateInterval?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: DateInterval?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -44,6 +44,6 @@ internal func copyToCType(_ swiftType: DateInterval?) -> RefHolder {
     let c_end = moveToCType(swiftType.end)
     return RefHolder(smoke_DateInterval_create_optional_handle(c_start.ref, c_end.ref))
 }
-internal func moveToCType(_ swiftType: DateInterval?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DateInterval_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: DateInterval?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_DateInterval_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Enums.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Enums.swift
@@ -22,7 +22,7 @@ public class Enums {
         case bar
     }
     public static func methodWithExternalEnum(input: Enums.ExternalEnum) -> Void {
-        let c_input = moveToCType(input)
+        let c_input = foobar_moveToCType(input)
         return moveFromCType(smoke_Enums_methodWithExternalEnum(c_input.ref))
     }
 }
@@ -46,7 +46,7 @@ extension Enums: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Enums_copyFromCType(_ handle: _baseRef) -> Enums {
+internal func foobar_Enums_copyFromCType(_ handle: _baseRef) -> Enums {
     if let swift_pointer = smoke_Enums_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Enums {
         return re_constructed
@@ -55,7 +55,7 @@ internal func Enums_copyFromCType(_ handle: _baseRef) -> Enums {
     smoke_Enums_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Enums_moveFromCType(_ handle: _baseRef) -> Enums {
+internal func foobar_Enums_moveFromCType(_ handle: _baseRef) -> Enums {
     if let swift_pointer = smoke_Enums_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Enums {
         smoke_Enums_release_handle(handle)
@@ -65,87 +65,87 @@ internal func Enums_moveFromCType(_ handle: _baseRef) -> Enums {
     smoke_Enums_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Enums_copyFromCType(_ handle: _baseRef) -> Enums? {
+internal func foobar_Enums_copyFromCType(_ handle: _baseRef) -> Enums? {
     guard handle != 0 else {
         return nil
     }
-    return Enums_moveFromCType(handle) as Enums
+    return foobar_Enums_moveFromCType(handle) as Enums
 }
-internal func Enums_moveFromCType(_ handle: _baseRef) -> Enums? {
+internal func foobar_Enums_moveFromCType(_ handle: _baseRef) -> Enums? {
     guard handle != 0 else {
         return nil
     }
-    return Enums_moveFromCType(handle) as Enums
+    return foobar_Enums_moveFromCType(handle) as Enums
 }
-internal func copyToCType(_ swiftClass: Enums) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Enums) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Enums) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Enums) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Enums?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Enums?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Enums?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Enums?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftEnum: Enums.ExternalEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Enums.ExternalEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Enums.ExternalEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Enums.ExternalEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Enums.ExternalEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Enums.ExternalEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Enums.ExternalEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Enums.ExternalEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Enums.ExternalEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Enums.ExternalEnum {
     return Enums.ExternalEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Enums.ExternalEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Enums.ExternalEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Enums.ExternalEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Enums.ExternalEnum? {
     guard handle != 0 else {
         return nil
     }
     return Enums.ExternalEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Enums.ExternalEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Enums.ExternalEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftEnum: Enums.VeryExternalEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Enums.VeryExternalEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Enums.VeryExternalEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Enums.VeryExternalEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Enums.VeryExternalEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Enums.VeryExternalEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Enums.VeryExternalEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Enums.VeryExternalEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Enums.VeryExternalEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Enums.VeryExternalEnum {
     return Enums.VeryExternalEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Enums.VeryExternalEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Enums.VeryExternalEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Enums.VeryExternalEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Enums.VeryExternalEnum? {
     guard handle != 0 else {
         return nil
     }
     return Enums.VeryExternalEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Enums.VeryExternalEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Enums.VeryExternalEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalClass.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalClass.swift
@@ -55,7 +55,7 @@ extension ExternalClass: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func ExternalClass_copyFromCType(_ handle: _baseRef) -> ExternalClass {
+internal func foobar_ExternalClass_copyFromCType(_ handle: _baseRef) -> ExternalClass {
     if let swift_pointer = smoke_ExternalClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExternalClass {
         return re_constructed
@@ -64,7 +64,7 @@ internal func ExternalClass_copyFromCType(_ handle: _baseRef) -> ExternalClass {
     smoke_ExternalClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func ExternalClass_moveFromCType(_ handle: _baseRef) -> ExternalClass {
+internal func foobar_ExternalClass_moveFromCType(_ handle: _baseRef) -> ExternalClass {
     if let swift_pointer = smoke_ExternalClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExternalClass {
         smoke_ExternalClass_release_handle(handle)
@@ -74,96 +74,96 @@ internal func ExternalClass_moveFromCType(_ handle: _baseRef) -> ExternalClass {
     smoke_ExternalClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func ExternalClass_copyFromCType(_ handle: _baseRef) -> ExternalClass? {
+internal func foobar_ExternalClass_copyFromCType(_ handle: _baseRef) -> ExternalClass? {
     guard handle != 0 else {
         return nil
     }
-    return ExternalClass_moveFromCType(handle) as ExternalClass
+    return foobar_ExternalClass_moveFromCType(handle) as ExternalClass
 }
-internal func ExternalClass_moveFromCType(_ handle: _baseRef) -> ExternalClass? {
+internal func foobar_ExternalClass_moveFromCType(_ handle: _baseRef) -> ExternalClass? {
     guard handle != 0 else {
         return nil
     }
-    return ExternalClass_moveFromCType(handle) as ExternalClass
+    return foobar_ExternalClass_moveFromCType(handle) as ExternalClass
 }
-internal func copyToCType(_ swiftClass: ExternalClass) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ExternalClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ExternalClass) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ExternalClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ExternalClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ExternalClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ExternalClass?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ExternalClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExternalClass.SomeStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExternalClass.SomeStruct {
     return ExternalClass.SomeStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExternalClass.SomeStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExternalClass.SomeStruct {
     defer {
         smoke_ExternalClass_SomeStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ExternalClass.SomeStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ExternalClass.SomeStruct) -> RefHolder {
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_ExternalClass_SomeStruct_create_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: ExternalClass.SomeStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ExternalClass_SomeStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: ExternalClass.SomeStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_ExternalClass_SomeStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExternalClass.SomeStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExternalClass.SomeStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_ExternalClass_SomeStruct_unwrap_optional_handle(handle)
     return ExternalClass.SomeStruct(cHandle: unwrappedHandle) as ExternalClass.SomeStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExternalClass.SomeStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExternalClass.SomeStruct? {
     defer {
         smoke_ExternalClass_SomeStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ExternalClass.SomeStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ExternalClass.SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_ExternalClass_SomeStruct_create_optional_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: ExternalClass.SomeStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ExternalClass_SomeStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: ExternalClass.SomeStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_ExternalClass_SomeStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: ExternalClass.SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: ExternalClass.SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ExternalClass.SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: ExternalClass.SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: ExternalClass.SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: ExternalClass.SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ExternalClass.SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: ExternalClass.SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> ExternalClass.SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> ExternalClass.SomeEnum {
     return ExternalClass.SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> ExternalClass.SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> ExternalClass.SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExternalClass.SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExternalClass.SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return ExternalClass.SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExternalClass.SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExternalClass.SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalInterface.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalInterface.swift
@@ -75,7 +75,7 @@ internal func getRef(_ ref: ExternalInterface?, owning: Bool = true) -> RefHolde
 extension _ExternalInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func ExternalInterface_copyFromCType(_ handle: _baseRef) -> ExternalInterface {
+internal func foobar_ExternalInterface_copyFromCType(_ handle: _baseRef) -> ExternalInterface {
     if let swift_pointer = smoke_ExternalInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExternalInterface {
         return re_constructed
@@ -91,7 +91,7 @@ internal func ExternalInterface_copyFromCType(_ handle: _baseRef) -> ExternalInt
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ExternalInterface_moveFromCType(_ handle: _baseRef) -> ExternalInterface {
+internal func foobar_ExternalInterface_moveFromCType(_ handle: _baseRef) -> ExternalInterface {
     if let swift_pointer = smoke_ExternalInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ExternalInterface {
         smoke_ExternalInterface_release_handle(handle)
@@ -109,96 +109,96 @@ internal func ExternalInterface_moveFromCType(_ handle: _baseRef) -> ExternalInt
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ExternalInterface_copyFromCType(_ handle: _baseRef) -> ExternalInterface? {
+internal func foobar_ExternalInterface_copyFromCType(_ handle: _baseRef) -> ExternalInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ExternalInterface_moveFromCType(handle) as ExternalInterface
+    return foobar_ExternalInterface_moveFromCType(handle) as ExternalInterface
 }
-internal func ExternalInterface_moveFromCType(_ handle: _baseRef) -> ExternalInterface? {
+internal func foobar_ExternalInterface_moveFromCType(_ handle: _baseRef) -> ExternalInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ExternalInterface_moveFromCType(handle) as ExternalInterface
+    return foobar_ExternalInterface_moveFromCType(handle) as ExternalInterface
 }
-internal func copyToCType(_ swiftClass: ExternalInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ExternalInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ExternalInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ExternalInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ExternalInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ExternalInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ExternalInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ExternalInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeStruct {
     return SomeStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeStruct {
     defer {
         smoke_ExternalInterface_SomeStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SomeStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SomeStruct) -> RefHolder {
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_ExternalInterface_SomeStruct_create_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: SomeStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ExternalInterface_SomeStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: SomeStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_ExternalInterface_SomeStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_ExternalInterface_SomeStruct_unwrap_optional_handle(handle)
     return SomeStruct(cHandle: unwrappedHandle) as SomeStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeStruct? {
     defer {
         smoke_ExternalInterface_SomeStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SomeStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_ExternalInterface_SomeStruct_create_optional_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: SomeStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ExternalInterface_SomeStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: SomeStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_ExternalInterface_SomeStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> SomeEnum {
     return SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Structs.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Structs.swift
@@ -28,7 +28,7 @@ public class Structs {
             stringField = moveFromCType(smoke_Structs_ExternalStruct_stringField_get(cHandle))
             externalStringField = moveFromCType(smoke_Structs_ExternalStruct_externalStringField_get(cHandle))
             externalArrayField = foobar_moveFromCType(smoke_Structs_ExternalStruct_externalArrayField_get(cHandle))
-            externalStructField = moveFromCType(smoke_Structs_ExternalStruct_externalStructField_get(cHandle))
+            externalStructField = foobar_moveFromCType(smoke_Structs_ExternalStruct_externalStructField_get(cHandle))
         }
     }
     public struct AnotherExternalStruct {
@@ -41,10 +41,10 @@ public class Structs {
         }
     }
     public static func getExternalStruct() -> Structs.ExternalStruct {
-        return moveFromCType(smoke_Structs_getExternalStruct())
+        return foobar_moveFromCType(smoke_Structs_getExternalStruct())
     }
     public static func getAnotherExternalStruct() -> Structs.AnotherExternalStruct {
-        return moveFromCType(smoke_Structs_getAnotherExternalStruct())
+        return foobar_moveFromCType(smoke_Structs_getAnotherExternalStruct())
     }
 }
 internal func getRef(_ ref: Structs?, owning: Bool = true) -> RefHolder {
@@ -67,7 +67,7 @@ extension Structs: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Structs_copyFromCType(_ handle: _baseRef) -> Structs {
+internal func foobar_Structs_copyFromCType(_ handle: _baseRef) -> Structs {
     if let swift_pointer = smoke_Structs_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Structs {
         return re_constructed
@@ -76,7 +76,7 @@ internal func Structs_copyFromCType(_ handle: _baseRef) -> Structs {
     smoke_Structs_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Structs_moveFromCType(_ handle: _baseRef) -> Structs {
+internal func foobar_Structs_moveFromCType(_ handle: _baseRef) -> Structs {
     if let swift_pointer = smoke_Structs_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Structs {
         smoke_Structs_release_handle(handle)
@@ -86,111 +86,111 @@ internal func Structs_moveFromCType(_ handle: _baseRef) -> Structs {
     smoke_Structs_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Structs_copyFromCType(_ handle: _baseRef) -> Structs? {
+internal func foobar_Structs_copyFromCType(_ handle: _baseRef) -> Structs? {
     guard handle != 0 else {
         return nil
     }
-    return Structs_moveFromCType(handle) as Structs
+    return foobar_Structs_moveFromCType(handle) as Structs
 }
-internal func Structs_moveFromCType(_ handle: _baseRef) -> Structs? {
+internal func foobar_Structs_moveFromCType(_ handle: _baseRef) -> Structs? {
     guard handle != 0 else {
         return nil
     }
-    return Structs_moveFromCType(handle) as Structs
+    return foobar_Structs_moveFromCType(handle) as Structs
 }
-internal func copyToCType(_ swiftClass: Structs) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Structs) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Structs) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Structs) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Structs?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Structs?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Structs?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Structs?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.ExternalStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.ExternalStruct {
     return Structs.ExternalStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.ExternalStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.ExternalStruct {
     defer {
         smoke_Structs_ExternalStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.ExternalStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.ExternalStruct) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     let c_externalStringField = moveToCType(swiftType.externalStringField)
     let c_externalArrayField = foobar_moveToCType(swiftType.externalArrayField)
-    let c_externalStructField = moveToCType(swiftType.externalStructField)
+    let c_externalStructField = foobar_moveToCType(swiftType.externalStructField)
     return RefHolder(smoke_Structs_ExternalStruct_create_handle(c_stringField.ref, c_externalStringField.ref, c_externalArrayField.ref, c_externalStructField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.ExternalStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_ExternalStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.ExternalStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_ExternalStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.ExternalStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.ExternalStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Structs_ExternalStruct_unwrap_optional_handle(handle)
     return Structs.ExternalStruct(cHandle: unwrappedHandle) as Structs.ExternalStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.ExternalStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.ExternalStruct? {
     defer {
         smoke_Structs_ExternalStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.ExternalStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.ExternalStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_stringField = moveToCType(swiftType.stringField)
     let c_externalStringField = moveToCType(swiftType.externalStringField)
     let c_externalArrayField = foobar_moveToCType(swiftType.externalArrayField)
-    let c_externalStructField = moveToCType(swiftType.externalStructField)
+    let c_externalStructField = foobar_moveToCType(swiftType.externalStructField)
     return RefHolder(smoke_Structs_ExternalStruct_create_optional_handle(c_stringField.ref, c_externalStringField.ref, c_externalArrayField.ref, c_externalStructField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.ExternalStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_ExternalStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.ExternalStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_ExternalStruct_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.AnotherExternalStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.AnotherExternalStruct {
     return Structs.AnotherExternalStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.AnotherExternalStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.AnotherExternalStruct {
     defer {
         smoke_Structs_AnotherExternalStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.AnotherExternalStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.AnotherExternalStruct) -> RefHolder {
     let c_intField = moveToCType(swiftType.intField)
     return RefHolder(smoke_Structs_AnotherExternalStruct_create_handle(c_intField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.AnotherExternalStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_AnotherExternalStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.AnotherExternalStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_AnotherExternalStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.AnotherExternalStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.AnotherExternalStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Structs_AnotherExternalStruct_unwrap_optional_handle(handle)
     return Structs.AnotherExternalStruct(cHandle: unwrappedHandle) as Structs.AnotherExternalStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.AnotherExternalStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.AnotherExternalStruct? {
     defer {
         smoke_Structs_AnotherExternalStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.AnotherExternalStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.AnotherExternalStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_intField = moveToCType(swiftType.intField)
     return RefHolder(smoke_Structs_AnotherExternalStruct_create_optional_handle(c_intField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.AnotherExternalStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_AnotherExternalStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.AnotherExternalStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_AnotherExternalStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/SwiftSeason.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/SwiftSeason.swift
@@ -7,42 +7,42 @@ internal enum SwiftSeason_internal : UInt32, CaseIterable, Codable {
     case summer
     case autumn
 }
-internal func copyToCType(_ swiftEnum_ext: SwiftSeason) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum_ext: SwiftSeason) -> PrimitiveHolder<UInt32> {
     let swiftEnum = SeasonConverter.convertToInternal(swiftEnum_ext)
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SwiftSeason) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: SwiftSeason) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum_ext: SwiftSeason?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum_ext: SwiftSeason?) -> RefHolder {
     guard let swiftEnum_ext = swiftEnum_ext else {
         return RefHolder(0)
     }
     let swiftEnum = SeasonConverter.convertToInternal(swiftEnum_ext) as SwiftSeason_internal?
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum_ext: SwiftSeason?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum_ext: SwiftSeason?) -> RefHolder {
     guard let swiftEnum_ext = swiftEnum_ext else {
         return RefHolder(0)
     }
     let swiftEnum = SeasonConverter.convertToInternal(swiftEnum_ext) as SwiftSeason_internal?
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> SwiftSeason {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> SwiftSeason {
     return SeasonConverter.convertFromInternal(SwiftSeason_internal(rawValue: cValue)!)
 }
-internal func moveFromCType(_ cValue: UInt32) -> SwiftSeason {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> SwiftSeason {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SwiftSeason? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SwiftSeason? {
     guard handle != 0 else {
         return nil
     }
     return SeasonConverter.convertFromInternal(SwiftSeason_internal(rawValue: uint32_t_value_get(handle))!)
 }
-internal func moveFromCType(_ handle: _baseRef) -> SwiftSeason? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SwiftSeason? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UIColor.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UIColor.swift
@@ -20,16 +20,16 @@ internal struct UIColor_internal {
         alpha = moveFromCType(smoke_UIColor_alpha_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> UIColor {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> UIColor {
     return ColorConverter.convertFromInternal(UIColor_internal(cHandle: handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> UIColor {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> UIColor {
     defer {
         smoke_UIColor_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType_ext: UIColor) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType_ext: UIColor) -> RefHolder {
     let swiftType = ColorConverter.convertToInternal(swiftType_ext)
     let c_red = moveToCType(swiftType.red)
     let c_green = moveToCType(swiftType.green)
@@ -37,23 +37,23 @@ internal func copyToCType(_ swiftType_ext: UIColor) -> RefHolder {
     let c_alpha = moveToCType(swiftType.alpha)
     return RefHolder(smoke_UIColor_create_handle(c_red.ref, c_green.ref, c_blue.ref, c_alpha.ref))
 }
-internal func moveToCType(_ swiftType: UIColor) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_UIColor_release_handle)
+internal func foobar_moveToCType(_ swiftType: UIColor) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_UIColor_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> UIColor? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> UIColor? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_UIColor_unwrap_optional_handle(handle)
     return ColorConverter.convertFromInternal(UIColor_internal(cHandle: unwrappedHandle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> UIColor? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> UIColor? {
     defer {
         smoke_UIColor_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType_ext: UIColor?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType_ext: UIColor?) -> RefHolder {
     guard let swiftType_ext = swiftType_ext else {
         return RefHolder(0)
     }
@@ -64,6 +64,6 @@ internal func copyToCType(_ swiftType_ext: UIColor?) -> RefHolder {
     let c_alpha = moveToCType(swiftType.alpha)
     return RefHolder(smoke_UIColor_create_optional_handle(c_red.ref, c_green.ref, c_blue.ref, c_alpha.ref))
 }
-internal func moveToCType(_ swiftType: UIColor?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_UIColor_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: UIColor?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_UIColor_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/URLCredential.Persistence.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/URLCredential.Persistence.swift
@@ -1,41 +1,41 @@
 //
 //
 import Foundation
-internal func copyToCType(_ swiftEnum: URLCredential.Persistence) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: URLCredential.Persistence) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(UInt32(swiftEnum.rawValue))
 }
-internal func moveToCType(_ swiftEnum: URLCredential.Persistence) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: URLCredential.Persistence) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: URLCredential.Persistence?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: URLCredential.Persistence?) -> RefHolder {
     if let rawValue = swiftEnum?.rawValue {
         return copyToCType(UInt32(rawValue) as UInt32?)
     } else {
         return RefHolder(0)
     }
 }
-internal func moveToCType(_ swiftEnum: URLCredential.Persistence?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: URLCredential.Persistence?) -> RefHolder {
     if let rawValue = swiftEnum?.rawValue {
         return moveToCType(UInt32(rawValue) as UInt32?)
     } else {
         return RefHolder(0)
     }
 }
-internal func copyFromCType(_ cValue: UInt32) -> URLCredential.Persistence {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> URLCredential.Persistence {
     return URLCredential.Persistence(rawValue: UInt(cValue))!
 }
-internal func moveFromCType(_ cValue: UInt32) -> URLCredential.Persistence {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> URLCredential.Persistence {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> URLCredential.Persistence? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> URLCredential.Persistence? {
     guard handle != 0 else {
         return nil
     }
     return URLCredential.Persistence(rawValue: UInt(uint32_t_value_get(handle)))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> URLCredential.Persistence? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> URLCredential.Persistence? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UseSwiftExternalTypes.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UseSwiftExternalTypes.swift
@@ -15,20 +15,20 @@ public class UseSwiftExternalTypes {
         smoke_UseSwiftExternalTypes_release_handle(c_instance)
     }
     public static func dateIntervalRoundTrip(input: DateInterval) -> DateInterval {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_UseSwiftExternalTypes_dateIntervalRoundTrip(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_UseSwiftExternalTypes_dateIntervalRoundTrip(c_input.ref))
     }
     public static func persistenceRoundTrip(input: URLCredential.Persistence) -> URLCredential.Persistence {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_UseSwiftExternalTypes_persistenceRoundTrip(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_UseSwiftExternalTypes_persistenceRoundTrip(c_input.ref))
     }
     public static func colorRoundTrip(input: UIColor) -> UIColor {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_UseSwiftExternalTypes_colorRoundTrip(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_UseSwiftExternalTypes_colorRoundTrip(c_input.ref))
     }
     public static func seasonRoundTrip(input: SwiftSeason) -> SwiftSeason {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_UseSwiftExternalTypes_seasonRoundTrip(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_UseSwiftExternalTypes_seasonRoundTrip(c_input.ref))
     }
 }
 internal func getRef(_ ref: UseSwiftExternalTypes?, owning: Bool = true) -> RefHolder {
@@ -51,7 +51,7 @@ extension UseSwiftExternalTypes: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func UseSwiftExternalTypes_copyFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes {
+internal func foobar_UseSwiftExternalTypes_copyFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes {
     if let swift_pointer = smoke_UseSwiftExternalTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UseSwiftExternalTypes {
         return re_constructed
@@ -60,7 +60,7 @@ internal func UseSwiftExternalTypes_copyFromCType(_ handle: _baseRef) -> UseSwif
     smoke_UseSwiftExternalTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func UseSwiftExternalTypes_moveFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes {
+internal func foobar_UseSwiftExternalTypes_moveFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes {
     if let swift_pointer = smoke_UseSwiftExternalTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UseSwiftExternalTypes {
         smoke_UseSwiftExternalTypes_release_handle(handle)
@@ -70,27 +70,27 @@ internal func UseSwiftExternalTypes_moveFromCType(_ handle: _baseRef) -> UseSwif
     smoke_UseSwiftExternalTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func UseSwiftExternalTypes_copyFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes? {
+internal func foobar_UseSwiftExternalTypes_copyFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes? {
     guard handle != 0 else {
         return nil
     }
-    return UseSwiftExternalTypes_moveFromCType(handle) as UseSwiftExternalTypes
+    return foobar_UseSwiftExternalTypes_moveFromCType(handle) as UseSwiftExternalTypes
 }
-internal func UseSwiftExternalTypes_moveFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes? {
+internal func foobar_UseSwiftExternalTypes_moveFromCType(_ handle: _baseRef) -> UseSwiftExternalTypes? {
     guard handle != 0 else {
         return nil
     }
-    return UseSwiftExternalTypes_moveFromCType(handle) as UseSwiftExternalTypes
+    return foobar_UseSwiftExternalTypes_moveFromCType(handle) as UseSwiftExternalTypes
 }
-internal func copyToCType(_ swiftClass: UseSwiftExternalTypes) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: UseSwiftExternalTypes) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: UseSwiftExternalTypes) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: UseSwiftExternalTypes) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: UseSwiftExternalTypes?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: UseSwiftExternalTypes?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: UseSwiftExternalTypes?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: UseSwiftExternalTypes?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/Collections.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/Collections.swift
@@ -5,7 +5,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [AnotherDummyClass] {
     var result: [AnotherDummyClass] = []
     let count = foobar_ArrayOf_smoke_AnotherDummyClass_count(handle)
     for idx in 0..<count {
-        result.append(AnotherDummyClass_copyFromCType(foobar_ArrayOf_smoke_AnotherDummyClass_get(handle, idx)))
+        result.append(foobar_AnotherDummyClass_copyFromCType(foobar_ArrayOf_smoke_AnotherDummyClass_get(handle, idx)))
     }
     return result
 }
@@ -18,7 +18,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [AnotherDummyClass] {
 internal func foobar_copyToCType(_ swiftArray: [AnotherDummyClass]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_AnotherDummyClass_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
+        let value = foobar_moveToCType(item)
         foobar_ArrayOf_smoke_AnotherDummyClass_append(handle, value.ref)
     }
     return RefHolder(handle)
@@ -33,7 +33,7 @@ internal func foobar_copyToCType(_ swiftArray: [AnotherDummyClass]?) -> RefHolde
     let optionalHandle = foobar_ArrayOf_smoke_AnotherDummyClass_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_AnotherDummyClass_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_AnotherDummyClass_append(handle, moveToCType(item).ref)
+        foobar_ArrayOf_smoke_AnotherDummyClass_append(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -57,7 +57,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [AuxStruct] {
     var result: [AuxStruct] = []
     let count = foobar_ArrayOf_smoke_AuxStruct_count(handle)
     for idx in 0..<count {
-        result.append(copyFromCType(foobar_ArrayOf_smoke_AuxStruct_get(handle, idx)))
+        result.append(foobar_copyFromCType(foobar_ArrayOf_smoke_AuxStruct_get(handle, idx)))
     }
     return result
 }
@@ -70,7 +70,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [AuxStruct] {
 internal func foobar_copyToCType(_ swiftArray: [AuxStruct]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_AuxStruct_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
+        let value = foobar_moveToCType(item)
         foobar_ArrayOf_smoke_AuxStruct_append(handle, value.ref)
     }
     return RefHolder(handle)
@@ -85,7 +85,7 @@ internal func foobar_copyToCType(_ swiftArray: [AuxStruct]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf_smoke_AuxStruct_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_AuxStruct_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_AuxStruct_append(handle, moveToCType(item).ref)
+        foobar_ArrayOf_smoke_AuxStruct_append(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -109,7 +109,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [DummyClass] {
     var result: [DummyClass] = []
     let count = foobar_ArrayOf_smoke_DummyClass_count(handle)
     for idx in 0..<count {
-        result.append(DummyClass_copyFromCType(foobar_ArrayOf_smoke_DummyClass_get(handle, idx)))
+        result.append(foobar_DummyClass_copyFromCType(foobar_ArrayOf_smoke_DummyClass_get(handle, idx)))
     }
     return result
 }
@@ -122,7 +122,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [DummyClass] {
 internal func foobar_copyToCType(_ swiftArray: [DummyClass]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_DummyClass_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
+        let value = foobar_moveToCType(item)
         foobar_ArrayOf_smoke_DummyClass_append(handle, value.ref)
     }
     return RefHolder(handle)
@@ -137,7 +137,7 @@ internal func foobar_copyToCType(_ swiftArray: [DummyClass]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf_smoke_DummyClass_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_DummyClass_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_DummyClass_append(handle, moveToCType(item).ref)
+        foobar_ArrayOf_smoke_DummyClass_append(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -161,7 +161,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [DummyInterface] {
     var result: [DummyInterface] = []
     let count = foobar_ArrayOf_smoke_DummyInterface_count(handle)
     for idx in 0..<count {
-        result.append(DummyInterface_copyFromCType(foobar_ArrayOf_smoke_DummyInterface_get(handle, idx)))
+        result.append(foobar_DummyInterface_copyFromCType(foobar_ArrayOf_smoke_DummyInterface_get(handle, idx)))
     }
     return result
 }
@@ -174,7 +174,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [DummyInterface] {
 internal func foobar_copyToCType(_ swiftArray: [DummyInterface]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_DummyInterface_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
+        let value = foobar_moveToCType(item)
         foobar_ArrayOf_smoke_DummyInterface_append(handle, value.ref)
     }
     return RefHolder(handle)
@@ -189,7 +189,7 @@ internal func foobar_copyToCType(_ swiftArray: [DummyInterface]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf_smoke_DummyInterface_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_DummyInterface_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_DummyInterface_append(handle, moveToCType(item).ref)
+        foobar_ArrayOf_smoke_DummyInterface_append(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -265,7 +265,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
     var result: [GenericTypesWithCompoundTypes.BasicStruct] = []
     let count = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_count(handle)
     for idx in 0..<count {
-        result.append(copyFromCType(foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get(handle, idx)))
+        result.append(foobar_copyFromCType(foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get(handle, idx)))
     }
     return result
 }
@@ -278,7 +278,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
 internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.BasicStruct]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
+        let value = foobar_moveToCType(item)
         foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_append(handle, value.ref)
     }
     return RefHolder(handle)
@@ -293,7 +293,7 @@ internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.Ba
     let optionalHandle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_append(handle, moveToCType(item).ref)
+        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_append(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -317,7 +317,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
     var result: [GenericTypesWithCompoundTypes.ExternalEnum] = []
     let count = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_count(handle)
     for idx in 0..<count {
-        result.append(copyFromCType(foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get(handle, idx)))
+        result.append(foobar_copyFromCType(foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get(handle, idx)))
     }
     return result
 }
@@ -330,7 +330,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
 internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.ExternalEnum]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
+        let value = foobar_moveToCType(item)
         foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_append(handle, value.ref)
     }
     return RefHolder(handle)
@@ -345,7 +345,7 @@ internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.Ex
     let optionalHandle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_append(handle, moveToCType(item).ref)
+        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_append(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -369,7 +369,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
     var result: [GenericTypesWithCompoundTypes.ExternalStruct] = []
     let count = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_count(handle)
     for idx in 0..<count {
-        result.append(copyFromCType(foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get(handle, idx)))
+        result.append(foobar_copyFromCType(foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get(handle, idx)))
     }
     return result
 }
@@ -382,7 +382,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
 internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.ExternalStruct]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
+        let value = foobar_moveToCType(item)
         foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_append(handle, value.ref)
     }
     return RefHolder(handle)
@@ -397,7 +397,7 @@ internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.Ex
     let optionalHandle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_append(handle, moveToCType(item).ref)
+        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_append(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -421,7 +421,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
     var result: [GenericTypesWithCompoundTypes.SomeEnum] = []
     let count = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_count(handle)
     for idx in 0..<count {
-        result.append(copyFromCType(foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get(handle, idx)))
+        result.append(foobar_copyFromCType(foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get(handle, idx)))
     }
     return result
 }
@@ -434,7 +434,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
 internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.SomeEnum]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
+        let value = foobar_moveToCType(item)
         foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_append(handle, value.ref)
     }
     return RefHolder(handle)
@@ -449,7 +449,7 @@ internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.So
     let optionalHandle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_append(handle, moveToCType(item).ref)
+        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_append(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -681,7 +681,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [YetAnotherDummyClass]
     var result: [YetAnotherDummyClass] = []
     let count = foobar_ArrayOf_smoke_YetAnotherDummyClass_count(handle)
     for idx in 0..<count {
-        result.append(YetAnotherDummyClass_copyFromCType(foobar_ArrayOf_smoke_YetAnotherDummyClass_get(handle, idx)))
+        result.append(foobar_YetAnotherDummyClass_copyFromCType(foobar_ArrayOf_smoke_YetAnotherDummyClass_get(handle, idx)))
     }
     return result
 }
@@ -694,7 +694,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [YetAnotherDummyClass]
 internal func foobar_copyToCType(_ swiftArray: [YetAnotherDummyClass]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_YetAnotherDummyClass_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
+        let value = foobar_moveToCType(item)
         foobar_ArrayOf_smoke_YetAnotherDummyClass_append(handle, value.ref)
     }
     return RefHolder(handle)
@@ -709,7 +709,7 @@ internal func foobar_copyToCType(_ swiftArray: [YetAnotherDummyClass]?) -> RefHo
     let optionalHandle = foobar_ArrayOf_smoke_YetAnotherDummyClass_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_YetAnotherDummyClass_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_YetAnotherDummyClass_append(handle, moveToCType(item).ref)
+        foobar_ArrayOf_smoke_YetAnotherDummyClass_append(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/Dictionaries.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/Dictionaries.swift
@@ -61,7 +61,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
     var swiftDict: [GenericTypesWithCompoundTypes.ExternalEnum: Bool] = [:]
     let iterator_handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_iterator(handle)
     while foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_iterator_is_valid(handle, iterator_handle) {
-        swiftDict[moveFromCType(foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_iterator_key(iterator_handle))] =
+        swiftDict[foobar_moveFromCType(foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_iterator_key(iterator_handle))] =
             moveFromCType(foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_iterator_value(iterator_handle)) as Bool
         foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_iterator_increment(iterator_handle)
     }
@@ -77,7 +77,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
 internal func foobar_copyToCType(_ swiftDict: [GenericTypesWithCompoundTypes.ExternalEnum: Bool]) -> RefHolder {
     let c_handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_create_handle()
     for (key, value) in swiftDict {
-        let c_key = moveToCType(key)
+        let c_key = foobar_moveToCType(key)
         let c_value = moveToCType(value)
         foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_put(c_handle, c_key.ref, c_value.ref)
     }
@@ -106,7 +106,7 @@ internal func foobar_copyToCType(_ swiftDict: [GenericTypesWithCompoundTypes.Ext
     let optionalHandle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_create_optional_handle()
     let handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_unwrap_optional_handle(optionalHandle)
     for (key, value) in swiftDict {
-        let c_key = moveToCType(key)
+        let c_key = foobar_moveToCType(key)
         let c_value = moveToCType(value)
         foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_To__Boolean_put(handle, c_key.ref, c_value.ref)
     }
@@ -119,7 +119,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
     var swiftDict: [GenericTypesWithCompoundTypes.SomeEnum: Bool] = [:]
     let iterator_handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_iterator(handle)
     while foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_iterator_is_valid(handle, iterator_handle) {
-        swiftDict[moveFromCType(foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_iterator_key(iterator_handle))] =
+        swiftDict[foobar_moveFromCType(foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_iterator_key(iterator_handle))] =
             moveFromCType(foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_iterator_value(iterator_handle)) as Bool
         foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_iterator_increment(iterator_handle)
     }
@@ -135,7 +135,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
 internal func foobar_copyToCType(_ swiftDict: [GenericTypesWithCompoundTypes.SomeEnum: Bool]) -> RefHolder {
     let c_handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_create_handle()
     for (key, value) in swiftDict {
-        let c_key = moveToCType(key)
+        let c_key = foobar_moveToCType(key)
         let c_value = moveToCType(value)
         foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_put(c_handle, c_key.ref, c_value.ref)
     }
@@ -164,7 +164,7 @@ internal func foobar_copyToCType(_ swiftDict: [GenericTypesWithCompoundTypes.Som
     let optionalHandle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_create_optional_handle()
     let handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_unwrap_optional_handle(optionalHandle)
     for (key, value) in swiftDict {
-        let c_key = moveToCType(key)
+        let c_key = foobar_moveToCType(key)
         let c_value = moveToCType(value)
         foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_To__Boolean_put(handle, c_key.ref, c_value.ref)
     }
@@ -236,7 +236,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [Int32: DummyClass] {
     let iterator_handle = foobar_MapOf__Int_To_smoke_DummyClass_iterator(handle)
     while foobar_MapOf__Int_To_smoke_DummyClass_iterator_is_valid(handle, iterator_handle) {
         swiftDict[moveFromCType(foobar_MapOf__Int_To_smoke_DummyClass_iterator_key(iterator_handle))] =
-            DummyClass_moveFromCType(foobar_MapOf__Int_To_smoke_DummyClass_iterator_value(iterator_handle)) as DummyClass
+            foobar_DummyClass_moveFromCType(foobar_MapOf__Int_To_smoke_DummyClass_iterator_value(iterator_handle)) as DummyClass
         foobar_MapOf__Int_To_smoke_DummyClass_iterator_increment(iterator_handle)
     }
     foobar_MapOf__Int_To_smoke_DummyClass_iterator_release_handle(iterator_handle)
@@ -252,7 +252,7 @@ internal func foobar_copyToCType(_ swiftDict: [Int32: DummyClass]) -> RefHolder 
     let c_handle = foobar_MapOf__Int_To_smoke_DummyClass_create_handle()
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf__Int_To_smoke_DummyClass_put(c_handle, c_key.ref, c_value.ref)
     }
     return RefHolder(c_handle)
@@ -281,7 +281,7 @@ internal func foobar_copyToCType(_ swiftDict: [Int32: DummyClass]?) -> RefHolder
     let handle = foobar_MapOf__Int_To_smoke_DummyClass_unwrap_optional_handle(optionalHandle)
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf__Int_To_smoke_DummyClass_put(handle, c_key.ref, c_value.ref)
     }
     return RefHolder(optionalHandle)
@@ -294,7 +294,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [Int32: DummyInterface
     let iterator_handle = foobar_MapOf__Int_To_smoke_DummyInterface_iterator(handle)
     while foobar_MapOf__Int_To_smoke_DummyInterface_iterator_is_valid(handle, iterator_handle) {
         swiftDict[moveFromCType(foobar_MapOf__Int_To_smoke_DummyInterface_iterator_key(iterator_handle))] =
-            DummyInterface_moveFromCType(foobar_MapOf__Int_To_smoke_DummyInterface_iterator_value(iterator_handle)) as DummyInterface
+            foobar_DummyInterface_moveFromCType(foobar_MapOf__Int_To_smoke_DummyInterface_iterator_value(iterator_handle)) as DummyInterface
         foobar_MapOf__Int_To_smoke_DummyInterface_iterator_increment(iterator_handle)
     }
     foobar_MapOf__Int_To_smoke_DummyInterface_iterator_release_handle(iterator_handle)
@@ -310,7 +310,7 @@ internal func foobar_copyToCType(_ swiftDict: [Int32: DummyInterface]) -> RefHol
     let c_handle = foobar_MapOf__Int_To_smoke_DummyInterface_create_handle()
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf__Int_To_smoke_DummyInterface_put(c_handle, c_key.ref, c_value.ref)
     }
     return RefHolder(c_handle)
@@ -339,7 +339,7 @@ internal func foobar_copyToCType(_ swiftDict: [Int32: DummyInterface]?) -> RefHo
     let handle = foobar_MapOf__Int_To_smoke_DummyInterface_unwrap_optional_handle(optionalHandle)
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf__Int_To_smoke_DummyInterface_put(handle, c_key.ref, c_value.ref)
     }
     return RefHolder(optionalHandle)
@@ -352,7 +352,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [Int32: GenericTypesWi
     let iterator_handle = foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(handle)
     while foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(handle, iterator_handle) {
         swiftDict[moveFromCType(foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_key(iterator_handle))] =
-            moveFromCType(foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_value(iterator_handle)) as GenericTypesWithCompoundTypes.ExternalEnum
+            foobar_moveFromCType(foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_value(iterator_handle)) as GenericTypesWithCompoundTypes.ExternalEnum
         foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(iterator_handle)
     }
     foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(iterator_handle)
@@ -368,7 +368,7 @@ internal func foobar_copyToCType(_ swiftDict: [Int32: GenericTypesWithCompoundTy
     let c_handle = foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle()
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_put(c_handle, c_key.ref, c_value.ref)
     }
     return RefHolder(c_handle)
@@ -397,7 +397,7 @@ internal func foobar_copyToCType(_ swiftDict: [Int32: GenericTypesWithCompoundTy
     let handle = foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_unwrap_optional_handle(optionalHandle)
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_ExternalEnum_put(handle, c_key.ref, c_value.ref)
     }
     return RefHolder(optionalHandle)
@@ -410,7 +410,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [Int32: GenericTypesWi
     let iterator_handle = foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(handle)
     while foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(handle, iterator_handle) {
         swiftDict[moveFromCType(foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_key(iterator_handle))] =
-            moveFromCType(foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_value(iterator_handle)) as GenericTypesWithCompoundTypes.SomeEnum
+            foobar_moveFromCType(foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_value(iterator_handle)) as GenericTypesWithCompoundTypes.SomeEnum
         foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(iterator_handle)
     }
     foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(iterator_handle)
@@ -426,7 +426,7 @@ internal func foobar_copyToCType(_ swiftDict: [Int32: GenericTypesWithCompoundTy
     let c_handle = foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle()
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_put(c_handle, c_key.ref, c_value.ref)
     }
     return RefHolder(c_handle)
@@ -455,7 +455,7 @@ internal func foobar_copyToCType(_ swiftDict: [Int32: GenericTypesWithCompoundTy
     let handle = foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_unwrap_optional_handle(optionalHandle)
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf__Int_To_smoke_GenericTypesWithCompoundTypes_SomeEnum_put(handle, c_key.ref, c_value.ref)
     }
     return RefHolder(optionalHandle)
@@ -700,7 +700,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [String: GenericTypesW
     let iterator_handle = foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator(handle)
     while foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid(handle, iterator_handle) {
         swiftDict[moveFromCType(foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_key(iterator_handle))] =
-            moveFromCType(foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_value(iterator_handle)) as GenericTypesWithCompoundTypes.BasicStruct
+            foobar_moveFromCType(foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_value(iterator_handle)) as GenericTypesWithCompoundTypes.BasicStruct
         foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment(iterator_handle)
     }
     foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle(iterator_handle)
@@ -716,7 +716,7 @@ internal func foobar_copyToCType(_ swiftDict: [String: GenericTypesWithCompoundT
     let c_handle = foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle()
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_put(c_handle, c_key.ref, c_value.ref)
     }
     return RefHolder(c_handle)
@@ -745,7 +745,7 @@ internal func foobar_copyToCType(_ swiftDict: [String: GenericTypesWithCompoundT
     let handle = foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_unwrap_optional_handle(optionalHandle)
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_BasicStruct_put(handle, c_key.ref, c_value.ref)
     }
     return RefHolder(optionalHandle)
@@ -758,7 +758,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [String: GenericTypesW
     let iterator_handle = foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator(handle)
     while foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid(handle, iterator_handle) {
         swiftDict[moveFromCType(foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_key(iterator_handle))] =
-            moveFromCType(foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_value(iterator_handle)) as GenericTypesWithCompoundTypes.ExternalStruct
+            foobar_moveFromCType(foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_value(iterator_handle)) as GenericTypesWithCompoundTypes.ExternalStruct
         foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment(iterator_handle)
     }
     foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle(iterator_handle)
@@ -774,7 +774,7 @@ internal func foobar_copyToCType(_ swiftDict: [String: GenericTypesWithCompoundT
     let c_handle = foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle()
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_put(c_handle, c_key.ref, c_value.ref)
     }
     return RefHolder(c_handle)
@@ -803,7 +803,7 @@ internal func foobar_copyToCType(_ swiftDict: [String: GenericTypesWithCompoundT
     let handle = foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_unwrap_optional_handle(optionalHandle)
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
-        let c_value = moveToCType(value)
+        let c_value = foobar_moveToCType(value)
         foobar_MapOf__String_To_smoke_GenericTypesWithCompoundTypes_ExternalStruct_put(handle, c_key.ref, c_value.ref)
     }
     return RefHolder(optionalHandle)

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/Sets.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/Sets.swift
@@ -58,7 +58,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> Set<GenericTypesWithCo
     var result: Set<GenericTypesWithCompoundTypes.ExternalEnum> = []
     let iterator_handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(handle)
     while foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(handle, iterator_handle) {
-        result.insert(copyFromCType(foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get(iterator_handle)))
+        result.insert(foobar_copyFromCType(foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get(iterator_handle)))
         foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(iterator_handle)
     }
     foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(iterator_handle)
@@ -73,7 +73,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<GenericTypesWithCo
 internal func foobar_copyToCType(_ swiftSet: Set<GenericTypesWithCompoundTypes.ExternalEnum>) -> RefHolder {
     let handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle()
     for item in swiftSet {
-        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(handle, moveToCType(item).ref)
+        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(handle)
 }
@@ -87,7 +87,7 @@ internal func foobar_copyToCType(_ swiftSet: Set<GenericTypesWithCompoundTypes.E
     let optionalHandle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_optional_handle()
     let handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(handle, moveToCType(item).ref)
+        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -111,7 +111,7 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> Set<GenericTypesWithCo
     var result: Set<GenericTypesWithCompoundTypes.SomeEnum> = []
     let iterator_handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(handle)
     while foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(handle, iterator_handle) {
-        result.insert(copyFromCType(foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get(iterator_handle)))
+        result.insert(foobar_copyFromCType(foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get(iterator_handle)))
         foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(iterator_handle)
     }
     foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(iterator_handle)
@@ -126,7 +126,7 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<GenericTypesWithCo
 internal func foobar_copyToCType(_ swiftSet: Set<GenericTypesWithCompoundTypes.SomeEnum>) -> RefHolder {
     let handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle()
     for item in swiftSet {
-        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(handle, moveToCType(item).ref)
+        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(handle)
 }
@@ -140,7 +140,7 @@ internal func foobar_copyToCType(_ swiftSet: Set<GenericTypesWithCompoundTypes.S
     let optionalHandle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_optional_handle()
     let handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(handle, moveToCType(item).ref)
+        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(handle, foobar_moveToCType(item).ref)
     }
     return RefHolder(optionalHandle)
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithBasicTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithBasicTypes.swift
@@ -103,7 +103,7 @@ extension GenericTypesWithBasicTypes: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func GenericTypesWithBasicTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes {
+internal func foobar_GenericTypesWithBasicTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes {
     if let swift_pointer = smoke_GenericTypesWithBasicTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithBasicTypes {
         return re_constructed
@@ -112,7 +112,7 @@ internal func GenericTypesWithBasicTypes_copyFromCType(_ handle: _baseRef) -> Ge
     smoke_GenericTypesWithBasicTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func GenericTypesWithBasicTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes {
+internal func foobar_GenericTypesWithBasicTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes {
     if let swift_pointer = smoke_GenericTypesWithBasicTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithBasicTypes {
         smoke_GenericTypesWithBasicTypes_release_handle(handle)
@@ -122,62 +122,62 @@ internal func GenericTypesWithBasicTypes_moveFromCType(_ handle: _baseRef) -> Ge
     smoke_GenericTypesWithBasicTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func GenericTypesWithBasicTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes? {
+internal func foobar_GenericTypesWithBasicTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes? {
     guard handle != 0 else {
         return nil
     }
-    return GenericTypesWithBasicTypes_moveFromCType(handle) as GenericTypesWithBasicTypes
+    return foobar_GenericTypesWithBasicTypes_moveFromCType(handle) as GenericTypesWithBasicTypes
 }
-internal func GenericTypesWithBasicTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes? {
+internal func foobar_GenericTypesWithBasicTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes? {
     guard handle != 0 else {
         return nil
     }
-    return GenericTypesWithBasicTypes_moveFromCType(handle) as GenericTypesWithBasicTypes
+    return foobar_GenericTypesWithBasicTypes_moveFromCType(handle) as GenericTypesWithBasicTypes
 }
-internal func copyToCType(_ swiftClass: GenericTypesWithBasicTypes) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: GenericTypesWithBasicTypes) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: GenericTypesWithBasicTypes) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: GenericTypesWithBasicTypes) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: GenericTypesWithBasicTypes?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: GenericTypesWithBasicTypes?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: GenericTypesWithBasicTypes?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: GenericTypesWithBasicTypes?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes.StructWithGenerics {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes.StructWithGenerics {
     return GenericTypesWithBasicTypes.StructWithGenerics(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes.StructWithGenerics {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes.StructWithGenerics {
     defer {
         smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: GenericTypesWithBasicTypes.StructWithGenerics) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: GenericTypesWithBasicTypes.StructWithGenerics) -> RefHolder {
     let c_numbersList = foobar_moveToCType(swiftType.numbersList)
     let c_numbersMap = foobar_moveToCType(swiftType.numbersMap)
     let c_numbersSet = foobar_moveToCType(swiftType.numbersSet)
     return RefHolder(smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle(c_numbersList.ref, c_numbersMap.ref, c_numbersSet.ref))
 }
-internal func moveToCType(_ swiftType: GenericTypesWithBasicTypes.StructWithGenerics) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle)
+internal func foobar_moveToCType(_ swiftType: GenericTypesWithBasicTypes.StructWithGenerics) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes.StructWithGenerics? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes.StructWithGenerics? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_GenericTypesWithBasicTypes_StructWithGenerics_unwrap_optional_handle(handle)
     return GenericTypesWithBasicTypes.StructWithGenerics(cHandle: unwrappedHandle) as GenericTypesWithBasicTypes.StructWithGenerics
 }
-internal func moveFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes.StructWithGenerics? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> GenericTypesWithBasicTypes.StructWithGenerics? {
     defer {
         smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: GenericTypesWithBasicTypes.StructWithGenerics?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: GenericTypesWithBasicTypes.StructWithGenerics?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -186,6 +186,6 @@ internal func copyToCType(_ swiftType: GenericTypesWithBasicTypes.StructWithGene
     let c_numbersSet = foobar_moveToCType(swiftType.numbersSet)
     return RefHolder(smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_optional_handle(c_numbersList.ref, c_numbersMap.ref, c_numbersSet.ref))
 }
-internal func moveToCType(_ swiftType: GenericTypesWithBasicTypes.StructWithGenerics?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: GenericTypesWithBasicTypes.StructWithGenerics?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithCompoundTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithCompoundTypes.swift
@@ -92,7 +92,7 @@ extension GenericTypesWithCompoundTypes: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func GenericTypesWithCompoundTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes {
+internal func foobar_GenericTypesWithCompoundTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes {
     if let swift_pointer = smoke_GenericTypesWithCompoundTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithCompoundTypes {
         return re_constructed
@@ -101,7 +101,7 @@ internal func GenericTypesWithCompoundTypes_copyFromCType(_ handle: _baseRef) ->
     smoke_GenericTypesWithCompoundTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func GenericTypesWithCompoundTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes {
+internal func foobar_GenericTypesWithCompoundTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes {
     if let swift_pointer = smoke_GenericTypesWithCompoundTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithCompoundTypes {
         smoke_GenericTypesWithCompoundTypes_release_handle(handle)
@@ -111,165 +111,165 @@ internal func GenericTypesWithCompoundTypes_moveFromCType(_ handle: _baseRef) ->
     smoke_GenericTypesWithCompoundTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func GenericTypesWithCompoundTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes? {
+internal func foobar_GenericTypesWithCompoundTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes? {
     guard handle != 0 else {
         return nil
     }
-    return GenericTypesWithCompoundTypes_moveFromCType(handle) as GenericTypesWithCompoundTypes
+    return foobar_GenericTypesWithCompoundTypes_moveFromCType(handle) as GenericTypesWithCompoundTypes
 }
-internal func GenericTypesWithCompoundTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes? {
+internal func foobar_GenericTypesWithCompoundTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes? {
     guard handle != 0 else {
         return nil
     }
-    return GenericTypesWithCompoundTypes_moveFromCType(handle) as GenericTypesWithCompoundTypes
+    return foobar_GenericTypesWithCompoundTypes_moveFromCType(handle) as GenericTypesWithCompoundTypes
 }
-internal func copyToCType(_ swiftClass: GenericTypesWithCompoundTypes) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: GenericTypesWithCompoundTypes) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: GenericTypesWithCompoundTypes) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: GenericTypesWithCompoundTypes) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: GenericTypesWithCompoundTypes?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: GenericTypesWithCompoundTypes?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: GenericTypesWithCompoundTypes?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: GenericTypesWithCompoundTypes?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.BasicStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.BasicStruct {
     return GenericTypesWithCompoundTypes.BasicStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.BasicStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.BasicStruct {
     defer {
         smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: GenericTypesWithCompoundTypes.BasicStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: GenericTypesWithCompoundTypes.BasicStruct) -> RefHolder {
     let c_value = moveToCType(swiftType.value)
     return RefHolder(smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle(c_value.ref))
 }
-internal func moveToCType(_ swiftType: GenericTypesWithCompoundTypes.BasicStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: GenericTypesWithCompoundTypes.BasicStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.BasicStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.BasicStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_GenericTypesWithCompoundTypes_BasicStruct_unwrap_optional_handle(handle)
     return GenericTypesWithCompoundTypes.BasicStruct(cHandle: unwrappedHandle) as GenericTypesWithCompoundTypes.BasicStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.BasicStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.BasicStruct? {
     defer {
         smoke_GenericTypesWithCompoundTypes_BasicStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: GenericTypesWithCompoundTypes.BasicStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: GenericTypesWithCompoundTypes.BasicStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_value = moveToCType(swiftType.value)
     return RefHolder(smoke_GenericTypesWithCompoundTypes_BasicStruct_create_optional_handle(c_value.ref))
 }
-internal func moveToCType(_ swiftType: GenericTypesWithCompoundTypes.BasicStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_GenericTypesWithCompoundTypes_BasicStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: GenericTypesWithCompoundTypes.BasicStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_GenericTypesWithCompoundTypes_BasicStruct_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.ExternalStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.ExternalStruct {
     return GenericTypesWithCompoundTypes.ExternalStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.ExternalStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.ExternalStruct {
     defer {
         smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: GenericTypesWithCompoundTypes.ExternalStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: GenericTypesWithCompoundTypes.ExternalStruct) -> RefHolder {
     let c_string = moveToCType(swiftType.string)
     return RefHolder(smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle(c_string.ref))
 }
-internal func moveToCType(_ swiftType: GenericTypesWithCompoundTypes.ExternalStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: GenericTypesWithCompoundTypes.ExternalStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.ExternalStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.ExternalStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_GenericTypesWithCompoundTypes_ExternalStruct_unwrap_optional_handle(handle)
     return GenericTypesWithCompoundTypes.ExternalStruct(cHandle: unwrappedHandle) as GenericTypesWithCompoundTypes.ExternalStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.ExternalStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.ExternalStruct? {
     defer {
         smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: GenericTypesWithCompoundTypes.ExternalStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: GenericTypesWithCompoundTypes.ExternalStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_string = moveToCType(swiftType.string)
     return RefHolder(smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_optional_handle(c_string.ref))
 }
-internal func moveToCType(_ swiftType: GenericTypesWithCompoundTypes.ExternalStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: GenericTypesWithCompoundTypes.ExternalStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: GenericTypesWithCompoundTypes.SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: GenericTypesWithCompoundTypes.SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: GenericTypesWithCompoundTypes.SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: GenericTypesWithCompoundTypes.SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: GenericTypesWithCompoundTypes.SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: GenericTypesWithCompoundTypes.SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: GenericTypesWithCompoundTypes.SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: GenericTypesWithCompoundTypes.SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> GenericTypesWithCompoundTypes.SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> GenericTypesWithCompoundTypes.SomeEnum {
     return GenericTypesWithCompoundTypes.SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> GenericTypesWithCompoundTypes.SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> GenericTypesWithCompoundTypes.SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return GenericTypesWithCompoundTypes.SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftEnum: GenericTypesWithCompoundTypes.ExternalEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: GenericTypesWithCompoundTypes.ExternalEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: GenericTypesWithCompoundTypes.ExternalEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: GenericTypesWithCompoundTypes.ExternalEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: GenericTypesWithCompoundTypes.ExternalEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: GenericTypesWithCompoundTypes.ExternalEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: GenericTypesWithCompoundTypes.ExternalEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: GenericTypesWithCompoundTypes.ExternalEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> GenericTypesWithCompoundTypes.ExternalEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> GenericTypesWithCompoundTypes.ExternalEnum {
     return GenericTypesWithCompoundTypes.ExternalEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> GenericTypesWithCompoundTypes.ExternalEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> GenericTypesWithCompoundTypes.ExternalEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.ExternalEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.ExternalEnum? {
     guard handle != 0 else {
         return nil
     }
     return GenericTypesWithCompoundTypes.ExternalEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.ExternalEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> GenericTypesWithCompoundTypes.ExternalEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithGenericTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithGenericTypes.swift
@@ -62,7 +62,7 @@ extension GenericTypesWithGenericTypes: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func GenericTypesWithGenericTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes {
+internal func foobar_GenericTypesWithGenericTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes {
     if let swift_pointer = smoke_GenericTypesWithGenericTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithGenericTypes {
         return re_constructed
@@ -71,7 +71,7 @@ internal func GenericTypesWithGenericTypes_copyFromCType(_ handle: _baseRef) -> 
     smoke_GenericTypesWithGenericTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func GenericTypesWithGenericTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes {
+internal func foobar_GenericTypesWithGenericTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes {
     if let swift_pointer = smoke_GenericTypesWithGenericTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? GenericTypesWithGenericTypes {
         smoke_GenericTypesWithGenericTypes_release_handle(handle)
@@ -81,27 +81,27 @@ internal func GenericTypesWithGenericTypes_moveFromCType(_ handle: _baseRef) -> 
     smoke_GenericTypesWithGenericTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func GenericTypesWithGenericTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes? {
+internal func foobar_GenericTypesWithGenericTypes_copyFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes? {
     guard handle != 0 else {
         return nil
     }
-    return GenericTypesWithGenericTypes_moveFromCType(handle) as GenericTypesWithGenericTypes
+    return foobar_GenericTypesWithGenericTypes_moveFromCType(handle) as GenericTypesWithGenericTypes
 }
-internal func GenericTypesWithGenericTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes? {
+internal func foobar_GenericTypesWithGenericTypes_moveFromCType(_ handle: _baseRef) -> GenericTypesWithGenericTypes? {
     guard handle != 0 else {
         return nil
     }
-    return GenericTypesWithGenericTypes_moveFromCType(handle) as GenericTypesWithGenericTypes
+    return foobar_GenericTypesWithGenericTypes_moveFromCType(handle) as GenericTypesWithGenericTypes
 }
-internal func copyToCType(_ swiftClass: GenericTypesWithGenericTypes) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: GenericTypesWithGenericTypes) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: GenericTypesWithGenericTypes) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: GenericTypesWithGenericTypes) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: GenericTypesWithGenericTypes?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: GenericTypesWithGenericTypes?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: GenericTypesWithGenericTypes?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: GenericTypesWithGenericTypes?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromClass.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromClass.swift
@@ -23,7 +23,7 @@ internal func getRef(_ ref: ChildClassFromClass?, owning: Bool = true) -> RefHol
         ? RefHolder(ref: handle_copy, release: smoke_ChildClassFromClass_release_handle)
         : RefHolder(handle_copy)
 }
-internal func ChildClassFromClass_copyFromCType(_ handle: _baseRef) -> ChildClassFromClass {
+internal func foobar_ChildClassFromClass_copyFromCType(_ handle: _baseRef) -> ChildClassFromClass {
     if let swift_pointer = smoke_ChildClassFromClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromClass {
         return re_constructed
@@ -35,7 +35,7 @@ internal func ChildClassFromClass_copyFromCType(_ handle: _baseRef) -> ChildClas
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ChildClassFromClass_moveFromCType(_ handle: _baseRef) -> ChildClassFromClass {
+internal func foobar_ChildClassFromClass_moveFromCType(_ handle: _baseRef) -> ChildClassFromClass {
     if let swift_pointer = smoke_ChildClassFromClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromClass {
         smoke_ChildClassFromClass_release_handle(handle)
@@ -48,27 +48,27 @@ internal func ChildClassFromClass_moveFromCType(_ handle: _baseRef) -> ChildClas
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ChildClassFromClass_copyFromCType(_ handle: _baseRef) -> ChildClassFromClass? {
+internal func foobar_ChildClassFromClass_copyFromCType(_ handle: _baseRef) -> ChildClassFromClass? {
     guard handle != 0 else {
         return nil
     }
-    return ChildClassFromClass_moveFromCType(handle) as ChildClassFromClass
+    return foobar_ChildClassFromClass_moveFromCType(handle) as ChildClassFromClass
 }
-internal func ChildClassFromClass_moveFromCType(_ handle: _baseRef) -> ChildClassFromClass? {
+internal func foobar_ChildClassFromClass_moveFromCType(_ handle: _baseRef) -> ChildClassFromClass? {
     guard handle != 0 else {
         return nil
     }
-    return ChildClassFromClass_moveFromCType(handle) as ChildClassFromClass
+    return foobar_ChildClassFromClass_moveFromCType(handle) as ChildClassFromClass
 }
-internal func copyToCType(_ swiftClass: ChildClassFromClass) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ChildClassFromClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ChildClassFromClass) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ChildClassFromClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ChildClassFromClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ChildClassFromClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ChildClassFromClass?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ChildClassFromClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromInterface.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromInterface.swift
@@ -54,7 +54,7 @@ extension ChildClassFromInterface: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func ChildClassFromInterface_copyFromCType(_ handle: _baseRef) -> ChildClassFromInterface {
+internal func foobar_ChildClassFromInterface_copyFromCType(_ handle: _baseRef) -> ChildClassFromInterface {
     if let swift_pointer = smoke_ChildClassFromInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromInterface {
         return re_constructed
@@ -66,7 +66,7 @@ internal func ChildClassFromInterface_copyFromCType(_ handle: _baseRef) -> Child
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ChildClassFromInterface_moveFromCType(_ handle: _baseRef) -> ChildClassFromInterface {
+internal func foobar_ChildClassFromInterface_moveFromCType(_ handle: _baseRef) -> ChildClassFromInterface {
     if let swift_pointer = smoke_ChildClassFromInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromInterface {
         smoke_ChildClassFromInterface_release_handle(handle)
@@ -79,27 +79,27 @@ internal func ChildClassFromInterface_moveFromCType(_ handle: _baseRef) -> Child
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ChildClassFromInterface_copyFromCType(_ handle: _baseRef) -> ChildClassFromInterface? {
+internal func foobar_ChildClassFromInterface_copyFromCType(_ handle: _baseRef) -> ChildClassFromInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ChildClassFromInterface_moveFromCType(handle) as ChildClassFromInterface
+    return foobar_ChildClassFromInterface_moveFromCType(handle) as ChildClassFromInterface
 }
-internal func ChildClassFromInterface_moveFromCType(_ handle: _baseRef) -> ChildClassFromInterface? {
+internal func foobar_ChildClassFromInterface_moveFromCType(_ handle: _baseRef) -> ChildClassFromInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ChildClassFromInterface_moveFromCType(handle) as ChildClassFromInterface
+    return foobar_ChildClassFromInterface_moveFromCType(handle) as ChildClassFromInterface
 }
-internal func copyToCType(_ swiftClass: ChildClassFromInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ChildClassFromInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ChildClassFromInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ChildClassFromInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ChildClassFromInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ChildClassFromInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ChildClassFromInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ChildClassFromInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildInterface.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildInterface.swift
@@ -78,7 +78,7 @@ internal func getRef(_ ref: ChildInterface?, owning: Bool = true) -> RefHolder {
 extension _ChildInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func ChildInterface_copyFromCType(_ handle: _baseRef) -> ChildInterface {
+internal func foobar_ChildInterface_copyFromCType(_ handle: _baseRef) -> ChildInterface {
     if let swift_pointer = smoke_ChildInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildInterface {
         return re_constructed
@@ -94,7 +94,7 @@ internal func ChildInterface_copyFromCType(_ handle: _baseRef) -> ChildInterface
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ChildInterface_moveFromCType(_ handle: _baseRef) -> ChildInterface {
+internal func foobar_ChildInterface_moveFromCType(_ handle: _baseRef) -> ChildInterface {
     if let swift_pointer = smoke_ChildInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildInterface {
         smoke_ChildInterface_release_handle(handle)
@@ -112,27 +112,27 @@ internal func ChildInterface_moveFromCType(_ handle: _baseRef) -> ChildInterface
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ChildInterface_copyFromCType(_ handle: _baseRef) -> ChildInterface? {
+internal func foobar_ChildInterface_copyFromCType(_ handle: _baseRef) -> ChildInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ChildInterface_moveFromCType(handle) as ChildInterface
+    return foobar_ChildInterface_moveFromCType(handle) as ChildInterface
 }
-internal func ChildInterface_moveFromCType(_ handle: _baseRef) -> ChildInterface? {
+internal func foobar_ChildInterface_moveFromCType(_ handle: _baseRef) -> ChildInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ChildInterface_moveFromCType(handle) as ChildInterface
+    return foobar_ChildInterface_moveFromCType(handle) as ChildInterface
 }
-internal func copyToCType(_ swiftClass: ChildInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ChildInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ChildInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ChildInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ChildInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ChildInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ChildInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ChildInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalChild.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalChild.swift
@@ -20,7 +20,7 @@ internal func getRef(_ ref: InternalChild?, owning: Bool = true) -> RefHolder {
         ? RefHolder(ref: handle_copy, release: smoke_InternalChild_release_handle)
         : RefHolder(handle_copy)
 }
-internal func InternalChild_copyFromCType(_ handle: _baseRef) -> InternalChild {
+internal func foobar_InternalChild_copyFromCType(_ handle: _baseRef) -> InternalChild {
     if let swift_pointer = smoke_InternalChild_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalChild {
         return re_constructed
@@ -32,7 +32,7 @@ internal func InternalChild_copyFromCType(_ handle: _baseRef) -> InternalChild {
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func InternalChild_moveFromCType(_ handle: _baseRef) -> InternalChild {
+internal func foobar_InternalChild_moveFromCType(_ handle: _baseRef) -> InternalChild {
     if let swift_pointer = smoke_InternalChild_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalChild {
         smoke_InternalChild_release_handle(handle)
@@ -45,27 +45,27 @@ internal func InternalChild_moveFromCType(_ handle: _baseRef) -> InternalChild {
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func InternalChild_copyFromCType(_ handle: _baseRef) -> InternalChild? {
+internal func foobar_InternalChild_copyFromCType(_ handle: _baseRef) -> InternalChild? {
     guard handle != 0 else {
         return nil
     }
-    return InternalChild_moveFromCType(handle) as InternalChild
+    return foobar_InternalChild_moveFromCType(handle) as InternalChild
 }
-internal func InternalChild_moveFromCType(_ handle: _baseRef) -> InternalChild? {
+internal func foobar_InternalChild_moveFromCType(_ handle: _baseRef) -> InternalChild? {
     guard handle != 0 else {
         return nil
     }
-    return InternalChild_moveFromCType(handle) as InternalChild
+    return foobar_InternalChild_moveFromCType(handle) as InternalChild
 }
-internal func copyToCType(_ swiftClass: InternalChild) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InternalChild) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InternalChild) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InternalChild) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: InternalChild?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InternalChild?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InternalChild?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InternalChild?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalParent.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalParent.swift
@@ -39,7 +39,7 @@ extension InternalParent: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func InternalParent_copyFromCType(_ handle: _baseRef) -> InternalParent {
+internal func foobar_InternalParent_copyFromCType(_ handle: _baseRef) -> InternalParent {
     if let swift_pointer = smoke_InternalParent_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalParent {
         return re_constructed
@@ -51,7 +51,7 @@ internal func InternalParent_copyFromCType(_ handle: _baseRef) -> InternalParent
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func InternalParent_moveFromCType(_ handle: _baseRef) -> InternalParent {
+internal func foobar_InternalParent_moveFromCType(_ handle: _baseRef) -> InternalParent {
     if let swift_pointer = smoke_InternalParent_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalParent {
         smoke_InternalParent_release_handle(handle)
@@ -64,27 +64,27 @@ internal func InternalParent_moveFromCType(_ handle: _baseRef) -> InternalParent
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func InternalParent_copyFromCType(_ handle: _baseRef) -> InternalParent? {
+internal func foobar_InternalParent_copyFromCType(_ handle: _baseRef) -> InternalParent? {
     guard handle != 0 else {
         return nil
     }
-    return InternalParent_moveFromCType(handle) as InternalParent
+    return foobar_InternalParent_moveFromCType(handle) as InternalParent
 }
-internal func InternalParent_moveFromCType(_ handle: _baseRef) -> InternalParent? {
+internal func foobar_InternalParent_moveFromCType(_ handle: _baseRef) -> InternalParent? {
     guard handle != 0 else {
         return nil
     }
-    return InternalParent_moveFromCType(handle) as InternalParent
+    return foobar_InternalParent_moveFromCType(handle) as InternalParent
 }
-internal func copyToCType(_ swiftClass: InternalParent) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InternalParent) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InternalParent) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InternalParent) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: InternalParent?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InternalParent?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InternalParent?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InternalParent?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleClass.swift
+++ b/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleClass.swift
@@ -17,8 +17,8 @@ public class SimpleClass {
         return moveFromCType(smoke_SimpleClass_getStringValue(self.c_instance))
     }
     public func useSimpleClass(input: SimpleClass) -> SimpleClass {
-        let c_input = moveToCType(input)
-        return SimpleClass_moveFromCType(smoke_SimpleClass_useSimpleClass(self.c_instance, c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_SimpleClass_moveFromCType(smoke_SimpleClass_useSimpleClass(self.c_instance, c_input.ref))
     }
 }
 internal func getRef(_ ref: SimpleClass?, owning: Bool = true) -> RefHolder {
@@ -41,7 +41,7 @@ extension SimpleClass: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func SimpleClass_copyFromCType(_ handle: _baseRef) -> SimpleClass {
+internal func foobar_SimpleClass_copyFromCType(_ handle: _baseRef) -> SimpleClass {
     if let swift_pointer = smoke_SimpleClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SimpleClass {
         return re_constructed
@@ -50,7 +50,7 @@ internal func SimpleClass_copyFromCType(_ handle: _baseRef) -> SimpleClass {
     smoke_SimpleClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func SimpleClass_moveFromCType(_ handle: _baseRef) -> SimpleClass {
+internal func foobar_SimpleClass_moveFromCType(_ handle: _baseRef) -> SimpleClass {
     if let swift_pointer = smoke_SimpleClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SimpleClass {
         smoke_SimpleClass_release_handle(handle)
@@ -60,27 +60,27 @@ internal func SimpleClass_moveFromCType(_ handle: _baseRef) -> SimpleClass {
     smoke_SimpleClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func SimpleClass_copyFromCType(_ handle: _baseRef) -> SimpleClass? {
+internal func foobar_SimpleClass_copyFromCType(_ handle: _baseRef) -> SimpleClass? {
     guard handle != 0 else {
         return nil
     }
-    return SimpleClass_moveFromCType(handle) as SimpleClass
+    return foobar_SimpleClass_moveFromCType(handle) as SimpleClass
 }
-internal func SimpleClass_moveFromCType(_ handle: _baseRef) -> SimpleClass? {
+internal func foobar_SimpleClass_moveFromCType(_ handle: _baseRef) -> SimpleClass? {
     guard handle != 0 else {
         return nil
     }
-    return SimpleClass_moveFromCType(handle) as SimpleClass
+    return foobar_SimpleClass_moveFromCType(handle) as SimpleClass
 }
-internal func copyToCType(_ swiftClass: SimpleClass) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: SimpleClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: SimpleClass) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: SimpleClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: SimpleClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: SimpleClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: SimpleClass?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: SimpleClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleInterface.swift
+++ b/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleInterface.swift
@@ -21,8 +21,8 @@ internal class _SimpleInterface: SimpleInterface {
         return moveFromCType(smoke_SimpleInterface_getStringValue(self.c_instance))
     }
     public func useSimpleInterface(input: SimpleInterface) -> SimpleInterface {
-        let c_input = moveToCType(input)
-        return SimpleInterface_moveFromCType(smoke_SimpleInterface_useSimpleInterface(self.c_instance, c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_SimpleInterface_moveFromCType(smoke_SimpleInterface_useSimpleInterface(self.c_instance, c_input.ref))
     }
 }
 @_cdecl("_CBridgeInitsmoke_SimpleInterface")
@@ -53,7 +53,7 @@ internal func getRef(_ ref: SimpleInterface?, owning: Bool = true) -> RefHolder 
     }
     functions.smoke_SimpleInterface_useSimpleInterface = {(swift_class_pointer, input) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SimpleInterface
-        return copyToCType(swift_class.useSimpleInterface(input: SimpleInterface_moveFromCType(input))).ref
+        return foobar_copyToCType(swift_class.useSimpleInterface(input: foobar_SimpleInterface_moveFromCType(input))).ref
     }
     let proxy = smoke_SimpleInterface_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_SimpleInterface_release_handle) : RefHolder(proxy)
@@ -61,7 +61,7 @@ internal func getRef(_ ref: SimpleInterface?, owning: Bool = true) -> RefHolder 
 extension _SimpleInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func SimpleInterface_copyFromCType(_ handle: _baseRef) -> SimpleInterface {
+internal func foobar_SimpleInterface_copyFromCType(_ handle: _baseRef) -> SimpleInterface {
     if let swift_pointer = smoke_SimpleInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SimpleInterface {
         return re_constructed
@@ -77,7 +77,7 @@ internal func SimpleInterface_copyFromCType(_ handle: _baseRef) -> SimpleInterfa
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func SimpleInterface_moveFromCType(_ handle: _baseRef) -> SimpleInterface {
+internal func foobar_SimpleInterface_moveFromCType(_ handle: _baseRef) -> SimpleInterface {
     if let swift_pointer = smoke_SimpleInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SimpleInterface {
         smoke_SimpleInterface_release_handle(handle)
@@ -95,27 +95,27 @@ internal func SimpleInterface_moveFromCType(_ handle: _baseRef) -> SimpleInterfa
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func SimpleInterface_copyFromCType(_ handle: _baseRef) -> SimpleInterface? {
+internal func foobar_SimpleInterface_copyFromCType(_ handle: _baseRef) -> SimpleInterface? {
     guard handle != 0 else {
         return nil
     }
-    return SimpleInterface_moveFromCType(handle) as SimpleInterface
+    return foobar_SimpleInterface_moveFromCType(handle) as SimpleInterface
 }
-internal func SimpleInterface_moveFromCType(_ handle: _baseRef) -> SimpleInterface? {
+internal func foobar_SimpleInterface_moveFromCType(_ handle: _baseRef) -> SimpleInterface? {
     guard handle != 0 else {
         return nil
     }
-    return SimpleInterface_moveFromCType(handle) as SimpleInterface
+    return foobar_SimpleInterface_moveFromCType(handle) as SimpleInterface
 }
-internal func copyToCType(_ swiftClass: SimpleInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: SimpleInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: SimpleInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: SimpleInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: SimpleInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: SimpleInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: SimpleInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: SimpleInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/StructWithClass.swift
+++ b/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/StructWithClass.swift
@@ -7,45 +7,45 @@ public struct StructWithClass {
         self.classInstance = classInstance
     }
     internal init(cHandle: _baseRef) {
-        classInstance = SimpleClass_moveFromCType(smoke_StructWithClass_classInstance_get(cHandle))
+        classInstance = foobar_SimpleClass_moveFromCType(smoke_StructWithClass_classInstance_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructWithClass {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructWithClass {
     return StructWithClass(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructWithClass {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructWithClass {
     defer {
         smoke_StructWithClass_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructWithClass) -> RefHolder {
-    let c_classInstance = moveToCType(swiftType.classInstance)
+internal func foobar_copyToCType(_ swiftType: StructWithClass) -> RefHolder {
+    let c_classInstance = foobar_moveToCType(swiftType.classInstance)
     return RefHolder(smoke_StructWithClass_create_handle(c_classInstance.ref))
 }
-internal func moveToCType(_ swiftType: StructWithClass) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructWithClass_release_handle)
+internal func foobar_moveToCType(_ swiftType: StructWithClass) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructWithClass_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructWithClass? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructWithClass? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_StructWithClass_unwrap_optional_handle(handle)
     return StructWithClass(cHandle: unwrappedHandle) as StructWithClass
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructWithClass? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructWithClass? {
     defer {
         smoke_StructWithClass_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructWithClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: StructWithClass?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_classInstance = moveToCType(swiftType.classInstance)
+    let c_classInstance = foobar_moveToCType(swiftType.classInstance)
     return RefHolder(smoke_StructWithClass_create_optional_handle(c_classInstance.ref))
 }
-internal func moveToCType(_ swiftType: StructWithClass?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructWithClass_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: StructWithClass?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructWithClass_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/StructWithInterface.swift
+++ b/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/StructWithInterface.swift
@@ -7,45 +7,45 @@ public struct StructWithInterface {
         self.interfaceInstance = interfaceInstance
     }
     internal init(cHandle: _baseRef) {
-        interfaceInstance = SimpleInterface_moveFromCType(smoke_StructWithInterface_interfaceInstance_get(cHandle))
+        interfaceInstance = foobar_SimpleInterface_moveFromCType(smoke_StructWithInterface_interfaceInstance_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructWithInterface {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructWithInterface {
     return StructWithInterface(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructWithInterface {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructWithInterface {
     defer {
         smoke_StructWithInterface_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructWithInterface) -> RefHolder {
-    let c_interfaceInstance = moveToCType(swiftType.interfaceInstance)
+internal func foobar_copyToCType(_ swiftType: StructWithInterface) -> RefHolder {
+    let c_interfaceInstance = foobar_moveToCType(swiftType.interfaceInstance)
     return RefHolder(smoke_StructWithInterface_create_handle(c_interfaceInstance.ref))
 }
-internal func moveToCType(_ swiftType: StructWithInterface) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructWithInterface_release_handle)
+internal func foobar_moveToCType(_ swiftType: StructWithInterface) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructWithInterface_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructWithInterface? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructWithInterface? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_StructWithInterface_unwrap_optional_handle(handle)
     return StructWithInterface(cHandle: unwrappedHandle) as StructWithInterface
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructWithInterface? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructWithInterface? {
     defer {
         smoke_StructWithInterface_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructWithInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: StructWithInterface?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_interfaceInstance = moveToCType(swiftType.interfaceInstance)
+    let c_interfaceInstance = foobar_moveToCType(swiftType.interfaceInstance)
     return RefHolder(smoke_StructWithInterface_create_optional_handle(c_interfaceInstance.ref))
 }
-internal func moveToCType(_ swiftType: StructWithInterface?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructWithInterface_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: StructWithInterface?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructWithInterface_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
@@ -21,12 +21,12 @@ public class Lambdas {
     }
     public func deconfuse(value: String, confuser: @escaping Lambdas.Convoluter) -> Lambdas.Producer {
         let c_value = moveToCType(value)
-        let c_confuser = moveToCType(confuser)
-        return moveFromCType(smoke_Lambdas_deconfuse(self.c_instance, c_value.ref, c_confuser.ref))
+        let c_confuser = foobar_moveToCType(confuser)
+        return foobar_moveFromCType(smoke_Lambdas_deconfuse(self.c_instance, c_value.ref, c_confuser.ref))
     }
     public static func fuse(items: [String], callback: @escaping Lambdas.Indexer) -> [Int32: String] {
         let c_items = foobar_moveToCType(items)
-        let c_callback = moveToCType(callback)
+        let c_callback = foobar_moveToCType(callback)
         return foobar_moveFromCType(smoke_Lambdas_fuse(c_items.ref, c_callback.ref))
     }
 }
@@ -50,7 +50,7 @@ extension Lambdas: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Lambdas_copyFromCType(_ handle: _baseRef) -> Lambdas {
+internal func foobar_Lambdas_copyFromCType(_ handle: _baseRef) -> Lambdas {
     if let swift_pointer = smoke_Lambdas_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Lambdas {
         return re_constructed
@@ -59,7 +59,7 @@ internal func Lambdas_copyFromCType(_ handle: _baseRef) -> Lambdas {
     smoke_Lambdas_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Lambdas_moveFromCType(_ handle: _baseRef) -> Lambdas {
+internal func foobar_Lambdas_moveFromCType(_ handle: _baseRef) -> Lambdas {
     if let swift_pointer = smoke_Lambdas_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Lambdas {
         smoke_Lambdas_release_handle(handle)
@@ -69,50 +69,50 @@ internal func Lambdas_moveFromCType(_ handle: _baseRef) -> Lambdas {
     smoke_Lambdas_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Lambdas_copyFromCType(_ handle: _baseRef) -> Lambdas? {
+internal func foobar_Lambdas_copyFromCType(_ handle: _baseRef) -> Lambdas? {
     guard handle != 0 else {
         return nil
     }
-    return Lambdas_moveFromCType(handle) as Lambdas
+    return foobar_Lambdas_moveFromCType(handle) as Lambdas
 }
-internal func Lambdas_moveFromCType(_ handle: _baseRef) -> Lambdas? {
+internal func foobar_Lambdas_moveFromCType(_ handle: _baseRef) -> Lambdas? {
     guard handle != 0 else {
         return nil
     }
-    return Lambdas_moveFromCType(handle) as Lambdas
+    return foobar_Lambdas_moveFromCType(handle) as Lambdas
 }
-internal func copyToCType(_ swiftClass: Lambdas) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Lambdas) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Lambdas) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Lambdas) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Lambdas?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Lambdas?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Lambdas?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Lambdas?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Producer {
-    return moveFromCType(smoke_Lambdas_Producer_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Producer {
+    return foobar_moveFromCType(smoke_Lambdas_Producer_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Producer {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.Producer {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_Producer_release_handle)
     return { () -> String in
         return moveFromCType(smoke_Lambdas_Producer_call(refHolder.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Producer? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Producer? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as Lambdas.Producer
+    return foobar_copyFromCType(handle) as Lambdas.Producer
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Producer? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.Producer? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as Lambdas.Producer
+    return foobar_moveFromCType(handle) as Lambdas.Producer
 }
 internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Producer) -> smoke_Lambdas_Producer_FunctionTable {
     class smoke_Lambdas_Producer_Holder {
@@ -134,48 +134,48 @@ internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Producer) -> 
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping Lambdas.Producer) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping Lambdas.Producer) -> RefHolder {
     let handle = smoke_Lambdas_Producer_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping Lambdas.Producer) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping Lambdas.Producer) -> RefHolder {
     let handle = smoke_Lambdas_Producer_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Producer_release_handle)
 }
-internal func copyToCType(_ swiftType: Lambdas.Producer?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Lambdas.Producer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_Lambdas_Producer_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: Lambdas.Producer?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: Lambdas.Producer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_Lambdas_Producer_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Producer_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Convoluter {
-    return moveFromCType(smoke_Lambdas_Convoluter_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Convoluter {
+    return foobar_moveFromCType(smoke_Lambdas_Convoluter_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Convoluter {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.Convoluter {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_Convoluter_release_handle)
     return { (p0: String) -> Lambdas.Producer in
-        return moveFromCType(smoke_Lambdas_Convoluter_call(refHolder.ref, moveToCType(p0).ref))
+        return foobar_moveFromCType(smoke_Lambdas_Convoluter_call(refHolder.ref, moveToCType(p0).ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Convoluter? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Convoluter? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as Lambdas.Convoluter
+    return foobar_copyFromCType(handle) as Lambdas.Convoluter
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Convoluter? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.Convoluter? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as Lambdas.Convoluter
+    return foobar_moveFromCType(handle) as Lambdas.Convoluter
 }
 internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Convoluter) -> smoke_Lambdas_Convoluter_FunctionTable {
     class smoke_Lambdas_Convoluter_Holder {
@@ -193,52 +193,52 @@ internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Convoluter) -
     }
     functions.smoke_Lambdas_Convoluter_call = { swift_closure_pointer, p0 in
         let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_Lambdas_Convoluter_Holder
-        return copyToCType(closure_holder.closure(moveFromCType(p0))).ref
+        return foobar_copyToCType(closure_holder.closure(moveFromCType(p0))).ref
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping Lambdas.Convoluter) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping Lambdas.Convoluter) -> RefHolder {
     let handle = smoke_Lambdas_Convoluter_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping Lambdas.Convoluter) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping Lambdas.Convoluter) -> RefHolder {
     let handle = smoke_Lambdas_Convoluter_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Convoluter_release_handle)
 }
-internal func copyToCType(_ swiftType: Lambdas.Convoluter?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Lambdas.Convoluter?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_Lambdas_Convoluter_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: Lambdas.Convoluter?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: Lambdas.Convoluter?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_Lambdas_Convoluter_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Convoluter_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Consumer {
-    return moveFromCType(smoke_Lambdas_Consumer_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Consumer {
+    return foobar_moveFromCType(smoke_Lambdas_Consumer_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Consumer {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.Consumer {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_Consumer_release_handle)
     return { (p0: String) -> Void in
         return moveFromCType(smoke_Lambdas_Consumer_call(refHolder.ref, moveToCType(p0).ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Consumer? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Consumer? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as Lambdas.Consumer
+    return foobar_copyFromCType(handle) as Lambdas.Consumer
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Consumer? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.Consumer? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as Lambdas.Consumer
+    return foobar_moveFromCType(handle) as Lambdas.Consumer
 }
 internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Consumer) -> smoke_Lambdas_Consumer_FunctionTable {
     class smoke_Lambdas_Consumer_Holder {
@@ -260,48 +260,48 @@ internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Consumer) -> 
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping Lambdas.Consumer) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping Lambdas.Consumer) -> RefHolder {
     let handle = smoke_Lambdas_Consumer_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping Lambdas.Consumer) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping Lambdas.Consumer) -> RefHolder {
     let handle = smoke_Lambdas_Consumer_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Consumer_release_handle)
 }
-internal func copyToCType(_ swiftType: Lambdas.Consumer?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Lambdas.Consumer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_Lambdas_Consumer_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: Lambdas.Consumer?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: Lambdas.Consumer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_Lambdas_Consumer_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Consumer_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Indexer {
-    return moveFromCType(smoke_Lambdas_Indexer_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Indexer {
+    return foobar_moveFromCType(smoke_Lambdas_Indexer_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Indexer {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.Indexer {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_Indexer_release_handle)
     return { (p0: String, p1: Float) -> Int32 in
         return moveFromCType(smoke_Lambdas_Indexer_call(refHolder.ref, moveToCType(p0).ref, moveToCType(p1).ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Indexer? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Indexer? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as Lambdas.Indexer
+    return foobar_copyFromCType(handle) as Lambdas.Indexer
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Indexer? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.Indexer? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as Lambdas.Indexer
+    return foobar_moveFromCType(handle) as Lambdas.Indexer
 }
 internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Indexer) -> smoke_Lambdas_Indexer_FunctionTable {
     class smoke_Lambdas_Indexer_Holder {
@@ -323,48 +323,48 @@ internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Indexer) -> s
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping Lambdas.Indexer) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping Lambdas.Indexer) -> RefHolder {
     let handle = smoke_Lambdas_Indexer_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping Lambdas.Indexer) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping Lambdas.Indexer) -> RefHolder {
     let handle = smoke_Lambdas_Indexer_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Indexer_release_handle)
 }
-internal func copyToCType(_ swiftType: Lambdas.Indexer?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Lambdas.Indexer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_Lambdas_Indexer_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: Lambdas.Indexer?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: Lambdas.Indexer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_Lambdas_Indexer_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Indexer_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser {
-    return moveFromCType(smoke_Lambdas_NullableConfuser_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser {
+    return foobar_moveFromCType(smoke_Lambdas_NullableConfuser_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_NullableConfuser_release_handle)
     return { (p0: String?) -> Lambdas.Producer? in
-        return moveFromCType(smoke_Lambdas_NullableConfuser_call(refHolder.ref, moveToCType(p0).ref))
+        return foobar_moveFromCType(smoke_Lambdas_NullableConfuser_call(refHolder.ref, moveToCType(p0).ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as Lambdas.NullableConfuser
+    return foobar_copyFromCType(handle) as Lambdas.NullableConfuser
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as Lambdas.NullableConfuser
+    return foobar_moveFromCType(handle) as Lambdas.NullableConfuser
 }
 internal func createFunctionalTable(_ swiftType: @escaping Lambdas.NullableConfuser) -> smoke_Lambdas_NullableConfuser_FunctionTable {
     class smoke_Lambdas_NullableConfuser_Holder {
@@ -382,26 +382,26 @@ internal func createFunctionalTable(_ swiftType: @escaping Lambdas.NullableConfu
     }
     functions.smoke_Lambdas_NullableConfuser_call = { swift_closure_pointer, p0 in
         let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_Lambdas_NullableConfuser_Holder
-        return copyToCType(closure_holder.closure(moveFromCType(p0))).ref
+        return foobar_copyToCType(closure_holder.closure(moveFromCType(p0))).ref
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping Lambdas.NullableConfuser) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping Lambdas.NullableConfuser) -> RefHolder {
     let handle = smoke_Lambdas_NullableConfuser_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping Lambdas.NullableConfuser) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping Lambdas.NullableConfuser) -> RefHolder {
     let handle = smoke_Lambdas_NullableConfuser_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_NullableConfuser_release_handle)
 }
-internal func copyToCType(_ swiftType: Lambdas.NullableConfuser?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Lambdas.NullableConfuser?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_Lambdas_NullableConfuser_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: Lambdas.NullableConfuser?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: Lambdas.NullableConfuser?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasInterface.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasInterface.swift
@@ -18,7 +18,7 @@ internal class _LambdasInterface: LambdasInterface {
         smoke_LambdasInterface_release_handle(c_instance)
     }
     public func takeScreenshot(callback: @escaping LambdasInterface.TakeScreenshotCallback) -> Void {
-        let c_callback = moveToCType(callback)
+        let c_callback = foobar_moveToCType(callback)
         return moveFromCType(smoke_LambdasInterface_takeScreenshot(self.c_instance, c_callback.ref))
     }
 }
@@ -46,7 +46,7 @@ internal func getRef(_ ref: LambdasInterface?, owning: Bool = true) -> RefHolder
     }
     functions.smoke_LambdasInterface_takeScreenshot = {(swift_class_pointer, callback) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! LambdasInterface
-        swift_class.takeScreenshot(callback: moveFromCType(callback))
+        swift_class.takeScreenshot(callback: foobar_moveFromCType(callback))
     }
     let proxy = smoke_LambdasInterface_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_LambdasInterface_release_handle) : RefHolder(proxy)
@@ -54,7 +54,7 @@ internal func getRef(_ ref: LambdasInterface?, owning: Bool = true) -> RefHolder
 extension _LambdasInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func LambdasInterface_copyFromCType(_ handle: _baseRef) -> LambdasInterface {
+internal func foobar_LambdasInterface_copyFromCType(_ handle: _baseRef) -> LambdasInterface {
     if let swift_pointer = smoke_LambdasInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LambdasInterface {
         return re_constructed
@@ -70,7 +70,7 @@ internal func LambdasInterface_copyFromCType(_ handle: _baseRef) -> LambdasInter
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func LambdasInterface_moveFromCType(_ handle: _baseRef) -> LambdasInterface {
+internal func foobar_LambdasInterface_moveFromCType(_ handle: _baseRef) -> LambdasInterface {
     if let swift_pointer = smoke_LambdasInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LambdasInterface {
         smoke_LambdasInterface_release_handle(handle)
@@ -88,50 +88,50 @@ internal func LambdasInterface_moveFromCType(_ handle: _baseRef) -> LambdasInter
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func LambdasInterface_copyFromCType(_ handle: _baseRef) -> LambdasInterface? {
+internal func foobar_LambdasInterface_copyFromCType(_ handle: _baseRef) -> LambdasInterface? {
     guard handle != 0 else {
         return nil
     }
-    return LambdasInterface_moveFromCType(handle) as LambdasInterface
+    return foobar_LambdasInterface_moveFromCType(handle) as LambdasInterface
 }
-internal func LambdasInterface_moveFromCType(_ handle: _baseRef) -> LambdasInterface? {
+internal func foobar_LambdasInterface_moveFromCType(_ handle: _baseRef) -> LambdasInterface? {
     guard handle != 0 else {
         return nil
     }
-    return LambdasInterface_moveFromCType(handle) as LambdasInterface
+    return foobar_LambdasInterface_moveFromCType(handle) as LambdasInterface
 }
-internal func copyToCType(_ swiftClass: LambdasInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: LambdasInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: LambdasInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: LambdasInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: LambdasInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: LambdasInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: LambdasInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: LambdasInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback {
-    return moveFromCType(smoke_LambdasInterface_TakeScreenshotCallback_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback {
+    return foobar_moveFromCType(smoke_LambdasInterface_TakeScreenshotCallback_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback {
     let refHolder = RefHolder(ref: handle, release: smoke_LambdasInterface_TakeScreenshotCallback_release_handle)
     return { (p0: Data?) -> Void in
         return moveFromCType(smoke_LambdasInterface_TakeScreenshotCallback_call(refHolder.ref, moveToCType(p0).ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as LambdasInterface.TakeScreenshotCallback
+    return foobar_copyFromCType(handle) as LambdasInterface.TakeScreenshotCallback
 }
-internal func moveFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as LambdasInterface.TakeScreenshotCallback
+    return foobar_moveFromCType(handle) as LambdasInterface.TakeScreenshotCallback
 }
 internal func createFunctionalTable(_ swiftType: @escaping LambdasInterface.TakeScreenshotCallback) -> smoke_LambdasInterface_TakeScreenshotCallback_FunctionTable {
     class smoke_LambdasInterface_TakeScreenshotCallback_Holder {
@@ -153,22 +153,22 @@ internal func createFunctionalTable(_ swiftType: @escaping LambdasInterface.Take
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping LambdasInterface.TakeScreenshotCallback) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping LambdasInterface.TakeScreenshotCallback) -> RefHolder {
     let handle = smoke_LambdasInterface_TakeScreenshotCallback_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping LambdasInterface.TakeScreenshotCallback) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping LambdasInterface.TakeScreenshotCallback) -> RefHolder {
     let handle = smoke_LambdasInterface_TakeScreenshotCallback_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_LambdasInterface_TakeScreenshotCallback_release_handle)
 }
-internal func copyToCType(_ swiftType: LambdasInterface.TakeScreenshotCallback?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: LambdasInterface.TakeScreenshotCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_LambdasInterface_TakeScreenshotCallback_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: LambdasInterface.TakeScreenshotCallback?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: LambdasInterface.TakeScreenshotCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
@@ -16,11 +16,11 @@ public class LambdasWithStructuredTypes {
         smoke_LambdasWithStructuredTypes_release_handle(c_instance)
     }
     public func doClassStuff(callback: @escaping LambdasWithStructuredTypes.ClassCallback) -> Void {
-        let c_callback = moveToCType(callback)
+        let c_callback = foobar_moveToCType(callback)
         return moveFromCType(smoke_LambdasWithStructuredTypes_doClassStuff(self.c_instance, c_callback.ref))
     }
     public func doStructStuff(callback: @escaping LambdasWithStructuredTypes.StructCallback) -> Void {
-        let c_callback = moveToCType(callback)
+        let c_callback = foobar_moveToCType(callback)
         return moveFromCType(smoke_LambdasWithStructuredTypes_doStructStuff(self.c_instance, c_callback.ref))
     }
 }
@@ -44,7 +44,7 @@ extension LambdasWithStructuredTypes: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func LambdasWithStructuredTypes_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes {
+internal func foobar_LambdasWithStructuredTypes_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes {
     if let swift_pointer = smoke_LambdasWithStructuredTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LambdasWithStructuredTypes {
         return re_constructed
@@ -53,7 +53,7 @@ internal func LambdasWithStructuredTypes_copyFromCType(_ handle: _baseRef) -> La
     smoke_LambdasWithStructuredTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func LambdasWithStructuredTypes_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes {
+internal func foobar_LambdasWithStructuredTypes_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes {
     if let swift_pointer = smoke_LambdasWithStructuredTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LambdasWithStructuredTypes {
         smoke_LambdasWithStructuredTypes_release_handle(handle)
@@ -63,50 +63,50 @@ internal func LambdasWithStructuredTypes_moveFromCType(_ handle: _baseRef) -> La
     smoke_LambdasWithStructuredTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func LambdasWithStructuredTypes_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes? {
+internal func foobar_LambdasWithStructuredTypes_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes? {
     guard handle != 0 else {
         return nil
     }
-    return LambdasWithStructuredTypes_moveFromCType(handle) as LambdasWithStructuredTypes
+    return foobar_LambdasWithStructuredTypes_moveFromCType(handle) as LambdasWithStructuredTypes
 }
-internal func LambdasWithStructuredTypes_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes? {
+internal func foobar_LambdasWithStructuredTypes_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes? {
     guard handle != 0 else {
         return nil
     }
-    return LambdasWithStructuredTypes_moveFromCType(handle) as LambdasWithStructuredTypes
+    return foobar_LambdasWithStructuredTypes_moveFromCType(handle) as LambdasWithStructuredTypes
 }
-internal func copyToCType(_ swiftClass: LambdasWithStructuredTypes) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: LambdasWithStructuredTypes) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: LambdasWithStructuredTypes) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: LambdasWithStructuredTypes) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: LambdasWithStructuredTypes?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: LambdasWithStructuredTypes?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: LambdasWithStructuredTypes?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: LambdasWithStructuredTypes?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback {
-    return moveFromCType(smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback {
+    return foobar_moveFromCType(smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback {
     let refHolder = RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_ClassCallback_release_handle)
     return { (p0: LambdasInterface) -> Void in
-        return moveFromCType(smoke_LambdasWithStructuredTypes_ClassCallback_call(refHolder.ref, moveToCType(p0).ref))
+        return moveFromCType(smoke_LambdasWithStructuredTypes_ClassCallback_call(refHolder.ref, foobar_moveToCType(p0).ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as LambdasWithStructuredTypes.ClassCallback
+    return foobar_copyFromCType(handle) as LambdasWithStructuredTypes.ClassCallback
 }
-internal func moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as LambdasWithStructuredTypes.ClassCallback
+    return foobar_moveFromCType(handle) as LambdasWithStructuredTypes.ClassCallback
 }
 internal func createFunctionalTable(_ swiftType: @escaping LambdasWithStructuredTypes.ClassCallback) -> smoke_LambdasWithStructuredTypes_ClassCallback_FunctionTable {
     class smoke_LambdasWithStructuredTypes_ClassCallback_Holder {
@@ -124,52 +124,52 @@ internal func createFunctionalTable(_ swiftType: @escaping LambdasWithStructured
     }
     functions.smoke_LambdasWithStructuredTypes_ClassCallback_call = { swift_closure_pointer, p0 in
         let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_LambdasWithStructuredTypes_ClassCallback_Holder
-        return copyToCType(closure_holder.closure(LambdasInterface_moveFromCType(p0))).ref
+        return copyToCType(closure_holder.closure(foobar_LambdasInterface_moveFromCType(p0))).ref
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping LambdasWithStructuredTypes.ClassCallback) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping LambdasWithStructuredTypes.ClassCallback) -> RefHolder {
     let handle = smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping LambdasWithStructuredTypes.ClassCallback) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping LambdasWithStructuredTypes.ClassCallback) -> RefHolder {
     let handle = smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_ClassCallback_release_handle)
 }
-internal func copyToCType(_ swiftType: LambdasWithStructuredTypes.ClassCallback?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: LambdasWithStructuredTypes.ClassCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_LambdasWithStructuredTypes_ClassCallback_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: LambdasWithStructuredTypes.ClassCallback?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: LambdasWithStructuredTypes.ClassCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_LambdasWithStructuredTypes_ClassCallback_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_ClassCallback_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback {
-    return moveFromCType(smoke_LambdasWithStructuredTypes_StructCallback_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback {
+    return foobar_moveFromCType(smoke_LambdasWithStructuredTypes_StructCallback_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback {
     let refHolder = RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_StructCallback_release_handle)
     return { (p0: LambdasDeclarationOrder.SomeStruct) -> Void in
-        return moveFromCType(smoke_LambdasWithStructuredTypes_StructCallback_call(refHolder.ref, moveToCType(p0).ref))
+        return moveFromCType(smoke_LambdasWithStructuredTypes_StructCallback_call(refHolder.ref, foobar_moveToCType(p0).ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as LambdasWithStructuredTypes.StructCallback
+    return foobar_copyFromCType(handle) as LambdasWithStructuredTypes.StructCallback
 }
-internal func moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as LambdasWithStructuredTypes.StructCallback
+    return foobar_moveFromCType(handle) as LambdasWithStructuredTypes.StructCallback
 }
 internal func createFunctionalTable(_ swiftType: @escaping LambdasWithStructuredTypes.StructCallback) -> smoke_LambdasWithStructuredTypes_StructCallback_FunctionTable {
     class smoke_LambdasWithStructuredTypes_StructCallback_Holder {
@@ -187,26 +187,26 @@ internal func createFunctionalTable(_ swiftType: @escaping LambdasWithStructured
     }
     functions.smoke_LambdasWithStructuredTypes_StructCallback_call = { swift_closure_pointer, p0 in
         let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_LambdasWithStructuredTypes_StructCallback_Holder
-        return copyToCType(closure_holder.closure(moveFromCType(p0))).ref
+        return copyToCType(closure_holder.closure(foobar_moveFromCType(p0))).ref
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping LambdasWithStructuredTypes.StructCallback) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping LambdasWithStructuredTypes.StructCallback) -> RefHolder {
     let handle = smoke_LambdasWithStructuredTypes_StructCallback_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping LambdasWithStructuredTypes.StructCallback) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping LambdasWithStructuredTypes.StructCallback) -> RefHolder {
     let handle = smoke_LambdasWithStructuredTypes_StructCallback_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_StructCallback_release_handle)
 }
-internal func copyToCType(_ swiftType: LambdasWithStructuredTypes.StructCallback?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: LambdasWithStructuredTypes.StructCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_LambdasWithStructuredTypes_StructCallback_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: LambdasWithStructuredTypes.StructCallback?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: LambdasWithStructuredTypes.StructCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/StandaloneProducer.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/StandaloneProducer.swift
@@ -2,26 +2,26 @@
 //
 import Foundation
 public typealias StandaloneProducer = () -> String
-internal func copyFromCType(_ handle: _baseRef) -> StandaloneProducer {
-    return moveFromCType(smoke_StandaloneProducer_copy_handle(handle))
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StandaloneProducer {
+    return foobar_moveFromCType(smoke_StandaloneProducer_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> StandaloneProducer {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StandaloneProducer {
     let refHolder = RefHolder(ref: handle, release: smoke_StandaloneProducer_release_handle)
     return { () -> String in
         return moveFromCType(smoke_StandaloneProducer_call(refHolder.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> StandaloneProducer? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StandaloneProducer? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as StandaloneProducer
+    return foobar_copyFromCType(handle) as StandaloneProducer
 }
-internal func moveFromCType(_ handle: _baseRef) -> StandaloneProducer? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StandaloneProducer? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as StandaloneProducer
+    return foobar_moveFromCType(handle) as StandaloneProducer
 }
 internal func createFunctionalTable(_ swiftType: @escaping StandaloneProducer) -> smoke_StandaloneProducer_FunctionTable {
     class smoke_StandaloneProducer_Holder {
@@ -43,22 +43,22 @@ internal func createFunctionalTable(_ swiftType: @escaping StandaloneProducer) -
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping StandaloneProducer) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: @escaping StandaloneProducer) -> RefHolder {
     let handle = smoke_StandaloneProducer_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping StandaloneProducer) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: @escaping StandaloneProducer) -> RefHolder {
     let handle = smoke_StandaloneProducer_create_proxy(createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_StandaloneProducer_release_handle)
 }
-internal func copyToCType(_ swiftType: StandaloneProducer?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: StandaloneProducer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let handle = smoke_StandaloneProducer_create_optional_proxy(createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: StandaloneProducer?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftType: StandaloneProducer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Calculator.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Calculator.swift
@@ -14,11 +14,11 @@ public class Calculator {
         smoke_Calculator_release_handle(c_instance)
     }
     public static func registerListener(listener: CalculatorListener) -> Void {
-        let c_listener = moveToCType(listener)
+        let c_listener = foobar_moveToCType(listener)
         return moveFromCType(smoke_Calculator_registerListener(c_listener.ref))
     }
     public static func unregisterListener(listener: CalculatorListener) -> Void {
-        let c_listener = moveToCType(listener)
+        let c_listener = foobar_moveToCType(listener)
         return moveFromCType(smoke_Calculator_unregisterListener(c_listener.ref))
     }
 }
@@ -42,7 +42,7 @@ extension Calculator: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Calculator_copyFromCType(_ handle: _baseRef) -> Calculator {
+internal func foobar_Calculator_copyFromCType(_ handle: _baseRef) -> Calculator {
     if let swift_pointer = smoke_Calculator_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Calculator {
         return re_constructed
@@ -51,7 +51,7 @@ internal func Calculator_copyFromCType(_ handle: _baseRef) -> Calculator {
     smoke_Calculator_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Calculator_moveFromCType(_ handle: _baseRef) -> Calculator {
+internal func foobar_Calculator_moveFromCType(_ handle: _baseRef) -> Calculator {
     if let swift_pointer = smoke_Calculator_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Calculator {
         smoke_Calculator_release_handle(handle)
@@ -61,27 +61,27 @@ internal func Calculator_moveFromCType(_ handle: _baseRef) -> Calculator {
     smoke_Calculator_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Calculator_copyFromCType(_ handle: _baseRef) -> Calculator? {
+internal func foobar_Calculator_copyFromCType(_ handle: _baseRef) -> Calculator? {
     guard handle != 0 else {
         return nil
     }
-    return Calculator_moveFromCType(handle) as Calculator
+    return foobar_Calculator_moveFromCType(handle) as Calculator
 }
-internal func Calculator_moveFromCType(_ handle: _baseRef) -> Calculator? {
+internal func foobar_Calculator_moveFromCType(_ handle: _baseRef) -> Calculator? {
     guard handle != 0 else {
         return nil
     }
-    return Calculator_moveFromCType(handle) as Calculator
+    return foobar_Calculator_moveFromCType(handle) as Calculator
 }
-internal func copyToCType(_ swiftClass: Calculator) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Calculator) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Calculator) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Calculator) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Calculator?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Calculator?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Calculator?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Calculator?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/CalculatorListener.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/CalculatorListener.swift
@@ -31,7 +31,7 @@ internal class _CalculatorListener: CalculatorListener {
         return moveFromCType(smoke_CalculatorListener_onCalculationResultConst(self.c_instance, c_calculationResult.ref))
     }
     public func onCalculationResultStruct(calculationResult: ResultStruct) -> Void {
-        let c_calculationResult = moveToCType(calculationResult)
+        let c_calculationResult = foobar_moveToCType(calculationResult)
         return moveFromCType(smoke_CalculatorListener_onCalculationResultStruct(self.c_instance, c_calculationResult.ref))
     }
     public func onCalculationResultArray(calculationResult: [Double]) -> Void {
@@ -43,7 +43,7 @@ internal class _CalculatorListener: CalculatorListener {
         return moveFromCType(smoke_CalculatorListener_onCalculationResultMap(self.c_instance, c_calculationResults.ref))
     }
     public func onCalculationResultInstance(calculationResult: CalculationResult) -> Void {
-        let c_calculationResult = moveToCType(calculationResult)
+        let c_calculationResult = foobar_moveToCType(calculationResult)
         return moveFromCType(smoke_CalculatorListener_onCalculationResultInstance(self.c_instance, c_calculationResult.ref))
     }
 }
@@ -88,7 +88,7 @@ internal func getRef(_ ref: CalculatorListener?, owning: Bool = true) -> RefHold
     }
     functions.smoke_CalculatorListener_onCalculationResultStruct = {(swift_class_pointer, calculationResult) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! CalculatorListener
-        swift_class.onCalculationResultStruct(calculationResult: moveFromCType(calculationResult))
+        swift_class.onCalculationResultStruct(calculationResult: foobar_moveFromCType(calculationResult))
     }
     functions.smoke_CalculatorListener_onCalculationResultArray = {(swift_class_pointer, calculationResult) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! CalculatorListener
@@ -100,7 +100,7 @@ internal func getRef(_ ref: CalculatorListener?, owning: Bool = true) -> RefHold
     }
     functions.smoke_CalculatorListener_onCalculationResultInstance = {(swift_class_pointer, calculationResult) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! CalculatorListener
-        swift_class.onCalculationResultInstance(calculationResult: CalculationResult_moveFromCType(calculationResult))
+        swift_class.onCalculationResultInstance(calculationResult: foobar_CalculationResult_moveFromCType(calculationResult))
     }
     let proxy = smoke_CalculatorListener_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_CalculatorListener_release_handle) : RefHolder(proxy)
@@ -108,7 +108,7 @@ internal func getRef(_ ref: CalculatorListener?, owning: Bool = true) -> RefHold
 extension _CalculatorListener: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func CalculatorListener_copyFromCType(_ handle: _baseRef) -> CalculatorListener {
+internal func foobar_CalculatorListener_copyFromCType(_ handle: _baseRef) -> CalculatorListener {
     if let swift_pointer = smoke_CalculatorListener_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CalculatorListener {
         return re_constructed
@@ -124,7 +124,7 @@ internal func CalculatorListener_copyFromCType(_ handle: _baseRef) -> Calculator
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func CalculatorListener_moveFromCType(_ handle: _baseRef) -> CalculatorListener {
+internal func foobar_CalculatorListener_moveFromCType(_ handle: _baseRef) -> CalculatorListener {
     if let swift_pointer = smoke_CalculatorListener_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CalculatorListener {
         smoke_CalculatorListener_release_handle(handle)
@@ -142,66 +142,66 @@ internal func CalculatorListener_moveFromCType(_ handle: _baseRef) -> Calculator
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func CalculatorListener_copyFromCType(_ handle: _baseRef) -> CalculatorListener? {
+internal func foobar_CalculatorListener_copyFromCType(_ handle: _baseRef) -> CalculatorListener? {
     guard handle != 0 else {
         return nil
     }
-    return CalculatorListener_moveFromCType(handle) as CalculatorListener
+    return foobar_CalculatorListener_moveFromCType(handle) as CalculatorListener
 }
-internal func CalculatorListener_moveFromCType(_ handle: _baseRef) -> CalculatorListener? {
+internal func foobar_CalculatorListener_moveFromCType(_ handle: _baseRef) -> CalculatorListener? {
     guard handle != 0 else {
         return nil
     }
-    return CalculatorListener_moveFromCType(handle) as CalculatorListener
+    return foobar_CalculatorListener_moveFromCType(handle) as CalculatorListener
 }
-internal func copyToCType(_ swiftClass: CalculatorListener) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: CalculatorListener) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: CalculatorListener) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: CalculatorListener) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: CalculatorListener?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: CalculatorListener?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: CalculatorListener?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: CalculatorListener?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ResultStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ResultStruct {
     return ResultStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> ResultStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ResultStruct {
     defer {
         smoke_CalculatorListener_ResultStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ResultStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ResultStruct) -> RefHolder {
     let c_result = moveToCType(swiftType.result)
     return RefHolder(smoke_CalculatorListener_ResultStruct_create_handle(c_result.ref))
 }
-internal func moveToCType(_ swiftType: ResultStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_CalculatorListener_ResultStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: ResultStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_CalculatorListener_ResultStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ResultStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ResultStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_CalculatorListener_ResultStruct_unwrap_optional_handle(handle)
     return ResultStruct(cHandle: unwrappedHandle) as ResultStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> ResultStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ResultStruct? {
     defer {
         smoke_CalculatorListener_ResultStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ResultStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ResultStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_result = moveToCType(swiftType.result)
     return RefHolder(smoke_CalculatorListener_ResultStruct_create_optional_handle(c_result.ref))
 }
-internal func moveToCType(_ swiftType: ResultStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_CalculatorListener_ResultStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: ResultStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_CalculatorListener_ResultStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenerInterface.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenerInterface.swift
@@ -66,13 +66,13 @@ internal func getRef(_ ref: ListenerInterface?, owning: Bool = true, isWeak: Boo
     let proxy = smoke_ListenerInterface_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_ListenerInterface_release_handle) : RefHolder(proxy)
 }
-internal func weakToCType(_ swiftClass: ListenerInterface?) -> RefHolder {
+internal func foobar_weakToCType(_ swiftClass: ListenerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true, isWeak: true)
 }
 extension _ListenerInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func ListenerInterface_copyFromCType(_ handle: _baseRef) -> ListenerInterface {
+internal func foobar_ListenerInterface_copyFromCType(_ handle: _baseRef) -> ListenerInterface {
     if let swift_pointer = smoke_ListenerInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerInterface {
         return re_constructed
@@ -88,7 +88,7 @@ internal func ListenerInterface_copyFromCType(_ handle: _baseRef) -> ListenerInt
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ListenerInterface_moveFromCType(_ handle: _baseRef) -> ListenerInterface {
+internal func foobar_ListenerInterface_moveFromCType(_ handle: _baseRef) -> ListenerInterface {
     if let swift_pointer = smoke_ListenerInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerInterface {
         smoke_ListenerInterface_release_handle(handle)
@@ -106,27 +106,27 @@ internal func ListenerInterface_moveFromCType(_ handle: _baseRef) -> ListenerInt
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ListenerInterface_copyFromCType(_ handle: _baseRef) -> ListenerInterface? {
+internal func foobar_ListenerInterface_copyFromCType(_ handle: _baseRef) -> ListenerInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ListenerInterface_moveFromCType(handle) as ListenerInterface
+    return foobar_ListenerInterface_moveFromCType(handle) as ListenerInterface
 }
-internal func ListenerInterface_moveFromCType(_ handle: _baseRef) -> ListenerInterface? {
+internal func foobar_ListenerInterface_moveFromCType(_ handle: _baseRef) -> ListenerInterface? {
     guard handle != 0 else {
         return nil
     }
-    return ListenerInterface_moveFromCType(handle) as ListenerInterface
+    return foobar_ListenerInterface_moveFromCType(handle) as ListenerInterface
 }
-internal func copyToCType(_ swiftClass: ListenerInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ListenerInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ListenerInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ListenerInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ListenerInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ListenerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ListenerInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ListenerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenerWithProperties.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenerWithProperties.swift
@@ -23,28 +23,28 @@ internal class _ListenerWithProperties: ListenerWithProperties {
     }
     var packedMessage: CalculationResult {
         get {
-            return CalculationResult_moveFromCType(smoke_ListenerWithProperties_packedMessage_get(self.c_instance))
+            return foobar_CalculationResult_moveFromCType(smoke_ListenerWithProperties_packedMessage_get(self.c_instance))
         }
         set {
-            let c_value = moveToCType(newValue)
+            let c_value = foobar_moveToCType(newValue)
             return moveFromCType(smoke_ListenerWithProperties_packedMessage_set(self.c_instance, c_value.ref))
         }
     }
     var structuredMessage: ResultStruct {
         get {
-            return moveFromCType(smoke_ListenerWithProperties_structuredMessage_get(self.c_instance))
+            return foobar_moveFromCType(smoke_ListenerWithProperties_structuredMessage_get(self.c_instance))
         }
         set {
-            let c_value = moveToCType(newValue)
+            let c_value = foobar_moveToCType(newValue)
             return moveFromCType(smoke_ListenerWithProperties_structuredMessage_set(self.c_instance, c_value.ref))
         }
     }
     var enumeratedMessage: ResultEnum {
         get {
-            return moveFromCType(smoke_ListenerWithProperties_enumeratedMessage_get(self.c_instance))
+            return foobar_moveFromCType(smoke_ListenerWithProperties_enumeratedMessage_get(self.c_instance))
         }
         set {
-            let c_value = moveToCType(newValue)
+            let c_value = foobar_moveToCType(newValue)
             return moveFromCType(smoke_ListenerWithProperties_enumeratedMessage_set(self.c_instance, c_value.ref))
         }
     }
@@ -132,27 +132,27 @@ internal func getRef(_ ref: ListenerWithProperties?, owning: Bool = true) -> Ref
     }
     functions.smoke_ListenerWithProperties_packedMessage_get = {(swift_class_pointer) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ListenerWithProperties
-        return copyToCType(swift_class.packedMessage).ref
+        return foobar_copyToCType(swift_class.packedMessage).ref
     }
     functions.smoke_ListenerWithProperties_packedMessage_set = {(swift_class_pointer, value) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ListenerWithProperties
-        swift_class.packedMessage = CalculationResult_moveFromCType(value)
+        swift_class.packedMessage = foobar_CalculationResult_moveFromCType(value)
     }
     functions.smoke_ListenerWithProperties_structuredMessage_get = {(swift_class_pointer) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ListenerWithProperties
-        return copyToCType(swift_class.structuredMessage).ref
+        return foobar_copyToCType(swift_class.structuredMessage).ref
     }
     functions.smoke_ListenerWithProperties_structuredMessage_set = {(swift_class_pointer, value) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ListenerWithProperties
-        swift_class.structuredMessage = moveFromCType(value)
+        swift_class.structuredMessage = foobar_moveFromCType(value)
     }
     functions.smoke_ListenerWithProperties_enumeratedMessage_get = {(swift_class_pointer) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ListenerWithProperties
-        return copyToCType(swift_class.enumeratedMessage).ref
+        return foobar_copyToCType(swift_class.enumeratedMessage).ref
     }
     functions.smoke_ListenerWithProperties_enumeratedMessage_set = {(swift_class_pointer, value) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ListenerWithProperties
-        swift_class.enumeratedMessage = moveFromCType(value)
+        swift_class.enumeratedMessage = foobar_moveFromCType(value)
     }
     functions.smoke_ListenerWithProperties_arrayedMessage_get = {(swift_class_pointer) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ListenerWithProperties
@@ -184,7 +184,7 @@ internal func getRef(_ ref: ListenerWithProperties?, owning: Bool = true) -> Ref
 extension _ListenerWithProperties: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func ListenerWithProperties_copyFromCType(_ handle: _baseRef) -> ListenerWithProperties {
+internal func foobar_ListenerWithProperties_copyFromCType(_ handle: _baseRef) -> ListenerWithProperties {
     if let swift_pointer = smoke_ListenerWithProperties_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerWithProperties {
         return re_constructed
@@ -200,7 +200,7 @@ internal func ListenerWithProperties_copyFromCType(_ handle: _baseRef) -> Listen
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ListenerWithProperties_moveFromCType(_ handle: _baseRef) -> ListenerWithProperties {
+internal func foobar_ListenerWithProperties_moveFromCType(_ handle: _baseRef) -> ListenerWithProperties {
     if let swift_pointer = smoke_ListenerWithProperties_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerWithProperties {
         smoke_ListenerWithProperties_release_handle(handle)
@@ -218,96 +218,96 @@ internal func ListenerWithProperties_moveFromCType(_ handle: _baseRef) -> Listen
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ListenerWithProperties_copyFromCType(_ handle: _baseRef) -> ListenerWithProperties? {
+internal func foobar_ListenerWithProperties_copyFromCType(_ handle: _baseRef) -> ListenerWithProperties? {
     guard handle != 0 else {
         return nil
     }
-    return ListenerWithProperties_moveFromCType(handle) as ListenerWithProperties
+    return foobar_ListenerWithProperties_moveFromCType(handle) as ListenerWithProperties
 }
-internal func ListenerWithProperties_moveFromCType(_ handle: _baseRef) -> ListenerWithProperties? {
+internal func foobar_ListenerWithProperties_moveFromCType(_ handle: _baseRef) -> ListenerWithProperties? {
     guard handle != 0 else {
         return nil
     }
-    return ListenerWithProperties_moveFromCType(handle) as ListenerWithProperties
+    return foobar_ListenerWithProperties_moveFromCType(handle) as ListenerWithProperties
 }
-internal func copyToCType(_ swiftClass: ListenerWithProperties) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ListenerWithProperties) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ListenerWithProperties) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ListenerWithProperties) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ListenerWithProperties?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ListenerWithProperties?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ListenerWithProperties?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ListenerWithProperties?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ResultStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ResultStruct {
     return ResultStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> ResultStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ResultStruct {
     defer {
         smoke_ListenerWithProperties_ResultStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ResultStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ResultStruct) -> RefHolder {
     let c_result = moveToCType(swiftType.result)
     return RefHolder(smoke_ListenerWithProperties_ResultStruct_create_handle(c_result.ref))
 }
-internal func moveToCType(_ swiftType: ResultStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ListenerWithProperties_ResultStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: ResultStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_ListenerWithProperties_ResultStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ResultStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ResultStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_ListenerWithProperties_ResultStruct_unwrap_optional_handle(handle)
     return ResultStruct(cHandle: unwrappedHandle) as ResultStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> ResultStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ResultStruct? {
     defer {
         smoke_ListenerWithProperties_ResultStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ResultStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ResultStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_result = moveToCType(swiftType.result)
     return RefHolder(smoke_ListenerWithProperties_ResultStruct_create_optional_handle(c_result.ref))
 }
-internal func moveToCType(_ swiftType: ResultStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ListenerWithProperties_ResultStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: ResultStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_ListenerWithProperties_ResultStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: ResultEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: ResultEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ResultEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: ResultEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: ResultEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: ResultEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ResultEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: ResultEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> ResultEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> ResultEnum {
     return ResultEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> ResultEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> ResultEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ResultEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ResultEnum? {
     guard handle != 0 else {
         return nil
     }
     return ResultEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> ResultEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ResultEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenersWithReturnValues.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenersWithReturnValues.swift
@@ -30,10 +30,10 @@ internal class _ListenersWithReturnValues: ListenersWithReturnValues {
         return moveFromCType(smoke_ListenersWithReturnValues_fetchDataString(self.c_instance))
     }
     public func fetchDataStruct() -> ResultStruct {
-        return moveFromCType(smoke_ListenersWithReturnValues_fetchDataStruct(self.c_instance))
+        return foobar_moveFromCType(smoke_ListenersWithReturnValues_fetchDataStruct(self.c_instance))
     }
     public func fetchDataEnum() -> ResultEnum {
-        return moveFromCType(smoke_ListenersWithReturnValues_fetchDataEnum(self.c_instance))
+        return foobar_moveFromCType(smoke_ListenersWithReturnValues_fetchDataEnum(self.c_instance))
     }
     public func fetchDataArray() -> [Double] {
         return foobar_moveFromCType(smoke_ListenersWithReturnValues_fetchDataArray(self.c_instance))
@@ -42,7 +42,7 @@ internal class _ListenersWithReturnValues: ListenersWithReturnValues {
         return foobar_moveFromCType(smoke_ListenersWithReturnValues_fetchDataMap(self.c_instance))
     }
     public func fetchDataInstance() -> CalculationResult {
-        return CalculationResult_moveFromCType(smoke_ListenersWithReturnValues_fetchDataInstance(self.c_instance))
+        return foobar_CalculationResult_moveFromCType(smoke_ListenersWithReturnValues_fetchDataInstance(self.c_instance))
     }
 }
 public enum ResultEnum : UInt32, CaseIterable, Codable {
@@ -90,11 +90,11 @@ internal func getRef(_ ref: ListenersWithReturnValues?, owning: Bool = true) -> 
     }
     functions.smoke_ListenersWithReturnValues_fetchDataStruct = {(swift_class_pointer) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ListenersWithReturnValues
-        return copyToCType(swift_class.fetchDataStruct()).ref
+        return foobar_copyToCType(swift_class.fetchDataStruct()).ref
     }
     functions.smoke_ListenersWithReturnValues_fetchDataEnum = {(swift_class_pointer) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ListenersWithReturnValues
-        return copyToCType(swift_class.fetchDataEnum()).ref
+        return foobar_copyToCType(swift_class.fetchDataEnum()).ref
     }
     functions.smoke_ListenersWithReturnValues_fetchDataArray = {(swift_class_pointer) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ListenersWithReturnValues
@@ -106,7 +106,7 @@ internal func getRef(_ ref: ListenersWithReturnValues?, owning: Bool = true) -> 
     }
     functions.smoke_ListenersWithReturnValues_fetchDataInstance = {(swift_class_pointer) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ListenersWithReturnValues
-        return copyToCType(swift_class.fetchDataInstance()).ref
+        return foobar_copyToCType(swift_class.fetchDataInstance()).ref
     }
     let proxy = smoke_ListenersWithReturnValues_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_ListenersWithReturnValues_release_handle) : RefHolder(proxy)
@@ -114,7 +114,7 @@ internal func getRef(_ ref: ListenersWithReturnValues?, owning: Bool = true) -> 
 extension _ListenersWithReturnValues: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func ListenersWithReturnValues_copyFromCType(_ handle: _baseRef) -> ListenersWithReturnValues {
+internal func foobar_ListenersWithReturnValues_copyFromCType(_ handle: _baseRef) -> ListenersWithReturnValues {
     if let swift_pointer = smoke_ListenersWithReturnValues_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenersWithReturnValues {
         return re_constructed
@@ -130,7 +130,7 @@ internal func ListenersWithReturnValues_copyFromCType(_ handle: _baseRef) -> Lis
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ListenersWithReturnValues_moveFromCType(_ handle: _baseRef) -> ListenersWithReturnValues {
+internal func foobar_ListenersWithReturnValues_moveFromCType(_ handle: _baseRef) -> ListenersWithReturnValues {
     if let swift_pointer = smoke_ListenersWithReturnValues_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenersWithReturnValues {
         smoke_ListenersWithReturnValues_release_handle(handle)
@@ -148,96 +148,96 @@ internal func ListenersWithReturnValues_moveFromCType(_ handle: _baseRef) -> Lis
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func ListenersWithReturnValues_copyFromCType(_ handle: _baseRef) -> ListenersWithReturnValues? {
+internal func foobar_ListenersWithReturnValues_copyFromCType(_ handle: _baseRef) -> ListenersWithReturnValues? {
     guard handle != 0 else {
         return nil
     }
-    return ListenersWithReturnValues_moveFromCType(handle) as ListenersWithReturnValues
+    return foobar_ListenersWithReturnValues_moveFromCType(handle) as ListenersWithReturnValues
 }
-internal func ListenersWithReturnValues_moveFromCType(_ handle: _baseRef) -> ListenersWithReturnValues? {
+internal func foobar_ListenersWithReturnValues_moveFromCType(_ handle: _baseRef) -> ListenersWithReturnValues? {
     guard handle != 0 else {
         return nil
     }
-    return ListenersWithReturnValues_moveFromCType(handle) as ListenersWithReturnValues
+    return foobar_ListenersWithReturnValues_moveFromCType(handle) as ListenersWithReturnValues
 }
-internal func copyToCType(_ swiftClass: ListenersWithReturnValues) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ListenersWithReturnValues) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ListenersWithReturnValues) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ListenersWithReturnValues) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: ListenersWithReturnValues?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: ListenersWithReturnValues?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: ListenersWithReturnValues?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: ListenersWithReturnValues?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ResultStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ResultStruct {
     return ResultStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> ResultStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ResultStruct {
     defer {
         smoke_ListenersWithReturnValues_ResultStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ResultStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ResultStruct) -> RefHolder {
     let c_result = moveToCType(swiftType.result)
     return RefHolder(smoke_ListenersWithReturnValues_ResultStruct_create_handle(c_result.ref))
 }
-internal func moveToCType(_ swiftType: ResultStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ListenersWithReturnValues_ResultStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: ResultStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_ListenersWithReturnValues_ResultStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ResultStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ResultStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_ListenersWithReturnValues_ResultStruct_unwrap_optional_handle(handle)
     return ResultStruct(cHandle: unwrappedHandle) as ResultStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> ResultStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ResultStruct? {
     defer {
         smoke_ListenersWithReturnValues_ResultStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ResultStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ResultStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_result = moveToCType(swiftType.result)
     return RefHolder(smoke_ListenersWithReturnValues_ResultStruct_create_optional_handle(c_result.ref))
 }
-internal func moveToCType(_ swiftType: ResultStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ListenersWithReturnValues_ResultStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: ResultStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_ListenersWithReturnValues_ResultStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: ResultEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: ResultEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ResultEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: ResultEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: ResultEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: ResultEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: ResultEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: ResultEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> ResultEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> ResultEnum {
     return ResultEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> ResultEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> ResultEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ResultEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ResultEnum? {
     guard handle != 0 else {
         return nil
     }
     return ResultEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> ResultEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ResultEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Weakling.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Weakling.swift
@@ -7,10 +7,10 @@ public protocol Weakling : AnyObject {
 internal class _Weakling: Weakling {
     weak var listener: ListenerInterface? {
         get {
-            return ListenerInterface_moveFromCType(smoke_Weakling_listener_get(self.c_instance))
+            return foobar_ListenerInterface_moveFromCType(smoke_Weakling_listener_get(self.c_instance))
         }
         set {
-            let c_value = weakToCType(newValue)
+            let c_value = foobar_weakToCType(newValue)
             return moveFromCType(smoke_Weakling_listener_set(self.c_instance, c_value.ref))
         }
     }
@@ -50,11 +50,11 @@ internal func getRef(_ ref: Weakling?, owning: Bool = true) -> RefHolder {
     }
     functions.smoke_Weakling_listener_get = {(swift_class_pointer) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! Weakling
-        return copyToCType(swift_class.listener).ref
+        return foobar_copyToCType(swift_class.listener).ref
     }
     functions.smoke_Weakling_listener_set = {(swift_class_pointer, value) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! Weakling
-        swift_class.listener = ListenerInterface_moveFromCType(value)
+        swift_class.listener = foobar_ListenerInterface_moveFromCType(value)
     }
     let proxy = smoke_Weakling_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_Weakling_release_handle) : RefHolder(proxy)
@@ -62,7 +62,7 @@ internal func getRef(_ ref: Weakling?, owning: Bool = true) -> RefHolder {
 extension _Weakling: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func Weakling_copyFromCType(_ handle: _baseRef) -> Weakling {
+internal func foobar_Weakling_copyFromCType(_ handle: _baseRef) -> Weakling {
     if let swift_pointer = smoke_Weakling_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Weakling {
         return re_constructed
@@ -78,7 +78,7 @@ internal func Weakling_copyFromCType(_ handle: _baseRef) -> Weakling {
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func Weakling_moveFromCType(_ handle: _baseRef) -> Weakling {
+internal func foobar_Weakling_moveFromCType(_ handle: _baseRef) -> Weakling {
     if let swift_pointer = smoke_Weakling_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Weakling {
         smoke_Weakling_release_handle(handle)
@@ -96,27 +96,27 @@ internal func Weakling_moveFromCType(_ handle: _baseRef) -> Weakling {
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func Weakling_copyFromCType(_ handle: _baseRef) -> Weakling? {
+internal func foobar_Weakling_copyFromCType(_ handle: _baseRef) -> Weakling? {
     guard handle != 0 else {
         return nil
     }
-    return Weakling_moveFromCType(handle) as Weakling
+    return foobar_Weakling_moveFromCType(handle) as Weakling
 }
-internal func Weakling_moveFromCType(_ handle: _baseRef) -> Weakling? {
+internal func foobar_Weakling_moveFromCType(_ handle: _baseRef) -> Weakling? {
     guard handle != 0 else {
         return nil
     }
-    return Weakling_moveFromCType(handle) as Weakling
+    return foobar_Weakling_moveFromCType(handle) as Weakling
 }
-internal func copyToCType(_ swiftClass: Weakling) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Weakling) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Weakling) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Weakling) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Weakling?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Weakling?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Weakling?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Weakling?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/Locales.swift
+++ b/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/Locales.swift
@@ -59,7 +59,7 @@ extension Locales: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Locales_copyFromCType(_ handle: _baseRef) -> Locales {
+internal func foobar_Locales_copyFromCType(_ handle: _baseRef) -> Locales {
     if let swift_pointer = smoke_Locales_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Locales {
         return re_constructed
@@ -68,7 +68,7 @@ internal func Locales_copyFromCType(_ handle: _baseRef) -> Locales {
     smoke_Locales_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Locales_moveFromCType(_ handle: _baseRef) -> Locales {
+internal func foobar_Locales_moveFromCType(_ handle: _baseRef) -> Locales {
     if let swift_pointer = smoke_Locales_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Locales {
         smoke_Locales_release_handle(handle)
@@ -78,66 +78,66 @@ internal func Locales_moveFromCType(_ handle: _baseRef) -> Locales {
     smoke_Locales_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Locales_copyFromCType(_ handle: _baseRef) -> Locales? {
+internal func foobar_Locales_copyFromCType(_ handle: _baseRef) -> Locales? {
     guard handle != 0 else {
         return nil
     }
-    return Locales_moveFromCType(handle) as Locales
+    return foobar_Locales_moveFromCType(handle) as Locales
 }
-internal func Locales_moveFromCType(_ handle: _baseRef) -> Locales? {
+internal func foobar_Locales_moveFromCType(_ handle: _baseRef) -> Locales? {
     guard handle != 0 else {
         return nil
     }
-    return Locales_moveFromCType(handle) as Locales
+    return foobar_Locales_moveFromCType(handle) as Locales
 }
-internal func copyToCType(_ swiftClass: Locales) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Locales) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Locales) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Locales) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Locales?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Locales?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Locales?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Locales?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Locales.LocaleStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Locales.LocaleStruct {
     return Locales.LocaleStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Locales.LocaleStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Locales.LocaleStruct {
     defer {
         smoke_Locales_LocaleStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Locales.LocaleStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Locales.LocaleStruct) -> RefHolder {
     let c_localeField = moveToCType(swiftType.localeField)
     return RefHolder(smoke_Locales_LocaleStruct_create_handle(c_localeField.ref))
 }
-internal func moveToCType(_ swiftType: Locales.LocaleStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Locales_LocaleStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Locales.LocaleStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Locales_LocaleStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Locales.LocaleStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Locales.LocaleStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Locales_LocaleStruct_unwrap_optional_handle(handle)
     return Locales.LocaleStruct(cHandle: unwrappedHandle) as Locales.LocaleStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Locales.LocaleStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Locales.LocaleStruct? {
     defer {
         smoke_Locales_LocaleStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Locales.LocaleStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Locales.LocaleStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_localeField = moveToCType(swiftType.localeField)
     return RefHolder(smoke_Locales_LocaleStruct_create_optional_handle(c_localeField.ref))
 }
-internal func moveToCType(_ swiftType: Locales.LocaleStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Locales_LocaleStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Locales.LocaleStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Locales_LocaleStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/MethodOverloads.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/MethodOverloads.swift
@@ -40,14 +40,14 @@ public class MethodOverloads {
         return moveFromCType(smoke_MethodOverloads_isBoolean_String(self.c_instance, c_input.ref))
     }
     public func isBoolean(input: MethodOverloads.Point) -> Bool {
-        let c_input = moveToCType(input)
+        let c_input = foobar_moveToCType(input)
         return moveFromCType(smoke_MethodOverloads_isBoolean_Point(self.c_instance, c_input.ref))
     }
     public func isBoolean(input1: Bool, input2: Int8, input3: String, input4: MethodOverloads.Point) -> Bool {
         let c_input1 = moveToCType(input1)
         let c_input2 = moveToCType(input2)
         let c_input3 = moveToCType(input3)
-        let c_input4 = moveToCType(input4)
+        let c_input4 = foobar_moveToCType(input4)
         return moveFromCType(smoke_MethodOverloads_isBoolean_Boolean_Byte_String_Point(self.c_instance, c_input1.ref, c_input2.ref, c_input3.ref, c_input4.ref))
     }
     public func isBoolean(input: MethodOverloads.StringArray) -> Bool {
@@ -90,7 +90,7 @@ extension MethodOverloads: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func MethodOverloads_copyFromCType(_ handle: _baseRef) -> MethodOverloads {
+internal func foobar_MethodOverloads_copyFromCType(_ handle: _baseRef) -> MethodOverloads {
     if let swift_pointer = smoke_MethodOverloads_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MethodOverloads {
         return re_constructed
@@ -99,7 +99,7 @@ internal func MethodOverloads_copyFromCType(_ handle: _baseRef) -> MethodOverloa
     smoke_MethodOverloads_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func MethodOverloads_moveFromCType(_ handle: _baseRef) -> MethodOverloads {
+internal func foobar_MethodOverloads_moveFromCType(_ handle: _baseRef) -> MethodOverloads {
     if let swift_pointer = smoke_MethodOverloads_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MethodOverloads {
         smoke_MethodOverloads_release_handle(handle)
@@ -109,61 +109,61 @@ internal func MethodOverloads_moveFromCType(_ handle: _baseRef) -> MethodOverloa
     smoke_MethodOverloads_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func MethodOverloads_copyFromCType(_ handle: _baseRef) -> MethodOverloads? {
+internal func foobar_MethodOverloads_copyFromCType(_ handle: _baseRef) -> MethodOverloads? {
     guard handle != 0 else {
         return nil
     }
-    return MethodOverloads_moveFromCType(handle) as MethodOverloads
+    return foobar_MethodOverloads_moveFromCType(handle) as MethodOverloads
 }
-internal func MethodOverloads_moveFromCType(_ handle: _baseRef) -> MethodOverloads? {
+internal func foobar_MethodOverloads_moveFromCType(_ handle: _baseRef) -> MethodOverloads? {
     guard handle != 0 else {
         return nil
     }
-    return MethodOverloads_moveFromCType(handle) as MethodOverloads
+    return foobar_MethodOverloads_moveFromCType(handle) as MethodOverloads
 }
-internal func copyToCType(_ swiftClass: MethodOverloads) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: MethodOverloads) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: MethodOverloads) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: MethodOverloads) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: MethodOverloads?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: MethodOverloads?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: MethodOverloads?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: MethodOverloads?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> MethodOverloads.Point {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> MethodOverloads.Point {
     return MethodOverloads.Point(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> MethodOverloads.Point {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> MethodOverloads.Point {
     defer {
         smoke_MethodOverloads_Point_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: MethodOverloads.Point) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: MethodOverloads.Point) -> RefHolder {
     let c_x = moveToCType(swiftType.x)
     let c_y = moveToCType(swiftType.y)
     return RefHolder(smoke_MethodOverloads_Point_create_handle(c_x.ref, c_y.ref))
 }
-internal func moveToCType(_ swiftType: MethodOverloads.Point) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_MethodOverloads_Point_release_handle)
+internal func foobar_moveToCType(_ swiftType: MethodOverloads.Point) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_MethodOverloads_Point_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> MethodOverloads.Point? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> MethodOverloads.Point? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_MethodOverloads_Point_unwrap_optional_handle(handle)
     return MethodOverloads.Point(cHandle: unwrappedHandle) as MethodOverloads.Point
 }
-internal func moveFromCType(_ handle: _baseRef) -> MethodOverloads.Point? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> MethodOverloads.Point? {
     defer {
         smoke_MethodOverloads_Point_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: MethodOverloads.Point?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: MethodOverloads.Point?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -171,6 +171,6 @@ internal func copyToCType(_ swiftType: MethodOverloads.Point?) -> RefHolder {
     let c_y = moveToCType(swiftType.y)
     return RefHolder(smoke_MethodOverloads_Point_create_optional_handle(c_x.ref, c_y.ref))
 }
-internal func moveToCType(_ swiftType: MethodOverloads.Point?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_MethodOverloads_Point_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: MethodOverloads.Point?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_MethodOverloads_Point_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SpecialNames.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SpecialNames.swift
@@ -46,7 +46,7 @@ extension SpecialNames: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func SpecialNames_copyFromCType(_ handle: _baseRef) -> SpecialNames {
+internal func foobar_SpecialNames_copyFromCType(_ handle: _baseRef) -> SpecialNames {
     if let swift_pointer = smoke_SpecialNames_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SpecialNames {
         return re_constructed
@@ -55,7 +55,7 @@ internal func SpecialNames_copyFromCType(_ handle: _baseRef) -> SpecialNames {
     smoke_SpecialNames_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func SpecialNames_moveFromCType(_ handle: _baseRef) -> SpecialNames {
+internal func foobar_SpecialNames_moveFromCType(_ handle: _baseRef) -> SpecialNames {
     if let swift_pointer = smoke_SpecialNames_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SpecialNames {
         smoke_SpecialNames_release_handle(handle)
@@ -65,27 +65,27 @@ internal func SpecialNames_moveFromCType(_ handle: _baseRef) -> SpecialNames {
     smoke_SpecialNames_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func SpecialNames_copyFromCType(_ handle: _baseRef) -> SpecialNames? {
+internal func foobar_SpecialNames_copyFromCType(_ handle: _baseRef) -> SpecialNames? {
     guard handle != 0 else {
         return nil
     }
-    return SpecialNames_moveFromCType(handle) as SpecialNames
+    return foobar_SpecialNames_moveFromCType(handle) as SpecialNames
 }
-internal func SpecialNames_moveFromCType(_ handle: _baseRef) -> SpecialNames? {
+internal func foobar_SpecialNames_moveFromCType(_ handle: _baseRef) -> SpecialNames? {
     guard handle != 0 else {
         return nil
     }
-    return SpecialNames_moveFromCType(handle) as SpecialNames
+    return foobar_SpecialNames_moveFromCType(handle) as SpecialNames
 }
-internal func copyToCType(_ swiftClass: SpecialNames) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: SpecialNames) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: SpecialNames) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: SpecialNames) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: SpecialNames?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: SpecialNames?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: SpecialNames?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: SpecialNames?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SwiftMethodOverloads.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SwiftMethodOverloads.swift
@@ -42,7 +42,7 @@ extension SwiftMethodOverloads: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func SwiftMethodOverloads_copyFromCType(_ handle: _baseRef) -> SwiftMethodOverloads {
+internal func foobar_SwiftMethodOverloads_copyFromCType(_ handle: _baseRef) -> SwiftMethodOverloads {
     if let swift_pointer = smoke_SwiftMethodOverloads_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SwiftMethodOverloads {
         return re_constructed
@@ -51,7 +51,7 @@ internal func SwiftMethodOverloads_copyFromCType(_ handle: _baseRef) -> SwiftMet
     smoke_SwiftMethodOverloads_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func SwiftMethodOverloads_moveFromCType(_ handle: _baseRef) -> SwiftMethodOverloads {
+internal func foobar_SwiftMethodOverloads_moveFromCType(_ handle: _baseRef) -> SwiftMethodOverloads {
     if let swift_pointer = smoke_SwiftMethodOverloads_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SwiftMethodOverloads {
         smoke_SwiftMethodOverloads_release_handle(handle)
@@ -61,27 +61,27 @@ internal func SwiftMethodOverloads_moveFromCType(_ handle: _baseRef) -> SwiftMet
     smoke_SwiftMethodOverloads_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func SwiftMethodOverloads_copyFromCType(_ handle: _baseRef) -> SwiftMethodOverloads? {
+internal func foobar_SwiftMethodOverloads_copyFromCType(_ handle: _baseRef) -> SwiftMethodOverloads? {
     guard handle != 0 else {
         return nil
     }
-    return SwiftMethodOverloads_moveFromCType(handle) as SwiftMethodOverloads
+    return foobar_SwiftMethodOverloads_moveFromCType(handle) as SwiftMethodOverloads
 }
-internal func SwiftMethodOverloads_moveFromCType(_ handle: _baseRef) -> SwiftMethodOverloads? {
+internal func foobar_SwiftMethodOverloads_moveFromCType(_ handle: _baseRef) -> SwiftMethodOverloads? {
     guard handle != 0 else {
         return nil
     }
-    return SwiftMethodOverloads_moveFromCType(handle) as SwiftMethodOverloads
+    return foobar_SwiftMethodOverloads_moveFromCType(handle) as SwiftMethodOverloads
 }
-internal func copyToCType(_ swiftClass: SwiftMethodOverloads) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: SwiftMethodOverloads) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: SwiftMethodOverloads) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: SwiftMethodOverloads) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: SwiftMethodOverloads?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: SwiftMethodOverloads?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: SwiftMethodOverloads?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: SwiftMethodOverloads?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/FreeEnum.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/FreeEnum.swift
@@ -1,38 +1,37 @@
 //
 //
-
 import Foundation
 public enum FreeEnum : UInt32, CaseIterable, Codable {
     case foo
     case bar
 }
-internal func copyToCType(_ swiftEnum: FreeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: FreeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: FreeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: FreeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: FreeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: FreeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: FreeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: FreeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> FreeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> FreeEnum {
     return FreeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> FreeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> FreeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> FreeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> FreeEnum? {
     guard handle != 0 else {
         return nil
     }
     return FreeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> FreeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> FreeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/FreePoint.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/FreePoint.swift
@@ -14,41 +14,41 @@ public struct FreePoint {
         y = moveFromCType(smoke_FreePoint_y_get(cHandle))
     }
     public func flip() -> FreePoint {
-        let c_self_handle = moveToCType(self)
-        return moveFromCType(smoke_FreePoint_flip(c_self_handle.ref))
+        let c_self_handle = foobar_moveToCType(self)
+        return foobar_moveFromCType(smoke_FreePoint_flip(c_self_handle.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> FreePoint {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> FreePoint {
     return FreePoint(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> FreePoint {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> FreePoint {
     defer {
         smoke_FreePoint_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: FreePoint) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: FreePoint) -> RefHolder {
     let c_x = moveToCType(swiftType.x)
     let c_y = moveToCType(swiftType.y)
     return RefHolder(smoke_FreePoint_create_handle(c_x.ref, c_y.ref))
 }
-internal func moveToCType(_ swiftType: FreePoint) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FreePoint_release_handle)
+internal func foobar_moveToCType(_ swiftType: FreePoint) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_FreePoint_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> FreePoint? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> FreePoint? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_FreePoint_unwrap_optional_handle(handle)
     return FreePoint(cHandle: unwrappedHandle) as FreePoint
 }
-internal func moveFromCType(_ handle: _baseRef) -> FreePoint? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> FreePoint? {
     defer {
         smoke_FreePoint_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: FreePoint?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: FreePoint?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -56,6 +56,6 @@ internal func copyToCType(_ swiftType: FreePoint?) -> RefHolder {
     let c_y = moveToCType(swiftType.y)
     return RefHolder(smoke_FreePoint_create_optional_handle(c_x.ref, c_y.ref))
 }
-internal func moveToCType(_ swiftType: FreePoint?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FreePoint_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: FreePoint?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_FreePoint_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/LevelOne.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/LevelOne.swift
@@ -50,12 +50,12 @@ public class LevelOne {
                     stringField = moveFromCType(smoke_LevelOne_LevelTwo_LevelThree_LevelFour_stringField_get(cHandle))
                 }
                 public static func fooFactory() -> LevelOne.LevelTwo.LevelThree.LevelFour {
-                    return moveFromCType(smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fooFactory())
+                    return foobar_moveFromCType(smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fooFactory())
                 }
             }
             public func foo(input: InnerInterface) -> InnerClass {
-                let c_input = moveToCType(input)
-                return InnerClass_moveFromCType(smoke_LevelOne_LevelTwo_LevelThree_foo(self.c_instance, c_input.ref))
+                let c_input = foobar_moveToCType(input)
+                return foobar_InnerClass_moveFromCType(smoke_LevelOne_LevelTwo_LevelThree_foo(self.c_instance, c_input.ref))
             }
         }
     }
@@ -80,7 +80,7 @@ extension LevelOne: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func LevelOne_copyFromCType(_ handle: _baseRef) -> LevelOne {
+internal func foobar_LevelOne_copyFromCType(_ handle: _baseRef) -> LevelOne {
     if let swift_pointer = smoke_LevelOne_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne {
         return re_constructed
@@ -89,7 +89,7 @@ internal func LevelOne_copyFromCType(_ handle: _baseRef) -> LevelOne {
     smoke_LevelOne_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func LevelOne_moveFromCType(_ handle: _baseRef) -> LevelOne {
+internal func foobar_LevelOne_moveFromCType(_ handle: _baseRef) -> LevelOne {
     if let swift_pointer = smoke_LevelOne_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne {
         smoke_LevelOne_release_handle(handle)
@@ -99,28 +99,28 @@ internal func LevelOne_moveFromCType(_ handle: _baseRef) -> LevelOne {
     smoke_LevelOne_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func LevelOne_copyFromCType(_ handle: _baseRef) -> LevelOne? {
+internal func foobar_LevelOne_copyFromCType(_ handle: _baseRef) -> LevelOne? {
     guard handle != 0 else {
         return nil
     }
-    return LevelOne_moveFromCType(handle) as LevelOne
+    return foobar_LevelOne_moveFromCType(handle) as LevelOne
 }
-internal func LevelOne_moveFromCType(_ handle: _baseRef) -> LevelOne? {
+internal func foobar_LevelOne_moveFromCType(_ handle: _baseRef) -> LevelOne? {
     guard handle != 0 else {
         return nil
     }
-    return LevelOne_moveFromCType(handle) as LevelOne
+    return foobar_LevelOne_moveFromCType(handle) as LevelOne
 }
-internal func copyToCType(_ swiftClass: LevelOne) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: LevelOne) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: LevelOne) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: LevelOne) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: LevelOne?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: LevelOne?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: LevelOne?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: LevelOne?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
 internal func getRef(_ ref: LevelOne.LevelTwo?, owning: Bool = true) -> RefHolder {
@@ -143,7 +143,7 @@ extension LevelOne.LevelTwo: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func LevelOne_LevelTwo_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo {
+internal func foobar_LevelOne_LevelTwo_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo {
     if let swift_pointer = smoke_LevelOne_LevelTwo_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne.LevelTwo {
         return re_constructed
@@ -152,7 +152,7 @@ internal func LevelOne_LevelTwo_copyFromCType(_ handle: _baseRef) -> LevelOne.Le
     smoke_LevelOne_LevelTwo_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func LevelOne_LevelTwo_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo {
+internal func foobar_LevelOne_LevelTwo_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo {
     if let swift_pointer = smoke_LevelOne_LevelTwo_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne.LevelTwo {
         smoke_LevelOne_LevelTwo_release_handle(handle)
@@ -162,28 +162,28 @@ internal func LevelOne_LevelTwo_moveFromCType(_ handle: _baseRef) -> LevelOne.Le
     smoke_LevelOne_LevelTwo_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func LevelOne_LevelTwo_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo? {
+internal func foobar_LevelOne_LevelTwo_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo? {
     guard handle != 0 else {
         return nil
     }
-    return LevelOne_LevelTwo_moveFromCType(handle) as LevelOne.LevelTwo
+    return foobar_LevelOne_LevelTwo_moveFromCType(handle) as LevelOne.LevelTwo
 }
-internal func LevelOne_LevelTwo_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo? {
+internal func foobar_LevelOne_LevelTwo_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo? {
     guard handle != 0 else {
         return nil
     }
-    return LevelOne_LevelTwo_moveFromCType(handle) as LevelOne.LevelTwo
+    return foobar_LevelOne_LevelTwo_moveFromCType(handle) as LevelOne.LevelTwo
 }
-internal func copyToCType(_ swiftClass: LevelOne.LevelTwo) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: LevelOne.LevelTwo) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: LevelOne.LevelTwo) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: LevelOne.LevelTwo) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: LevelOne.LevelTwo?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: LevelOne.LevelTwo?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: LevelOne.LevelTwo?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: LevelOne.LevelTwo?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
 internal func getRef(_ ref: LevelOne.LevelTwo.LevelThree?, owning: Bool = true) -> RefHolder {
@@ -206,7 +206,7 @@ extension LevelOne.LevelTwo.LevelThree: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func LevelOne_LevelTwo_LevelThree_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree {
+internal func foobar_LevelOne_LevelTwo_LevelThree_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree {
     if let swift_pointer = smoke_LevelOne_LevelTwo_LevelThree_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne.LevelTwo.LevelThree {
         return re_constructed
@@ -215,7 +215,7 @@ internal func LevelOne_LevelTwo_LevelThree_copyFromCType(_ handle: _baseRef) -> 
     smoke_LevelOne_LevelTwo_LevelThree_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func LevelOne_LevelTwo_LevelThree_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree {
+internal func foobar_LevelOne_LevelTwo_LevelThree_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree {
     if let swift_pointer = smoke_LevelOne_LevelTwo_LevelThree_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LevelOne.LevelTwo.LevelThree {
         smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle)
@@ -225,96 +225,96 @@ internal func LevelOne_LevelTwo_LevelThree_moveFromCType(_ handle: _baseRef) -> 
     smoke_LevelOne_LevelTwo_LevelThree_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func LevelOne_LevelTwo_LevelThree_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree? {
+internal func foobar_LevelOne_LevelTwo_LevelThree_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree? {
     guard handle != 0 else {
         return nil
     }
-    return LevelOne_LevelTwo_LevelThree_moveFromCType(handle) as LevelOne.LevelTwo.LevelThree
+    return foobar_LevelOne_LevelTwo_LevelThree_moveFromCType(handle) as LevelOne.LevelTwo.LevelThree
 }
-internal func LevelOne_LevelTwo_LevelThree_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree? {
+internal func foobar_LevelOne_LevelTwo_LevelThree_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree? {
     guard handle != 0 else {
         return nil
     }
-    return LevelOne_LevelTwo_LevelThree_moveFromCType(handle) as LevelOne.LevelTwo.LevelThree
+    return foobar_LevelOne_LevelTwo_LevelThree_moveFromCType(handle) as LevelOne.LevelTwo.LevelThree
 }
-internal func copyToCType(_ swiftClass: LevelOne.LevelTwo.LevelThree) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: LevelOne.LevelTwo.LevelThree) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: LevelOne.LevelTwo.LevelThree) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: LevelOne.LevelTwo.LevelThree) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: LevelOne.LevelTwo.LevelThree?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: LevelOne.LevelTwo.LevelThree?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: LevelOne.LevelTwo.LevelThree?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: LevelOne.LevelTwo.LevelThree?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree.LevelFour {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree.LevelFour {
     return LevelOne.LevelTwo.LevelThree.LevelFour(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree.LevelFour {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree.LevelFour {
     defer {
         smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: LevelOne.LevelTwo.LevelThree.LevelFour) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: LevelOne.LevelTwo.LevelThree.LevelFour) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: LevelOne.LevelTwo.LevelThree.LevelFour) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle)
+internal func foobar_moveToCType(_ swiftType: LevelOne.LevelTwo.LevelThree.LevelFour) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree.LevelFour? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree.LevelFour? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_LevelOne_LevelTwo_LevelThree_LevelFour_unwrap_optional_handle(handle)
     return LevelOne.LevelTwo.LevelThree.LevelFour(cHandle: unwrappedHandle) as LevelOne.LevelTwo.LevelThree.LevelFour
 }
-internal func moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree.LevelFour? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree.LevelFour? {
     defer {
         smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: LevelOne.LevelTwo.LevelThree.LevelFour?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: LevelOne.LevelTwo.LevelThree.LevelFour?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_optional_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: LevelOne.LevelTwo.LevelThree.LevelFour?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: LevelOne.LevelTwo.LevelThree.LevelFour?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: LevelOne.LevelTwo.LevelThree.LevelFourEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: LevelOne.LevelTwo.LevelThree.LevelFourEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: LevelOne.LevelTwo.LevelThree.LevelFourEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: LevelOne.LevelTwo.LevelThree.LevelFourEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: LevelOne.LevelTwo.LevelThree.LevelFourEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: LevelOne.LevelTwo.LevelThree.LevelFourEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: LevelOne.LevelTwo.LevelThree.LevelFourEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: LevelOne.LevelTwo.LevelThree.LevelFourEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> LevelOne.LevelTwo.LevelThree.LevelFourEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> LevelOne.LevelTwo.LevelThree.LevelFourEnum {
     return LevelOne.LevelTwo.LevelThree.LevelFourEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> LevelOne.LevelTwo.LevelThree.LevelFourEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> LevelOne.LevelTwo.LevelThree.LevelFourEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree.LevelFourEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree.LevelFourEnum? {
     guard handle != 0 else {
         return nil
     }
     return LevelOne.LevelTwo.LevelThree.LevelFourEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree.LevelFourEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> LevelOne.LevelTwo.LevelThree.LevelFourEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/NestedReferences.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/NestedReferences.swift
@@ -23,9 +23,9 @@ public class NestedReferences {
         }
     }
     public func insideOut(struct1: NestedReferences.NestedReferences, struct2: NestedReferences.NestedReferences) -> NestedReferences {
-        let c_struct1 = moveToCType(struct1)
-        let c_struct2 = moveToCType(struct2)
-        return NestedReferences_moveFromCType(smoke_NestedReferences_insideOut(self.c_instance, c_struct1.ref, c_struct2.ref))
+        let c_struct1 = foobar_moveToCType(struct1)
+        let c_struct2 = foobar_moveToCType(struct2)
+        return foobar_NestedReferences_moveFromCType(smoke_NestedReferences_insideOut(self.c_instance, c_struct1.ref, c_struct2.ref))
     }
 }
 internal func getRef(_ ref: NestedReferences?, owning: Bool = true) -> RefHolder {
@@ -48,7 +48,7 @@ extension NestedReferences: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func NestedReferences_copyFromCType(_ handle: _baseRef) -> NestedReferences {
+internal func foobar_NestedReferences_copyFromCType(_ handle: _baseRef) -> NestedReferences {
     if let swift_pointer = smoke_NestedReferences_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? NestedReferences {
         return re_constructed
@@ -57,7 +57,7 @@ internal func NestedReferences_copyFromCType(_ handle: _baseRef) -> NestedRefere
     smoke_NestedReferences_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func NestedReferences_moveFromCType(_ handle: _baseRef) -> NestedReferences {
+internal func foobar_NestedReferences_moveFromCType(_ handle: _baseRef) -> NestedReferences {
     if let swift_pointer = smoke_NestedReferences_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? NestedReferences {
         smoke_NestedReferences_release_handle(handle)
@@ -67,66 +67,66 @@ internal func NestedReferences_moveFromCType(_ handle: _baseRef) -> NestedRefere
     smoke_NestedReferences_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func NestedReferences_copyFromCType(_ handle: _baseRef) -> NestedReferences? {
+internal func foobar_NestedReferences_copyFromCType(_ handle: _baseRef) -> NestedReferences? {
     guard handle != 0 else {
         return nil
     }
-    return NestedReferences_moveFromCType(handle) as NestedReferences
+    return foobar_NestedReferences_moveFromCType(handle) as NestedReferences
 }
-internal func NestedReferences_moveFromCType(_ handle: _baseRef) -> NestedReferences? {
+internal func foobar_NestedReferences_moveFromCType(_ handle: _baseRef) -> NestedReferences? {
     guard handle != 0 else {
         return nil
     }
-    return NestedReferences_moveFromCType(handle) as NestedReferences
+    return foobar_NestedReferences_moveFromCType(handle) as NestedReferences
 }
-internal func copyToCType(_ swiftClass: NestedReferences) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: NestedReferences) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: NestedReferences) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: NestedReferences) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: NestedReferences?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: NestedReferences?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: NestedReferences?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: NestedReferences?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> NestedReferences.NestedReferences {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> NestedReferences.NestedReferences {
     return NestedReferences.NestedReferences(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> NestedReferences.NestedReferences {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> NestedReferences.NestedReferences {
     defer {
         smoke_NestedReferences_NestedReferences_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: NestedReferences.NestedReferences) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: NestedReferences.NestedReferences) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_NestedReferences_NestedReferences_create_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: NestedReferences.NestedReferences) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_NestedReferences_NestedReferences_release_handle)
+internal func foobar_moveToCType(_ swiftType: NestedReferences.NestedReferences) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_NestedReferences_NestedReferences_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> NestedReferences.NestedReferences? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> NestedReferences.NestedReferences? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_NestedReferences_NestedReferences_unwrap_optional_handle(handle)
     return NestedReferences.NestedReferences(cHandle: unwrappedHandle) as NestedReferences.NestedReferences
 }
-internal func moveFromCType(_ handle: _baseRef) -> NestedReferences.NestedReferences? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> NestedReferences.NestedReferences? {
     defer {
         smoke_NestedReferences_NestedReferences_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: NestedReferences.NestedReferences?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: NestedReferences.NestedReferences?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_NestedReferences_NestedReferences_create_optional_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: NestedReferences.NestedReferences?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_NestedReferences_NestedReferences_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: NestedReferences.NestedReferences?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_NestedReferences_NestedReferences_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClass.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClass.swift
@@ -75,7 +75,7 @@ extension OuterClass: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func OuterClass_copyFromCType(_ handle: _baseRef) -> OuterClass {
+internal func foobar_OuterClass_copyFromCType(_ handle: _baseRef) -> OuterClass {
     if let swift_pointer = smoke_OuterClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass {
         return re_constructed
@@ -84,7 +84,7 @@ internal func OuterClass_copyFromCType(_ handle: _baseRef) -> OuterClass {
     smoke_OuterClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func OuterClass_moveFromCType(_ handle: _baseRef) -> OuterClass {
+internal func foobar_OuterClass_moveFromCType(_ handle: _baseRef) -> OuterClass {
     if let swift_pointer = smoke_OuterClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass {
         smoke_OuterClass_release_handle(handle)
@@ -94,28 +94,28 @@ internal func OuterClass_moveFromCType(_ handle: _baseRef) -> OuterClass {
     smoke_OuterClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func OuterClass_copyFromCType(_ handle: _baseRef) -> OuterClass? {
+internal func foobar_OuterClass_copyFromCType(_ handle: _baseRef) -> OuterClass? {
     guard handle != 0 else {
         return nil
     }
-    return OuterClass_moveFromCType(handle) as OuterClass
+    return foobar_OuterClass_moveFromCType(handle) as OuterClass
 }
-internal func OuterClass_moveFromCType(_ handle: _baseRef) -> OuterClass? {
+internal func foobar_OuterClass_moveFromCType(_ handle: _baseRef) -> OuterClass? {
     guard handle != 0 else {
         return nil
     }
-    return OuterClass_moveFromCType(handle) as OuterClass
+    return foobar_OuterClass_moveFromCType(handle) as OuterClass
 }
-internal func copyToCType(_ swiftClass: OuterClass) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: OuterClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: OuterClass) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: OuterClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: OuterClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: OuterClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: OuterClass?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: OuterClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
 internal func getRef(_ ref: OuterClass.InnerClass?, owning: Bool = true) -> RefHolder {
@@ -138,7 +138,7 @@ extension OuterClass.InnerClass: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func OuterClass_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterClass.InnerClass {
+internal func foobar_OuterClass_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterClass.InnerClass {
     if let swift_pointer = smoke_OuterClass_InnerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerClass {
         return re_constructed
@@ -147,7 +147,7 @@ internal func OuterClass_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterCl
     smoke_OuterClass_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func OuterClass_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterClass.InnerClass {
+internal func foobar_OuterClass_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterClass.InnerClass {
     if let swift_pointer = smoke_OuterClass_InnerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClass.InnerClass {
         smoke_OuterClass_InnerClass_release_handle(handle)
@@ -157,28 +157,28 @@ internal func OuterClass_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterCl
     smoke_OuterClass_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func OuterClass_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterClass.InnerClass? {
+internal func foobar_OuterClass_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterClass.InnerClass? {
     guard handle != 0 else {
         return nil
     }
-    return OuterClass_InnerClass_moveFromCType(handle) as OuterClass.InnerClass
+    return foobar_OuterClass_InnerClass_moveFromCType(handle) as OuterClass.InnerClass
 }
-internal func OuterClass_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterClass.InnerClass? {
+internal func foobar_OuterClass_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterClass.InnerClass? {
     guard handle != 0 else {
         return nil
     }
-    return OuterClass_InnerClass_moveFromCType(handle) as OuterClass.InnerClass
+    return foobar_OuterClass_InnerClass_moveFromCType(handle) as OuterClass.InnerClass
 }
-internal func copyToCType(_ swiftClass: OuterClass.InnerClass) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: OuterClass.InnerClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: OuterClass.InnerClass) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: OuterClass.InnerClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: OuterClass.InnerClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: OuterClass.InnerClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: OuterClass.InnerClass?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: OuterClass.InnerClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
 @_cdecl("_CBridgeInitsmoke_OuterClass_InnerInterface")
@@ -213,7 +213,7 @@ internal func getRef(_ ref: InnerInterface?, owning: Bool = true) -> RefHolder {
 extension _InnerInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface {
+internal func foobar_InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface {
     if let swift_pointer = smoke_OuterClass_InnerInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
         return re_constructed
@@ -229,7 +229,7 @@ internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface {
+internal func foobar_InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface {
     if let swift_pointer = smoke_OuterClass_InnerInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
         smoke_OuterClass_InnerInterface_release_handle(handle)
@@ -247,27 +247,27 @@ internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface? {
+internal func foobar_InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface? {
     guard handle != 0 else {
         return nil
     }
-    return InnerInterface_moveFromCType(handle) as InnerInterface
+    return foobar_InnerInterface_moveFromCType(handle) as InnerInterface
 }
-internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface? {
+internal func foobar_InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface? {
     guard handle != 0 else {
         return nil
     }
-    return InnerInterface_moveFromCType(handle) as InnerInterface
+    return foobar_InnerInterface_moveFromCType(handle) as InnerInterface
 }
-internal func copyToCType(_ swiftClass: InnerInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InnerInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InnerInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InnerInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: InnerInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InnerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InnerInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InnerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterInterface.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterInterface.swift
@@ -90,7 +90,7 @@ internal func getRef(_ ref: OuterInterface?, owning: Bool = true) -> RefHolder {
 extension _OuterInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func OuterInterface_copyFromCType(_ handle: _baseRef) -> OuterInterface {
+internal func foobar_OuterInterface_copyFromCType(_ handle: _baseRef) -> OuterInterface {
     if let swift_pointer = smoke_OuterInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterInterface {
         return re_constructed
@@ -106,7 +106,7 @@ internal func OuterInterface_copyFromCType(_ handle: _baseRef) -> OuterInterface
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func OuterInterface_moveFromCType(_ handle: _baseRef) -> OuterInterface {
+internal func foobar_OuterInterface_moveFromCType(_ handle: _baseRef) -> OuterInterface {
     if let swift_pointer = smoke_OuterInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterInterface {
         smoke_OuterInterface_release_handle(handle)
@@ -124,28 +124,28 @@ internal func OuterInterface_moveFromCType(_ handle: _baseRef) -> OuterInterface
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func OuterInterface_copyFromCType(_ handle: _baseRef) -> OuterInterface? {
+internal func foobar_OuterInterface_copyFromCType(_ handle: _baseRef) -> OuterInterface? {
     guard handle != 0 else {
         return nil
     }
-    return OuterInterface_moveFromCType(handle) as OuterInterface
+    return foobar_OuterInterface_moveFromCType(handle) as OuterInterface
 }
-internal func OuterInterface_moveFromCType(_ handle: _baseRef) -> OuterInterface? {
+internal func foobar_OuterInterface_moveFromCType(_ handle: _baseRef) -> OuterInterface? {
     guard handle != 0 else {
         return nil
     }
-    return OuterInterface_moveFromCType(handle) as OuterInterface
+    return foobar_OuterInterface_moveFromCType(handle) as OuterInterface
 }
-internal func copyToCType(_ swiftClass: OuterInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: OuterInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: OuterInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: OuterInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: OuterInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: OuterInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: OuterInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: OuterInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
 internal func getRef(_ ref: InnerClass?, owning: Bool = true) -> RefHolder {
@@ -168,7 +168,7 @@ extension InnerClass: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func InnerClass_copyFromCType(_ handle: _baseRef) -> InnerClass {
+internal func foobar_InnerClass_copyFromCType(_ handle: _baseRef) -> InnerClass {
     if let swift_pointer = smoke_OuterInterface_InnerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerClass {
         return re_constructed
@@ -177,7 +177,7 @@ internal func InnerClass_copyFromCType(_ handle: _baseRef) -> InnerClass {
     smoke_OuterInterface_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func InnerClass_moveFromCType(_ handle: _baseRef) -> InnerClass {
+internal func foobar_InnerClass_moveFromCType(_ handle: _baseRef) -> InnerClass {
     if let swift_pointer = smoke_OuterInterface_InnerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerClass {
         smoke_OuterInterface_InnerClass_release_handle(handle)
@@ -187,28 +187,28 @@ internal func InnerClass_moveFromCType(_ handle: _baseRef) -> InnerClass {
     smoke_OuterInterface_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func InnerClass_copyFromCType(_ handle: _baseRef) -> InnerClass? {
+internal func foobar_InnerClass_copyFromCType(_ handle: _baseRef) -> InnerClass? {
     guard handle != 0 else {
         return nil
     }
-    return InnerClass_moveFromCType(handle) as InnerClass
+    return foobar_InnerClass_moveFromCType(handle) as InnerClass
 }
-internal func InnerClass_moveFromCType(_ handle: _baseRef) -> InnerClass? {
+internal func foobar_InnerClass_moveFromCType(_ handle: _baseRef) -> InnerClass? {
     guard handle != 0 else {
         return nil
     }
-    return InnerClass_moveFromCType(handle) as InnerClass
+    return foobar_InnerClass_moveFromCType(handle) as InnerClass
 }
-internal func copyToCType(_ swiftClass: InnerClass) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InnerClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InnerClass) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InnerClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: InnerClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InnerClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InnerClass?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InnerClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
 @_cdecl("_CBridgeInitsmoke_OuterInterface_InnerInterface")
@@ -243,7 +243,7 @@ internal func getRef(_ ref: InnerInterface?, owning: Bool = true) -> RefHolder {
 extension _InnerInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface {
+internal func foobar_InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface {
     if let swift_pointer = smoke_OuterInterface_InnerInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
         return re_constructed
@@ -259,7 +259,7 @@ internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface {
+internal func foobar_InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface {
     if let swift_pointer = smoke_OuterInterface_InnerInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
         smoke_OuterInterface_InnerInterface_release_handle(handle)
@@ -277,27 +277,27 @@ internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface? {
+internal func foobar_InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface? {
     guard handle != 0 else {
         return nil
     }
-    return InnerInterface_moveFromCType(handle) as InnerInterface
+    return foobar_InnerInterface_moveFromCType(handle) as InnerInterface
 }
-internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface? {
+internal func foobar_InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface? {
     guard handle != 0 else {
         return nil
     }
-    return InnerInterface_moveFromCType(handle) as InnerInterface
+    return foobar_InnerInterface_moveFromCType(handle) as InnerInterface
 }
-internal func copyToCType(_ swiftClass: InnerInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InnerInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InnerInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InnerInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: InnerInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InnerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InnerInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InnerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterStruct.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterStruct.swift
@@ -22,7 +22,7 @@ public struct OuterStruct {
             otherField = foobar_moveFromCType(smoke_OuterStruct_InnerStruct_otherField_get(cHandle))
         }
         public func doSomething() -> Void {
-            let c_self_handle = moveToCType(self)
+            let c_self_handle = foobar_moveToCType(self)
             return moveFromCType(smoke_OuterStruct_InnerStruct_doSomething(c_self_handle.ref))
         }
     }
@@ -43,7 +43,7 @@ public struct OuterStruct {
         }
     }
     public func doNothing() -> Void {
-        let c_self_handle = moveToCType(self)
+        let c_self_handle = foobar_moveToCType(self)
         return moveFromCType(smoke_OuterStruct_doNothing(c_self_handle.ref))
     }
 }
@@ -66,44 +66,44 @@ internal class _InnerInterface: InnerInterface {
         return foobar_moveFromCType(smoke_OuterStruct_InnerInterface_barBaz(self.c_instance))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> OuterStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> OuterStruct {
     return OuterStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> OuterStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> OuterStruct {
     defer {
         smoke_OuterStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: OuterStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: OuterStruct) -> RefHolder {
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_OuterStruct_create_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: OuterStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: OuterStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_OuterStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> OuterStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> OuterStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_OuterStruct_unwrap_optional_handle(handle)
     return OuterStruct(cHandle: unwrappedHandle) as OuterStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> OuterStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> OuterStruct? {
     defer {
         smoke_OuterStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: OuterStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: OuterStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_OuterStruct_create_optional_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: OuterStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: OuterStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_OuterStruct_release_optional_handle)
 }
 internal func getRef(_ ref: OuterStruct.InnerClass?, owning: Bool = true) -> RefHolder {
     guard let c_handle = ref?.c_instance else {
@@ -125,7 +125,7 @@ extension OuterStruct.InnerClass: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func OuterStruct_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass {
+internal func foobar_OuterStruct_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass {
     if let swift_pointer = smoke_OuterStruct_InnerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterStruct.InnerClass {
         return re_constructed
@@ -134,7 +134,7 @@ internal func OuterStruct_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterS
     smoke_OuterStruct_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func OuterStruct_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass {
+internal func foobar_OuterStruct_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass {
     if let swift_pointer = smoke_OuterStruct_InnerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterStruct.InnerClass {
         smoke_OuterStruct_InnerClass_release_handle(handle)
@@ -144,28 +144,28 @@ internal func OuterStruct_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterS
     smoke_OuterStruct_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func OuterStruct_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass? {
+internal func foobar_OuterStruct_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass? {
     guard handle != 0 else {
         return nil
     }
-    return OuterStruct_InnerClass_moveFromCType(handle) as OuterStruct.InnerClass
+    return foobar_OuterStruct_InnerClass_moveFromCType(handle) as OuterStruct.InnerClass
 }
-internal func OuterStruct_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass? {
+internal func foobar_OuterStruct_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass? {
     guard handle != 0 else {
         return nil
     }
-    return OuterStruct_InnerClass_moveFromCType(handle) as OuterStruct.InnerClass
+    return foobar_OuterStruct_InnerClass_moveFromCType(handle) as OuterStruct.InnerClass
 }
-internal func copyToCType(_ swiftClass: OuterStruct.InnerClass) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: OuterStruct.InnerClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: OuterStruct.InnerClass) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: OuterStruct.InnerClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: OuterStruct.InnerClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: OuterStruct.InnerClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: OuterStruct.InnerClass?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: OuterStruct.InnerClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
 @_cdecl("_CBridgeInitsmoke_OuterStruct_InnerInterface")
@@ -200,7 +200,7 @@ internal func getRef(_ ref: InnerInterface?, owning: Bool = true) -> RefHolder {
 extension _InnerInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface {
+internal func foobar_InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface {
     if let swift_pointer = smoke_OuterStruct_InnerInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
         return re_constructed
@@ -216,7 +216,7 @@ internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface {
+internal func foobar_InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface {
     if let swift_pointer = smoke_OuterStruct_InnerInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
         smoke_OuterStruct_InnerInterface_release_handle(handle)
@@ -234,96 +234,96 @@ internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface? {
+internal func foobar_InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface? {
     guard handle != 0 else {
         return nil
     }
-    return InnerInterface_moveFromCType(handle) as InnerInterface
+    return foobar_InnerInterface_moveFromCType(handle) as InnerInterface
 }
-internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface? {
+internal func foobar_InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface? {
     guard handle != 0 else {
         return nil
     }
-    return InnerInterface_moveFromCType(handle) as InnerInterface
+    return foobar_InnerInterface_moveFromCType(handle) as InnerInterface
 }
-internal func copyToCType(_ swiftClass: InnerInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InnerInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InnerInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InnerInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: InnerInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InnerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InnerInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InnerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct {
     return OuterStruct.InnerStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct {
     defer {
         smoke_OuterStruct_InnerStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: OuterStruct.InnerStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: OuterStruct.InnerStruct) -> RefHolder {
     let c_otherField = foobar_moveToCType(swiftType.otherField)
     return RefHolder(smoke_OuterStruct_InnerStruct_create_handle(c_otherField.ref))
 }
-internal func moveToCType(_ swiftType: OuterStruct.InnerStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStruct_InnerStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: OuterStruct.InnerStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_OuterStruct_InnerStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_OuterStruct_InnerStruct_unwrap_optional_handle(handle)
     return OuterStruct.InnerStruct(cHandle: unwrappedHandle) as OuterStruct.InnerStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct? {
     defer {
         smoke_OuterStruct_InnerStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: OuterStruct.InnerStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: OuterStruct.InnerStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_otherField = foobar_moveToCType(swiftType.otherField)
     return RefHolder(smoke_OuterStruct_InnerStruct_create_optional_handle(c_otherField.ref))
 }
-internal func moveToCType(_ swiftType: OuterStruct.InnerStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStruct_InnerStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: OuterStruct.InnerStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_OuterStruct_InnerStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: OuterStruct.InnerEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: OuterStruct.InnerEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: OuterStruct.InnerEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: OuterStruct.InnerEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: OuterStruct.InnerEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: OuterStruct.InnerEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: OuterStruct.InnerEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: OuterStruct.InnerEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> OuterStruct.InnerEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> OuterStruct.InnerEnum {
     return OuterStruct.InnerEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> OuterStruct.InnerEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> OuterStruct.InnerEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerEnum? {
     guard handle != 0 else {
         return nil
     }
     return OuterStruct.InnerEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/UseFreeTypes.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/UseFreeTypes.swift
@@ -14,11 +14,11 @@ public class UseFreeTypes {
         smoke_UseFreeTypes_release_handle(c_instance)
     }
     public func doStuff(point: FreePoint, mode: FreeEnum) throws -> FreeTypeDef {
-        let c_point = moveToCType(point)
-        let c_mode = moveToCType(mode)
+        let c_point = foobar_moveToCType(point)
+        let c_mode = foobar_moveToCType(mode)
         let RESULT = smoke_UseFreeTypes_doStuff(self.c_instance, c_point.ref, c_mode.ref)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as FreeError
+            throw foobar_moveFromCType(RESULT.error_value) as FreeError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
@@ -44,7 +44,7 @@ extension UseFreeTypes: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func UseFreeTypes_copyFromCType(_ handle: _baseRef) -> UseFreeTypes {
+internal func foobar_UseFreeTypes_copyFromCType(_ handle: _baseRef) -> UseFreeTypes {
     if let swift_pointer = smoke_UseFreeTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UseFreeTypes {
         return re_constructed
@@ -53,7 +53,7 @@ internal func UseFreeTypes_copyFromCType(_ handle: _baseRef) -> UseFreeTypes {
     smoke_UseFreeTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func UseFreeTypes_moveFromCType(_ handle: _baseRef) -> UseFreeTypes {
+internal func foobar_UseFreeTypes_moveFromCType(_ handle: _baseRef) -> UseFreeTypes {
     if let swift_pointer = smoke_UseFreeTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? UseFreeTypes {
         smoke_UseFreeTypes_release_handle(handle)
@@ -63,27 +63,27 @@ internal func UseFreeTypes_moveFromCType(_ handle: _baseRef) -> UseFreeTypes {
     smoke_UseFreeTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func UseFreeTypes_copyFromCType(_ handle: _baseRef) -> UseFreeTypes? {
+internal func foobar_UseFreeTypes_copyFromCType(_ handle: _baseRef) -> UseFreeTypes? {
     guard handle != 0 else {
         return nil
     }
-    return UseFreeTypes_moveFromCType(handle) as UseFreeTypes
+    return foobar_UseFreeTypes_moveFromCType(handle) as UseFreeTypes
 }
-internal func UseFreeTypes_moveFromCType(_ handle: _baseRef) -> UseFreeTypes? {
+internal func foobar_UseFreeTypes_moveFromCType(_ handle: _baseRef) -> UseFreeTypes? {
     guard handle != 0 else {
         return nil
     }
-    return UseFreeTypes_moveFromCType(handle) as UseFreeTypes
+    return foobar_UseFreeTypes_moveFromCType(handle) as UseFreeTypes
 }
-internal func copyToCType(_ swiftClass: UseFreeTypes) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: UseFreeTypes) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: UseFreeTypes) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: UseFreeTypes) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: UseFreeTypes?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: UseFreeTypes?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: UseFreeTypes?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: UseFreeTypes?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/nullable/output/swift/smoke/Nullable.swift
+++ b/gluecodium/src/test/resources/smoke/nullable/output/swift/smoke/Nullable.swift
@@ -42,19 +42,19 @@ public class Nullable {
     }
     public var structProperty: Nullable.SomeStruct? {
         get {
-            return moveFromCType(smoke_Nullable_structProperty_get(self.c_instance))
+            return foobar_moveFromCType(smoke_Nullable_structProperty_get(self.c_instance))
         }
         set {
-            let c_value = moveToCType(newValue)
+            let c_value = foobar_moveToCType(newValue)
             return moveFromCType(smoke_Nullable_structProperty_set(self.c_instance, c_value.ref))
         }
     }
     public var enumProperty: Nullable.SomeEnum? {
         get {
-            return moveFromCType(smoke_Nullable_enumProperty_get(self.c_instance))
+            return foobar_moveFromCType(smoke_Nullable_enumProperty_get(self.c_instance))
         }
         set {
-            let c_value = moveToCType(newValue)
+            let c_value = foobar_moveToCType(newValue)
             return moveFromCType(smoke_Nullable_enumProperty_set(self.c_instance, c_value.ref))
         }
     }
@@ -87,10 +87,10 @@ public class Nullable {
     }
     public var instanceProperty: SomeInterface? {
         get {
-            return SomeInterface_moveFromCType(smoke_Nullable_instanceProperty_get(self.c_instance))
+            return foobar_SomeInterface_moveFromCType(smoke_Nullable_instanceProperty_get(self.c_instance))
         }
         set {
-            let c_value = moveToCType(newValue)
+            let c_value = foobar_moveToCType(newValue)
             return moveFromCType(smoke_Nullable_instanceProperty_set(self.c_instance, c_value.ref))
         }
     }
@@ -143,12 +143,12 @@ public class Nullable {
             stringField = moveFromCType(smoke_Nullable_NullableStruct_stringField_get(cHandle))
             boolField = moveFromCType(smoke_Nullable_NullableStruct_boolField_get(cHandle))
             doubleField = moveFromCType(smoke_Nullable_NullableStruct_doubleField_get(cHandle))
-            structField = moveFromCType(smoke_Nullable_NullableStruct_structField_get(cHandle))
-            enumField = moveFromCType(smoke_Nullable_NullableStruct_enumField_get(cHandle))
+            structField = foobar_moveFromCType(smoke_Nullable_NullableStruct_structField_get(cHandle))
+            enumField = foobar_moveFromCType(smoke_Nullable_NullableStruct_enumField_get(cHandle))
             arrayField = foobar_moveFromCType(smoke_Nullable_NullableStruct_arrayField_get(cHandle))
             inlineArrayField = foobar_moveFromCType(smoke_Nullable_NullableStruct_inlineArrayField_get(cHandle))
             mapField = foobar_moveFromCType(smoke_Nullable_NullableStruct_mapField_get(cHandle))
-            instanceField = SomeInterface_moveFromCType(smoke_Nullable_NullableStruct_instanceField_get(cHandle))
+            instanceField = foobar_SomeInterface_moveFromCType(smoke_Nullable_NullableStruct_instanceField_get(cHandle))
         }
     }
     public struct NullableIntsStruct {
@@ -198,12 +198,12 @@ public class Nullable {
         return moveFromCType(smoke_Nullable_methodWithInt(self.c_instance, c_input.ref))
     }
     public func methodWithSomeStruct(input: Nullable.SomeStruct?) -> Nullable.SomeStruct? {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_Nullable_methodWithSomeStruct(self.c_instance, c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_Nullable_methodWithSomeStruct(self.c_instance, c_input.ref))
     }
     public func methodWithSomeEnum(input: Nullable.SomeEnum?) -> Nullable.SomeEnum? {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_Nullable_methodWithSomeEnum(self.c_instance, c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_Nullable_methodWithSomeEnum(self.c_instance, c_input.ref))
     }
     public func methodWithSomeArray(input: Nullable.SomeArray?) -> Nullable.SomeArray? {
         let c_input = foobar_moveToCType(input)
@@ -218,8 +218,8 @@ public class Nullable {
         return foobar_moveFromCType(smoke_Nullable_methodWithSomeMap(self.c_instance, c_input.ref))
     }
     public func methodWithInstance(input: SomeInterface?) -> SomeInterface? {
-        let c_input = moveToCType(input)
-        return SomeInterface_moveFromCType(smoke_Nullable_methodWithInstance(self.c_instance, c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_SomeInterface_moveFromCType(smoke_Nullable_methodWithInstance(self.c_instance, c_input.ref))
     }
 }
 internal func getRef(_ ref: Nullable?, owning: Bool = true) -> RefHolder {
@@ -242,7 +242,7 @@ extension Nullable: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Nullable_copyFromCType(_ handle: _baseRef) -> Nullable {
+internal func foobar_Nullable_copyFromCType(_ handle: _baseRef) -> Nullable {
     if let swift_pointer = smoke_Nullable_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Nullable {
         return re_constructed
@@ -251,7 +251,7 @@ internal func Nullable_copyFromCType(_ handle: _baseRef) -> Nullable {
     smoke_Nullable_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Nullable_moveFromCType(_ handle: _baseRef) -> Nullable {
+internal func foobar_Nullable_moveFromCType(_ handle: _baseRef) -> Nullable {
     if let swift_pointer = smoke_Nullable_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Nullable {
         smoke_Nullable_release_handle(handle)
@@ -261,134 +261,134 @@ internal func Nullable_moveFromCType(_ handle: _baseRef) -> Nullable {
     smoke_Nullable_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Nullable_copyFromCType(_ handle: _baseRef) -> Nullable? {
+internal func foobar_Nullable_copyFromCType(_ handle: _baseRef) -> Nullable? {
     guard handle != 0 else {
         return nil
     }
-    return Nullable_moveFromCType(handle) as Nullable
+    return foobar_Nullable_moveFromCType(handle) as Nullable
 }
-internal func Nullable_moveFromCType(_ handle: _baseRef) -> Nullable? {
+internal func foobar_Nullable_moveFromCType(_ handle: _baseRef) -> Nullable? {
     guard handle != 0 else {
         return nil
     }
-    return Nullable_moveFromCType(handle) as Nullable
+    return foobar_Nullable_moveFromCType(handle) as Nullable
 }
-internal func copyToCType(_ swiftClass: Nullable) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Nullable) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Nullable) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Nullable) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Nullable?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Nullable?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Nullable?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Nullable?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Nullable.SomeStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Nullable.SomeStruct {
     return Nullable.SomeStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Nullable.SomeStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Nullable.SomeStruct {
     defer {
         smoke_Nullable_SomeStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Nullable.SomeStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Nullable.SomeStruct) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_Nullable_SomeStruct_create_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: Nullable.SomeStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Nullable_SomeStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Nullable.SomeStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Nullable_SomeStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Nullable.SomeStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Nullable.SomeStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Nullable_SomeStruct_unwrap_optional_handle(handle)
     return Nullable.SomeStruct(cHandle: unwrappedHandle) as Nullable.SomeStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Nullable.SomeStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Nullable.SomeStruct? {
     defer {
         smoke_Nullable_SomeStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Nullable.SomeStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Nullable.SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_Nullable_SomeStruct_create_optional_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: Nullable.SomeStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Nullable_SomeStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Nullable.SomeStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Nullable_SomeStruct_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Nullable.NullableStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Nullable.NullableStruct {
     return Nullable.NullableStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Nullable.NullableStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Nullable.NullableStruct {
     defer {
         smoke_Nullable_NullableStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Nullable.NullableStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Nullable.NullableStruct) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     let c_boolField = moveToCType(swiftType.boolField)
     let c_doubleField = moveToCType(swiftType.doubleField)
-    let c_structField = moveToCType(swiftType.structField)
-    let c_enumField = moveToCType(swiftType.enumField)
+    let c_structField = foobar_moveToCType(swiftType.structField)
+    let c_enumField = foobar_moveToCType(swiftType.enumField)
     let c_arrayField = foobar_moveToCType(swiftType.arrayField)
     let c_inlineArrayField = foobar_moveToCType(swiftType.inlineArrayField)
     let c_mapField = foobar_moveToCType(swiftType.mapField)
-    let c_instanceField = moveToCType(swiftType.instanceField)
+    let c_instanceField = foobar_moveToCType(swiftType.instanceField)
     return RefHolder(smoke_Nullable_NullableStruct_create_handle(c_stringField.ref, c_boolField.ref, c_doubleField.ref, c_structField.ref, c_enumField.ref, c_arrayField.ref, c_inlineArrayField.ref, c_mapField.ref, c_instanceField.ref))
 }
-internal func moveToCType(_ swiftType: Nullable.NullableStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Nullable_NullableStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Nullable.NullableStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Nullable_NullableStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Nullable.NullableStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Nullable.NullableStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Nullable_NullableStruct_unwrap_optional_handle(handle)
     return Nullable.NullableStruct(cHandle: unwrappedHandle) as Nullable.NullableStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Nullable.NullableStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Nullable.NullableStruct? {
     defer {
         smoke_Nullable_NullableStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Nullable.NullableStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Nullable.NullableStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_stringField = moveToCType(swiftType.stringField)
     let c_boolField = moveToCType(swiftType.boolField)
     let c_doubleField = moveToCType(swiftType.doubleField)
-    let c_structField = moveToCType(swiftType.structField)
-    let c_enumField = moveToCType(swiftType.enumField)
+    let c_structField = foobar_moveToCType(swiftType.structField)
+    let c_enumField = foobar_moveToCType(swiftType.enumField)
     let c_arrayField = foobar_moveToCType(swiftType.arrayField)
     let c_inlineArrayField = foobar_moveToCType(swiftType.inlineArrayField)
     let c_mapField = foobar_moveToCType(swiftType.mapField)
-    let c_instanceField = moveToCType(swiftType.instanceField)
+    let c_instanceField = foobar_moveToCType(swiftType.instanceField)
     return RefHolder(smoke_Nullable_NullableStruct_create_optional_handle(c_stringField.ref, c_boolField.ref, c_doubleField.ref, c_structField.ref, c_enumField.ref, c_arrayField.ref, c_inlineArrayField.ref, c_mapField.ref, c_instanceField.ref))
 }
-internal func moveToCType(_ swiftType: Nullable.NullableStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Nullable_NullableStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Nullable.NullableStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Nullable_NullableStruct_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Nullable.NullableIntsStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Nullable.NullableIntsStruct {
     return Nullable.NullableIntsStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Nullable.NullableIntsStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Nullable.NullableIntsStruct {
     defer {
         smoke_Nullable_NullableIntsStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Nullable.NullableIntsStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Nullable.NullableIntsStruct) -> RefHolder {
     let c_int8Field = moveToCType(swiftType.int8Field)
     let c_int16Field = moveToCType(swiftType.int16Field)
     let c_int32Field = moveToCType(swiftType.int32Field)
@@ -399,23 +399,23 @@ internal func copyToCType(_ swiftType: Nullable.NullableIntsStruct) -> RefHolder
     let c_uint64Field = moveToCType(swiftType.uint64Field)
     return RefHolder(smoke_Nullable_NullableIntsStruct_create_handle(c_int8Field.ref, c_int16Field.ref, c_int32Field.ref, c_int64Field.ref, c_uint8Field.ref, c_uint16Field.ref, c_uint32Field.ref, c_uint64Field.ref))
 }
-internal func moveToCType(_ swiftType: Nullable.NullableIntsStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Nullable_NullableIntsStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Nullable.NullableIntsStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Nullable_NullableIntsStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Nullable.NullableIntsStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Nullable.NullableIntsStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Nullable_NullableIntsStruct_unwrap_optional_handle(handle)
     return Nullable.NullableIntsStruct(cHandle: unwrappedHandle) as Nullable.NullableIntsStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Nullable.NullableIntsStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Nullable.NullableIntsStruct? {
     defer {
         smoke_Nullable_NullableIntsStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Nullable.NullableIntsStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Nullable.NullableIntsStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -429,36 +429,36 @@ internal func copyToCType(_ swiftType: Nullable.NullableIntsStruct?) -> RefHolde
     let c_uint64Field = moveToCType(swiftType.uint64Field)
     return RefHolder(smoke_Nullable_NullableIntsStruct_create_optional_handle(c_int8Field.ref, c_int16Field.ref, c_int32Field.ref, c_int64Field.ref, c_uint8Field.ref, c_uint16Field.ref, c_uint32Field.ref, c_uint64Field.ref))
 }
-internal func moveToCType(_ swiftType: Nullable.NullableIntsStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Nullable_NullableIntsStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Nullable.NullableIntsStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Nullable_NullableIntsStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: Nullable.SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Nullable.SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Nullable.SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Nullable.SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Nullable.SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Nullable.SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Nullable.SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Nullable.SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Nullable.SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Nullable.SomeEnum {
     return Nullable.SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Nullable.SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Nullable.SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Nullable.SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Nullable.SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return Nullable.SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Nullable.SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Nullable.SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/nullable/output/swift/smoke/NullableCollectionsStruct.swift
+++ b/gluecodium/src/test/resources/smoke/nullable/output/swift/smoke/NullableCollectionsStruct.swift
@@ -13,37 +13,37 @@ public struct NullableCollectionsStruct {
         structs = foobar_moveFromCType(smoke_NullableCollectionsStruct_structs_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> NullableCollectionsStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> NullableCollectionsStruct {
     return NullableCollectionsStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> NullableCollectionsStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> NullableCollectionsStruct {
     defer {
         smoke_NullableCollectionsStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: NullableCollectionsStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: NullableCollectionsStruct) -> RefHolder {
     let c_dates = foobar_moveToCType(swiftType.dates)
     let c_structs = foobar_moveToCType(swiftType.structs)
     return RefHolder(smoke_NullableCollectionsStruct_create_handle(c_dates.ref, c_structs.ref))
 }
-internal func moveToCType(_ swiftType: NullableCollectionsStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_NullableCollectionsStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: NullableCollectionsStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_NullableCollectionsStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> NullableCollectionsStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> NullableCollectionsStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_NullableCollectionsStruct_unwrap_optional_handle(handle)
     return NullableCollectionsStruct(cHandle: unwrappedHandle) as NullableCollectionsStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> NullableCollectionsStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> NullableCollectionsStruct? {
     defer {
         smoke_NullableCollectionsStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: NullableCollectionsStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: NullableCollectionsStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -51,6 +51,6 @@ internal func copyToCType(_ swiftType: NullableCollectionsStruct?) -> RefHolder 
     let c_structs = foobar_moveToCType(swiftType.structs)
     return RefHolder(smoke_NullableCollectionsStruct_create_optional_handle(c_dates.ref, c_structs.ref))
 }
-internal func moveToCType(_ swiftType: NullableCollectionsStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_NullableCollectionsStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: NullableCollectionsStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_NullableCollectionsStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazInterface.swift
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazInterface.swift
@@ -32,7 +32,7 @@ public class bazInterface {
     }
     public func BazMethod(_ BazParameter: String) -> bazStruct {
         let c_BazParameter = moveToCType(BazParameter)
-        return moveFromCType(smoke_bazInterface_BazMethod(self.c_instance, c_BazParameter.ref))
+        return foobar_moveFromCType(smoke_bazInterface_BazMethod(self.c_instance, c_BazParameter.ref))
     }
     private static func make(_ makeParameter: String) -> _baseRef {
         let c_makeParameter = moveToCType(makeParameter)
@@ -59,7 +59,7 @@ extension bazInterface: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func bazInterface_copyFromCType(_ handle: _baseRef) -> bazInterface {
+internal func foobar_bazInterface_copyFromCType(_ handle: _baseRef) -> bazInterface {
     if let swift_pointer = smoke_bazInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? bazInterface {
         return re_constructed
@@ -68,7 +68,7 @@ internal func bazInterface_copyFromCType(_ handle: _baseRef) -> bazInterface {
     smoke_bazInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func bazInterface_moveFromCType(_ handle: _baseRef) -> bazInterface {
+internal func foobar_bazInterface_moveFromCType(_ handle: _baseRef) -> bazInterface {
     if let swift_pointer = smoke_bazInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? bazInterface {
         smoke_bazInterface_release_handle(handle)
@@ -78,27 +78,27 @@ internal func bazInterface_moveFromCType(_ handle: _baseRef) -> bazInterface {
     smoke_bazInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func bazInterface_copyFromCType(_ handle: _baseRef) -> bazInterface? {
+internal func foobar_bazInterface_copyFromCType(_ handle: _baseRef) -> bazInterface? {
     guard handle != 0 else {
         return nil
     }
-    return bazInterface_moveFromCType(handle) as bazInterface
+    return foobar_bazInterface_moveFromCType(handle) as bazInterface
 }
-internal func bazInterface_moveFromCType(_ handle: _baseRef) -> bazInterface? {
+internal func foobar_bazInterface_moveFromCType(_ handle: _baseRef) -> bazInterface? {
     guard handle != 0 else {
         return nil
     }
-    return bazInterface_moveFromCType(handle) as bazInterface
+    return foobar_bazInterface_moveFromCType(handle) as bazInterface
 }
-internal func copyToCType(_ swiftClass: bazInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: bazInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: bazInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: bazInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: bazInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: bazInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: bazInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: bazInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazListener.swift
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazListener.swift
@@ -53,7 +53,7 @@ internal func getRef(_ ref: bazListener?, owning: Bool = true) -> RefHolder {
 extension _bazListener: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func bazListener_copyFromCType(_ handle: _baseRef) -> bazListener {
+internal func foobar_bazListener_copyFromCType(_ handle: _baseRef) -> bazListener {
     if let swift_pointer = smoke_bazListener_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? bazListener {
         return re_constructed
@@ -69,7 +69,7 @@ internal func bazListener_copyFromCType(_ handle: _baseRef) -> bazListener {
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func bazListener_moveFromCType(_ handle: _baseRef) -> bazListener {
+internal func foobar_bazListener_moveFromCType(_ handle: _baseRef) -> bazListener {
     if let swift_pointer = smoke_bazListener_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? bazListener {
         smoke_bazListener_release_handle(handle)
@@ -87,27 +87,27 @@ internal func bazListener_moveFromCType(_ handle: _baseRef) -> bazListener {
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func bazListener_copyFromCType(_ handle: _baseRef) -> bazListener? {
+internal func foobar_bazListener_copyFromCType(_ handle: _baseRef) -> bazListener? {
     guard handle != 0 else {
         return nil
     }
-    return bazListener_moveFromCType(handle) as bazListener
+    return foobar_bazListener_moveFromCType(handle) as bazListener
 }
-internal func bazListener_moveFromCType(_ handle: _baseRef) -> bazListener? {
+internal func foobar_bazListener_moveFromCType(_ handle: _baseRef) -> bazListener? {
     guard handle != 0 else {
         return nil
     }
-    return bazListener_moveFromCType(handle) as bazListener
+    return foobar_bazListener_moveFromCType(handle) as bazListener
 }
-internal func copyToCType(_ swiftClass: bazListener) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: bazListener) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: bazListener) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: bazListener) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: bazListener?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: bazListener?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: bazListener?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: bazListener?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazTypes.swift
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazTypes.swift
@@ -5,35 +5,35 @@ public typealias bazTypedef = Double
 public enum bazEnum : UInt32, CaseIterable, Codable {
     case BAZ_ITEM
 }
-internal func copyToCType(_ swiftEnum: bazEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: bazEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: bazEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: bazEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: bazEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: bazEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: bazEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: bazEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> bazEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> bazEnum {
     return bazEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> bazEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> bazEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> bazEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> bazEnum? {
     guard handle != 0 else {
         return nil
     }
     return bazEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> bazEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> bazEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 public struct bazStruct {
     public var BAZ_FIELD: String
@@ -45,7 +45,7 @@ public struct bazStruct {
         guard _result_handle != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
-        let _result: bazStruct = moveFromCType(_result_handle)
+        let _result: bazStruct = foobar_moveFromCType(_result_handle)
         self.BAZ_FIELD = _result.BAZ_FIELD
     }
     private static func BazCreate(_ BazParameter: String) -> _baseRef {
@@ -53,42 +53,42 @@ public struct bazStruct {
         return moveFromCType(smoke_bazTypes_bazStruct_BazCreate(c_BazParameter.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> bazStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> bazStruct {
     return bazStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> bazStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> bazStruct {
     defer {
         smoke_bazTypes_bazStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: bazStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: bazStruct) -> RefHolder {
     let c_BAZ_FIELD = moveToCType(swiftType.BAZ_FIELD)
     return RefHolder(smoke_bazTypes_bazStruct_create_handle(c_BAZ_FIELD.ref))
 }
-internal func moveToCType(_ swiftType: bazStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_bazTypes_bazStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: bazStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_bazTypes_bazStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> bazStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> bazStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_bazTypes_bazStruct_unwrap_optional_handle(handle)
     return bazStruct(cHandle: unwrappedHandle) as bazStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> bazStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> bazStruct? {
     defer {
         smoke_bazTypes_bazStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: bazStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: bazStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_BAZ_FIELD = moveToCType(swiftType.BAZ_FIELD)
     return RefHolder(smoke_bazTypes_bazStruct_create_optional_handle(c_BAZ_FIELD.ref))
 }
-internal func moveToCType(_ swiftType: bazStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_bazTypes_bazStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: bazStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_bazTypes_bazStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/CachedProperties.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/CachedProperties.swift
@@ -40,7 +40,7 @@ extension CachedProperties: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func CachedProperties_copyFromCType(_ handle: _baseRef) -> CachedProperties {
+internal func foobar_CachedProperties_copyFromCType(_ handle: _baseRef) -> CachedProperties {
     if let swift_pointer = smoke_CachedProperties_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CachedProperties {
         return re_constructed
@@ -49,7 +49,7 @@ internal func CachedProperties_copyFromCType(_ handle: _baseRef) -> CachedProper
     smoke_CachedProperties_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func CachedProperties_moveFromCType(_ handle: _baseRef) -> CachedProperties {
+internal func foobar_CachedProperties_moveFromCType(_ handle: _baseRef) -> CachedProperties {
     if let swift_pointer = smoke_CachedProperties_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? CachedProperties {
         smoke_CachedProperties_release_handle(handle)
@@ -59,27 +59,27 @@ internal func CachedProperties_moveFromCType(_ handle: _baseRef) -> CachedProper
     smoke_CachedProperties_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func CachedProperties_copyFromCType(_ handle: _baseRef) -> CachedProperties? {
+internal func foobar_CachedProperties_copyFromCType(_ handle: _baseRef) -> CachedProperties? {
     guard handle != 0 else {
         return nil
     }
-    return CachedProperties_moveFromCType(handle) as CachedProperties
+    return foobar_CachedProperties_moveFromCType(handle) as CachedProperties
 }
-internal func CachedProperties_moveFromCType(_ handle: _baseRef) -> CachedProperties? {
+internal func foobar_CachedProperties_moveFromCType(_ handle: _baseRef) -> CachedProperties? {
     guard handle != 0 else {
         return nil
     }
-    return CachedProperties_moveFromCType(handle) as CachedProperties
+    return foobar_CachedProperties_moveFromCType(handle) as CachedProperties
 }
-internal func copyToCType(_ swiftClass: CachedProperties) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: CachedProperties) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: CachedProperties) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: CachedProperties) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: CachedProperties?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: CachedProperties?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: CachedProperties?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: CachedProperties?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/Properties.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/Properties.swift
@@ -18,10 +18,10 @@ public class Properties {
     }
     public var structProperty: Properties.ExampleStruct {
         get {
-            return moveFromCType(smoke_Properties_structProperty_get(self.c_instance))
+            return foobar_moveFromCType(smoke_Properties_structProperty_get(self.c_instance))
         }
         set {
-            let c_value = moveToCType(newValue)
+            let c_value = foobar_moveToCType(newValue)
             return moveFromCType(smoke_Properties_structProperty_set(self.c_instance, c_value.ref))
         }
     }
@@ -36,10 +36,10 @@ public class Properties {
     }
     public var complexTypeProperty: Properties.InternalErrorCode {
         get {
-            return moveFromCType(smoke_Properties_complexTypeProperty_get(self.c_instance))
+            return foobar_moveFromCType(smoke_Properties_complexTypeProperty_get(self.c_instance))
         }
         set {
-            let c_value = moveToCType(newValue)
+            let c_value = foobar_moveToCType(newValue)
             return moveFromCType(smoke_Properties_complexTypeProperty_set(self.c_instance, c_value.ref))
         }
     }
@@ -54,10 +54,10 @@ public class Properties {
     }
     public var instanceProperty: PropertiesInterface {
         get {
-            return PropertiesInterface_moveFromCType(smoke_Properties_instanceProperty_get(self.c_instance))
+            return foobar_PropertiesInterface_moveFromCType(smoke_Properties_instanceProperty_get(self.c_instance))
         }
         set {
-            let c_value = moveToCType(newValue)
+            let c_value = foobar_moveToCType(newValue)
             return moveFromCType(smoke_Properties_instanceProperty_set(self.c_instance, c_value.ref))
         }
     }
@@ -81,7 +81,7 @@ public class Properties {
     }
     public static var staticReadonlyProperty: Properties.ExampleStruct {
         get {
-            return moveFromCType(smoke_Properties_staticReadonlyProperty_get())
+            return foobar_moveFromCType(smoke_Properties_staticReadonlyProperty_get())
         }
     }
     let c_instance : _baseRef
@@ -129,7 +129,7 @@ extension Properties: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Properties_copyFromCType(_ handle: _baseRef) -> Properties {
+internal func foobar_Properties_copyFromCType(_ handle: _baseRef) -> Properties {
     if let swift_pointer = smoke_Properties_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Properties {
         return re_constructed
@@ -138,7 +138,7 @@ internal func Properties_copyFromCType(_ handle: _baseRef) -> Properties {
     smoke_Properties_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Properties_moveFromCType(_ handle: _baseRef) -> Properties {
+internal func foobar_Properties_moveFromCType(_ handle: _baseRef) -> Properties {
     if let swift_pointer = smoke_Properties_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Properties {
         smoke_Properties_release_handle(handle)
@@ -148,96 +148,96 @@ internal func Properties_moveFromCType(_ handle: _baseRef) -> Properties {
     smoke_Properties_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Properties_copyFromCType(_ handle: _baseRef) -> Properties? {
+internal func foobar_Properties_copyFromCType(_ handle: _baseRef) -> Properties? {
     guard handle != 0 else {
         return nil
     }
-    return Properties_moveFromCType(handle) as Properties
+    return foobar_Properties_moveFromCType(handle) as Properties
 }
-internal func Properties_moveFromCType(_ handle: _baseRef) -> Properties? {
+internal func foobar_Properties_moveFromCType(_ handle: _baseRef) -> Properties? {
     guard handle != 0 else {
         return nil
     }
-    return Properties_moveFromCType(handle) as Properties
+    return foobar_Properties_moveFromCType(handle) as Properties
 }
-internal func copyToCType(_ swiftClass: Properties) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Properties) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Properties) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Properties) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Properties?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Properties?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Properties?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Properties?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Properties.ExampleStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Properties.ExampleStruct {
     return Properties.ExampleStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Properties.ExampleStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Properties.ExampleStruct {
     defer {
         smoke_Properties_ExampleStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Properties.ExampleStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Properties.ExampleStruct) -> RefHolder {
     let c_value = moveToCType(swiftType.value)
     return RefHolder(smoke_Properties_ExampleStruct_create_handle(c_value.ref))
 }
-internal func moveToCType(_ swiftType: Properties.ExampleStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Properties_ExampleStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Properties.ExampleStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Properties_ExampleStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Properties.ExampleStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Properties.ExampleStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Properties_ExampleStruct_unwrap_optional_handle(handle)
     return Properties.ExampleStruct(cHandle: unwrappedHandle) as Properties.ExampleStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Properties.ExampleStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Properties.ExampleStruct? {
     defer {
         smoke_Properties_ExampleStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Properties.ExampleStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Properties.ExampleStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_value = moveToCType(swiftType.value)
     return RefHolder(smoke_Properties_ExampleStruct_create_optional_handle(c_value.ref))
 }
-internal func moveToCType(_ swiftType: Properties.ExampleStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Properties_ExampleStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Properties.ExampleStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Properties_ExampleStruct_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: Properties.InternalErrorCode) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Properties.InternalErrorCode) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Properties.InternalErrorCode) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Properties.InternalErrorCode) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Properties.InternalErrorCode?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Properties.InternalErrorCode?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Properties.InternalErrorCode?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Properties.InternalErrorCode?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Properties.InternalErrorCode {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Properties.InternalErrorCode {
     return Properties.InternalErrorCode(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Properties.InternalErrorCode {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Properties.InternalErrorCode {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Properties.InternalErrorCode? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Properties.InternalErrorCode? {
     guard handle != 0 else {
         return nil
     }
     return Properties.InternalErrorCode(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Properties.InternalErrorCode? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Properties.InternalErrorCode? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/PropertiesInterface.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/PropertiesInterface.swift
@@ -7,10 +7,10 @@ public protocol PropertiesInterface : AnyObject {
 internal class _PropertiesInterface: PropertiesInterface {
     var structProperty: ExampleStruct {
         get {
-            return moveFromCType(smoke_PropertiesInterface_structProperty_get(self.c_instance))
+            return foobar_moveFromCType(smoke_PropertiesInterface_structProperty_get(self.c_instance))
         }
         set {
-            let c_value = moveToCType(newValue)
+            let c_value = foobar_moveToCType(newValue)
             return moveFromCType(smoke_PropertiesInterface_structProperty_set(self.c_instance, c_value.ref))
         }
     }
@@ -59,11 +59,11 @@ internal func getRef(_ ref: PropertiesInterface?, owning: Bool = true) -> RefHol
     }
     functions.smoke_PropertiesInterface_structProperty_get = {(swift_class_pointer) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! PropertiesInterface
-        return copyToCType(swift_class.structProperty).ref
+        return foobar_copyToCType(swift_class.structProperty).ref
     }
     functions.smoke_PropertiesInterface_structProperty_set = {(swift_class_pointer, value) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! PropertiesInterface
-        swift_class.structProperty = moveFromCType(value)
+        swift_class.structProperty = foobar_moveFromCType(value)
     }
     let proxy = smoke_PropertiesInterface_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_PropertiesInterface_release_handle) : RefHolder(proxy)
@@ -71,7 +71,7 @@ internal func getRef(_ ref: PropertiesInterface?, owning: Bool = true) -> RefHol
 extension _PropertiesInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func PropertiesInterface_copyFromCType(_ handle: _baseRef) -> PropertiesInterface {
+internal func foobar_PropertiesInterface_copyFromCType(_ handle: _baseRef) -> PropertiesInterface {
     if let swift_pointer = smoke_PropertiesInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PropertiesInterface {
         return re_constructed
@@ -87,7 +87,7 @@ internal func PropertiesInterface_copyFromCType(_ handle: _baseRef) -> Propertie
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func PropertiesInterface_moveFromCType(_ handle: _baseRef) -> PropertiesInterface {
+internal func foobar_PropertiesInterface_moveFromCType(_ handle: _baseRef) -> PropertiesInterface {
     if let swift_pointer = smoke_PropertiesInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PropertiesInterface {
         smoke_PropertiesInterface_release_handle(handle)
@@ -105,66 +105,66 @@ internal func PropertiesInterface_moveFromCType(_ handle: _baseRef) -> Propertie
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func PropertiesInterface_copyFromCType(_ handle: _baseRef) -> PropertiesInterface? {
+internal func foobar_PropertiesInterface_copyFromCType(_ handle: _baseRef) -> PropertiesInterface? {
     guard handle != 0 else {
         return nil
     }
-    return PropertiesInterface_moveFromCType(handle) as PropertiesInterface
+    return foobar_PropertiesInterface_moveFromCType(handle) as PropertiesInterface
 }
-internal func PropertiesInterface_moveFromCType(_ handle: _baseRef) -> PropertiesInterface? {
+internal func foobar_PropertiesInterface_moveFromCType(_ handle: _baseRef) -> PropertiesInterface? {
     guard handle != 0 else {
         return nil
     }
-    return PropertiesInterface_moveFromCType(handle) as PropertiesInterface
+    return foobar_PropertiesInterface_moveFromCType(handle) as PropertiesInterface
 }
-internal func copyToCType(_ swiftClass: PropertiesInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: PropertiesInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: PropertiesInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: PropertiesInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: PropertiesInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: PropertiesInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: PropertiesInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: PropertiesInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExampleStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExampleStruct {
     return ExampleStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExampleStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExampleStruct {
     defer {
         smoke_PropertiesInterface_ExampleStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ExampleStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ExampleStruct) -> RefHolder {
     let c_value = moveToCType(swiftType.value)
     return RefHolder(smoke_PropertiesInterface_ExampleStruct_create_handle(c_value.ref))
 }
-internal func moveToCType(_ swiftType: ExampleStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PropertiesInterface_ExampleStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: ExampleStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PropertiesInterface_ExampleStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExampleStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> ExampleStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_PropertiesInterface_ExampleStruct_unwrap_optional_handle(handle)
     return ExampleStruct(cHandle: unwrappedHandle) as ExampleStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExampleStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> ExampleStruct? {
     defer {
         smoke_PropertiesInterface_ExampleStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: ExampleStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: ExampleStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_value = moveToCType(swiftType.value)
     return RefHolder(smoke_PropertiesInterface_ExampleStruct_create_optional_handle(c_value.ref))
 }
-internal func moveToCType(_ swiftType: ExampleStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PropertiesInterface_ExampleStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: ExampleStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PropertiesInterface_ExampleStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/serialization/output/swift/smoke/SerializableEquatableStruct.swift
+++ b/gluecodium/src/test/resources/smoke/serialization/output/swift/smoke/SerializableEquatableStruct.swift
@@ -10,42 +10,42 @@ public struct SerializableEquatableStruct: Hashable, Codable {
         fooField = moveFromCType(smoke_SerializableEquatableStruct_fooField_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> SerializableEquatableStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SerializableEquatableStruct {
     return SerializableEquatableStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> SerializableEquatableStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SerializableEquatableStruct {
     defer {
         smoke_SerializableEquatableStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SerializableEquatableStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SerializableEquatableStruct) -> RefHolder {
     let c_fooField = moveToCType(swiftType.fooField)
     return RefHolder(smoke_SerializableEquatableStruct_create_handle(c_fooField.ref))
 }
-internal func moveToCType(_ swiftType: SerializableEquatableStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_SerializableEquatableStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: SerializableEquatableStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_SerializableEquatableStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SerializableEquatableStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SerializableEquatableStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_SerializableEquatableStruct_unwrap_optional_handle(handle)
     return SerializableEquatableStruct(cHandle: unwrappedHandle) as SerializableEquatableStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> SerializableEquatableStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SerializableEquatableStruct? {
     defer {
         smoke_SerializableEquatableStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SerializableEquatableStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SerializableEquatableStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_fooField = moveToCType(swiftType.fooField)
     return RefHolder(smoke_SerializableEquatableStruct_create_optional_handle(c_fooField.ref))
 }
-internal func moveToCType(_ swiftType: SerializableEquatableStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_SerializableEquatableStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: SerializableEquatableStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_SerializableEquatableStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/serialization/output/swift/smoke/Serialization.swift
+++ b/gluecodium/src/test/resources/smoke/serialization/output/swift/smoke/Serialization.swift
@@ -7,35 +7,35 @@ public enum SomeEnum : UInt32, CaseIterable, Codable {
     case foo
     case bar = 7
 }
-internal func copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: SomeEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> SomeEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> SomeEnum {
     return SomeEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> SomeEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> SomeEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SomeEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SomeEnum? {
     guard handle != 0 else {
         return nil
     }
     return SomeEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> SomeEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SomeEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
 public struct SerializableStruct: Codable {
     public var boolField: Bool
@@ -81,26 +81,26 @@ public struct SerializableStruct: Codable {
         floatField = moveFromCType(smoke_Serialization_SerializableStruct_floatField_get(cHandle))
         doubleField = moveFromCType(smoke_Serialization_SerializableStruct_doubleField_get(cHandle))
         stringField = moveFromCType(smoke_Serialization_SerializableStruct_stringField_get(cHandle))
-        structField = moveFromCType(smoke_Serialization_SerializableStruct_structField_get(cHandle))
+        structField = foobar_moveFromCType(smoke_Serialization_SerializableStruct_structField_get(cHandle))
         byteBufferField = moveFromCType(smoke_Serialization_SerializableStruct_byteBufferField_get(cHandle))
         arrayField = foobar_moveFromCType(smoke_Serialization_SerializableStruct_arrayField_get(cHandle))
         structArrayField = foobar_moveFromCType(smoke_Serialization_SerializableStruct_structArrayField_get(cHandle))
         mapField = foobar_moveFromCType(smoke_Serialization_SerializableStruct_mapField_get(cHandle))
         setField = foobar_moveFromCType(smoke_Serialization_SerializableStruct_setField_get(cHandle))
         enumSetField = foobar_moveFromCType(smoke_Serialization_SerializableStruct_enumSetField_get(cHandle))
-        enumField = moveFromCType(smoke_Serialization_SerializableStruct_enumField_get(cHandle))
+        enumField = foobar_moveFromCType(smoke_Serialization_SerializableStruct_enumField_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> SerializableStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SerializableStruct {
     return SerializableStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> SerializableStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SerializableStruct {
     defer {
         smoke_Serialization_SerializableStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SerializableStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SerializableStruct) -> RefHolder {
     let c_boolField = moveToCType(swiftType.boolField)
     let c_byteField = moveToCType(swiftType.byteField)
     let c_shortField = moveToCType(swiftType.shortField)
@@ -109,33 +109,33 @@ internal func copyToCType(_ swiftType: SerializableStruct) -> RefHolder {
     let c_floatField = moveToCType(swiftType.floatField)
     let c_doubleField = moveToCType(swiftType.doubleField)
     let c_stringField = moveToCType(swiftType.stringField)
-    let c_structField = moveToCType(swiftType.structField)
+    let c_structField = foobar_moveToCType(swiftType.structField)
     let c_byteBufferField = moveToCType(swiftType.byteBufferField)
     let c_arrayField = foobar_moveToCType(swiftType.arrayField)
     let c_structArrayField = foobar_moveToCType(swiftType.structArrayField)
     let c_mapField = foobar_moveToCType(swiftType.mapField)
     let c_setField = foobar_moveToCType(swiftType.setField)
     let c_enumSetField = foobar_moveToCType(swiftType.enumSetField)
-    let c_enumField = moveToCType(swiftType.enumField)
+    let c_enumField = foobar_moveToCType(swiftType.enumField)
     return RefHolder(smoke_Serialization_SerializableStruct_create_handle(c_boolField.ref, c_byteField.ref, c_shortField.ref, c_intField.ref, c_longField.ref, c_floatField.ref, c_doubleField.ref, c_stringField.ref, c_structField.ref, c_byteBufferField.ref, c_arrayField.ref, c_structArrayField.ref, c_mapField.ref, c_setField.ref, c_enumSetField.ref, c_enumField.ref))
 }
-internal func moveToCType(_ swiftType: SerializableStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Serialization_SerializableStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: SerializableStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Serialization_SerializableStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> SerializableStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> SerializableStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Serialization_SerializableStruct_unwrap_optional_handle(handle)
     return SerializableStruct(cHandle: unwrappedHandle) as SerializableStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> SerializableStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> SerializableStruct? {
     defer {
         smoke_Serialization_SerializableStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: SerializableStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: SerializableStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -147,18 +147,18 @@ internal func copyToCType(_ swiftType: SerializableStruct?) -> RefHolder {
     let c_floatField = moveToCType(swiftType.floatField)
     let c_doubleField = moveToCType(swiftType.doubleField)
     let c_stringField = moveToCType(swiftType.stringField)
-    let c_structField = moveToCType(swiftType.structField)
+    let c_structField = foobar_moveToCType(swiftType.structField)
     let c_byteBufferField = moveToCType(swiftType.byteBufferField)
     let c_arrayField = foobar_moveToCType(swiftType.arrayField)
     let c_structArrayField = foobar_moveToCType(swiftType.structArrayField)
     let c_mapField = foobar_moveToCType(swiftType.mapField)
     let c_setField = foobar_moveToCType(swiftType.setField)
     let c_enumSetField = foobar_moveToCType(swiftType.enumSetField)
-    let c_enumField = moveToCType(swiftType.enumField)
+    let c_enumField = foobar_moveToCType(swiftType.enumField)
     return RefHolder(smoke_Serialization_SerializableStruct_create_optional_handle(c_boolField.ref, c_byteField.ref, c_shortField.ref, c_intField.ref, c_longField.ref, c_floatField.ref, c_doubleField.ref, c_stringField.ref, c_structField.ref, c_byteBufferField.ref, c_arrayField.ref, c_structArrayField.ref, c_mapField.ref, c_setField.ref, c_enumSetField.ref, c_enumField.ref))
 }
-internal func moveToCType(_ swiftType: SerializableStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Serialization_SerializableStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: SerializableStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Serialization_SerializableStruct_release_optional_handle)
 }
 public struct NestedSerializableStruct: Codable {
     public var someField: String
@@ -169,42 +169,42 @@ public struct NestedSerializableStruct: Codable {
         someField = moveFromCType(smoke_Serialization_NestedSerializableStruct_someField_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> NestedSerializableStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> NestedSerializableStruct {
     return NestedSerializableStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> NestedSerializableStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> NestedSerializableStruct {
     defer {
         smoke_Serialization_NestedSerializableStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: NestedSerializableStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: NestedSerializableStruct) -> RefHolder {
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_Serialization_NestedSerializableStruct_create_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: NestedSerializableStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Serialization_NestedSerializableStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: NestedSerializableStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Serialization_NestedSerializableStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> NestedSerializableStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> NestedSerializableStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Serialization_NestedSerializableStruct_unwrap_optional_handle(handle)
     return NestedSerializableStruct(cHandle: unwrappedHandle) as NestedSerializableStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> NestedSerializableStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> NestedSerializableStruct? {
     defer {
         smoke_Serialization_NestedSerializableStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: NestedSerializableStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: NestedSerializableStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_someField = moveToCType(swiftType.someField)
     return RefHolder(smoke_Serialization_NestedSerializableStruct_create_optional_handle(c_someField.ref))
 }
-internal func moveToCType(_ swiftType: NestedSerializableStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Serialization_NestedSerializableStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: NestedSerializableStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Serialization_NestedSerializableStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/Structs.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/Structs.swift
@@ -38,8 +38,8 @@ public class Structs {
             self.b = b
         }
         internal init(cHandle: _baseRef) {
-            a = moveFromCType(smoke_Structs_Line_a_get(cHandle))
-            b = moveFromCType(smoke_Structs_Line_b_get(cHandle))
+            a = foobar_moveFromCType(smoke_Structs_Line_a_get(cHandle))
+            b = foobar_moveFromCType(smoke_Structs_Line_b_get(cHandle))
         }
     }
     public struct AllTypesStruct {
@@ -87,7 +87,7 @@ public class Structs {
             stringField = moveFromCType(smoke_Structs_AllTypesStruct_stringField_get(cHandle))
             booleanField = moveFromCType(smoke_Structs_AllTypesStruct_booleanField_get(cHandle))
             bytesField = moveFromCType(smoke_Structs_AllTypesStruct_bytesField_get(cHandle))
-            pointField = moveFromCType(smoke_Structs_AllTypesStruct_pointField_get(cHandle))
+            pointField = foobar_moveFromCType(smoke_Structs_AllTypesStruct_pointField_get(cHandle))
         }
     }
     public struct NestingImmutableStruct {
@@ -96,7 +96,7 @@ public class Structs {
             self.structField = structField
         }
         internal init(cHandle: _baseRef) {
-            structField = moveFromCType(smoke_Structs_NestingImmutableStruct_structField_get(cHandle))
+            structField = foobar_moveFromCType(smoke_Structs_NestingImmutableStruct_structField_get(cHandle))
         }
     }
     public struct DoubleNestingImmutableStruct {
@@ -105,7 +105,7 @@ public class Structs {
             self.nestingStructField = nestingStructField
         }
         internal init(cHandle: _baseRef) {
-            nestingStructField = moveFromCType(smoke_Structs_DoubleNestingImmutableStruct_nestingStructField_get(cHandle))
+            nestingStructField = foobar_moveFromCType(smoke_Structs_DoubleNestingImmutableStruct_nestingStructField_get(cHandle))
         }
     }
     public struct StructWithArrayOfImmutable {
@@ -136,21 +136,21 @@ public class Structs {
         }
     }
     public static func swapPointCoordinates(input: Structs.Point) -> Structs.Point {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_Structs_swapPointCoordinates(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_Structs_swapPointCoordinates(c_input.ref))
     }
     public static func returnAllTypesStruct(input: Structs.AllTypesStruct) -> Structs.AllTypesStruct {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_Structs_returnAllTypesStruct(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_Structs_returnAllTypesStruct(c_input.ref))
     }
     public static func createPoint(x: Double, y: Double) -> Point {
         let c_x = moveToCType(x)
         let c_y = moveToCType(y)
-        return moveFromCType(smoke_Structs_createPoint(c_x.ref, c_y.ref))
+        return foobar_moveFromCType(smoke_Structs_createPoint(c_x.ref, c_y.ref))
     }
     public static func modifyAllTypesStruct(input: AllTypesStruct) -> AllTypesStruct {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_Structs_modifyAllTypesStruct(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_Structs_modifyAllTypesStruct(c_input.ref))
     }
 }
 internal func getRef(_ ref: Structs?, owning: Bool = true) -> RefHolder {
@@ -173,7 +173,7 @@ extension Structs: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func Structs_copyFromCType(_ handle: _baseRef) -> Structs {
+internal func foobar_Structs_copyFromCType(_ handle: _baseRef) -> Structs {
     if let swift_pointer = smoke_Structs_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Structs {
         return re_constructed
@@ -182,7 +182,7 @@ internal func Structs_copyFromCType(_ handle: _baseRef) -> Structs {
     smoke_Structs_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Structs_moveFromCType(_ handle: _baseRef) -> Structs {
+internal func foobar_Structs_moveFromCType(_ handle: _baseRef) -> Structs {
     if let swift_pointer = smoke_Structs_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Structs {
         smoke_Structs_release_handle(handle)
@@ -192,61 +192,61 @@ internal func Structs_moveFromCType(_ handle: _baseRef) -> Structs {
     smoke_Structs_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func Structs_copyFromCType(_ handle: _baseRef) -> Structs? {
+internal func foobar_Structs_copyFromCType(_ handle: _baseRef) -> Structs? {
     guard handle != 0 else {
         return nil
     }
-    return Structs_moveFromCType(handle) as Structs
+    return foobar_Structs_moveFromCType(handle) as Structs
 }
-internal func Structs_moveFromCType(_ handle: _baseRef) -> Structs? {
+internal func foobar_Structs_moveFromCType(_ handle: _baseRef) -> Structs? {
     guard handle != 0 else {
         return nil
     }
-    return Structs_moveFromCType(handle) as Structs
+    return foobar_Structs_moveFromCType(handle) as Structs
 }
-internal func copyToCType(_ swiftClass: Structs) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Structs) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Structs) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Structs) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: Structs?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: Structs?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: Structs?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: Structs?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.Point {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.Point {
     return Structs.Point(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.Point {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.Point {
     defer {
         smoke_Structs_Point_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.Point) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.Point) -> RefHolder {
     let c_x = moveToCType(swiftType.x)
     let c_y = moveToCType(swiftType.y)
     return RefHolder(smoke_Structs_Point_create_handle(c_x.ref, c_y.ref))
 }
-internal func moveToCType(_ swiftType: Structs.Point) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_Point_release_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.Point) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_Point_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.Point? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.Point? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Structs_Point_unwrap_optional_handle(handle)
     return Structs.Point(cHandle: unwrappedHandle) as Structs.Point
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.Point? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.Point? {
     defer {
         smoke_Structs_Point_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.Point?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.Point?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -254,60 +254,60 @@ internal func copyToCType(_ swiftType: Structs.Point?) -> RefHolder {
     let c_y = moveToCType(swiftType.y)
     return RefHolder(smoke_Structs_Point_create_optional_handle(c_x.ref, c_y.ref))
 }
-internal func moveToCType(_ swiftType: Structs.Point?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_Point_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.Point?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_Point_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.Line {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.Line {
     return Structs.Line(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.Line {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.Line {
     defer {
         smoke_Structs_Line_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.Line) -> RefHolder {
-    let c_a = moveToCType(swiftType.a)
-    let c_b = moveToCType(swiftType.b)
+internal func foobar_copyToCType(_ swiftType: Structs.Line) -> RefHolder {
+    let c_a = foobar_moveToCType(swiftType.a)
+    let c_b = foobar_moveToCType(swiftType.b)
     return RefHolder(smoke_Structs_Line_create_handle(c_a.ref, c_b.ref))
 }
-internal func moveToCType(_ swiftType: Structs.Line) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_Line_release_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.Line) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_Line_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.Line? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.Line? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Structs_Line_unwrap_optional_handle(handle)
     return Structs.Line(cHandle: unwrappedHandle) as Structs.Line
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.Line? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.Line? {
     defer {
         smoke_Structs_Line_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.Line?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.Line?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_a = moveToCType(swiftType.a)
-    let c_b = moveToCType(swiftType.b)
+    let c_a = foobar_moveToCType(swiftType.a)
+    let c_b = foobar_moveToCType(swiftType.b)
     return RefHolder(smoke_Structs_Line_create_optional_handle(c_a.ref, c_b.ref))
 }
-internal func moveToCType(_ swiftType: Structs.Line?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_Line_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.Line?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_Line_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.AllTypesStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.AllTypesStruct {
     return Structs.AllTypesStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.AllTypesStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.AllTypesStruct {
     defer {
         smoke_Structs_AllTypesStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.AllTypesStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.AllTypesStruct) -> RefHolder {
     let c_int8Field = moveToCType(swiftType.int8Field)
     let c_uint8Field = moveToCType(swiftType.uint8Field)
     let c_int16Field = moveToCType(swiftType.int16Field)
@@ -321,26 +321,26 @@ internal func copyToCType(_ swiftType: Structs.AllTypesStruct) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     let c_booleanField = moveToCType(swiftType.booleanField)
     let c_bytesField = moveToCType(swiftType.bytesField)
-    let c_pointField = moveToCType(swiftType.pointField)
+    let c_pointField = foobar_moveToCType(swiftType.pointField)
     return RefHolder(smoke_Structs_AllTypesStruct_create_handle(c_int8Field.ref, c_uint8Field.ref, c_int16Field.ref, c_uint16Field.ref, c_int32Field.ref, c_uint32Field.ref, c_int64Field.ref, c_uint64Field.ref, c_floatField.ref, c_doubleField.ref, c_stringField.ref, c_booleanField.ref, c_bytesField.ref, c_pointField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.AllTypesStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_AllTypesStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.AllTypesStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_AllTypesStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.AllTypesStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.AllTypesStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Structs_AllTypesStruct_unwrap_optional_handle(handle)
     return Structs.AllTypesStruct(cHandle: unwrappedHandle) as Structs.AllTypesStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.AllTypesStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.AllTypesStruct? {
     defer {
         smoke_Structs_AllTypesStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.AllTypesStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.AllTypesStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -357,234 +357,234 @@ internal func copyToCType(_ swiftType: Structs.AllTypesStruct?) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     let c_booleanField = moveToCType(swiftType.booleanField)
     let c_bytesField = moveToCType(swiftType.bytesField)
-    let c_pointField = moveToCType(swiftType.pointField)
+    let c_pointField = foobar_moveToCType(swiftType.pointField)
     return RefHolder(smoke_Structs_AllTypesStruct_create_optional_handle(c_int8Field.ref, c_uint8Field.ref, c_int16Field.ref, c_uint16Field.ref, c_int32Field.ref, c_uint32Field.ref, c_int64Field.ref, c_uint64Field.ref, c_floatField.ref, c_doubleField.ref, c_stringField.ref, c_booleanField.ref, c_bytesField.ref, c_pointField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.AllTypesStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_AllTypesStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.AllTypesStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_AllTypesStruct_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.NestingImmutableStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.NestingImmutableStruct {
     return Structs.NestingImmutableStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.NestingImmutableStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.NestingImmutableStruct {
     defer {
         smoke_Structs_NestingImmutableStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.NestingImmutableStruct) -> RefHolder {
-    let c_structField = moveToCType(swiftType.structField)
+internal func foobar_copyToCType(_ swiftType: Structs.NestingImmutableStruct) -> RefHolder {
+    let c_structField = foobar_moveToCType(swiftType.structField)
     return RefHolder(smoke_Structs_NestingImmutableStruct_create_handle(c_structField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.NestingImmutableStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_NestingImmutableStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.NestingImmutableStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_NestingImmutableStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.NestingImmutableStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.NestingImmutableStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Structs_NestingImmutableStruct_unwrap_optional_handle(handle)
     return Structs.NestingImmutableStruct(cHandle: unwrappedHandle) as Structs.NestingImmutableStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.NestingImmutableStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.NestingImmutableStruct? {
     defer {
         smoke_Structs_NestingImmutableStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.NestingImmutableStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.NestingImmutableStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_structField = moveToCType(swiftType.structField)
+    let c_structField = foobar_moveToCType(swiftType.structField)
     return RefHolder(smoke_Structs_NestingImmutableStruct_create_optional_handle(c_structField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.NestingImmutableStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_NestingImmutableStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.NestingImmutableStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_NestingImmutableStruct_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.DoubleNestingImmutableStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.DoubleNestingImmutableStruct {
     return Structs.DoubleNestingImmutableStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.DoubleNestingImmutableStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.DoubleNestingImmutableStruct {
     defer {
         smoke_Structs_DoubleNestingImmutableStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.DoubleNestingImmutableStruct) -> RefHolder {
-    let c_nestingStructField = moveToCType(swiftType.nestingStructField)
+internal func foobar_copyToCType(_ swiftType: Structs.DoubleNestingImmutableStruct) -> RefHolder {
+    let c_nestingStructField = foobar_moveToCType(swiftType.nestingStructField)
     return RefHolder(smoke_Structs_DoubleNestingImmutableStruct_create_handle(c_nestingStructField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.DoubleNestingImmutableStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_DoubleNestingImmutableStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.DoubleNestingImmutableStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_DoubleNestingImmutableStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.DoubleNestingImmutableStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.DoubleNestingImmutableStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Structs_DoubleNestingImmutableStruct_unwrap_optional_handle(handle)
     return Structs.DoubleNestingImmutableStruct(cHandle: unwrappedHandle) as Structs.DoubleNestingImmutableStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.DoubleNestingImmutableStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.DoubleNestingImmutableStruct? {
     defer {
         smoke_Structs_DoubleNestingImmutableStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.DoubleNestingImmutableStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.DoubleNestingImmutableStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_nestingStructField = moveToCType(swiftType.nestingStructField)
+    let c_nestingStructField = foobar_moveToCType(swiftType.nestingStructField)
     return RefHolder(smoke_Structs_DoubleNestingImmutableStruct_create_optional_handle(c_nestingStructField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.DoubleNestingImmutableStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_DoubleNestingImmutableStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.DoubleNestingImmutableStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_DoubleNestingImmutableStruct_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.StructWithArrayOfImmutable {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.StructWithArrayOfImmutable {
     return Structs.StructWithArrayOfImmutable(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.StructWithArrayOfImmutable {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.StructWithArrayOfImmutable {
     defer {
         smoke_Structs_StructWithArrayOfImmutable_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.StructWithArrayOfImmutable) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.StructWithArrayOfImmutable) -> RefHolder {
     let c_arrayField = foobar_moveToCType(swiftType.arrayField)
     return RefHolder(smoke_Structs_StructWithArrayOfImmutable_create_handle(c_arrayField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.StructWithArrayOfImmutable) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_StructWithArrayOfImmutable_release_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.StructWithArrayOfImmutable) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_StructWithArrayOfImmutable_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.StructWithArrayOfImmutable? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.StructWithArrayOfImmutable? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Structs_StructWithArrayOfImmutable_unwrap_optional_handle(handle)
     return Structs.StructWithArrayOfImmutable(cHandle: unwrappedHandle) as Structs.StructWithArrayOfImmutable
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.StructWithArrayOfImmutable? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.StructWithArrayOfImmutable? {
     defer {
         smoke_Structs_StructWithArrayOfImmutable_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.StructWithArrayOfImmutable?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.StructWithArrayOfImmutable?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_arrayField = foobar_moveToCType(swiftType.arrayField)
     return RefHolder(smoke_Structs_StructWithArrayOfImmutable_create_optional_handle(c_arrayField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.StructWithArrayOfImmutable?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_StructWithArrayOfImmutable_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.StructWithArrayOfImmutable?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_StructWithArrayOfImmutable_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.ImmutableStructWithCppAccessors {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.ImmutableStructWithCppAccessors {
     return Structs.ImmutableStructWithCppAccessors(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.ImmutableStructWithCppAccessors {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.ImmutableStructWithCppAccessors {
     defer {
         smoke_Structs_ImmutableStructWithCppAccessors_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.ImmutableStructWithCppAccessors) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.ImmutableStructWithCppAccessors) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_Structs_ImmutableStructWithCppAccessors_create_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.ImmutableStructWithCppAccessors) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_ImmutableStructWithCppAccessors_release_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.ImmutableStructWithCppAccessors) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_ImmutableStructWithCppAccessors_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.ImmutableStructWithCppAccessors? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.ImmutableStructWithCppAccessors? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Structs_ImmutableStructWithCppAccessors_unwrap_optional_handle(handle)
     return Structs.ImmutableStructWithCppAccessors(cHandle: unwrappedHandle) as Structs.ImmutableStructWithCppAccessors
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.ImmutableStructWithCppAccessors? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.ImmutableStructWithCppAccessors? {
     defer {
         smoke_Structs_ImmutableStructWithCppAccessors_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.ImmutableStructWithCppAccessors?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.ImmutableStructWithCppAccessors?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_Structs_ImmutableStructWithCppAccessors_create_optional_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.ImmutableStructWithCppAccessors?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_ImmutableStructWithCppAccessors_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.ImmutableStructWithCppAccessors?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_ImmutableStructWithCppAccessors_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.MutableStructWithCppAccessors {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.MutableStructWithCppAccessors {
     return Structs.MutableStructWithCppAccessors(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.MutableStructWithCppAccessors {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.MutableStructWithCppAccessors {
     defer {
         smoke_Structs_MutableStructWithCppAccessors_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.MutableStructWithCppAccessors) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.MutableStructWithCppAccessors) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_Structs_MutableStructWithCppAccessors_create_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.MutableStructWithCppAccessors) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_MutableStructWithCppAccessors_release_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.MutableStructWithCppAccessors) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_MutableStructWithCppAccessors_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.MutableStructWithCppAccessors? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.MutableStructWithCppAccessors? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_Structs_MutableStructWithCppAccessors_unwrap_optional_handle(handle)
     return Structs.MutableStructWithCppAccessors(cHandle: unwrappedHandle) as Structs.MutableStructWithCppAccessors
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.MutableStructWithCppAccessors? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.MutableStructWithCppAccessors? {
     defer {
         smoke_Structs_MutableStructWithCppAccessors_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Structs.MutableStructWithCppAccessors?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Structs.MutableStructWithCppAccessors?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_Structs_MutableStructWithCppAccessors_create_optional_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: Structs.MutableStructWithCppAccessors?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Structs_MutableStructWithCppAccessors_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Structs.MutableStructWithCppAccessors?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_Structs_MutableStructWithCppAccessors_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: Structs.FooBar) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: Structs.FooBar) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Structs.FooBar) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: Structs.FooBar) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: Structs.FooBar?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: Structs.FooBar?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: Structs.FooBar?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: Structs.FooBar?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> Structs.FooBar {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> Structs.FooBar {
     return Structs.FooBar(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> Structs.FooBar {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> Structs.FooBar {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Structs.FooBar? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Structs.FooBar? {
     guard handle != 0 else {
         return nil
     }
     return Structs.FooBar(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> Structs.FooBar? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Structs.FooBar? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithConstants.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithConstants.swift
@@ -1,6 +1,5 @@
 //
 //
-
 import Foundation
 public struct Route {
     public static let defaultDescription: String = "Nonsense"
@@ -13,47 +12,47 @@ public struct Route {
     }
     internal init(cHandle: _baseRef) {
         description = moveFromCType(smoke_StructsWithConstants_Route_description_get(cHandle))
-        type = moveFromCType(smoke_StructsWithConstants_Route_type_get(cHandle))
+        type = foobar_moveFromCType(smoke_StructsWithConstants_Route_type_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Route {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Route {
     return Route(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Route {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Route {
     defer {
         smoke_StructsWithConstants_Route_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Route) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Route) -> RefHolder {
     let c_description = moveToCType(swiftType.description)
-    let c_type = moveToCType(swiftType.type)
+    let c_type = foobar_moveToCType(swiftType.type)
     return RefHolder(smoke_StructsWithConstants_Route_create_handle(c_description.ref, c_type.ref))
 }
-internal func moveToCType(_ swiftType: Route) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructsWithConstants_Route_release_handle)
+internal func foobar_moveToCType(_ swiftType: Route) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructsWithConstants_Route_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Route? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Route? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_StructsWithConstants_Route_unwrap_optional_handle(handle)
     return Route(cHandle: unwrappedHandle) as Route
 }
-internal func moveFromCType(_ handle: _baseRef) -> Route? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Route? {
     defer {
         smoke_StructsWithConstants_Route_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Route?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Route?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_description = moveToCType(swiftType.description)
-    let c_type = moveToCType(swiftType.type)
+    let c_type = foobar_moveToCType(swiftType.type)
     return RefHolder(smoke_StructsWithConstants_Route_create_optional_handle(c_description.ref, c_type.ref))
 }
-internal func moveToCType(_ swiftType: Route?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructsWithConstants_Route_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Route?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructsWithConstants_Route_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithConstantsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithConstantsInterface.swift
@@ -24,7 +24,7 @@ public class StructsWithConstantsInterface {
         }
         internal init(cHandle: _baseRef) {
             descriptions = foobar_moveFromCType(smoke_StructsWithConstantsInterface_MultiRoute_descriptions_get(cHandle))
-            type = moveFromCType(smoke_StructsWithConstantsInterface_MultiRoute_type_get(cHandle))
+            type = foobar_moveFromCType(smoke_StructsWithConstantsInterface_MultiRoute_type_get(cHandle))
         }
     }
     public struct StructWithConstantsOnly {
@@ -51,7 +51,7 @@ extension StructsWithConstantsInterface: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func StructsWithConstantsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface {
+internal func foobar_StructsWithConstantsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface {
     if let swift_pointer = smoke_StructsWithConstantsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructsWithConstantsInterface {
         return re_constructed
@@ -60,7 +60,7 @@ internal func StructsWithConstantsInterface_copyFromCType(_ handle: _baseRef) ->
     smoke_StructsWithConstantsInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func StructsWithConstantsInterface_moveFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface {
+internal func foobar_StructsWithConstantsInterface_moveFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface {
     if let swift_pointer = smoke_StructsWithConstantsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructsWithConstantsInterface {
         smoke_StructsWithConstantsInterface_release_handle(handle)
@@ -70,68 +70,68 @@ internal func StructsWithConstantsInterface_moveFromCType(_ handle: _baseRef) ->
     smoke_StructsWithConstantsInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func StructsWithConstantsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface? {
+internal func foobar_StructsWithConstantsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface? {
     guard handle != 0 else {
         return nil
     }
-    return StructsWithConstantsInterface_moveFromCType(handle) as StructsWithConstantsInterface
+    return foobar_StructsWithConstantsInterface_moveFromCType(handle) as StructsWithConstantsInterface
 }
-internal func StructsWithConstantsInterface_moveFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface? {
+internal func foobar_StructsWithConstantsInterface_moveFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface? {
     guard handle != 0 else {
         return nil
     }
-    return StructsWithConstantsInterface_moveFromCType(handle) as StructsWithConstantsInterface
+    return foobar_StructsWithConstantsInterface_moveFromCType(handle) as StructsWithConstantsInterface
 }
-internal func copyToCType(_ swiftClass: StructsWithConstantsInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: StructsWithConstantsInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: StructsWithConstantsInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: StructsWithConstantsInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: StructsWithConstantsInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: StructsWithConstantsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: StructsWithConstantsInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: StructsWithConstantsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface.MultiRoute {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface.MultiRoute {
     return StructsWithConstantsInterface.MultiRoute(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface.MultiRoute {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface.MultiRoute {
     defer {
         smoke_StructsWithConstantsInterface_MultiRoute_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructsWithConstantsInterface.MultiRoute) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: StructsWithConstantsInterface.MultiRoute) -> RefHolder {
     let c_descriptions = foobar_moveToCType(swiftType.descriptions)
-    let c_type = moveToCType(swiftType.type)
+    let c_type = foobar_moveToCType(swiftType.type)
     return RefHolder(smoke_StructsWithConstantsInterface_MultiRoute_create_handle(c_descriptions.ref, c_type.ref))
 }
-internal func moveToCType(_ swiftType: StructsWithConstantsInterface.MultiRoute) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructsWithConstantsInterface_MultiRoute_release_handle)
+internal func foobar_moveToCType(_ swiftType: StructsWithConstantsInterface.MultiRoute) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructsWithConstantsInterface_MultiRoute_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface.MultiRoute? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface.MultiRoute? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_StructsWithConstantsInterface_MultiRoute_unwrap_optional_handle(handle)
     return StructsWithConstantsInterface.MultiRoute(cHandle: unwrappedHandle) as StructsWithConstantsInterface.MultiRoute
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface.MultiRoute? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructsWithConstantsInterface.MultiRoute? {
     defer {
         smoke_StructsWithConstantsInterface_MultiRoute_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructsWithConstantsInterface.MultiRoute?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: StructsWithConstantsInterface.MultiRoute?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_descriptions = foobar_moveToCType(swiftType.descriptions)
-    let c_type = moveToCType(swiftType.type)
+    let c_type = foobar_moveToCType(swiftType.type)
     return RefHolder(smoke_StructsWithConstantsInterface_MultiRoute_create_optional_handle(c_descriptions.ref, c_type.ref))
 }
-internal func moveToCType(_ swiftType: StructsWithConstantsInterface.MultiRoute?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructsWithConstantsInterface_MultiRoute_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: StructsWithConstantsInterface.MultiRoute?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructsWithConstantsInterface_MultiRoute_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithMethods.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithMethods.swift
@@ -13,7 +13,7 @@ public struct Vector {
         guard _result_handle != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
-        let _result: Vector = moveFromCType(_result_handle)
+        let _result: Vector = foobar_moveFromCType(_result_handle)
         self.x = _result.x
         self.y = _result.y
     }
@@ -22,19 +22,19 @@ public struct Vector {
         guard _result_handle != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
-        let _result: Vector = moveFromCType(_result_handle)
+        let _result: Vector = foobar_moveFromCType(_result_handle)
         self.x = _result.x
         self.y = _result.y
     }
     public func distanceTo(other: Vector) -> Double {
-        let c_self_handle = moveToCType(self)
-        let c_other = moveToCType(other)
+        let c_self_handle = foobar_moveToCType(self)
+        let c_other = foobar_moveToCType(other)
         return moveFromCType(smoke_StructsWithMethods_Vector_distanceTo(c_self_handle.ref, c_other.ref))
     }
     public func add(other: Vector) -> Vector {
-        let c_self_handle = moveToCType(self)
-        let c_other = moveToCType(other)
-        return moveFromCType(smoke_StructsWithMethods_Vector_add(c_self_handle.ref, c_other.ref))
+        let c_self_handle = foobar_moveToCType(self)
+        let c_other = foobar_moveToCType(other)
+        return foobar_moveFromCType(smoke_StructsWithMethods_Vector_add(c_self_handle.ref, c_other.ref))
     }
     public static func validate(x: Double, y: Double) -> Bool {
         let c_x = moveToCType(x)
@@ -47,46 +47,46 @@ public struct Vector {
         return moveFromCType(smoke_StructsWithMethods_Vector_create_Double_Double(c_x.ref, c_y.ref))
     }
     private static func create(other: Vector) throws -> _baseRef {
-        let c_other = moveToCType(other)
+        let c_other = foobar_moveToCType(other)
         let RESULT = smoke_StructsWithMethods_Vector_create_Vector(c_other.ref)
         if (!RESULT.has_value) {
-            throw moveFromCType(RESULT.error_value) as ValidationError
+            throw foobar_moveFromCType(RESULT.error_value) as ValidationError
         } else {
             return moveFromCType(RESULT.returned_value)
         }
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Vector {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Vector {
     return Vector(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Vector {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Vector {
     defer {
         smoke_StructsWithMethods_Vector_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Vector) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Vector) -> RefHolder {
     let c_x = moveToCType(swiftType.x)
     let c_y = moveToCType(swiftType.y)
     return RefHolder(smoke_StructsWithMethods_Vector_create_handle(c_x.ref, c_y.ref))
 }
-internal func moveToCType(_ swiftType: Vector) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructsWithMethods_Vector_release_handle)
+internal func foobar_moveToCType(_ swiftType: Vector) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructsWithMethods_Vector_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Vector? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Vector? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_StructsWithMethods_Vector_unwrap_optional_handle(handle)
     return Vector(cHandle: unwrappedHandle) as Vector
 }
-internal func moveFromCType(_ handle: _baseRef) -> Vector? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Vector? {
     defer {
         smoke_StructsWithMethods_Vector_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Vector?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Vector?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -94,6 +94,6 @@ internal func copyToCType(_ swiftType: Vector?) -> RefHolder {
     let c_y = moveToCType(swiftType.y)
     return RefHolder(smoke_StructsWithMethods_Vector_create_optional_handle(c_x.ref, c_y.ref))
 }
-internal func moveToCType(_ swiftType: Vector?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructsWithMethods_Vector_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Vector?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructsWithMethods_Vector_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithMethodsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithMethodsInterface.swift
@@ -27,7 +27,7 @@ public class StructsWithMethodsInterface {
             guard _result_handle != 0 else {
                 fatalError("Nullptr value is not supported for initializers")
             }
-            let _result: StructsWithMethodsInterface.Vector3 = moveFromCType(_result_handle)
+            let _result: StructsWithMethodsInterface.Vector3 = foobar_moveFromCType(_result_handle)
             self.x = _result.x
             self.y = _result.y
             self.z = _result.z
@@ -37,20 +37,20 @@ public class StructsWithMethodsInterface {
             guard _result_handle != 0 else {
                 fatalError("Nullptr value is not supported for initializers")
             }
-            let _result: StructsWithMethodsInterface.Vector3 = moveFromCType(_result_handle)
+            let _result: StructsWithMethodsInterface.Vector3 = foobar_moveFromCType(_result_handle)
             self.x = _result.x
             self.y = _result.y
             self.z = _result.z
         }
         public func distanceTo(other: StructsWithMethodsInterface.Vector3) -> Double {
-            let c_self_handle = moveToCType(self)
-            let c_other = moveToCType(other)
+            let c_self_handle = foobar_moveToCType(self)
+            let c_other = foobar_moveToCType(other)
             return moveFromCType(smoke_StructsWithMethodsInterface_Vector3_distanceTo(c_self_handle.ref, c_other.ref))
         }
         public func add(other: StructsWithMethodsInterface.Vector3) -> StructsWithMethodsInterface.Vector3 {
-            let c_self_handle = moveToCType(self)
-            let c_other = moveToCType(other)
-            return moveFromCType(smoke_StructsWithMethodsInterface_Vector3_add(c_self_handle.ref, c_other.ref))
+            let c_self_handle = foobar_moveToCType(self)
+            let c_other = foobar_moveToCType(other)
+            return foobar_moveFromCType(smoke_StructsWithMethodsInterface_Vector3_add(c_self_handle.ref, c_other.ref))
         }
         public static func validate(x: Double, y: Double, z: Double) -> Bool {
             let c_x = moveToCType(x)
@@ -63,10 +63,10 @@ public class StructsWithMethodsInterface {
             return moveFromCType(smoke_StructsWithMethodsInterface_Vector3_create_String(c_input.ref))
         }
         private static func create(other: StructsWithMethodsInterface.Vector3) throws -> _baseRef {
-            let c_other = moveToCType(other)
+            let c_other = foobar_moveToCType(other)
             let RESULT = smoke_StructsWithMethodsInterface_Vector3_create_Vector3(c_other.ref)
             if (!RESULT.has_value) {
-                throw moveFromCType(RESULT.error_value) as ValidationError
+                throw foobar_moveFromCType(RESULT.error_value) as ValidationError
             } else {
                 return moveFromCType(RESULT.returned_value)
             }
@@ -98,7 +98,7 @@ extension StructsWithMethodsInterface: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func StructsWithMethodsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface {
+internal func foobar_StructsWithMethodsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface {
     if let swift_pointer = smoke_StructsWithMethodsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructsWithMethodsInterface {
         return re_constructed
@@ -107,7 +107,7 @@ internal func StructsWithMethodsInterface_copyFromCType(_ handle: _baseRef) -> S
     smoke_StructsWithMethodsInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func StructsWithMethodsInterface_moveFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface {
+internal func foobar_StructsWithMethodsInterface_moveFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface {
     if let swift_pointer = smoke_StructsWithMethodsInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? StructsWithMethodsInterface {
         smoke_StructsWithMethodsInterface_release_handle(handle)
@@ -117,62 +117,62 @@ internal func StructsWithMethodsInterface_moveFromCType(_ handle: _baseRef) -> S
     smoke_StructsWithMethodsInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func StructsWithMethodsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface? {
+internal func foobar_StructsWithMethodsInterface_copyFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface? {
     guard handle != 0 else {
         return nil
     }
-    return StructsWithMethodsInterface_moveFromCType(handle) as StructsWithMethodsInterface
+    return foobar_StructsWithMethodsInterface_moveFromCType(handle) as StructsWithMethodsInterface
 }
-internal func StructsWithMethodsInterface_moveFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface? {
+internal func foobar_StructsWithMethodsInterface_moveFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface? {
     guard handle != 0 else {
         return nil
     }
-    return StructsWithMethodsInterface_moveFromCType(handle) as StructsWithMethodsInterface
+    return foobar_StructsWithMethodsInterface_moveFromCType(handle) as StructsWithMethodsInterface
 }
-internal func copyToCType(_ swiftClass: StructsWithMethodsInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: StructsWithMethodsInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: StructsWithMethodsInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: StructsWithMethodsInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: StructsWithMethodsInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: StructsWithMethodsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: StructsWithMethodsInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: StructsWithMethodsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface.Vector3 {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface.Vector3 {
     return StructsWithMethodsInterface.Vector3(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface.Vector3 {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface.Vector3 {
     defer {
         smoke_StructsWithMethodsInterface_Vector3_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructsWithMethodsInterface.Vector3) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: StructsWithMethodsInterface.Vector3) -> RefHolder {
     let c_x = moveToCType(swiftType.x)
     let c_y = moveToCType(swiftType.y)
     let c_z = moveToCType(swiftType.z)
     return RefHolder(smoke_StructsWithMethodsInterface_Vector3_create_handle(c_x.ref, c_y.ref, c_z.ref))
 }
-internal func moveToCType(_ swiftType: StructsWithMethodsInterface.Vector3) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructsWithMethodsInterface_Vector3_release_handle)
+internal func foobar_moveToCType(_ swiftType: StructsWithMethodsInterface.Vector3) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructsWithMethodsInterface_Vector3_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface.Vector3? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface.Vector3? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_StructsWithMethodsInterface_Vector3_unwrap_optional_handle(handle)
     return StructsWithMethodsInterface.Vector3(cHandle: unwrappedHandle) as StructsWithMethodsInterface.Vector3
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface.Vector3? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructsWithMethodsInterface.Vector3? {
     defer {
         smoke_StructsWithMethodsInterface_Vector3_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructsWithMethodsInterface.Vector3?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: StructsWithMethodsInterface.Vector3?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -181,6 +181,6 @@ internal func copyToCType(_ swiftType: StructsWithMethodsInterface.Vector3?) -> 
     let c_z = moveToCType(swiftType.z)
     return RefHolder(smoke_StructsWithMethodsInterface_Vector3_create_optional_handle(c_x.ref, c_y.ref, c_z.ref))
 }
-internal func moveToCType(_ swiftType: StructsWithMethodsInterface.Vector3?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_StructsWithMethodsInterface_Vector3_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: StructsWithMethodsInterface.Vector3?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_StructsWithMethodsInterface_Vector3_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/TypeCollection.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/TypeCollection.swift
@@ -1,6 +1,5 @@
 //
 //
-
 import Foundation
 public typealias PointTypedef = Point
 public struct Point {
@@ -15,37 +14,37 @@ public struct Point {
         y = moveFromCType(smoke_TypeCollection_Point_y_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Point {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Point {
     return Point(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Point {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Point {
     defer {
         smoke_TypeCollection_Point_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Point) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Point) -> RefHolder {
     let c_x = moveToCType(swiftType.x)
     let c_y = moveToCType(swiftType.y)
     return RefHolder(smoke_TypeCollection_Point_create_handle(c_x.ref, c_y.ref))
 }
-internal func moveToCType(_ swiftType: Point) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeCollection_Point_release_handle)
+internal func foobar_moveToCType(_ swiftType: Point) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeCollection_Point_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Point? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Point? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_TypeCollection_Point_unwrap_optional_handle(handle)
     return Point(cHandle: unwrappedHandle) as Point
 }
-internal func moveFromCType(_ handle: _baseRef) -> Point? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Point? {
     defer {
         smoke_TypeCollection_Point_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Point?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Point?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -53,8 +52,8 @@ internal func copyToCType(_ swiftType: Point?) -> RefHolder {
     let c_y = moveToCType(swiftType.y)
     return RefHolder(smoke_TypeCollection_Point_create_optional_handle(c_x.ref, c_y.ref))
 }
-internal func moveToCType(_ swiftType: Point?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeCollection_Point_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Point?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeCollection_Point_release_optional_handle)
 }
 public struct Line {
     public var a: Point
@@ -64,50 +63,50 @@ public struct Line {
         self.b = b
     }
     internal init(cHandle: _baseRef) {
-        a = moveFromCType(smoke_TypeCollection_Line_a_get(cHandle))
-        b = moveFromCType(smoke_TypeCollection_Line_b_get(cHandle))
+        a = foobar_moveFromCType(smoke_TypeCollection_Line_a_get(cHandle))
+        b = foobar_moveFromCType(smoke_TypeCollection_Line_b_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Line {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Line {
     return Line(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Line {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Line {
     defer {
         smoke_TypeCollection_Line_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Line) -> RefHolder {
-    let c_a = moveToCType(swiftType.a)
-    let c_b = moveToCType(swiftType.b)
+internal func foobar_copyToCType(_ swiftType: Line) -> RefHolder {
+    let c_a = foobar_moveToCType(swiftType.a)
+    let c_b = foobar_moveToCType(swiftType.b)
     return RefHolder(smoke_TypeCollection_Line_create_handle(c_a.ref, c_b.ref))
 }
-internal func moveToCType(_ swiftType: Line) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeCollection_Line_release_handle)
+internal func foobar_moveToCType(_ swiftType: Line) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeCollection_Line_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Line? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Line? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_TypeCollection_Line_unwrap_optional_handle(handle)
     return Line(cHandle: unwrappedHandle) as Line
 }
-internal func moveFromCType(_ handle: _baseRef) -> Line? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Line? {
     defer {
         smoke_TypeCollection_Line_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Line?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Line?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_a = moveToCType(swiftType.a)
-    let c_b = moveToCType(swiftType.b)
+    let c_a = foobar_moveToCType(swiftType.a)
+    let c_b = foobar_moveToCType(swiftType.b)
     return RefHolder(smoke_TypeCollection_Line_create_optional_handle(c_a.ref, c_b.ref))
 }
-internal func moveToCType(_ swiftType: Line?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeCollection_Line_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Line?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeCollection_Line_release_optional_handle)
 }
 public struct AllTypesStruct {
     public var int8Field: Int8
@@ -154,19 +153,19 @@ public struct AllTypesStruct {
         stringField = moveFromCType(smoke_TypeCollection_AllTypesStruct_stringField_get(cHandle))
         booleanField = moveFromCType(smoke_TypeCollection_AllTypesStruct_booleanField_get(cHandle))
         bytesField = moveFromCType(smoke_TypeCollection_AllTypesStruct_bytesField_get(cHandle))
-        pointField = moveFromCType(smoke_TypeCollection_AllTypesStruct_pointField_get(cHandle))
+        pointField = foobar_moveFromCType(smoke_TypeCollection_AllTypesStruct_pointField_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> AllTypesStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AllTypesStruct {
     return AllTypesStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> AllTypesStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AllTypesStruct {
     defer {
         smoke_TypeCollection_AllTypesStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: AllTypesStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: AllTypesStruct) -> RefHolder {
     let c_int8Field = moveToCType(swiftType.int8Field)
     let c_uint8Field = moveToCType(swiftType.uint8Field)
     let c_int16Field = moveToCType(swiftType.int16Field)
@@ -180,26 +179,26 @@ internal func copyToCType(_ swiftType: AllTypesStruct) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     let c_booleanField = moveToCType(swiftType.booleanField)
     let c_bytesField = moveToCType(swiftType.bytesField)
-    let c_pointField = moveToCType(swiftType.pointField)
+    let c_pointField = foobar_moveToCType(swiftType.pointField)
     return RefHolder(smoke_TypeCollection_AllTypesStruct_create_handle(c_int8Field.ref, c_uint8Field.ref, c_int16Field.ref, c_uint16Field.ref, c_int32Field.ref, c_uint32Field.ref, c_int64Field.ref, c_uint64Field.ref, c_floatField.ref, c_doubleField.ref, c_stringField.ref, c_booleanField.ref, c_bytesField.ref, c_pointField.ref))
 }
-internal func moveToCType(_ swiftType: AllTypesStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeCollection_AllTypesStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: AllTypesStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeCollection_AllTypesStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> AllTypesStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AllTypesStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_TypeCollection_AllTypesStruct_unwrap_optional_handle(handle)
     return AllTypesStruct(cHandle: unwrappedHandle) as AllTypesStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> AllTypesStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AllTypesStruct? {
     defer {
         smoke_TypeCollection_AllTypesStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: AllTypesStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: AllTypesStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -216,9 +215,9 @@ internal func copyToCType(_ swiftType: AllTypesStruct?) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     let c_booleanField = moveToCType(swiftType.booleanField)
     let c_bytesField = moveToCType(swiftType.bytesField)
-    let c_pointField = moveToCType(swiftType.pointField)
+    let c_pointField = foobar_moveToCType(swiftType.pointField)
     return RefHolder(smoke_TypeCollection_AllTypesStruct_create_optional_handle(c_int8Field.ref, c_uint8Field.ref, c_int16Field.ref, c_uint16Field.ref, c_int32Field.ref, c_uint32Field.ref, c_int64Field.ref, c_uint64Field.ref, c_floatField.ref, c_doubleField.ref, c_stringField.ref, c_booleanField.ref, c_bytesField.ref, c_pointField.ref))
 }
-internal func moveToCType(_ swiftType: AllTypesStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeCollection_AllTypesStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: AllTypesStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeCollection_AllTypesStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/TypeCollection.swift
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/TypeCollection.swift
@@ -1,6 +1,5 @@
 //
 //
-
 import Foundation
 public typealias PointTypeDef = Point
 public typealias StorageId = UInt64
@@ -16,37 +15,37 @@ public struct Point {
         y = moveFromCType(smoke_TypeCollection_Point_y_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Point {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Point {
     return Point(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> Point {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Point {
     defer {
         smoke_TypeCollection_Point_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Point) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Point) -> RefHolder {
     let c_x = moveToCType(swiftType.x)
     let c_y = moveToCType(swiftType.y)
     return RefHolder(smoke_TypeCollection_Point_create_handle(c_x.ref, c_y.ref))
 }
-internal func moveToCType(_ swiftType: Point) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeCollection_Point_release_handle)
+internal func foobar_moveToCType(_ swiftType: Point) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeCollection_Point_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Point? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Point? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_TypeCollection_Point_unwrap_optional_handle(handle)
     return Point(cHandle: unwrappedHandle) as Point
 }
-internal func moveFromCType(_ handle: _baseRef) -> Point? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Point? {
     defer {
         smoke_TypeCollection_Point_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: Point?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: Point?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -54,8 +53,8 @@ internal func copyToCType(_ swiftType: Point?) -> RefHolder {
     let c_y = moveToCType(swiftType.y)
     return RefHolder(smoke_TypeCollection_Point_create_optional_handle(c_x.ref, c_y.ref))
 }
-internal func moveToCType(_ swiftType: Point?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeCollection_Point_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Point?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeCollection_Point_release_optional_handle)
 }
 public struct StructHavingAliasFieldDefinedBelow {
     public var field: StorageId
@@ -66,44 +65,44 @@ public struct StructHavingAliasFieldDefinedBelow {
         field = moveFromCType(smoke_TypeCollection_StructHavingAliasFieldDefinedBelow_field_get(cHandle))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructHavingAliasFieldDefinedBelow {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructHavingAliasFieldDefinedBelow {
     return StructHavingAliasFieldDefinedBelow(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructHavingAliasFieldDefinedBelow {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructHavingAliasFieldDefinedBelow {
     defer {
         smoke_TypeCollection_StructHavingAliasFieldDefinedBelow_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructHavingAliasFieldDefinedBelow) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: StructHavingAliasFieldDefinedBelow) -> RefHolder {
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_TypeCollection_StructHavingAliasFieldDefinedBelow_create_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: StructHavingAliasFieldDefinedBelow) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeCollection_StructHavingAliasFieldDefinedBelow_release_handle)
+internal func foobar_moveToCType(_ swiftType: StructHavingAliasFieldDefinedBelow) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeCollection_StructHavingAliasFieldDefinedBelow_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> StructHavingAliasFieldDefinedBelow? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructHavingAliasFieldDefinedBelow? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_TypeCollection_StructHavingAliasFieldDefinedBelow_unwrap_optional_handle(handle)
     return StructHavingAliasFieldDefinedBelow(cHandle: unwrappedHandle) as StructHavingAliasFieldDefinedBelow
 }
-internal func moveFromCType(_ handle: _baseRef) -> StructHavingAliasFieldDefinedBelow? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructHavingAliasFieldDefinedBelow? {
     defer {
         smoke_TypeCollection_StructHavingAliasFieldDefinedBelow_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: StructHavingAliasFieldDefinedBelow?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: StructHavingAliasFieldDefinedBelow?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_TypeCollection_StructHavingAliasFieldDefinedBelow_create_optional_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: StructHavingAliasFieldDefinedBelow?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeCollection_StructHavingAliasFieldDefinedBelow_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: StructHavingAliasFieldDefinedBelow?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeCollection_StructHavingAliasFieldDefinedBelow_release_optional_handle)
 }
 public struct TypeCollection {
     public static let invalidStorageId: StorageId = 0

--- a/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/TypeDefs.swift
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/TypeDefs.swift
@@ -59,16 +59,16 @@ public class TypeDefs {
         return moveFromCType(smoke_TypeDefs_returnNestedIntTypeDef(c_input.ref))
     }
     public static func returnTestStructTypeDef(input: TypeDefs.TestStructTypeDef) -> TypeDefs.TestStructTypeDef {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_TypeDefs_returnTestStructTypeDef(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_TypeDefs_returnTestStructTypeDef(c_input.ref))
     }
     public static func returnNestedStructTypeDef(input: TypeDefs.NestedStructTypeDef) -> TypeDefs.NestedStructTypeDef {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_TypeDefs_returnNestedStructTypeDef(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_TypeDefs_returnNestedStructTypeDef(c_input.ref))
     }
     public static func returnTypeDefPointFromTypeCollection(input: PointTypeDef) -> PointTypeDef {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_TypeDefs_returnTypeDefPointFromTypeCollection(c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_TypeDefs_returnTypeDefPointFromTypeCollection(c_input.ref))
     }
 }
 internal func getRef(_ ref: TypeDefs?, owning: Bool = true) -> RefHolder {
@@ -91,7 +91,7 @@ extension TypeDefs: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func TypeDefs_copyFromCType(_ handle: _baseRef) -> TypeDefs {
+internal func foobar_TypeDefs_copyFromCType(_ handle: _baseRef) -> TypeDefs {
     if let swift_pointer = smoke_TypeDefs_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? TypeDefs {
         return re_constructed
@@ -100,7 +100,7 @@ internal func TypeDefs_copyFromCType(_ handle: _baseRef) -> TypeDefs {
     smoke_TypeDefs_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func TypeDefs_moveFromCType(_ handle: _baseRef) -> TypeDefs {
+internal func foobar_TypeDefs_moveFromCType(_ handle: _baseRef) -> TypeDefs {
     if let swift_pointer = smoke_TypeDefs_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? TypeDefs {
         smoke_TypeDefs_release_handle(handle)
@@ -110,105 +110,105 @@ internal func TypeDefs_moveFromCType(_ handle: _baseRef) -> TypeDefs {
     smoke_TypeDefs_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func TypeDefs_copyFromCType(_ handle: _baseRef) -> TypeDefs? {
+internal func foobar_TypeDefs_copyFromCType(_ handle: _baseRef) -> TypeDefs? {
     guard handle != 0 else {
         return nil
     }
-    return TypeDefs_moveFromCType(handle) as TypeDefs
+    return foobar_TypeDefs_moveFromCType(handle) as TypeDefs
 }
-internal func TypeDefs_moveFromCType(_ handle: _baseRef) -> TypeDefs? {
+internal func foobar_TypeDefs_moveFromCType(_ handle: _baseRef) -> TypeDefs? {
     guard handle != 0 else {
         return nil
     }
-    return TypeDefs_moveFromCType(handle) as TypeDefs
+    return foobar_TypeDefs_moveFromCType(handle) as TypeDefs
 }
-internal func copyToCType(_ swiftClass: TypeDefs) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: TypeDefs) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: TypeDefs) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: TypeDefs) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: TypeDefs?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: TypeDefs?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: TypeDefs?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: TypeDefs?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> TypeDefs.StructHavingAliasFieldDefinedBelow {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> TypeDefs.StructHavingAliasFieldDefinedBelow {
     return TypeDefs.StructHavingAliasFieldDefinedBelow(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> TypeDefs.StructHavingAliasFieldDefinedBelow {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> TypeDefs.StructHavingAliasFieldDefinedBelow {
     defer {
         smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: TypeDefs.StructHavingAliasFieldDefinedBelow) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: TypeDefs.StructHavingAliasFieldDefinedBelow) -> RefHolder {
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: TypeDefs.StructHavingAliasFieldDefinedBelow) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle)
+internal func foobar_moveToCType(_ swiftType: TypeDefs.StructHavingAliasFieldDefinedBelow) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> TypeDefs.StructHavingAliasFieldDefinedBelow? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> TypeDefs.StructHavingAliasFieldDefinedBelow? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_unwrap_optional_handle(handle)
     return TypeDefs.StructHavingAliasFieldDefinedBelow(cHandle: unwrappedHandle) as TypeDefs.StructHavingAliasFieldDefinedBelow
 }
-internal func moveFromCType(_ handle: _baseRef) -> TypeDefs.StructHavingAliasFieldDefinedBelow? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> TypeDefs.StructHavingAliasFieldDefinedBelow? {
     defer {
         smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: TypeDefs.StructHavingAliasFieldDefinedBelow?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: TypeDefs.StructHavingAliasFieldDefinedBelow?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_optional_handle(c_field.ref))
 }
-internal func moveToCType(_ swiftType: TypeDefs.StructHavingAliasFieldDefinedBelow?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: TypeDefs.StructHavingAliasFieldDefinedBelow?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> TypeDefs.TestStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> TypeDefs.TestStruct {
     return TypeDefs.TestStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> TypeDefs.TestStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> TypeDefs.TestStruct {
     defer {
         smoke_TypeDefs_TestStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: TypeDefs.TestStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: TypeDefs.TestStruct) -> RefHolder {
     let c_something = moveToCType(swiftType.something)
     return RefHolder(smoke_TypeDefs_TestStruct_create_handle(c_something.ref))
 }
-internal func moveToCType(_ swiftType: TypeDefs.TestStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeDefs_TestStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: TypeDefs.TestStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeDefs_TestStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> TypeDefs.TestStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> TypeDefs.TestStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_TypeDefs_TestStruct_unwrap_optional_handle(handle)
     return TypeDefs.TestStruct(cHandle: unwrappedHandle) as TypeDefs.TestStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> TypeDefs.TestStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> TypeDefs.TestStruct? {
     defer {
         smoke_TypeDefs_TestStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: TypeDefs.TestStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: TypeDefs.TestStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_something = moveToCType(swiftType.something)
     return RefHolder(smoke_TypeDefs_TestStruct_create_optional_handle(c_something.ref))
 }
-internal func moveToCType(_ swiftType: TypeDefs.TestStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypeDefs_TestStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: TypeDefs.TestStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_TypeDefs_TestStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalClass.swift
@@ -37,7 +37,7 @@ extension InternalClass: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func InternalClass_copyFromCType(_ handle: _baseRef) -> InternalClass {
+internal func foobar_InternalClass_copyFromCType(_ handle: _baseRef) -> InternalClass {
     if let swift_pointer = smoke_InternalClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalClass {
         return re_constructed
@@ -46,7 +46,7 @@ internal func InternalClass_copyFromCType(_ handle: _baseRef) -> InternalClass {
     smoke_InternalClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func InternalClass_moveFromCType(_ handle: _baseRef) -> InternalClass {
+internal func foobar_InternalClass_moveFromCType(_ handle: _baseRef) -> InternalClass {
     if let swift_pointer = smoke_InternalClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalClass {
         smoke_InternalClass_release_handle(handle)
@@ -56,27 +56,27 @@ internal func InternalClass_moveFromCType(_ handle: _baseRef) -> InternalClass {
     smoke_InternalClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func InternalClass_copyFromCType(_ handle: _baseRef) -> InternalClass? {
+internal func foobar_InternalClass_copyFromCType(_ handle: _baseRef) -> InternalClass? {
     guard handle != 0 else {
         return nil
     }
-    return InternalClass_moveFromCType(handle) as InternalClass
+    return foobar_InternalClass_moveFromCType(handle) as InternalClass
 }
-internal func InternalClass_moveFromCType(_ handle: _baseRef) -> InternalClass? {
+internal func foobar_InternalClass_moveFromCType(_ handle: _baseRef) -> InternalClass? {
     guard handle != 0 else {
         return nil
     }
-    return InternalClass_moveFromCType(handle) as InternalClass
+    return foobar_InternalClass_moveFromCType(handle) as InternalClass
 }
-internal func copyToCType(_ swiftClass: InternalClass) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InternalClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InternalClass) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InternalClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: InternalClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InternalClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InternalClass?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InternalClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalInterface.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalInterface.swift
@@ -52,7 +52,7 @@ internal func getRef(_ ref: InternalInterface?, owning: Bool = true) -> RefHolde
 extension _InternalInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func InternalInterface_copyFromCType(_ handle: _baseRef) -> InternalInterface {
+internal func foobar_InternalInterface_copyFromCType(_ handle: _baseRef) -> InternalInterface {
     if let swift_pointer = smoke_InternalInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalInterface {
         return re_constructed
@@ -68,7 +68,7 @@ internal func InternalInterface_copyFromCType(_ handle: _baseRef) -> InternalInt
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func InternalInterface_moveFromCType(_ handle: _baseRef) -> InternalInterface {
+internal func foobar_InternalInterface_moveFromCType(_ handle: _baseRef) -> InternalInterface {
     if let swift_pointer = smoke_InternalInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InternalInterface {
         smoke_InternalInterface_release_handle(handle)
@@ -86,27 +86,27 @@ internal func InternalInterface_moveFromCType(_ handle: _baseRef) -> InternalInt
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func InternalInterface_copyFromCType(_ handle: _baseRef) -> InternalInterface? {
+internal func foobar_InternalInterface_copyFromCType(_ handle: _baseRef) -> InternalInterface? {
     guard handle != 0 else {
         return nil
     }
-    return InternalInterface_moveFromCType(handle) as InternalInterface
+    return foobar_InternalInterface_moveFromCType(handle) as InternalInterface
 }
-internal func InternalInterface_moveFromCType(_ handle: _baseRef) -> InternalInterface? {
+internal func foobar_InternalInterface_moveFromCType(_ handle: _baseRef) -> InternalInterface? {
     guard handle != 0 else {
         return nil
     }
-    return InternalInterface_moveFromCType(handle) as InternalInterface
+    return foobar_InternalInterface_moveFromCType(handle) as InternalInterface
 }
-internal func copyToCType(_ swiftClass: InternalInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InternalInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InternalInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InternalInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: InternalInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: InternalInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: InternalInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: InternalInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicClass.swift
@@ -7,10 +7,10 @@ public class PublicClass {
     internal typealias StringToInternalStructMap = [String: PublicClass.InternalStruct]
     internal var internalStructProperty: PublicClass.InternalStruct {
         get {
-            return moveFromCType(smoke_PublicClass_internalStructProperty_get(self.c_instance))
+            return foobar_moveFromCType(smoke_PublicClass_internalStructProperty_get(self.c_instance))
         }
         set {
-            let c_value = moveToCType(newValue)
+            let c_value = foobar_moveToCType(newValue)
             return moveFromCType(smoke_PublicClass_internalStructProperty_set(self.c_instance, c_value.ref))
         }
     }
@@ -53,7 +53,7 @@ public class PublicClass {
             self.internalField = internalField
         }
         internal init(cHandle: _baseRef) {
-            internalField = moveFromCType(smoke_PublicClass_PublicStruct_internalField_get(cHandle))
+            internalField = foobar_moveFromCType(smoke_PublicClass_PublicStruct_internalField_get(cHandle))
         }
     }
     public struct PublicStructWithInternalDefaults {
@@ -73,8 +73,8 @@ public class PublicClass {
         }
     }
     internal func internalMethod(input: PublicClass.InternalStruct) -> PublicClass.InternalStructTypeDef {
-        let c_input = moveToCType(input)
-        return moveFromCType(smoke_PublicClass_internalMethod(self.c_instance, c_input.ref))
+        let c_input = foobar_moveToCType(input)
+        return foobar_moveFromCType(smoke_PublicClass_internalMethod(self.c_instance, c_input.ref))
     }
 }
 internal func getRef(_ ref: PublicClass?, owning: Bool = true) -> RefHolder {
@@ -97,7 +97,7 @@ extension PublicClass: Hashable {
         hasher.combine(c_handle)
     }
 }
-internal func PublicClass_copyFromCType(_ handle: _baseRef) -> PublicClass {
+internal func foobar_PublicClass_copyFromCType(_ handle: _baseRef) -> PublicClass {
     if let swift_pointer = smoke_PublicClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PublicClass {
         return re_constructed
@@ -106,7 +106,7 @@ internal func PublicClass_copyFromCType(_ handle: _baseRef) -> PublicClass {
     smoke_PublicClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func PublicClass_moveFromCType(_ handle: _baseRef) -> PublicClass {
+internal func foobar_PublicClass_moveFromCType(_ handle: _baseRef) -> PublicClass {
     if let swift_pointer = smoke_PublicClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PublicClass {
         smoke_PublicClass_release_handle(handle)
@@ -116,139 +116,139 @@ internal func PublicClass_moveFromCType(_ handle: _baseRef) -> PublicClass {
     smoke_PublicClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
-internal func PublicClass_copyFromCType(_ handle: _baseRef) -> PublicClass? {
+internal func foobar_PublicClass_copyFromCType(_ handle: _baseRef) -> PublicClass? {
     guard handle != 0 else {
         return nil
     }
-    return PublicClass_moveFromCType(handle) as PublicClass
+    return foobar_PublicClass_moveFromCType(handle) as PublicClass
 }
-internal func PublicClass_moveFromCType(_ handle: _baseRef) -> PublicClass? {
+internal func foobar_PublicClass_moveFromCType(_ handle: _baseRef) -> PublicClass? {
     guard handle != 0 else {
         return nil
     }
-    return PublicClass_moveFromCType(handle) as PublicClass
+    return foobar_PublicClass_moveFromCType(handle) as PublicClass
 }
-internal func copyToCType(_ swiftClass: PublicClass) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: PublicClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: PublicClass) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: PublicClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: PublicClass?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: PublicClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: PublicClass?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: PublicClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> PublicClass.InternalStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> PublicClass.InternalStruct {
     return PublicClass.InternalStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> PublicClass.InternalStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> PublicClass.InternalStruct {
     defer {
         smoke_PublicClass_InternalStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: PublicClass.InternalStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: PublicClass.InternalStruct) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_PublicClass_InternalStruct_create_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: PublicClass.InternalStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicClass_InternalStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: PublicClass.InternalStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PublicClass_InternalStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> PublicClass.InternalStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> PublicClass.InternalStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_PublicClass_InternalStruct_unwrap_optional_handle(handle)
     return PublicClass.InternalStruct(cHandle: unwrappedHandle) as PublicClass.InternalStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> PublicClass.InternalStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> PublicClass.InternalStruct? {
     defer {
         smoke_PublicClass_InternalStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: PublicClass.InternalStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: PublicClass.InternalStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_PublicClass_InternalStruct_create_optional_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: PublicClass.InternalStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicClass_InternalStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: PublicClass.InternalStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PublicClass_InternalStruct_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> PublicClass.PublicStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> PublicClass.PublicStruct {
     return PublicClass.PublicStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> PublicClass.PublicStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> PublicClass.PublicStruct {
     defer {
         smoke_PublicClass_PublicStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: PublicClass.PublicStruct) -> RefHolder {
-    let c_internalField = moveToCType(swiftType.internalField)
+internal func foobar_copyToCType(_ swiftType: PublicClass.PublicStruct) -> RefHolder {
+    let c_internalField = foobar_moveToCType(swiftType.internalField)
     return RefHolder(smoke_PublicClass_PublicStruct_create_handle(c_internalField.ref))
 }
-internal func moveToCType(_ swiftType: PublicClass.PublicStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicClass_PublicStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: PublicClass.PublicStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PublicClass_PublicStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> PublicClass.PublicStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> PublicClass.PublicStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_PublicClass_PublicStruct_unwrap_optional_handle(handle)
     return PublicClass.PublicStruct(cHandle: unwrappedHandle) as PublicClass.PublicStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> PublicClass.PublicStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> PublicClass.PublicStruct? {
     defer {
         smoke_PublicClass_PublicStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: PublicClass.PublicStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: PublicClass.PublicStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_internalField = moveToCType(swiftType.internalField)
+    let c_internalField = foobar_moveToCType(swiftType.internalField)
     return RefHolder(smoke_PublicClass_PublicStruct_create_optional_handle(c_internalField.ref))
 }
-internal func moveToCType(_ swiftType: PublicClass.PublicStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicClass_PublicStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: PublicClass.PublicStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PublicClass_PublicStruct_release_optional_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> PublicClass.PublicStructWithInternalDefaults {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> PublicClass.PublicStructWithInternalDefaults {
     return PublicClass.PublicStructWithInternalDefaults(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> PublicClass.PublicStructWithInternalDefaults {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> PublicClass.PublicStructWithInternalDefaults {
     defer {
         smoke_PublicClass_PublicStructWithInternalDefaults_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: PublicClass.PublicStructWithInternalDefaults) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: PublicClass.PublicStructWithInternalDefaults) -> RefHolder {
     let c_internalField = moveToCType(swiftType.internalField)
     let c_publicField = moveToCType(swiftType.publicField)
     return RefHolder(smoke_PublicClass_PublicStructWithInternalDefaults_create_handle(c_internalField.ref, c_publicField.ref))
 }
-internal func moveToCType(_ swiftType: PublicClass.PublicStructWithInternalDefaults) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicClass_PublicStructWithInternalDefaults_release_handle)
+internal func foobar_moveToCType(_ swiftType: PublicClass.PublicStructWithInternalDefaults) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PublicClass_PublicStructWithInternalDefaults_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> PublicClass.PublicStructWithInternalDefaults? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> PublicClass.PublicStructWithInternalDefaults? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_PublicClass_PublicStructWithInternalDefaults_unwrap_optional_handle(handle)
     return PublicClass.PublicStructWithInternalDefaults(cHandle: unwrappedHandle) as PublicClass.PublicStructWithInternalDefaults
 }
-internal func moveFromCType(_ handle: _baseRef) -> PublicClass.PublicStructWithInternalDefaults? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> PublicClass.PublicStructWithInternalDefaults? {
     defer {
         smoke_PublicClass_PublicStructWithInternalDefaults_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: PublicClass.PublicStructWithInternalDefaults?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: PublicClass.PublicStructWithInternalDefaults?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
@@ -256,36 +256,36 @@ internal func copyToCType(_ swiftType: PublicClass.PublicStructWithInternalDefau
     let c_publicField = moveToCType(swiftType.publicField)
     return RefHolder(smoke_PublicClass_PublicStructWithInternalDefaults_create_optional_handle(c_internalField.ref, c_publicField.ref))
 }
-internal func moveToCType(_ swiftType: PublicClass.PublicStructWithInternalDefaults?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicClass_PublicStructWithInternalDefaults_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: PublicClass.PublicStructWithInternalDefaults?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PublicClass_PublicStructWithInternalDefaults_release_optional_handle)
 }
-internal func copyToCType(_ swiftEnum: PublicClass.InternalEnum) -> PrimitiveHolder<UInt32> {
+internal func foobar_copyToCType(_ swiftEnum: PublicClass.InternalEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
-internal func moveToCType(_ swiftEnum: PublicClass.InternalEnum) -> PrimitiveHolder<UInt32> {
-    return copyToCType(swiftEnum)
+internal func foobar_moveToCType(_ swiftEnum: PublicClass.InternalEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
 }
-internal func copyToCType(_ swiftEnum: PublicClass.InternalEnum?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftEnum: PublicClass.InternalEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
-internal func moveToCType(_ swiftEnum: PublicClass.InternalEnum?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftEnum: PublicClass.InternalEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
-internal func copyFromCType(_ cValue: UInt32) -> PublicClass.InternalEnum {
+internal func foobar_copyFromCType(_ cValue: UInt32) -> PublicClass.InternalEnum {
     return PublicClass.InternalEnum(rawValue: cValue)!
 }
-internal func moveFromCType(_ cValue: UInt32) -> PublicClass.InternalEnum {
-    return copyFromCType(cValue)
+internal func foobar_moveFromCType(_ cValue: UInt32) -> PublicClass.InternalEnum {
+    return foobar_copyFromCType(cValue)
 }
-internal func copyFromCType(_ handle: _baseRef) -> PublicClass.InternalEnum? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> PublicClass.InternalEnum? {
     guard handle != 0 else {
         return nil
     }
     return PublicClass.InternalEnum(rawValue: uint32_t_value_get(handle))!
 }
-internal func moveFromCType(_ handle: _baseRef) -> PublicClass.InternalEnum? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> PublicClass.InternalEnum? {
     defer {
         uint32_t_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicInterface.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicInterface.swift
@@ -22,7 +22,7 @@ internal struct InternalStruct {
         self.fieldOfInternalType = fieldOfInternalType
     }
     internal init(cHandle: _baseRef) {
-        fieldOfInternalType = moveFromCType(smoke_PublicInterface_InternalStruct_fieldOfInternalType_get(cHandle))
+        fieldOfInternalType = foobar_moveFromCType(smoke_PublicInterface_InternalStruct_fieldOfInternalType_get(cHandle))
     }
 }
 @_cdecl("_CBridgeInitsmoke_PublicInterface")
@@ -53,7 +53,7 @@ internal func getRef(_ ref: PublicInterface?, owning: Bool = true) -> RefHolder 
 extension _PublicInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-internal func PublicInterface_copyFromCType(_ handle: _baseRef) -> PublicInterface {
+internal func foobar_PublicInterface_copyFromCType(_ handle: _baseRef) -> PublicInterface {
     if let swift_pointer = smoke_PublicInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PublicInterface {
         return re_constructed
@@ -69,7 +69,7 @@ internal func PublicInterface_copyFromCType(_ handle: _baseRef) -> PublicInterfa
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func PublicInterface_moveFromCType(_ handle: _baseRef) -> PublicInterface {
+internal func foobar_PublicInterface_moveFromCType(_ handle: _baseRef) -> PublicInterface {
     if let swift_pointer = smoke_PublicInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PublicInterface {
         smoke_PublicInterface_release_handle(handle)
@@ -87,66 +87,66 @@ internal func PublicInterface_moveFromCType(_ handle: _baseRef) -> PublicInterfa
     }
     fatalError("Failed to initialize Swift object")
 }
-internal func PublicInterface_copyFromCType(_ handle: _baseRef) -> PublicInterface? {
+internal func foobar_PublicInterface_copyFromCType(_ handle: _baseRef) -> PublicInterface? {
     guard handle != 0 else {
         return nil
     }
-    return PublicInterface_moveFromCType(handle) as PublicInterface
+    return foobar_PublicInterface_moveFromCType(handle) as PublicInterface
 }
-internal func PublicInterface_moveFromCType(_ handle: _baseRef) -> PublicInterface? {
+internal func foobar_PublicInterface_moveFromCType(_ handle: _baseRef) -> PublicInterface? {
     guard handle != 0 else {
         return nil
     }
-    return PublicInterface_moveFromCType(handle) as PublicInterface
+    return foobar_PublicInterface_moveFromCType(handle) as PublicInterface
 }
-internal func copyToCType(_ swiftClass: PublicInterface) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: PublicInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: PublicInterface) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: PublicInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyToCType(_ swiftClass: PublicInterface?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftClass: PublicInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
-internal func moveToCType(_ swiftClass: PublicInterface?) -> RefHolder {
+internal func foobar_moveToCType(_ swiftClass: PublicInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> InternalStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> InternalStruct {
     return InternalStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> InternalStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> InternalStruct {
     defer {
         smoke_PublicInterface_InternalStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: InternalStruct) -> RefHolder {
-    let c_fieldOfInternalType = moveToCType(swiftType.fieldOfInternalType)
+internal func foobar_copyToCType(_ swiftType: InternalStruct) -> RefHolder {
+    let c_fieldOfInternalType = foobar_moveToCType(swiftType.fieldOfInternalType)
     return RefHolder(smoke_PublicInterface_InternalStruct_create_handle(c_fieldOfInternalType.ref))
 }
-internal func moveToCType(_ swiftType: InternalStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicInterface_InternalStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: InternalStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PublicInterface_InternalStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> InternalStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> InternalStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_PublicInterface_InternalStruct_unwrap_optional_handle(handle)
     return InternalStruct(cHandle: unwrappedHandle) as InternalStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> InternalStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> InternalStruct? {
     defer {
         smoke_PublicInterface_InternalStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: InternalStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: InternalStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let c_fieldOfInternalType = moveToCType(swiftType.fieldOfInternalType)
+    let c_fieldOfInternalType = foobar_moveToCType(swiftType.fieldOfInternalType)
     return RefHolder(smoke_PublicInterface_InternalStruct_create_optional_handle(c_fieldOfInternalType.ref))
 }
-internal func moveToCType(_ swiftType: InternalStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicInterface_InternalStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: InternalStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PublicInterface_InternalStruct_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicTypeCollection.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicTypeCollection.swift
@@ -10,46 +10,46 @@ internal struct InternalStruct {
         stringField = moveFromCType(smoke_PublicTypeCollection_InternalStruct_stringField_get(cHandle))
     }
     internal func fooBar() -> Void {
-        let c_self_handle = moveToCType(self)
+        let c_self_handle = foobar_moveToCType(self)
         return moveFromCType(smoke_PublicTypeCollection_InternalStruct_fooBar(c_self_handle.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> InternalStruct {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> InternalStruct {
     return InternalStruct(cHandle: handle)
 }
-internal func moveFromCType(_ handle: _baseRef) -> InternalStruct {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> InternalStruct {
     defer {
         smoke_PublicTypeCollection_InternalStruct_release_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: InternalStruct) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: InternalStruct) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_PublicTypeCollection_InternalStruct_create_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: InternalStruct) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicTypeCollection_InternalStruct_release_handle)
+internal func foobar_moveToCType(_ swiftType: InternalStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PublicTypeCollection_InternalStruct_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> InternalStruct? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> InternalStruct? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = smoke_PublicTypeCollection_InternalStruct_unwrap_optional_handle(handle)
     return InternalStruct(cHandle: unwrappedHandle) as InternalStruct
 }
-internal func moveFromCType(_ handle: _baseRef) -> InternalStruct? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> InternalStruct? {
     defer {
         smoke_PublicTypeCollection_InternalStruct_release_optional_handle(handle)
     }
-    return copyFromCType(handle)
+    return foobar_copyFromCType(handle)
 }
-internal func copyToCType(_ swiftType: InternalStruct?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftType: InternalStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
     let c_stringField = moveToCType(swiftType.stringField)
     return RefHolder(smoke_PublicTypeCollection_InternalStruct_create_optional_handle(c_stringField.ref))
 }
-internal func moveToCType(_ swiftType: InternalStruct?) -> RefHolder {
-    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicTypeCollection_InternalStruct_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: InternalStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_PublicTypeCollection_InternalStruct_release_optional_handle)
 }


### PR DESCRIPTION
Updated Swift templates to add "internal prefix" to the names of all conversion functions (it was used only for generic
types conversion functions before). This is a preparation for adding conversion functions for "auxiliary" types in
Swift.

Updated smoke tests.

See: #745
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
