### PR TITLE
Fix a functional test for Locale in Swift

### DIFF
--- a/functional-tests/functional/swift/Tests/LocalesTests.swift
+++ b/functional-tests/functional/swift/Tests/LocalesTests.swift
@@ -92,7 +92,9 @@ class LocalesTests: XCTestCase {
 
         let result = LocalesStruct.localesStructRoundTrip(input: localesStruct)
 
-        XCTAssertEqual(result, localesStruct)
+        XCTAssertEqual(result.primaryLocale.identifier, localesStruct.primaryLocale.identifier)
+        XCTAssertNotNil(result.secondaryLocale)
+        XCTAssertEqual(result.secondaryLocale!.identifier, localesStruct.secondaryLocale!.identifier)
         XCTAssertEqual(hash(result), hash(localesStruct))
     }
 


### PR DESCRIPTION
Updated "testLocalesStructRoundTrip" functional test in Swift to compare `Locale.identifier` fields instead of `Locale`
objects directly, as other "round trip" tests in the same file do.