### PR TITLE
Generate conversion functions for AUX types in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Gluecodium project Release Notes
 
 ## Unreleased
+### Bug fixes:
+  * Fixed compilation issues for modularized Swift builds.
 ### Removed:
   * Deprecated IDL attribute `@Swift(ObjC)` was removed.
 

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassConversion.mustache
@@ -18,14 +18,14 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#ifPredicate "hasTypeRepository"}}
+{{#unless isAuxiliary}}{{#ifPredicate "hasTypeRepository"}}
 @_cdecl("_CBridgeInit{{resolveName "CBridge"}}")
 internal func _CBridgeInit{{resolveName "CBridge"}}(handle: _baseRef) -> UnsafeMutableRawPointer {
     let reference = {{>implName}}(c{{resolveName}}: handle)
     return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
 }
 
-{{/ifPredicate}}
+{{/ifPredicate}}{{/unless}}
 {{#instanceOf this "LimeInterface"}}{{>swift/GetReference}}{{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeInterface"}}
 internal func getRef(_ ref: {{resolveName this "" "ref"}}?, owning: Bool = true) -> RefHolder {
@@ -39,7 +39,7 @@ internal func getRef(_ ref: {{resolveName this "" "ref"}}?, owning: Bool = true)
 }
 {{/notInstanceOf}}
 
-{{#unlessPredicate "parentIsClass"}}
+{{#unless isAuxiliary}}{{#unlessPredicate "parentIsClass"}}
 extension {{>implName}}: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }{{/unlessPredicate}}{{!!
@@ -76,7 +76,7 @@ extension {{>implName}}: Hashable {
     }
 }
 {{/unlessPredicate}}{{/instanceOf}}
-{{/unless}}
+{{/unless}}{{/unless}}
 
 internal func {{internalPrefix}}{{resolveName "mangled"}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
 {{#instanceOf this "LimeInterface"}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}{{!!
+{{#unless isAuxiliary}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}{{!!
 }}{{resolveName visibility}} class {{resolveName}}{{!!
 }}{{#if parent}}: {{resolveName parent}}{{/if}}{{#unless parent}}{{/unless}} {
 
@@ -51,4 +51,4 @@
 
 {{#interfaces}}
 {{>swift/SwiftInterfaceDefinition}}
-{{/interfaces}}
+{{/interfaces}}{{/unless}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftEnumDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftEnumDefinition.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unlessPredicate "skipDeclaration"}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
+{{#unless isAuxiliary}}{{#unlessPredicate "skipDeclaration"}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
 {{>swift/TypeVisibility}} enum {{resolveName}}{{#if external.swift.converter}}_internal{{/if}} : UInt32, CaseIterable, Codable {
 {{#enumerators}}{{prefixPartial "enumerator" "    "}}
 {{/enumerators}}{{!!
@@ -59,6 +59,7 @@
     }
 {{/ifPredicate}}
 }
-{{/unlessPredicate}}{{!!
+{{/unlessPredicate}}{{/unless}}{{!!
+
 }}{{+enumerator}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
 case {{resolveName}}{{#if explicitValue}} = {{resolveName explicitValue}}{{/if}}{{/enumerator}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftInterfaceDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftInterfaceDefinition.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}{{!!
+{{#unless isAuxiliary}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}{{!!
 }}{{resolveName visibility}} protocol {{resolveName}} : {{!!
 }}{{#if parent}}{{resolveName parent}}{{/if}}{{#unless parent}}AnyObject{{/unless}} {
 {{#set isInterface=true interface=this}}{{#each typeAliases exceptions}}
@@ -59,4 +59,4 @@ internal class _{{resolveName}}: {{resolveName}} {
 
 {{#structs}}
 {{>swift/SwiftStructDefinition}}
-{{/structs}}
+{{/structs}}{{/unless}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftLambdaDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftLambdaDefinition.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
+{{#unless isAuxiliary}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
 {{#unless isInterface}}{{resolveName visibility}} {{/unless}}typealias {{resolveName}} = {{!!
 }}({{#parameters}}{{#unless typeRef.isNullable}}{{#instanceOf typeRef.type.actualType "LimeLambda"}}@escaping {{/instanceOf}}{{/unless}}{{!!
-}}{{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) -> {{resolveName returnType}}
+}}{{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) -> {{resolveName returnType}}{{/unless}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftStructDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftStructDefinition.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unlessPredicate "skipDeclaration"}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
+{{#unless isAuxiliary}}{{#unlessPredicate "skipDeclaration"}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
 {{>swift/TypeVisibility}} struct {{resolveName}}{{#if external.swift.converter}}_internal{{/if}}{{#unless external.swift.converter}}{{!!
 }}{{#if attributes.equatable attributes.serializable logic="or"}}{{!!
 }}:{{#if attributes.equatable}} Hashable{{/if}}{{#if attributes.equatable attributes.serializable logic="and"}},{{/if}}{{!!
@@ -141,7 +141,7 @@ extension {{resolveName}} {
         }}{{#if iter.hasNext}}, {{/if}}{{/fields}}{{/set}})
     }
 }
-{{/ifPredicate}}{{!!
+{{/ifPredicate}}{{/unless}}{{!!
 
 }}{{+initParameter}}{{!!
 }}{{resolveName}}: {{#unless typeRef.isNullable}}{{#instanceOf typeRef.type.actualType "LimeLambda"}}@escaping {{/instanceOf}}{{/unless}}{{!!

--- a/gluecodium/src/test/resources/smoke/aux_conversions/auxiliary/AuxConversionsAux.lime
+++ b/gluecodium/src/test/resources/smoke/aux_conversions/auxiliary/AuxConversionsAux.lime
@@ -1,0 +1,61 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Skip(Java, Dart)
+class AuxClass {
+    class ClassInAuxClass {}
+    interface InterfaceInAuxClass {}
+    struct StructInAuxClass {
+        fooBar: String
+    }
+    enum EnumInAuxClass {
+        FOO
+    }    
+}
+
+@Skip(Java, Dart)
+interface AuxInterface {
+    class ClassInAuxInterface {}
+    interface InterfaceInAuxInterface {}
+    struct StructInAuxInterface {
+        fooBar: String
+    }
+    enum EnumInAuxInterface {
+        FOO
+    }  
+}
+
+@Skip(Java, Dart)
+struct AuxStruct {
+    fooBar: String
+
+    class ClassInAuxStruct {}
+    interface InterfaceInAuxStruct {}
+    struct StructInAuxStruct {
+        fooBar: String
+    }
+    enum EnumInAuxStruct {
+        FOO
+    }
+}
+
+@Skip(Java, Dart)
+enum AuxEnum {
+    FOO
+}

--- a/gluecodium/src/test/resources/smoke/aux_conversions/input/AuxConversionsMain.lime
+++ b/gluecodium/src/test/resources/smoke/aux_conversions/input/AuxConversionsMain.lime
@@ -1,0 +1,21 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Skip(Java, Dart)
+class AuxConversionsMain {}

--- a/gluecodium/src/test/resources/smoke/aux_conversions/output/swift/smoke/AuxClass.swift
+++ b/gluecodium/src/test/resources/smoke/aux_conversions/output/swift/smoke/AuxClass.swift
@@ -1,0 +1,254 @@
+//
+//
+import Foundation
+internal func getRef(_ ref: AuxClass?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_AuxClass_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_AuxClass_release_handle)
+        : RefHolder(handle_copy)
+}
+internal func foobar_AuxClass_copyFromCType(_ handle: _baseRef) -> AuxClass {
+    if let swift_pointer = smoke_AuxClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AuxClass {
+        return re_constructed
+    }
+    let result = AuxClass(cAuxClass: smoke_AuxClass_copy_handle(handle))
+    smoke_AuxClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func foobar_AuxClass_moveFromCType(_ handle: _baseRef) -> AuxClass {
+    if let swift_pointer = smoke_AuxClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AuxClass {
+        smoke_AuxClass_release_handle(handle)
+        return re_constructed
+    }
+    let result = AuxClass(cAuxClass: handle)
+    smoke_AuxClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func foobar_AuxClass_copyFromCType(_ handle: _baseRef) -> AuxClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_AuxClass_moveFromCType(handle) as AuxClass
+}
+internal func foobar_AuxClass_moveFromCType(_ handle: _baseRef) -> AuxClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_AuxClass_moveFromCType(handle) as AuxClass
+}
+internal func foobar_copyToCType(_ swiftClass: AuxClass) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: AuxClass) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func foobar_copyToCType(_ swiftClass: AuxClass?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: AuxClass?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func getRef(_ ref: AuxClass.ClassInAuxClass?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_AuxClass_ClassInAuxClass_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_AuxClass_ClassInAuxClass_release_handle)
+        : RefHolder(handle_copy)
+}
+internal func foobar_AuxClass_ClassInAuxClass_copyFromCType(_ handle: _baseRef) -> AuxClass.ClassInAuxClass {
+    if let swift_pointer = smoke_AuxClass_ClassInAuxClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AuxClass.ClassInAuxClass {
+        return re_constructed
+    }
+    let result = AuxClass.ClassInAuxClass(cClassInAuxClass: smoke_AuxClass_ClassInAuxClass_copy_handle(handle))
+    smoke_AuxClass_ClassInAuxClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func foobar_AuxClass_ClassInAuxClass_moveFromCType(_ handle: _baseRef) -> AuxClass.ClassInAuxClass {
+    if let swift_pointer = smoke_AuxClass_ClassInAuxClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AuxClass.ClassInAuxClass {
+        smoke_AuxClass_ClassInAuxClass_release_handle(handle)
+        return re_constructed
+    }
+    let result = AuxClass.ClassInAuxClass(cClassInAuxClass: handle)
+    smoke_AuxClass_ClassInAuxClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func foobar_AuxClass_ClassInAuxClass_copyFromCType(_ handle: _baseRef) -> AuxClass.ClassInAuxClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_AuxClass_ClassInAuxClass_moveFromCType(handle) as AuxClass.ClassInAuxClass
+}
+internal func foobar_AuxClass_ClassInAuxClass_moveFromCType(_ handle: _baseRef) -> AuxClass.ClassInAuxClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_AuxClass_ClassInAuxClass_moveFromCType(handle) as AuxClass.ClassInAuxClass
+}
+internal func foobar_copyToCType(_ swiftClass: AuxClass.ClassInAuxClass) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: AuxClass.ClassInAuxClass) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func foobar_copyToCType(_ swiftClass: AuxClass.ClassInAuxClass?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: AuxClass.ClassInAuxClass?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func getRef(_ ref: InterfaceInAuxClass?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_AuxClass_InterfaceInAuxClass_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_AuxClass_InterfaceInAuxClass_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_AuxClass_InterfaceInAuxClass_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    let proxy = smoke_AuxClass_InterfaceInAuxClass_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_AuxClass_InterfaceInAuxClass_release_handle) : RefHolder(proxy)
+}
+internal func foobar_InterfaceInAuxClass_copyFromCType(_ handle: _baseRef) -> InterfaceInAuxClass {
+    if let swift_pointer = smoke_AuxClass_InterfaceInAuxClass_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InterfaceInAuxClass {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxClass_InterfaceInAuxClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InterfaceInAuxClass {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxClass_InterfaceInAuxClass_get_typed(smoke_AuxClass_InterfaceInAuxClass_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InterfaceInAuxClass {
+        smoke_AuxClass_InterfaceInAuxClass_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func foobar_InterfaceInAuxClass_moveFromCType(_ handle: _baseRef) -> InterfaceInAuxClass {
+    if let swift_pointer = smoke_AuxClass_InterfaceInAuxClass_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InterfaceInAuxClass {
+        smoke_AuxClass_InterfaceInAuxClass_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxClass_InterfaceInAuxClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InterfaceInAuxClass {
+        smoke_AuxClass_InterfaceInAuxClass_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxClass_InterfaceInAuxClass_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InterfaceInAuxClass {
+        smoke_AuxClass_InterfaceInAuxClass_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func foobar_InterfaceInAuxClass_copyFromCType(_ handle: _baseRef) -> InterfaceInAuxClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_InterfaceInAuxClass_moveFromCType(handle) as InterfaceInAuxClass
+}
+internal func foobar_InterfaceInAuxClass_moveFromCType(_ handle: _baseRef) -> InterfaceInAuxClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_InterfaceInAuxClass_moveFromCType(handle) as InterfaceInAuxClass
+}
+internal func foobar_copyToCType(_ swiftClass: InterfaceInAuxClass) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: InterfaceInAuxClass) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func foobar_copyToCType(_ swiftClass: InterfaceInAuxClass?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: InterfaceInAuxClass?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AuxClass.StructInAuxClass {
+    return AuxClass.StructInAuxClass(cHandle: handle)
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AuxClass.StructInAuxClass {
+    defer {
+        smoke_AuxClass_StructInAuxClass_release_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyToCType(_ swiftType: AuxClass.StructInAuxClass) -> RefHolder {
+    let c_fooBar = moveToCType(swiftType.fooBar)
+    return RefHolder(smoke_AuxClass_StructInAuxClass_create_handle(c_fooBar.ref))
+}
+internal func foobar_moveToCType(_ swiftType: AuxClass.StructInAuxClass) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AuxClass_StructInAuxClass_release_handle)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AuxClass.StructInAuxClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_AuxClass_StructInAuxClass_unwrap_optional_handle(handle)
+    return AuxClass.StructInAuxClass(cHandle: unwrappedHandle) as AuxClass.StructInAuxClass
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AuxClass.StructInAuxClass? {
+    defer {
+        smoke_AuxClass_StructInAuxClass_release_optional_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyToCType(_ swiftType: AuxClass.StructInAuxClass?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_fooBar = moveToCType(swiftType.fooBar)
+    return RefHolder(smoke_AuxClass_StructInAuxClass_create_optional_handle(c_fooBar.ref))
+}
+internal func foobar_moveToCType(_ swiftType: AuxClass.StructInAuxClass?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AuxClass_StructInAuxClass_release_optional_handle)
+}
+internal func foobar_copyToCType(_ swiftEnum: AuxClass.EnumInAuxClass) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func foobar_moveToCType(_ swiftEnum: AuxClass.EnumInAuxClass) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
+}
+internal func foobar_copyToCType(_ swiftEnum: AuxClass.EnumInAuxClass?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func foobar_moveToCType(_ swiftEnum: AuxClass.EnumInAuxClass?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func foobar_copyFromCType(_ cValue: UInt32) -> AuxClass.EnumInAuxClass {
+    return AuxClass.EnumInAuxClass(rawValue: cValue)!
+}
+internal func foobar_moveFromCType(_ cValue: UInt32) -> AuxClass.EnumInAuxClass {
+    return foobar_copyFromCType(cValue)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AuxClass.EnumInAuxClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return AuxClass.EnumInAuxClass(rawValue: uint32_t_value_get(handle))!
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AuxClass.EnumInAuxClass? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}

--- a/gluecodium/src/test/resources/smoke/aux_conversions/output/swift/smoke/AuxEnum.swift
+++ b/gluecodium/src/test/resources/smoke/aux_conversions/output/swift/smoke/AuxEnum.swift
@@ -1,0 +1,33 @@
+//
+//
+import Foundation
+internal func foobar_copyToCType(_ swiftEnum: AuxEnum) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func foobar_moveToCType(_ swiftEnum: AuxEnum) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
+}
+internal func foobar_copyToCType(_ swiftEnum: AuxEnum?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func foobar_moveToCType(_ swiftEnum: AuxEnum?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func foobar_copyFromCType(_ cValue: UInt32) -> AuxEnum {
+    return AuxEnum(rawValue: cValue)!
+}
+internal func foobar_moveFromCType(_ cValue: UInt32) -> AuxEnum {
+    return foobar_copyFromCType(cValue)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AuxEnum? {
+    guard handle != 0 else {
+        return nil
+    }
+    return AuxEnum(rawValue: uint32_t_value_get(handle))!
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AuxEnum? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}

--- a/gluecodium/src/test/resources/smoke/aux_conversions/output/swift/smoke/AuxInterface.swift
+++ b/gluecodium/src/test/resources/smoke/aux_conversions/output/swift/smoke/AuxInterface.swift
@@ -1,0 +1,280 @@
+//
+//
+import Foundation
+internal func getRef(_ ref: AuxInterface?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_AuxInterface_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_AuxInterface_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_AuxInterface_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    let proxy = smoke_AuxInterface_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_AuxInterface_release_handle) : RefHolder(proxy)
+}
+internal func foobar_AuxInterface_copyFromCType(_ handle: _baseRef) -> AuxInterface {
+    if let swift_pointer = smoke_AuxInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AuxInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AuxInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxInterface_get_typed(smoke_AuxInterface_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? AuxInterface {
+        smoke_AuxInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func foobar_AuxInterface_moveFromCType(_ handle: _baseRef) -> AuxInterface {
+    if let swift_pointer = smoke_AuxInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AuxInterface {
+        smoke_AuxInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AuxInterface {
+        smoke_AuxInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxInterface_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? AuxInterface {
+        smoke_AuxInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func foobar_AuxInterface_copyFromCType(_ handle: _baseRef) -> AuxInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_AuxInterface_moveFromCType(handle) as AuxInterface
+}
+internal func foobar_AuxInterface_moveFromCType(_ handle: _baseRef) -> AuxInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_AuxInterface_moveFromCType(handle) as AuxInterface
+}
+internal func foobar_copyToCType(_ swiftClass: AuxInterface) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: AuxInterface) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func foobar_copyToCType(_ swiftClass: AuxInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: AuxInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func getRef(_ ref: ClassInAuxInterface?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_AuxInterface_ClassInAuxInterface_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_AuxInterface_ClassInAuxInterface_release_handle)
+        : RefHolder(handle_copy)
+}
+internal func foobar_ClassInAuxInterface_copyFromCType(_ handle: _baseRef) -> ClassInAuxInterface {
+    if let swift_pointer = smoke_AuxInterface_ClassInAuxInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ClassInAuxInterface {
+        return re_constructed
+    }
+    let result = ClassInAuxInterface(cClassInAuxInterface: smoke_AuxInterface_ClassInAuxInterface_copy_handle(handle))
+    smoke_AuxInterface_ClassInAuxInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func foobar_ClassInAuxInterface_moveFromCType(_ handle: _baseRef) -> ClassInAuxInterface {
+    if let swift_pointer = smoke_AuxInterface_ClassInAuxInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ClassInAuxInterface {
+        smoke_AuxInterface_ClassInAuxInterface_release_handle(handle)
+        return re_constructed
+    }
+    let result = ClassInAuxInterface(cClassInAuxInterface: handle)
+    smoke_AuxInterface_ClassInAuxInterface_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func foobar_ClassInAuxInterface_copyFromCType(_ handle: _baseRef) -> ClassInAuxInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_ClassInAuxInterface_moveFromCType(handle) as ClassInAuxInterface
+}
+internal func foobar_ClassInAuxInterface_moveFromCType(_ handle: _baseRef) -> ClassInAuxInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_ClassInAuxInterface_moveFromCType(handle) as ClassInAuxInterface
+}
+internal func foobar_copyToCType(_ swiftClass: ClassInAuxInterface) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: ClassInAuxInterface) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func foobar_copyToCType(_ swiftClass: ClassInAuxInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: ClassInAuxInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func getRef(_ ref: InterfaceInAuxInterface?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_AuxInterface_InterfaceInAuxInterface_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_AuxInterface_InterfaceInAuxInterface_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_AuxInterface_InterfaceInAuxInterface_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    let proxy = smoke_AuxInterface_InterfaceInAuxInterface_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_AuxInterface_InterfaceInAuxInterface_release_handle) : RefHolder(proxy)
+}
+internal func foobar_InterfaceInAuxInterface_copyFromCType(_ handle: _baseRef) -> InterfaceInAuxInterface {
+    if let swift_pointer = smoke_AuxInterface_InterfaceInAuxInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InterfaceInAuxInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxInterface_InterfaceInAuxInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InterfaceInAuxInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxInterface_InterfaceInAuxInterface_get_typed(smoke_AuxInterface_InterfaceInAuxInterface_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InterfaceInAuxInterface {
+        smoke_AuxInterface_InterfaceInAuxInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func foobar_InterfaceInAuxInterface_moveFromCType(_ handle: _baseRef) -> InterfaceInAuxInterface {
+    if let swift_pointer = smoke_AuxInterface_InterfaceInAuxInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InterfaceInAuxInterface {
+        smoke_AuxInterface_InterfaceInAuxInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxInterface_InterfaceInAuxInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InterfaceInAuxInterface {
+        smoke_AuxInterface_InterfaceInAuxInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxInterface_InterfaceInAuxInterface_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InterfaceInAuxInterface {
+        smoke_AuxInterface_InterfaceInAuxInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func foobar_InterfaceInAuxInterface_copyFromCType(_ handle: _baseRef) -> InterfaceInAuxInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_InterfaceInAuxInterface_moveFromCType(handle) as InterfaceInAuxInterface
+}
+internal func foobar_InterfaceInAuxInterface_moveFromCType(_ handle: _baseRef) -> InterfaceInAuxInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_InterfaceInAuxInterface_moveFromCType(handle) as InterfaceInAuxInterface
+}
+internal func foobar_copyToCType(_ swiftClass: InterfaceInAuxInterface) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: InterfaceInAuxInterface) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func foobar_copyToCType(_ swiftClass: InterfaceInAuxInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: InterfaceInAuxInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructInAuxInterface {
+    return StructInAuxInterface(cHandle: handle)
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructInAuxInterface {
+    defer {
+        smoke_AuxInterface_StructInAuxInterface_release_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyToCType(_ swiftType: StructInAuxInterface) -> RefHolder {
+    let c_fooBar = moveToCType(swiftType.fooBar)
+    return RefHolder(smoke_AuxInterface_StructInAuxInterface_create_handle(c_fooBar.ref))
+}
+internal func foobar_moveToCType(_ swiftType: StructInAuxInterface) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AuxInterface_StructInAuxInterface_release_handle)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> StructInAuxInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_AuxInterface_StructInAuxInterface_unwrap_optional_handle(handle)
+    return StructInAuxInterface(cHandle: unwrappedHandle) as StructInAuxInterface
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> StructInAuxInterface? {
+    defer {
+        smoke_AuxInterface_StructInAuxInterface_release_optional_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyToCType(_ swiftType: StructInAuxInterface?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_fooBar = moveToCType(swiftType.fooBar)
+    return RefHolder(smoke_AuxInterface_StructInAuxInterface_create_optional_handle(c_fooBar.ref))
+}
+internal func foobar_moveToCType(_ swiftType: StructInAuxInterface?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AuxInterface_StructInAuxInterface_release_optional_handle)
+}
+internal func foobar_copyToCType(_ swiftEnum: EnumInAuxInterface) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func foobar_moveToCType(_ swiftEnum: EnumInAuxInterface) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
+}
+internal func foobar_copyToCType(_ swiftEnum: EnumInAuxInterface?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func foobar_moveToCType(_ swiftEnum: EnumInAuxInterface?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func foobar_copyFromCType(_ cValue: UInt32) -> EnumInAuxInterface {
+    return EnumInAuxInterface(rawValue: cValue)!
+}
+internal func foobar_moveFromCType(_ cValue: UInt32) -> EnumInAuxInterface {
+    return foobar_copyFromCType(cValue)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> EnumInAuxInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return EnumInAuxInterface(rawValue: uint32_t_value_get(handle))!
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> EnumInAuxInterface? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}

--- a/gluecodium/src/test/resources/smoke/aux_conversions/output/swift/smoke/AuxStruct.swift
+++ b/gluecodium/src/test/resources/smoke/aux_conversions/output/swift/smoke/AuxStruct.swift
@@ -1,0 +1,241 @@
+//
+//
+import Foundation
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AuxStruct {
+    return AuxStruct(cHandle: handle)
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AuxStruct {
+    defer {
+        smoke_AuxStruct_release_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyToCType(_ swiftType: AuxStruct) -> RefHolder {
+    let c_fooBar = moveToCType(swiftType.fooBar)
+    return RefHolder(smoke_AuxStruct_create_handle(c_fooBar.ref))
+}
+internal func foobar_moveToCType(_ swiftType: AuxStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AuxStruct_release_handle)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AuxStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_AuxStruct_unwrap_optional_handle(handle)
+    return AuxStruct(cHandle: unwrappedHandle) as AuxStruct
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AuxStruct? {
+    defer {
+        smoke_AuxStruct_release_optional_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyToCType(_ swiftType: AuxStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_fooBar = moveToCType(swiftType.fooBar)
+    return RefHolder(smoke_AuxStruct_create_optional_handle(c_fooBar.ref))
+}
+internal func foobar_moveToCType(_ swiftType: AuxStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AuxStruct_release_optional_handle)
+}
+internal func getRef(_ ref: AuxStruct.ClassInAuxStruct?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_AuxStruct_ClassInAuxStruct_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_AuxStruct_ClassInAuxStruct_release_handle)
+        : RefHolder(handle_copy)
+}
+internal func foobar_AuxStruct_ClassInAuxStruct_copyFromCType(_ handle: _baseRef) -> AuxStruct.ClassInAuxStruct {
+    if let swift_pointer = smoke_AuxStruct_ClassInAuxStruct_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AuxStruct.ClassInAuxStruct {
+        return re_constructed
+    }
+    let result = AuxStruct.ClassInAuxStruct(cClassInAuxStruct: smoke_AuxStruct_ClassInAuxStruct_copy_handle(handle))
+    smoke_AuxStruct_ClassInAuxStruct_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func foobar_AuxStruct_ClassInAuxStruct_moveFromCType(_ handle: _baseRef) -> AuxStruct.ClassInAuxStruct {
+    if let swift_pointer = smoke_AuxStruct_ClassInAuxStruct_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? AuxStruct.ClassInAuxStruct {
+        smoke_AuxStruct_ClassInAuxStruct_release_handle(handle)
+        return re_constructed
+    }
+    let result = AuxStruct.ClassInAuxStruct(cClassInAuxStruct: handle)
+    smoke_AuxStruct_ClassInAuxStruct_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func foobar_AuxStruct_ClassInAuxStruct_copyFromCType(_ handle: _baseRef) -> AuxStruct.ClassInAuxStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_AuxStruct_ClassInAuxStruct_moveFromCType(handle) as AuxStruct.ClassInAuxStruct
+}
+internal func foobar_AuxStruct_ClassInAuxStruct_moveFromCType(_ handle: _baseRef) -> AuxStruct.ClassInAuxStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_AuxStruct_ClassInAuxStruct_moveFromCType(handle) as AuxStruct.ClassInAuxStruct
+}
+internal func foobar_copyToCType(_ swiftClass: AuxStruct.ClassInAuxStruct) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: AuxStruct.ClassInAuxStruct) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func foobar_copyToCType(_ swiftClass: AuxStruct.ClassInAuxStruct?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: AuxStruct.ClassInAuxStruct?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func getRef(_ ref: InterfaceInAuxStruct?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_AuxStruct_InterfaceInAuxStruct_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_AuxStruct_InterfaceInAuxStruct_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_AuxStruct_InterfaceInAuxStruct_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    let proxy = smoke_AuxStruct_InterfaceInAuxStruct_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_AuxStruct_InterfaceInAuxStruct_release_handle) : RefHolder(proxy)
+}
+internal func foobar_InterfaceInAuxStruct_copyFromCType(_ handle: _baseRef) -> InterfaceInAuxStruct {
+    if let swift_pointer = smoke_AuxStruct_InterfaceInAuxStruct_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InterfaceInAuxStruct {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxStruct_InterfaceInAuxStruct_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InterfaceInAuxStruct {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxStruct_InterfaceInAuxStruct_get_typed(smoke_AuxStruct_InterfaceInAuxStruct_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InterfaceInAuxStruct {
+        smoke_AuxStruct_InterfaceInAuxStruct_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func foobar_InterfaceInAuxStruct_moveFromCType(_ handle: _baseRef) -> InterfaceInAuxStruct {
+    if let swift_pointer = smoke_AuxStruct_InterfaceInAuxStruct_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InterfaceInAuxStruct {
+        smoke_AuxStruct_InterfaceInAuxStruct_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxStruct_InterfaceInAuxStruct_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InterfaceInAuxStruct {
+        smoke_AuxStruct_InterfaceInAuxStruct_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_AuxStruct_InterfaceInAuxStruct_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InterfaceInAuxStruct {
+        smoke_AuxStruct_InterfaceInAuxStruct_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func foobar_InterfaceInAuxStruct_copyFromCType(_ handle: _baseRef) -> InterfaceInAuxStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_InterfaceInAuxStruct_moveFromCType(handle) as InterfaceInAuxStruct
+}
+internal func foobar_InterfaceInAuxStruct_moveFromCType(_ handle: _baseRef) -> InterfaceInAuxStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    return foobar_InterfaceInAuxStruct_moveFromCType(handle) as InterfaceInAuxStruct
+}
+internal func foobar_copyToCType(_ swiftClass: InterfaceInAuxStruct) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: InterfaceInAuxStruct) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func foobar_copyToCType(_ swiftClass: InterfaceInAuxStruct?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func foobar_moveToCType(_ swiftClass: InterfaceInAuxStruct?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AuxStruct.StructInAuxStruct {
+    return AuxStruct.StructInAuxStruct(cHandle: handle)
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AuxStruct.StructInAuxStruct {
+    defer {
+        smoke_AuxStruct_StructInAuxStruct_release_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyToCType(_ swiftType: AuxStruct.StructInAuxStruct) -> RefHolder {
+    let c_fooBar = moveToCType(swiftType.fooBar)
+    return RefHolder(smoke_AuxStruct_StructInAuxStruct_create_handle(c_fooBar.ref))
+}
+internal func foobar_moveToCType(_ swiftType: AuxStruct.StructInAuxStruct) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AuxStruct_StructInAuxStruct_release_handle)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AuxStruct.StructInAuxStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_AuxStruct_StructInAuxStruct_unwrap_optional_handle(handle)
+    return AuxStruct.StructInAuxStruct(cHandle: unwrappedHandle) as AuxStruct.StructInAuxStruct
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AuxStruct.StructInAuxStruct? {
+    defer {
+        smoke_AuxStruct_StructInAuxStruct_release_optional_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyToCType(_ swiftType: AuxStruct.StructInAuxStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_fooBar = moveToCType(swiftType.fooBar)
+    return RefHolder(smoke_AuxStruct_StructInAuxStruct_create_optional_handle(c_fooBar.ref))
+}
+internal func foobar_moveToCType(_ swiftType: AuxStruct.StructInAuxStruct?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: smoke_AuxStruct_StructInAuxStruct_release_optional_handle)
+}
+internal func foobar_copyToCType(_ swiftEnum: AuxStruct.EnumInAuxStruct) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func foobar_moveToCType(_ swiftEnum: AuxStruct.EnumInAuxStruct) -> PrimitiveHolder<UInt32> {
+    return foobar_copyToCType(swiftEnum)
+}
+internal func foobar_copyToCType(_ swiftEnum: AuxStruct.EnumInAuxStruct?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func foobar_moveToCType(_ swiftEnum: AuxStruct.EnumInAuxStruct?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func foobar_copyFromCType(_ cValue: UInt32) -> AuxStruct.EnumInAuxStruct {
+    return AuxStruct.EnumInAuxStruct(rawValue: cValue)!
+}
+internal func foobar_moveFromCType(_ cValue: UInt32) -> AuxStruct.EnumInAuxStruct {
+    return foobar_copyFromCType(cValue)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> AuxStruct.EnumInAuxStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    return AuxStruct.EnumInAuxStruct(rawValue: uint32_t_value_get(handle))!
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> AuxStruct.EnumInAuxStruct? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}


### PR DESCRIPTION
Updated SwiftGeneratorSuite and Swift templates to generate conversion functions for types from "aux" IDL sources. Swift
definitions for these files are still not generated.

Added dedicated smoke test "aux_conversions".

Resolves: #745
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>