### PR TITLE
Add :nodoc: to equality operator and hash function in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed compilation issues for modularized Swift builds.
+  * Suppressed documentation for equality operator and hash function overloads in Swift.
 ### Removed:
   * Deprecated IDL attribute `@Swift(ObjC)` was removed.
 

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassConversion.mustache
@@ -46,7 +46,8 @@ extension {{>implName}}: NativeBase {
 
 }}{{#if attributes.equatable attributes.pointerEquatable logic="or"}}
 {{#instanceOf this "LimeInterface"}}
-public func ==(lhs: {{resolveName this "" "ref"}}, rhs: {{resolveName this "" "ref"}}) -> Bool {
+// :nodoc:
+public func == (lhs: {{resolveName this "" "ref"}}, rhs: {{resolveName this "" "ref"}}) -> Bool {
     guard let lhsImpl = lhs as? {{>implName}} else { return lhs === rhs }
     guard let rhsImpl = rhs as? {{>implName}} else { return lhs === rhs }
     return lhsImpl == rhsImpl
@@ -54,10 +55,12 @@ public func ==(lhs: {{resolveName this "" "ref"}}, rhs: {{resolveName this "" "r
 
 {{/instanceOf}}
 extension {{>implName}}: Hashable {
+    // :nodoc:
     public static func == (lhs: {{>implName}}, rhs: {{>implName}}) -> Bool {
         return {{resolveName "CBridge"}}_equal(lhs.c_handle, rhs.c_handle)
     }
 
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine({{resolveName "CBridge"}}_hash(c_handle))
     }
@@ -67,10 +70,12 @@ extension {{>implName}}: Hashable {
 {{#instanceOf this "LimeClass"}}{{#unlessPredicate "parentIsClass"}}
 
 extension {{>implName}}: Hashable {
+    // :nodoc:
     public static func == (lhs: {{>implName}}, rhs: {{>implName}}) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
 
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/main/resources/templates/swift/SwiftStructDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftStructDefinition.mustache
@@ -104,6 +104,7 @@
 {{prefixPartial "swift/SwiftClassDefinition" "    "}}
 {{/classes}}
 {{#ifPredicate "needsExplicitHashable"}}
+    // :nodoc:
     public static func == (lhs: {{resolveName}}, rhs: {{resolveName}}) -> Bool {
         return
 {{#fields}}
@@ -111,6 +112,7 @@
 {{/fields}}
     }
 
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
 {{#fields}}{{#ifPredicate "isRefEquatable"}}{{#if typeRef.isNullable}}
         hasher.combine({{resolveName}} != nil ? Unmanaged<AnyObject>.passUnretained({{resolveName}}!).toOpaque().hashValue : 0)

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesClass.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesClass.swift
@@ -45,9 +45,11 @@ extension AttributesClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension AttributesClass: Hashable {
+    // :nodoc:
     public static func == (lhs: AttributesClass, rhs: AttributesClass) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithComments.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithComments.swift
@@ -59,9 +59,11 @@ extension AttributesWithComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension AttributesWithComments: Hashable {
+    // :nodoc:
     public static func == (lhs: AttributesWithComments, rhs: AttributesWithComments) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithDeprecated.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithDeprecated.swift
@@ -60,9 +60,11 @@ extension AttributesWithDeprecated: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension AttributesWithDeprecated: Hashable {
+    // :nodoc:
     public static func == (lhs: AttributesWithDeprecated, rhs: AttributesWithDeprecated) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/MultipleAttributesSwift.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/MultipleAttributesSwift.swift
@@ -57,9 +57,11 @@ extension MultipleAttributesSwift: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension MultipleAttributesSwift: Hashable {
+    // :nodoc:
     public static func == (lhs: MultipleAttributesSwift, rhs: MultipleAttributesSwift) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/SpecialAttributes.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/SpecialAttributes.swift
@@ -35,9 +35,11 @@ extension SpecialAttributes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension SpecialAttributes: Hashable {
+    // :nodoc:
     public static func == (lhs: SpecialAttributes, rhs: SpecialAttributes) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/swift/smoke/BasicTypes.swift
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/swift/smoke/BasicTypes.swift
@@ -75,9 +75,11 @@ extension BasicTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension BasicTypes: Hashable {
+    // :nodoc:
     public static func == (lhs: BasicTypes, rhs: BasicTypes) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -154,9 +154,11 @@ extension Comments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Comments: Hashable {
+    // :nodoc:
     public static func == (lhs: Comments, rhs: Comments) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/CommentsLinks.swift
@@ -103,9 +103,11 @@ extension CommentsLinks: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension CommentsLinks: Hashable {
+    // :nodoc:
     public static func == (lhs: CommentsLinks, rhs: CommentsLinks) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
@@ -96,9 +96,11 @@ extension ExcludedComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension ExcludedComments: Hashable {
+    // :nodoc:
     public static func == (lhs: ExcludedComments, rhs: ExcludedComments) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
@@ -81,9 +81,11 @@ extension ExcludedCommentsOnly: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension ExcludedCommentsOnly: Hashable {
+    // :nodoc:
     public static func == (lhs: ExcludedCommentsOnly, rhs: ExcludedCommentsOnly) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/LongComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/LongComments.swift
@@ -38,9 +38,11 @@ extension LongComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension LongComments: Hashable {
+    // :nodoc:
     public static func == (lhs: LongComments, rhs: LongComments) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MultiLineComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MultiLineComments.swift
@@ -59,9 +59,11 @@ extension MultiLineComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension MultiLineComments: Hashable {
+    // :nodoc:
     public static func == (lhs: MultiLineComments, rhs: MultiLineComments) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformComments.swift
@@ -69,9 +69,11 @@ extension PlatformComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension PlatformComments: Hashable {
+    // :nodoc:
     public static func == (lhs: PlatformComments, rhs: PlatformComments) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/UnicodeComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/UnicodeComments.swift
@@ -40,9 +40,11 @@ extension UnicodeComments: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension UnicodeComments: Hashable {
+    // :nodoc:
     public static func == (lhs: UnicodeComments, rhs: UnicodeComments) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/CollectionConstants.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/CollectionConstants.swift
@@ -31,9 +31,11 @@ extension CollectionConstants: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension CollectionConstants: Hashable {
+    // :nodoc:
     public static func == (lhs: CollectionConstants, rhs: CollectionConstants) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/ConstantsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/ConstantsInterface.swift
@@ -38,9 +38,11 @@ extension ConstantsInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension ConstantsInterface: Hashable {
+    // :nodoc:
     public static func == (lhs: ConstantsInterface, rhs: ConstantsInterface) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/StructConstants.swift
+++ b/gluecodium/src/test/resources/smoke/constants/output/swift/smoke/StructConstants.swift
@@ -50,9 +50,11 @@ extension StructConstants: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension StructConstants: Hashable {
+    // :nodoc:
     public static func == (lhs: StructConstants, rhs: StructConstants) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/Constructors.swift
+++ b/gluecodium/src/test/resources/smoke/constructors/output/swift/smoke/Constructors.swift
@@ -102,9 +102,11 @@ extension Constructors: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Constructors: Hashable {
+    // :nodoc:
     public static func == (lhs: Constructors, rhs: Constructors) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/Dates.swift
+++ b/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/Dates.swift
@@ -52,9 +52,11 @@ extension Dates: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Dates: Hashable {
+    // :nodoc:
     public static func == (lhs: Dates, rhs: Dates) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/DefaultValues.swift
+++ b/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/DefaultValues.swift
@@ -163,9 +163,11 @@ extension DefaultValues: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension DefaultValues: Hashable {
+    // :nodoc:
     public static func == (lhs: DefaultValues, rhs: DefaultValues) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/Enums.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/Enums.swift
@@ -65,9 +65,11 @@ extension Enums: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Enums: Hashable {
+    // :nodoc:
     public static func == (lhs: Enums, rhs: Enums) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumsInTypeCollectionInterface.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumsInTypeCollectionInterface.swift
@@ -31,9 +31,11 @@ extension EnumsInTypeCollectionInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension EnumsInTypeCollectionInterface: Hashable {
+    // :nodoc:
     public static func == (lhs: EnumsInTypeCollectionInterface, rhs: EnumsInTypeCollectionInterface) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableClass.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableClass.swift
@@ -45,9 +45,11 @@ extension EquatableClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension EquatableClass: Hashable {
+    // :nodoc:
     public static func == (lhs: EquatableClass, rhs: EquatableClass) -> Bool {
         return smoke_EquatableClass_equal(lhs.c_handle, rhs.c_handle)
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(smoke_EquatableClass_hash(c_handle))
     }

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableInterface.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/EquatableInterface.swift
@@ -44,15 +44,18 @@ internal func getRef(_ ref: EquatableInterface?, owning: Bool = true) -> RefHold
 extension _EquatableInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
-public func ==(lhs: EquatableInterface, rhs: EquatableInterface) -> Bool {
+// :nodoc:
+public func == (lhs: EquatableInterface, rhs: EquatableInterface) -> Bool {
     guard let lhsImpl = lhs as? _EquatableInterface else { return lhs === rhs }
     guard let rhsImpl = rhs as? _EquatableInterface else { return lhs === rhs }
     return lhsImpl == rhsImpl
 }
 extension _EquatableInterface: Hashable {
+    // :nodoc:
     public static func == (lhs: _EquatableInterface, rhs: _EquatableInterface) -> Bool {
         return smoke_EquatableInterface_equal(lhs.c_handle, rhs.c_handle)
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(smoke_EquatableInterface_hash(c_handle))
     }

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/PointerEquatableClass.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/PointerEquatableClass.swift
@@ -27,9 +27,11 @@ extension PointerEquatableClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension PointerEquatableClass: Hashable {
+    // :nodoc:
     public static func == (lhs: PointerEquatableClass, rhs: PointerEquatableClass) -> Bool {
         return smoke_PointerEquatableClass_equal(lhs.c_handle, rhs.c_handle)
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(smoke_PointerEquatableClass_hash(c_handle))
     }

--- a/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/SimpleEquatableStruct.swift
+++ b/gluecodium/src/test/resources/smoke/equatable/output/swift/smoke/SimpleEquatableStruct.swift
@@ -18,6 +18,7 @@ public struct SimpleEquatableStruct: Hashable {
         nullableClassField = foobar_NonEquatableClass_moveFromCType(smoke_SimpleEquatableStruct_nullableClassField_get(cHandle))
         nullableInterfaceField = foobar_NonEquatableInterface_moveFromCType(smoke_SimpleEquatableStruct_nullableInterfaceField_get(cHandle))
     }
+    // :nodoc:
     public static func == (lhs: SimpleEquatableStruct, rhs: SimpleEquatableStruct) -> Bool {
         return
             lhs.classField === rhs.classField &&
@@ -25,6 +26,7 @@ public struct SimpleEquatableStruct: Hashable {
             lhs.nullableClassField === rhs.nullableClassField &&
             lhs.nullableInterfaceField === rhs.nullableInterfaceField
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(Unmanaged<AnyObject>.passUnretained(classField).toOpaque().hashValue)
         hasher.combine(Unmanaged<AnyObject>.passUnretained(interfaceField).toOpaque().hashValue)

--- a/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/Errors.swift
+++ b/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/Errors.swift
@@ -72,9 +72,11 @@ extension Errors: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Errors: Hashable {
+    // :nodoc:
     public static func == (lhs: Errors, rhs: Errors) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Class.swift
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/swift/package/Class.swift
@@ -61,9 +61,11 @@ extension Class: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Class: Hashable {
+    // :nodoc:
     public static func == (lhs: Class, rhs: Class) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Enums.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Enums.swift
@@ -39,9 +39,11 @@ extension Enums: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Enums: Hashable {
+    // :nodoc:
     public static func == (lhs: Enums, rhs: Enums) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalClass.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalClass.swift
@@ -48,9 +48,11 @@ extension ExternalClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension ExternalClass: Hashable {
+    // :nodoc:
     public static func == (lhs: ExternalClass, rhs: ExternalClass) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Structs.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/Structs.swift
@@ -60,9 +60,11 @@ extension Structs: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Structs: Hashable {
+    // :nodoc:
     public static func == (lhs: Structs, rhs: Structs) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UseSwiftExternalTypes.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/UseSwiftExternalTypes.swift
@@ -44,9 +44,11 @@ extension UseSwiftExternalTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension UseSwiftExternalTypes: Hashable {
+    // :nodoc:
     public static func == (lhs: UseSwiftExternalTypes, rhs: UseSwiftExternalTypes) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithBasicTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithBasicTypes.swift
@@ -96,9 +96,11 @@ extension GenericTypesWithBasicTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension GenericTypesWithBasicTypes: Hashable {
+    // :nodoc:
     public static func == (lhs: GenericTypesWithBasicTypes, rhs: GenericTypesWithBasicTypes) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithCompoundTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithCompoundTypes.swift
@@ -85,9 +85,11 @@ extension GenericTypesWithCompoundTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension GenericTypesWithCompoundTypes: Hashable {
+    // :nodoc:
     public static func == (lhs: GenericTypesWithCompoundTypes, rhs: GenericTypesWithCompoundTypes) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithGenericTypes.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/smoke/GenericTypesWithGenericTypes.swift
@@ -55,9 +55,11 @@ extension GenericTypesWithGenericTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension GenericTypesWithGenericTypes: Hashable {
+    // :nodoc:
     public static func == (lhs: GenericTypesWithGenericTypes, rhs: GenericTypesWithGenericTypes) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromInterface.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromInterface.swift
@@ -47,9 +47,11 @@ extension ChildClassFromInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension ChildClassFromInterface: Hashable {
+    // :nodoc:
     public static func == (lhs: ChildClassFromInterface, rhs: ChildClassFromInterface) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalParent.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/InternalParent.swift
@@ -32,9 +32,11 @@ extension InternalParent: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension InternalParent: Hashable {
+    // :nodoc:
     public static func == (lhs: InternalParent, rhs: InternalParent) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleClass.swift
+++ b/gluecodium/src/test/resources/smoke/instances/output/swift/smoke/SimpleClass.swift
@@ -34,9 +34,11 @@ extension SimpleClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension SimpleClass: Hashable {
+    // :nodoc:
     public static func == (lhs: SimpleClass, rhs: SimpleClass) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
@@ -43,9 +43,11 @@ extension Lambdas: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Lambdas: Hashable {
+    // :nodoc:
     public static func == (lhs: Lambdas, rhs: Lambdas) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
@@ -37,9 +37,11 @@ extension LambdasWithStructuredTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension LambdasWithStructuredTypes: Hashable {
+    // :nodoc:
     public static func == (lhs: LambdasWithStructuredTypes, rhs: LambdasWithStructuredTypes) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Calculator.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Calculator.swift
@@ -35,9 +35,11 @@ extension Calculator: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Calculator: Hashable {
+    // :nodoc:
     public static func == (lhs: Calculator, rhs: Calculator) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/Locales.swift
+++ b/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/Locales.swift
@@ -52,9 +52,11 @@ extension Locales: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Locales: Hashable {
+    // :nodoc:
     public static func == (lhs: Locales, rhs: Locales) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/MethodOverloads.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/MethodOverloads.swift
@@ -83,9 +83,11 @@ extension MethodOverloads: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension MethodOverloads: Hashable {
+    // :nodoc:
     public static func == (lhs: MethodOverloads, rhs: MethodOverloads) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SpecialNames.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SpecialNames.swift
@@ -39,9 +39,11 @@ extension SpecialNames: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension SpecialNames: Hashable {
+    // :nodoc:
     public static func == (lhs: SpecialNames, rhs: SpecialNames) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SwiftMethodOverloads.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SwiftMethodOverloads.swift
@@ -35,9 +35,11 @@ extension SwiftMethodOverloads: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension SwiftMethodOverloads: Hashable {
+    // :nodoc:
     public static func == (lhs: SwiftMethodOverloads, rhs: SwiftMethodOverloads) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/name_rules/output/swift/namerules/INameRules.swift
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/swift/namerules/INameRules.swift
@@ -92,9 +92,11 @@ extension INameRules: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension INameRules: Hashable {
+    // :nodoc:
     public static func == (lhs: INameRules, rhs: INameRules) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/LevelOne.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/LevelOne.swift
@@ -73,9 +73,11 @@ extension LevelOne: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension LevelOne: Hashable {
+    // :nodoc:
     public static func == (lhs: LevelOne, rhs: LevelOne) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }
@@ -136,9 +138,11 @@ extension LevelOne.LevelTwo: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension LevelOne.LevelTwo: Hashable {
+    // :nodoc:
     public static func == (lhs: LevelOne.LevelTwo, rhs: LevelOne.LevelTwo) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }
@@ -199,9 +203,11 @@ extension LevelOne.LevelTwo.LevelThree: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension LevelOne.LevelTwo.LevelThree: Hashable {
+    // :nodoc:
     public static func == (lhs: LevelOne.LevelTwo.LevelThree, rhs: LevelOne.LevelTwo.LevelThree) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/NestedReferences.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/NestedReferences.swift
@@ -41,9 +41,11 @@ extension NestedReferences: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension NestedReferences: Hashable {
+    // :nodoc:
     public static func == (lhs: NestedReferences, rhs: NestedReferences) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClass.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClass.swift
@@ -68,9 +68,11 @@ extension OuterClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension OuterClass: Hashable {
+    // :nodoc:
     public static func == (lhs: OuterClass, rhs: OuterClass) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }
@@ -131,9 +133,11 @@ extension OuterClass.InnerClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension OuterClass.InnerClass: Hashable {
+    // :nodoc:
     public static func == (lhs: OuterClass.InnerClass, rhs: OuterClass.InnerClass) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterInterface.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterInterface.swift
@@ -161,9 +161,11 @@ extension InnerClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension InnerClass: Hashable {
+    // :nodoc:
     public static func == (lhs: InnerClass, rhs: InnerClass) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterStruct.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterStruct.swift
@@ -118,9 +118,11 @@ extension OuterStruct.InnerClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension OuterStruct.InnerClass: Hashable {
+    // :nodoc:
     public static func == (lhs: OuterStruct.InnerClass, rhs: OuterStruct.InnerClass) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/UseFreeTypes.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/UseFreeTypes.swift
@@ -37,9 +37,11 @@ extension UseFreeTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension UseFreeTypes: Hashable {
+    // :nodoc:
     public static func == (lhs: UseFreeTypes, rhs: UseFreeTypes) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/nullable/output/swift/smoke/Nullable.swift
+++ b/gluecodium/src/test/resources/smoke/nullable/output/swift/smoke/Nullable.swift
@@ -235,9 +235,11 @@ extension Nullable: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Nullable: Hashable {
+    // :nodoc:
     public static func == (lhs: Nullable, rhs: Nullable) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazInterface.swift
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/swift/smoke/bazInterface.swift
@@ -52,9 +52,11 @@ extension bazInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension bazInterface: Hashable {
+    // :nodoc:
     public static func == (lhs: bazInterface, rhs: bazInterface) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/CachedProperties.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/CachedProperties.swift
@@ -33,9 +33,11 @@ extension CachedProperties: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension CachedProperties: Hashable {
+    // :nodoc:
     public static func == (lhs: CachedProperties, rhs: CachedProperties) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/Properties.swift
+++ b/gluecodium/src/test/resources/smoke/properties/output/swift/smoke/Properties.swift
@@ -122,9 +122,11 @@ extension Properties: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Properties: Hashable {
+    // :nodoc:
     public static func == (lhs: Properties, rhs: Properties) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipFunctions.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipFunctions.swift
@@ -35,9 +35,11 @@ extension SkipFunctions: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension SkipFunctions: Hashable {
+    // :nodoc:
     public static func == (lhs: SkipFunctions, rhs: SkipFunctions) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTagsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTagsOnly.swift
@@ -27,9 +27,11 @@ extension SkipTagsOnly: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension SkipTagsOnly: Hashable {
+    // :nodoc:
     public static func == (lhs: SkipTagsOnly, rhs: SkipTagsOnly) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTypes.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTypes.swift
@@ -45,9 +45,11 @@ extension SkipTypes: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension SkipTypes: Hashable {
+    // :nodoc:
     public static func == (lhs: SkipTypes, rhs: SkipTypes) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/Structs.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/Structs.swift
@@ -166,9 +166,11 @@ extension Structs: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension Structs: Hashable {
+    // :nodoc:
     public static func == (lhs: Structs, rhs: Structs) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithConstantsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithConstantsInterface.swift
@@ -44,9 +44,11 @@ extension StructsWithConstantsInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension StructsWithConstantsInterface: Hashable {
+    // :nodoc:
     public static func == (lhs: StructsWithConstantsInterface, rhs: StructsWithConstantsInterface) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithMethodsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/StructsWithMethodsInterface.swift
@@ -91,9 +91,11 @@ extension StructsWithMethodsInterface: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension StructsWithMethodsInterface: Hashable {
+    // :nodoc:
     public static func == (lhs: StructsWithMethodsInterface, rhs: StructsWithMethodsInterface) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/TypeDefs.swift
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/TypeDefs.swift
@@ -84,9 +84,11 @@ extension TypeDefs: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension TypeDefs: Hashable {
+    // :nodoc:
     public static func == (lhs: TypeDefs, rhs: TypeDefs) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/InternalClass.swift
@@ -30,9 +30,11 @@ extension InternalClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension InternalClass: Hashable {
+    // :nodoc:
     public static func == (lhs: InternalClass, rhs: InternalClass) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }

--- a/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility/output/swift/smoke/PublicClass.swift
@@ -90,9 +90,11 @@ extension PublicClass: NativeBase {
     var c_handle: _baseRef { return c_instance }
 }
 extension PublicClass: Hashable {
+    // :nodoc:
     public static func == (lhs: PublicClass, rhs: PublicClass) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+    // :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }


### PR DESCRIPTION
Updated Swift templates to suppress (:nodoc:) documentation for equality operator and hash function overloads.

Resolves: #748
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>