### PR TITLE
Fix "moveToCType" usage in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Bug fixes:
   * Fixed compilation issues for modularized Swift builds.
   * Suppressed documentation for equality operator and hash function overloads in Swift.
+  * Fixed run-time issues when passing lambdas, sets, or nullable lists from Swift to C++.
 ### Removed:
   * Deprecated IDL attribute `@Swift(ObjC)` was removed.
   * Removed "-mergemanifest" command line option. Android manifest merger should be performed with external tools

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -325,9 +325,11 @@ feature(Equatable cpp android swift dart SOURCES
 feature(Nullable cpp android swift dart SOURCES
     input/src/cpp/NullableInstances.cpp
     input/src/cpp/NullableInterfaceImpl.cpp
+    input/src/cpp/NullableCollections.cpp
 
     input/lime/NullableInstances.lime
     input/lime/NullableInterface.lime
+    input/lime/NullableCollections.lime
 )
 
 feature(CallbacksWithThreads cpp android dart SOURCES

--- a/functional-tests/functional/input/lime/NullableCollections.lime
+++ b/functional-tests/functional/input/lime/NullableCollections.lime
@@ -1,0 +1,32 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+@Equatable
+struct NullableCollections {
+    listField: List<String>? = null
+    setField: Set<String>? = null
+    mapField: Map<String, String>? = null
+}
+
+class UseNullableCollections {
+    static fun nullableListRoundTrip(input: List<String>?): List<String>?
+    static fun nullableSetRoundTrip(input: Set<String>?): Set<String>?
+    static fun nullableMapRoundTrip(input: Map<String, String>?): Map<String, String>?
+    static fun nullableCollectionsRoundTrip(input: NullableCollections): NullableCollections
+}

--- a/functional-tests/functional/input/src/cpp/NullableCollections.cpp
+++ b/functional-tests/functional/input/src/cpp/NullableCollections.cpp
@@ -1,0 +1,47 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/NullableCollections.h"
+#include "test/UseNullableCollections.h"
+
+namespace test
+{
+using namespace lorem_ipsum::test;
+
+Optional<std::vector<std::string>>
+UseNullableCollections::nullable_list_round_trip(const Optional<std::vector<std::string>>& input) {
+    return input;
+}
+
+Optional<std::unordered_set<std::string>>
+UseNullableCollections::nullable_set_round_trip(const Optional<std::unordered_set<std::string>>& input) {
+    return input;
+}
+
+Optional<std::unordered_map<std::string, std::string>>
+UseNullableCollections::nullable_map_round_trip(const Optional<std::unordered_map<std::string, std::string>>& input) {
+    return input;
+}
+
+NullableCollections
+UseNullableCollections::nullable_collections_round_trip(const NullableCollections& input) {
+    return input;
+}
+}

--- a/functional-tests/functional/swift/Tests/NullableCollectionsTests.swift
+++ b/functional-tests/functional/swift/Tests/NullableCollectionsTests.swift
@@ -1,0 +1,65 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import functional
+
+class NullableCollectionsTests: XCTestCase {
+
+    func testNullableListRoundTripRoundTrip() {
+        let input = ["foo", "bar"]
+
+        let result = UseNullableCollections.nullableListRoundTrip(input: input)
+
+        XCTAssertEqual(result, input)
+    }
+
+    func testNullableSetRoundTripRoundTrip() {
+        let input: Set<String> = ["foo", "bar"]
+
+        let result = UseNullableCollections.nullableSetRoundTrip(input: input)
+
+        XCTAssertEqual(result, input)
+    }
+
+    func testNullableMapRoundTripRoundTrip() {
+        let input = ["foo": "bar", "baz": "fizz"]
+
+        let result = UseNullableCollections.nullableMapRoundTrip(input: input)
+
+        XCTAssertEqual(result, input)
+    }
+
+    func testNullableCollectionsRoundTripRoundTrip() {
+        let input = NullableCollections(listField: ["foo", "bar"], setField: ["foo", "bar"],
+                                        mapField: ["foo": "bar", "baz": "fizz"])
+
+        let result = UseNullableCollections.nullableCollectionsRoundTrip(input: input)
+
+        XCTAssertEqual(result, input)
+    }
+
+    static var allTests = [
+        ("testNullableListRoundTripRoundTrip", testNullableListRoundTripRoundTrip),
+        ("testNullableSetRoundTripRoundTrip", testNullableSetRoundTripRoundTrip),
+        ("testNullableMapRoundTripRoundTrip", testNullableMapRoundTripRoundTrip),
+        ("testNullableCollectionsRoundTripRoundTrip", testNullableCollectionsRoundTripRoundTrip)
+    ]
+}

--- a/functional-tests/functional/swift/main.swift
+++ b/functional-tests/functional/swift/main.swift
@@ -55,6 +55,7 @@ let allTests = platformSpecificTests + [
     testCase(MultiListenerTests.allTests),
     testCase(NestingTests.allTests),
     testCase(NullableAttributesTests.allTests),
+    testCase(NullableCollectionsTests.allTests),
     testCase(NullableInstancesTests.allTests),
     testCase(NullableListenersTests.allTests),
     testCase(NullableMethodArgumentsTests.allTests),

--- a/gluecodium/src/main/resources/templates/swift/SwiftLambdaConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftLambdaConversion.mustache
@@ -26,8 +26,11 @@ internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveNa
     let refHolder = RefHolder(ref: handle, release: {{resolveName "CBridge"}}_release_handle)
     return { ({{#parameters}}p{{iter.position}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
     }} -> {{resolveName returnType}} in
+{{#parameters}}
+        let _p{{iter.position}} = {{>swift/ConversionPrefixTo}}moveToCType(p{{iter.position}})
+{{/parameters}}
         return {{#returnType}}{{>swift/ConversionPrefixFrom}}{{/returnType}}moveFromCType({{resolveName "CBridge"}}_call(refHolder.ref{{!!
-        }}{{#parameters}}, {{>swift/ConversionPrefixTo}}moveToCType(p{{iter.position}}).ref{{/parameters}}))
+        }}{{#parameters}}, _p{{iter.position}}.ref{{/parameters}}))
     }
 }
 

--- a/gluecodium/src/main/resources/templates/swift/SwiftLists.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftLists.mustache
@@ -47,8 +47,8 @@ internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveNa
 internal func {{internalPrefix}}copyToCType(_ swiftArray: {{resolveName}}) -> RefHolder {
     let handle = {{resolveName "CBridge"}}_create_handle()
     for item in swiftArray {
-        let value = {{#set typeRef=elementType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(item)
-        {{resolveName "CBridge"}}_append(handle, value.ref)
+        let _item = {{#set typeRef=elementType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(item)
+        {{resolveName "CBridge"}}_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -67,7 +67,8 @@ internal func {{internalPrefix}}copyToCType(_ swiftArray: {{resolveName}}?) -> R
     let optionalHandle = {{resolveName "CBridge"}}_create_optional_handle()
     let handle = {{resolveName "CBridge"}}_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        {{resolveName "CBridge"}}_append(handle, {{#set typeRef=elementType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(item).ref)
+        let _item = {{#set typeRef=elementType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(item)
+        {{resolveName "CBridge"}}_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }

--- a/gluecodium/src/main/resources/templates/swift/SwiftSets.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftSets.mustache
@@ -49,7 +49,8 @@ internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveNa
 internal func {{internalPrefix}}copyToCType(_ swiftSet: {{resolveName}}) -> RefHolder {
     let handle = {{resolveName "CBridge"}}_create_handle()
     for item in swiftSet {
-        {{resolveName "CBridge"}}_insert(handle, {{#set typeRef=elementType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(item).ref)
+        let _item = {{#set typeRef=elementType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(item)
+        {{resolveName "CBridge"}}_insert(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -68,7 +69,8 @@ internal func {{internalPrefix}}copyToCType(_ swiftSet: {{resolveName}}?) -> Ref
     let optionalHandle = {{resolveName "CBridge"}}_create_optional_handle()
     let handle = {{resolveName "CBridge"}}_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        {{resolveName "CBridge"}}_insert(handle, {{#set typeRef=elementType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(item).ref)
+        let _item = {{#set typeRef=elementType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(item)
+        {{resolveName "CBridge"}}_insert(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -212,7 +212,9 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
 internal func foobar_moveFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
     let refHolder = RefHolder(ref: handle, release: smoke_Comments_SomeLambda_release_handle)
     return { (p0: String, p1: Int32) -> Double in
-        return moveFromCType(smoke_Comments_SomeLambda_call(refHolder.ref, moveToCType(p0).ref, moveToCType(p1).ref))
+        let _p0 = moveToCType(p0)
+        let _p1 = moveToCType(p1)
+        return moveFromCType(smoke_Comments_SomeLambda_call(refHolder.ref, _p0.ref, _p1.ref))
     }
 }
 internal func foobar_copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda? {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
@@ -154,7 +154,9 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeL
 internal func foobar_moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda {
     let refHolder = RefHolder(ref: handle, release: smoke_ExcludedComments_SomeLambda_release_handle)
     return { (p0: String, p1: Int32) -> Double in
-        return moveFromCType(smoke_ExcludedComments_SomeLambda_call(refHolder.ref, moveToCType(p0).ref, moveToCType(p1).ref))
+        let _p0 = moveToCType(p0)
+        let _p1 = moveToCType(p1)
+        return moveFromCType(smoke_ExcludedComments_SomeLambda_call(refHolder.ref, _p0.ref, _p1.ref))
     }
 }
 internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda? {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
@@ -139,7 +139,9 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.S
 internal func foobar_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda {
     let refHolder = RefHolder(ref: handle, release: smoke_ExcludedCommentsOnly_SomeLambda_release_handle)
     return { (p0: String, p1: Int32) -> Double in
-        return moveFromCType(smoke_ExcludedCommentsOnly_SomeLambda_call(refHolder.ref, moveToCType(p0).ref, moveToCType(p1).ref))
+        let _p0 = moveToCType(p0)
+        let _p1 = moveToCType(p1)
+        return moveFromCType(smoke_ExcludedCommentsOnly_SomeLambda_call(refHolder.ref, _p0.ref, _p1.ref))
     }
 }
 internal func foobar_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda? {

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/Collections.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/Collections.swift
@@ -18,8 +18,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [DateInterval] {
 internal func foobar_copyToCType(_ swiftArray: [DateInterval]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_DateInterval_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_smoke_DateInterval_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_DateInterval_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -33,7 +33,8 @@ internal func foobar_copyToCType(_ swiftArray: [DateInterval]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf_smoke_DateInterval_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_DateInterval_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_DateInterval_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_DateInterval_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -70,8 +71,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [Int8] {
 internal func foobar_copyToCType(_ swiftArray: [Int8]) -> RefHolder {
     let handle = foobar_ArrayOf__Byte_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
-        foobar_ArrayOf__Byte_append(handle, value.ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__Byte_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -85,7 +86,8 @@ internal func foobar_copyToCType(_ swiftArray: [Int8]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf__Byte_create_optional_handle()
     let handle = foobar_ArrayOf__Byte_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf__Byte_append(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__Byte_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -122,8 +124,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [String] {
 internal func foobar_copyToCType(_ swiftArray: [String]) -> RefHolder {
     let handle = foobar_ArrayOf__String_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
-        foobar_ArrayOf__String_append(handle, value.ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__String_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -137,7 +139,8 @@ internal func foobar_copyToCType(_ swiftArray: [String]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf__String_create_optional_handle()
     let handle = foobar_ArrayOf__String_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf__String_append(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__String_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/Sets.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/Sets.swift
@@ -20,7 +20,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<URLCredential.Pers
 internal func foobar_copyToCType(_ swiftSet: Set<URLCredential.Persistence>) -> RefHolder {
     let handle = foobar_SetOf_smoke_URLCredential_1Persistence_create_handle()
     for item in swiftSet {
-        foobar_SetOf_smoke_URLCredential_1Persistence_insert(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_SetOf_smoke_URLCredential_1Persistence_insert(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -34,7 +35,8 @@ internal func foobar_copyToCType(_ swiftSet: Set<URLCredential.Persistence>?) ->
     let optionalHandle = foobar_SetOf_smoke_URLCredential_1Persistence_create_optional_handle()
     let handle = foobar_SetOf_smoke_URLCredential_1Persistence_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf_smoke_URLCredential_1Persistence_insert(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_SetOf_smoke_URLCredential_1Persistence_insert(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/Collections.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/Collections.swift
@@ -18,8 +18,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [AnotherDummyClass] {
 internal func foobar_copyToCType(_ swiftArray: [AnotherDummyClass]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_AnotherDummyClass_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_smoke_AnotherDummyClass_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_AnotherDummyClass_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -33,7 +33,8 @@ internal func foobar_copyToCType(_ swiftArray: [AnotherDummyClass]?) -> RefHolde
     let optionalHandle = foobar_ArrayOf_smoke_AnotherDummyClass_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_AnotherDummyClass_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_AnotherDummyClass_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_AnotherDummyClass_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -70,8 +71,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [AuxStruct] {
 internal func foobar_copyToCType(_ swiftArray: [AuxStruct]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_AuxStruct_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_smoke_AuxStruct_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_AuxStruct_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -85,7 +86,8 @@ internal func foobar_copyToCType(_ swiftArray: [AuxStruct]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf_smoke_AuxStruct_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_AuxStruct_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_AuxStruct_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_AuxStruct_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -122,8 +124,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [DummyClass] {
 internal func foobar_copyToCType(_ swiftArray: [DummyClass]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_DummyClass_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_smoke_DummyClass_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_DummyClass_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -137,7 +139,8 @@ internal func foobar_copyToCType(_ swiftArray: [DummyClass]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf_smoke_DummyClass_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_DummyClass_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_DummyClass_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_DummyClass_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -174,8 +177,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [DummyInterface] {
 internal func foobar_copyToCType(_ swiftArray: [DummyInterface]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_DummyInterface_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_smoke_DummyInterface_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_DummyInterface_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -189,7 +192,8 @@ internal func foobar_copyToCType(_ swiftArray: [DummyInterface]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf_smoke_DummyInterface_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_DummyInterface_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_DummyInterface_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_DummyInterface_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -226,8 +230,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [Float] {
 internal func foobar_copyToCType(_ swiftArray: [Float]) -> RefHolder {
     let handle = foobar_ArrayOf__Float_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
-        foobar_ArrayOf__Float_append(handle, value.ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__Float_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -241,7 +245,8 @@ internal func foobar_copyToCType(_ swiftArray: [Float]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf__Float_create_optional_handle()
     let handle = foobar_ArrayOf__Float_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf__Float_append(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__Float_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -278,8 +283,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
 internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.BasicStruct]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -293,7 +298,8 @@ internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.Ba
     let optionalHandle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -330,8 +336,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
 internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.ExternalEnum]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -345,7 +351,8 @@ internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.Ex
     let optionalHandle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -382,8 +389,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
 internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.ExternalStruct]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -397,7 +404,8 @@ internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.Ex
     let optionalHandle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -434,8 +442,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [GenericTypesWithCompo
 internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.SomeEnum]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -449,7 +457,8 @@ internal func foobar_copyToCType(_ swiftArray: [GenericTypesWithCompoundTypes.So
     let optionalHandle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -486,8 +495,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [Int32] {
 internal func foobar_copyToCType(_ swiftArray: [Int32]) -> RefHolder {
     let handle = foobar_ArrayOf__Int_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
-        foobar_ArrayOf__Int_append(handle, value.ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__Int_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -501,7 +510,8 @@ internal func foobar_copyToCType(_ swiftArray: [Int32]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf__Int_create_optional_handle()
     let handle = foobar_ArrayOf__Int_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf__Int_append(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__Int_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -538,8 +548,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [Set<Int32>] {
 internal func foobar_copyToCType(_ swiftArray: [Set<Int32>]) -> RefHolder {
     let handle = foobar_ArrayOf_foobar_SetOf__Int_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_foobar_SetOf__Int_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_foobar_SetOf__Int_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -553,7 +563,8 @@ internal func foobar_copyToCType(_ swiftArray: [Set<Int32>]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf_foobar_SetOf__Int_create_optional_handle()
     let handle = foobar_ArrayOf_foobar_SetOf__Int_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_foobar_SetOf__Int_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_foobar_SetOf__Int_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -590,8 +601,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [String] {
 internal func foobar_copyToCType(_ swiftArray: [String]) -> RefHolder {
     let handle = foobar_ArrayOf__String_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
-        foobar_ArrayOf__String_append(handle, value.ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__String_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -605,7 +616,8 @@ internal func foobar_copyToCType(_ swiftArray: [String]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf__String_create_optional_handle()
     let handle = foobar_ArrayOf__String_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf__String_append(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__String_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -642,8 +654,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [UInt8] {
 internal func foobar_copyToCType(_ swiftArray: [UInt8]) -> RefHolder {
     let handle = foobar_ArrayOf__UByte_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
-        foobar_ArrayOf__UByte_append(handle, value.ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__UByte_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -657,7 +669,8 @@ internal func foobar_copyToCType(_ swiftArray: [UInt8]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf__UByte_create_optional_handle()
     let handle = foobar_ArrayOf__UByte_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf__UByte_append(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__UByte_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -694,8 +707,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [YetAnotherDummyClass]
 internal func foobar_copyToCType(_ swiftArray: [YetAnotherDummyClass]) -> RefHolder {
     let handle = foobar_ArrayOf_smoke_YetAnotherDummyClass_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_smoke_YetAnotherDummyClass_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_YetAnotherDummyClass_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -709,7 +722,8 @@ internal func foobar_copyToCType(_ swiftArray: [YetAnotherDummyClass]?) -> RefHo
     let optionalHandle = foobar_ArrayOf_smoke_YetAnotherDummyClass_create_optional_handle()
     let handle = foobar_ArrayOf_smoke_YetAnotherDummyClass_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_smoke_YetAnotherDummyClass_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_smoke_YetAnotherDummyClass_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -746,8 +760,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [[Int32: Bool]] {
 internal func foobar_copyToCType(_ swiftArray: [[Int32: Bool]]) -> RefHolder {
     let handle = foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -761,7 +775,8 @@ internal func foobar_copyToCType(_ swiftArray: [[Int32: Bool]]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_create_optional_handle()
     let handle = foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_foobar_MapOf__Int_To__Boolean_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -798,8 +813,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [[Int32]] {
 internal func foobar_copyToCType(_ swiftArray: [[Int32]]) -> RefHolder {
     let handle = foobar_ArrayOf_foobar_ArrayOf__Int_create_handle()
     for item in swiftArray {
-        let value = foobar_moveToCType(item)
-        foobar_ArrayOf_foobar_ArrayOf__Int_append(handle, value.ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_foobar_ArrayOf__Int_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -813,7 +828,8 @@ internal func foobar_copyToCType(_ swiftArray: [[Int32]]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf_foobar_ArrayOf__Int_create_optional_handle()
     let handle = foobar_ArrayOf_foobar_ArrayOf__Int_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_foobar_ArrayOf__Int_append(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_ArrayOf_foobar_ArrayOf__Int_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/swift/Sets.swift
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/swift/Sets.swift
@@ -20,7 +20,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<Float> {
 internal func foobar_copyToCType(_ swiftSet: Set<Float>) -> RefHolder {
     let handle = foobar_SetOf__Float_create_handle()
     for item in swiftSet {
-        foobar_SetOf__Float_insert(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_SetOf__Float_insert(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -34,7 +35,8 @@ internal func foobar_copyToCType(_ swiftSet: Set<Float>?) -> RefHolder {
     let optionalHandle = foobar_SetOf__Float_create_optional_handle()
     let handle = foobar_SetOf__Float_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf__Float_insert(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_SetOf__Float_insert(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -73,7 +75,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<GenericTypesWithCo
 internal func foobar_copyToCType(_ swiftSet: Set<GenericTypesWithCompoundTypes.ExternalEnum>) -> RefHolder {
     let handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle()
     for item in swiftSet {
-        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -87,7 +90,8 @@ internal func foobar_copyToCType(_ swiftSet: Set<GenericTypesWithCompoundTypes.E
     let optionalHandle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_optional_handle()
     let handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -126,7 +130,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<GenericTypesWithCo
 internal func foobar_copyToCType(_ swiftSet: Set<GenericTypesWithCompoundTypes.SomeEnum>) -> RefHolder {
     let handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle()
     for item in swiftSet {
-        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -140,7 +145,8 @@ internal func foobar_copyToCType(_ swiftSet: Set<GenericTypesWithCompoundTypes.S
     let optionalHandle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_optional_handle()
     let handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -179,7 +185,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<Int32> {
 internal func foobar_copyToCType(_ swiftSet: Set<Int32>) -> RefHolder {
     let handle = foobar_SetOf__Int_create_handle()
     for item in swiftSet {
-        foobar_SetOf__Int_insert(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_SetOf__Int_insert(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -193,7 +200,8 @@ internal func foobar_copyToCType(_ swiftSet: Set<Int32>?) -> RefHolder {
     let optionalHandle = foobar_SetOf__Int_create_optional_handle()
     let handle = foobar_SetOf__Int_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf__Int_insert(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_SetOf__Int_insert(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -232,7 +240,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<Set<Int32>> {
 internal func foobar_copyToCType(_ swiftSet: Set<Set<Int32>>) -> RefHolder {
     let handle = foobar_SetOf_foobar_SetOf__Int_create_handle()
     for item in swiftSet {
-        foobar_SetOf_foobar_SetOf__Int_insert(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_SetOf_foobar_SetOf__Int_insert(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -246,7 +255,8 @@ internal func foobar_copyToCType(_ swiftSet: Set<Set<Int32>>?) -> RefHolder {
     let optionalHandle = foobar_SetOf_foobar_SetOf__Int_create_optional_handle()
     let handle = foobar_SetOf_foobar_SetOf__Int_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf_foobar_SetOf__Int_insert(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_SetOf_foobar_SetOf__Int_insert(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -285,7 +295,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<String> {
 internal func foobar_copyToCType(_ swiftSet: Set<String>) -> RefHolder {
     let handle = foobar_SetOf__String_create_handle()
     for item in swiftSet {
-        foobar_SetOf__String_insert(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_SetOf__String_insert(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -299,7 +310,8 @@ internal func foobar_copyToCType(_ swiftSet: Set<String>?) -> RefHolder {
     let optionalHandle = foobar_SetOf__String_create_optional_handle()
     let handle = foobar_SetOf__String_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf__String_insert(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_SetOf__String_insert(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -338,7 +350,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<UInt8> {
 internal func foobar_copyToCType(_ swiftSet: Set<UInt8>) -> RefHolder {
     let handle = foobar_SetOf__UByte_create_handle()
     for item in swiftSet {
-        foobar_SetOf__UByte_insert(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_SetOf__UByte_insert(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -352,7 +365,8 @@ internal func foobar_copyToCType(_ swiftSet: Set<UInt8>?) -> RefHolder {
     let optionalHandle = foobar_SetOf__UByte_create_optional_handle()
     let handle = foobar_SetOf__UByte_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf__UByte_insert(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_SetOf__UByte_insert(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -391,7 +405,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<[Int32: Bool]> {
 internal func foobar_copyToCType(_ swiftSet: Set<[Int32: Bool]>) -> RefHolder {
     let handle = foobar_SetOf_foobar_MapOf__Int_To__Boolean_create_handle()
     for item in swiftSet {
-        foobar_SetOf_foobar_MapOf__Int_To__Boolean_insert(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_SetOf_foobar_MapOf__Int_To__Boolean_insert(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -405,7 +420,8 @@ internal func foobar_copyToCType(_ swiftSet: Set<[Int32: Bool]>?) -> RefHolder {
     let optionalHandle = foobar_SetOf_foobar_MapOf__Int_To__Boolean_create_optional_handle()
     let handle = foobar_SetOf_foobar_MapOf__Int_To__Boolean_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf_foobar_MapOf__Int_To__Boolean_insert(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_SetOf_foobar_MapOf__Int_To__Boolean_insert(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -444,7 +460,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<[Int32]> {
 internal func foobar_copyToCType(_ swiftSet: Set<[Int32]>) -> RefHolder {
     let handle = foobar_SetOf_foobar_ArrayOf__Int_create_handle()
     for item in swiftSet {
-        foobar_SetOf_foobar_ArrayOf__Int_insert(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_SetOf_foobar_ArrayOf__Int_insert(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -458,7 +475,8 @@ internal func foobar_copyToCType(_ swiftSet: Set<[Int32]>?) -> RefHolder {
     let optionalHandle = foobar_SetOf_foobar_ArrayOf__Int_create_optional_handle()
     let handle = foobar_SetOf_foobar_ArrayOf__Int_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
-        foobar_SetOf_foobar_ArrayOf__Int_insert(handle, foobar_moveToCType(item).ref)
+        let _item = foobar_moveToCType(item)
+        foobar_SetOf_foobar_ArrayOf__Int_insert(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
@@ -164,7 +164,8 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Convoluter {
 internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.Convoluter {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_Convoluter_release_handle)
     return { (p0: String) -> Lambdas.Producer in
-        return foobar_moveFromCType(smoke_Lambdas_Convoluter_call(refHolder.ref, moveToCType(p0).ref))
+        let _p0 = moveToCType(p0)
+        return foobar_moveFromCType(smoke_Lambdas_Convoluter_call(refHolder.ref, _p0.ref))
     }
 }
 internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Convoluter? {
@@ -227,7 +228,8 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Consumer {
 internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.Consumer {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_Consumer_release_handle)
     return { (p0: String) -> Void in
-        return moveFromCType(smoke_Lambdas_Consumer_call(refHolder.ref, moveToCType(p0).ref))
+        let _p0 = moveToCType(p0)
+        return moveFromCType(smoke_Lambdas_Consumer_call(refHolder.ref, _p0.ref))
     }
 }
 internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Consumer? {
@@ -290,7 +292,9 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Indexer {
 internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.Indexer {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_Indexer_release_handle)
     return { (p0: String, p1: Float) -> Int32 in
-        return moveFromCType(smoke_Lambdas_Indexer_call(refHolder.ref, moveToCType(p0).ref, moveToCType(p1).ref))
+        let _p0 = moveToCType(p0)
+        let _p1 = moveToCType(p1)
+        return moveFromCType(smoke_Lambdas_Indexer_call(refHolder.ref, _p0.ref, _p1.ref))
     }
 }
 internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.Indexer? {
@@ -353,7 +357,8 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.NullableConfus
 internal func foobar_moveFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_NullableConfuser_release_handle)
     return { (p0: String?) -> Lambdas.Producer? in
-        return foobar_moveFromCType(smoke_Lambdas_NullableConfuser_call(refHolder.ref, moveToCType(p0).ref))
+        let _p0 = moveToCType(p0)
+        return foobar_moveFromCType(smoke_Lambdas_NullableConfuser_call(refHolder.ref, _p0.ref))
     }
 }
 internal func foobar_copyFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser? {

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasInterface.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasInterface.swift
@@ -118,7 +118,8 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> LambdasInterface.TakeS
 internal func foobar_moveFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback {
     let refHolder = RefHolder(ref: handle, release: smoke_LambdasInterface_TakeScreenshotCallback_release_handle)
     return { (p0: Data?) -> Void in
-        return moveFromCType(smoke_LambdasInterface_TakeScreenshotCallback_call(refHolder.ref, moveToCType(p0).ref))
+        let _p0 = moveToCType(p0)
+        return moveFromCType(smoke_LambdasInterface_TakeScreenshotCallback_call(refHolder.ref, _p0.ref))
     }
 }
 internal func foobar_copyFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback? {

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
@@ -95,7 +95,8 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredT
 internal func foobar_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback {
     let refHolder = RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_ClassCallback_release_handle)
     return { (p0: LambdasInterface) -> Void in
-        return moveFromCType(smoke_LambdasWithStructuredTypes_ClassCallback_call(refHolder.ref, foobar_moveToCType(p0).ref))
+        let _p0 = foobar_moveToCType(p0)
+        return moveFromCType(smoke_LambdasWithStructuredTypes_ClassCallback_call(refHolder.ref, _p0.ref))
     }
 }
 internal func foobar_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback? {
@@ -158,7 +159,8 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredT
 internal func foobar_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback {
     let refHolder = RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_StructCallback_release_handle)
     return { (p0: LambdasDeclarationOrder.SomeStruct) -> Void in
-        return moveFromCType(smoke_LambdasWithStructuredTypes_StructCallback_call(refHolder.ref, foobar_moveToCType(p0).ref))
+        let _p0 = foobar_moveToCType(p0)
+        return moveFromCType(smoke_LambdasWithStructuredTypes_StructCallback_call(refHolder.ref, _p0.ref))
     }
 }
 internal func foobar_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback? {

--- a/gluecodium/src/test/resources/smoke/nullable/output/swift/Collections.swift
+++ b/gluecodium/src/test/resources/smoke/nullable/output/swift/Collections.swift
@@ -18,8 +18,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [Date?] {
 internal func foobar_copyToCType(_ swiftArray: [Date?]) -> RefHolder {
     let handle = foobar_ArrayOf_nullable_Date_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
-        foobar_ArrayOf_nullable_Date_append(handle, value.ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf_nullable_Date_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -33,7 +33,8 @@ internal func foobar_copyToCType(_ swiftArray: [Date?]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf_nullable_Date_create_optional_handle()
     let handle = foobar_ArrayOf_nullable_Date_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf_nullable_Date_append(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf_nullable_Date_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -70,8 +71,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [Date] {
 internal func foobar_copyToCType(_ swiftArray: [Date]) -> RefHolder {
     let handle = foobar_ArrayOf__Date_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
-        foobar_ArrayOf__Date_append(handle, value.ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__Date_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -85,7 +86,8 @@ internal func foobar_copyToCType(_ swiftArray: [Date]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf__Date_create_optional_handle()
     let handle = foobar_ArrayOf__Date_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf__Date_append(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__Date_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
@@ -122,8 +124,8 @@ internal func foobar_moveFromCType(_ handle: _baseRef) -> [String] {
 internal func foobar_copyToCType(_ swiftArray: [String]) -> RefHolder {
     let handle = foobar_ArrayOf__String_create_handle()
     for item in swiftArray {
-        let value = moveToCType(item)
-        foobar_ArrayOf__String_append(handle, value.ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__String_append(handle, _item.ref)
     }
     return RefHolder(handle)
 }
@@ -137,7 +139,8 @@ internal func foobar_copyToCType(_ swiftArray: [String]?) -> RefHolder {
     let optionalHandle = foobar_ArrayOf__String_create_optional_handle()
     let handle = foobar_ArrayOf__String_unwrap_optional_handle(optionalHandle)
     for item in swiftArray {
-        foobar_ArrayOf__String_append(handle, moveToCType(item).ref)
+        let _item = moveToCType(item)
+        foobar_ArrayOf__String_append(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }


### PR DESCRIPTION
Updated Swift templates to avoid usage of `moveToCType().ref` antipattern. The result of `moveToCType()` call needs to
be stored in a local varable instead, to extend its lifetime to the lifetime of the current scope and thus preventing
the releasing of `.ref` handle long enough for it to be used.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>