### PR TITLE
Fixes crash in tests due to init order of global variables

### DIFF
--- a/functional-tests/functional/swift/XCTMain.swift
+++ b/functional-tests/functional/swift/XCTMain.swift
@@ -29,15 +29,15 @@ import XCTest
 
 #if !os(Linux)
 
-    typealias TestCaseEntry = (String, allTests: [String])
+    typealias XCTestCaseEntry = (String, allTests: [String])
 
-    func testCase<T: XCTestCase>(_ allTests: [(String, (T) -> () throws -> Void)]) -> TestCaseEntry {
+    func testCase<T: XCTestCase>(_ allTests: [(String, (T) -> () throws -> Void)]) -> XCTestCaseEntry {
         let tests: [String] = allTests.map { $0.0 }
         let name = String(describing: T.self)
         return (name, tests)
     }
 
-    func testCase<T: XCTestCase>(_ allTests: [(String, (T) -> () -> Void)]) -> TestCaseEntry {
+    func testCase<T: XCTestCase>(_ allTests: [(String, (T) -> () -> Void)]) -> XCTestCaseEntry {
         let tests: [String] = allTests.map { $0.0 }
         let name = String(describing: T.self)
         return (name, tests)
@@ -49,7 +49,7 @@ import XCTest
 
             // Check the difference between automatically discovered and statically added tests
             var staticTestCases: [String: Set<String>] = [:]
-            allTests.forEach { staticTestCases[$0] = Set($1) }
+            getAllTests().forEach { staticTestCases[$0] = Set($1) }
 
             var dynamicTestCases: [String: Set<String>] = [:]
             defaultSuite.tests.forEach { bundle in
@@ -92,7 +92,7 @@ import XCTest
         }
     }
 
-    func XCTMain(_: [TestCaseEntry]) -> Never {
+    func XCTMain(_: [XCTestCaseEntry]) -> Never {
         let defaultSuite = XCTestSuite.default
         defaultSuite.run()
         exit(Int32(defaultSuite.testRun!.failureCount))

--- a/functional-tests/functional/swift/main.swift
+++ b/functional-tests/functional/swift/main.swift
@@ -21,62 +21,66 @@
 import XCTest
 import functional
 
-#if os(macOS)
-let platformSpecificTests = [TestCaseEntry]()
-#else
-let platformSpecificTests = [testCase(ExternalTypesTests.allTests)]
-#endif
+func getAllTests() -> [XCTestCaseEntry] {
 
-let allTests = platformSpecificTests + [
-    testCase(ArraysTests.allTests),
-    testCase(AttributesInterfaceTests.allTests),
-    testCase(AttributesTests.allTests),
-    testCase(ConstantsTests.allTests),
-    testCase(CppConstMethodsTests.allTests),
-    testCase(DatesTests.allTests),
-    testCase(DefaultsTests.allTests),
-    testCase(EnumsTests.allTests),
-    testCase(EquatableInstancesTests.allTests),
-    testCase(EquatableNullableTests.allTests),
-    testCase(EquatableTests.allTests),
-    testCase(ErrorsInInterfaceTests.allTests),
-    testCase(ErrorsTests.allTests),
-    testCase(ExtensionsTests.allTests),
-    testCase(InheritanceTests.allTests),
-    testCase(InterfacesTests.allTests),
-    testCase(LambdasTests.allTests),
-    testCase(ListenerRoundtripTests.allTests),
-    testCase(ListenerWithAttributesTests.allTests),
-    testCase(ListenersReturnValuesTests.allTests),
-    testCase(ListenersWithDictionaries.allTests),
-    testCase(LocalesTests.allTests),
-    testCase(MapsTests.allTests),
-    testCase(MethodOverloadsTests.allTests),
-    testCase(MultiListenerTests.allTests),
-    testCase(NestingTests.allTests),
-    testCase(NullableAttributesTests.allTests),
-    testCase(NullableCollectionsTests.allTests),
-    testCase(NullableInstancesTests.allTests),
-    testCase(NullableListenersTests.allTests),
-    testCase(NullableMethodArgumentsTests.allTests),
-    testCase(NullableStructsTests.allTests),
-    testCase(PodTypeCollectionTests.allTests),
-    testCase(PlainDataStructuresTests.allTests),
-    testCase(RefEqualityTests.allTests),
-    testCase(SerializationTests.allTests),
-    testCase(SetTypeTests.allTests),
-    testCase(SimpleEqualityTests.allTests),
-    testCase(SkipEnumeratorTests.allTests),
-    testCase(StaticBooleanMethodsTests.allTests),
-    testCase(StaticByteArrayMethodsTests.allTests),
-    testCase(StaticFloatDoubleMethodsTests.allTests),
-    testCase(StaticIntMethodsTests.allTests),
-    testCase(StaticStringMethodsTests.allTests),
-    testCase(StructWithConstantsTests.allTests),
-    testCase(StructsWithMethodsTests.allTests),
-    testCase(StructWithInstanceTests.allTests),
-    testCase(TypeDefTests.allTests),
-    testCase(WeakListenersTests.allTests)
-]
+    #if os(macOS)
+    let platformSpecificTests = [XCTestCaseEntry]()
+    #else
+    let platformSpecificTests = [testCase(ExternalTypesTests.allTests)]
+    #endif
 
-XCTMain(allTests)
+    let allTests = platformSpecificTests + [
+        testCase(ArraysTests.allTests),
+        testCase(AttributesInterfaceTests.allTests),
+        testCase(AttributesTests.allTests),
+        testCase(ConstantsTests.allTests),
+        testCase(CppConstMethodsTests.allTests),
+        testCase(DatesTests.allTests),
+        testCase(DefaultsTests.allTests),
+        testCase(EnumsTests.allTests),
+        testCase(EquatableInstancesTests.allTests),
+        testCase(EquatableNullableTests.allTests),
+        testCase(EquatableTests.allTests),
+        testCase(ErrorsInInterfaceTests.allTests),
+        testCase(ErrorsTests.allTests),
+        testCase(ExtensionsTests.allTests),
+        testCase(InheritanceTests.allTests),
+        testCase(InterfacesTests.allTests),
+        testCase(LambdasTests.allTests),
+        testCase(ListenerRoundtripTests.allTests),
+        testCase(ListenerWithAttributesTests.allTests),
+        testCase(ListenersReturnValuesTests.allTests),
+        testCase(ListenersWithDictionaries.allTests),
+        testCase(LocalesTests.allTests),
+        testCase(MapsTests.allTests),
+        testCase(MethodOverloadsTests.allTests),
+        testCase(MultiListenerTests.allTests),
+        testCase(NestingTests.allTests),
+        testCase(NullableAttributesTests.allTests),
+        testCase(NullableCollectionsTests.allTests),
+        testCase(NullableInstancesTests.allTests),
+        testCase(NullableListenersTests.allTests),
+        testCase(NullableMethodArgumentsTests.allTests),
+        testCase(NullableStructsTests.allTests),
+        testCase(PodTypeCollectionTests.allTests),
+        testCase(PlainDataStructuresTests.allTests),
+        testCase(RefEqualityTests.allTests),
+        testCase(SerializationTests.allTests),
+        testCase(SetTypeTests.allTests),
+        testCase(SimpleEqualityTests.allTests),
+        testCase(SkipEnumeratorTests.allTests),
+        testCase(StaticBooleanMethodsTests.allTests),
+        testCase(StaticByteArrayMethodsTests.allTests),
+        testCase(StaticFloatDoubleMethodsTests.allTests),
+        testCase(StaticIntMethodsTests.allTests),
+        testCase(StaticStringMethodsTests.allTests),
+        testCase(StructWithConstantsTests.allTests),
+        testCase(StructsWithMethodsTests.allTests),
+        testCase(StructWithInstanceTests.allTests),
+        testCase(TypeDefTests.allTests),
+        testCase(WeakListenersTests.allTests)
+    ]
+    return allTests
+}
+
+XCTMain(getAllTests())


### PR DESCRIPTION
Signed-off-by: Yauheni Khnykin <yauheni.khnykin@here.com>
