### PR TITLE
Fix doc references to function overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed processing of documentation links to method overloads when one of the paramers refers to a nested type.
+  * Fixed DoxyGen comment generation for links to method overloads with nullable parameters in C++.
+
 ## 8.9.2
 Release date: 2021-02-17
 ### Bug fixes:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -675,10 +675,12 @@ There are three ways to specify web links:
 3. automatic web link, e.g. `<https://www.example.com/details3>`.
 
 Any square-brackets link that does not resolve into a web link is treated as a link to some IDL element, e.g. `[Mode]`.
+Please note that all whitespace between the square brackets is ignored during link resolution.
 
 When referring to a function, you can also optionally mention its signature (list of parameter types, but not the return
-type), e.g. `[Processor.process(Mode,String)]`. This way you can refer to a specific overload of an overloaded function.
-Please note the lack of whitespace after a comma between parameters.
+type), e.g. `[Processor.process(Mode, String)]`. This way you can refer to a specific overload of an overloaded
+function. Please not that parameter type names should be simple unqualified names, i.e.
+`[Processor.process(Mode, String)]` instead of `[Processor.process(com.example.Processor.Mode, String)]`
 
 When referring to a property element, you can also specifically refer to its getter or its setter by adding `.get` or
 `.set` suffix respectively, e.g. `[Processor.secretDelegate.set]`.

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
@@ -63,12 +63,12 @@ internal class CppNameResolver(
     private val commentsProcessor: CommentsProcessor? = null
 ) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
-    private val signatureResolver = PlatformSignatureResolver(limeReferenceMap, CPP, nameCache.nameRules)
-    private val limeToCppNames = buildPathMap()
-
     private val hashTypeName = (listOf("") + internalNamespace + "hash").joinToString("::")
     private val optionalTypeName = (listOf("") + internalNamespace + "optional").joinToString("::")
     private val localeTypeName = (listOf("") + internalNamespace + "Locale").joinToString("::")
+
+    private val signatureResolver = PlatformSignatureResolver(limeReferenceMap, CPP, nameCache.nameRules)
+    private val limeToCppNames = buildPathMap()
 
     override fun resolveName(element: Any): String =
         when (element) {
@@ -213,7 +213,7 @@ internal class CppNameResolver(
             when {
                 limeElement is LimeFunction && signatureResolver.isOverloaded(limeElement) ->
                     limeElement.parameters.joinToString(prefix = "(", postfix = ")") {
-                        "const ${resolveName(it.typeRef)}" + if (needsRefSuffix(it.typeRef)) "&" else ""
+                        "const ${resolveTypeRef(it.typeRef)}" + if (needsRefSuffix(it.typeRef)) "&" else ""
                     }
                 else -> ""
             }

--- a/gluecodium/src/test/resources/smoke/comments/input/ReferToNestedType.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/ReferToNestedType.lime
@@ -1,0 +1,29 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+// Referencing some type [MapScene.load_scene(Int, MapScene.LoadSceneCallback?)].
+class MapScene {
+    lambda LoadSceneCallback = (String?) -> Void
+
+    @Dart("loadSceneWithInt")
+    fun load_scene(map_scheme: Int, callback: LoadSceneCallback?)
+
+    @Dart("loadSceneWithString")
+    fun load_scene(configuration_file: String, callback: LoadSceneCallback?)
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/MapScene.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/MapScene.java
@@ -1,0 +1,46 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import com.example.NativeBase;
+/**
+ * <p>Referencing some type {@link com.example.smoke.MapScene#loadScene(int, MapScene.LoadSceneCallback)}.</p>
+ */
+public final class MapScene extends NativeBase {
+    /**
+     * @exclude
+     */
+    static class LoadSceneCallbackImpl extends NativeBase implements LoadSceneCallback {
+        protected LoadSceneCallbackImpl(final long nativeHandle, final Object dummy) {
+            super(nativeHandle, new Disposer() {
+                @Override
+                public void disposeNative(long handle) {
+                    disposeNativeHandle(handle);
+                }
+            });
+        }
+        private static native void disposeNativeHandle(long nativeHandle);
+        public native void apply(@Nullable final String p0);
+    }
+    @FunctionalInterface
+    public interface LoadSceneCallback {
+        void apply(@Nullable final String p0);
+    }
+    /**
+     * For internal use only.
+     * @exclude
+     */
+    protected MapScene(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+    private static native void disposeNativeHandle(long nativeHandle);
+    public native void loadScene(final int mapScheme, @Nullable final MapScene.LoadSceneCallback callback);
+    public native void loadScene(@NonNull final String configurationFile, @Nullable final MapScene.LoadSceneCallback callback);
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/MapScene.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/MapScene.h
@@ -1,0 +1,25 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/Optional.h"
+#include <cstdint>
+#include <functional>
+#include <string>
+namespace smoke {
+/**
+ * Referencing some type ::smoke::MapScene::load_scene(const int32_t, const ::gluecodium::optional< ::smoke::MapScene::LoadSceneCallback >&).
+ */
+class _GLUECODIUM_CPP_EXPORT MapScene {
+public:
+    MapScene();
+    virtual ~MapScene() = 0;
+public:
+    using LoadSceneCallback = ::std::function<void(const ::gluecodium::optional< ::std::string >&)>;
+public:
+    virtual void load_scene( const int32_t map_scheme, const ::gluecodium::optional< ::smoke::MapScene::LoadSceneCallback >& callback ) = 0;
+    virtual void load_scene( const ::std::string& configuration_file, const ::gluecodium::optional< ::smoke::MapScene::LoadSceneCallback >& callback ) = 0;
+};
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -1,0 +1,178 @@
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+/// Referencing some type [MapScene.loadSceneWithInt].
+abstract class MapScene {
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+  loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback callback);
+  loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback callback);
+}
+typedef MapScene_LoadSceneCallback = void Function(String);
+// MapScene_LoadSceneCallback "private" section, not exported.
+final _smoke_MapScene_LoadSceneCallback_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MapScene_LoadSceneCallback_copy_handle'));
+final _smoke_MapScene_LoadSceneCallback_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MapScene_LoadSceneCallback_release_handle'));
+final _smoke_MapScene_LoadSceneCallback_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
+    Pointer<Void> Function(int, int, Pointer, Pointer)
+  >('library_smoke_MapScene_LoadSceneCallback_create_proxy'));
+class MapScene_LoadSceneCallback$Impl {
+  Pointer<Void> get _handle => handle;
+  final Pointer<Void> handle;
+  MapScene_LoadSceneCallback$Impl(this.handle);
+  void release() => _smoke_MapScene_LoadSceneCallback_release_handle(handle);
+  call(String p0) {
+    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MapScene_LoadSceneCallback_call__String'));
+    final _p0_handle = String_toFfi_nullable(p0);
+    final _handle = this.handle;
+    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
+    String_releaseFfiHandle_nullable(_p0_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+}
+int _MapScene_LoadSceneCallback_call_static(int _token, Pointer<Void> p0) {
+  try {
+    (__lib.instanceCache[_token] as MapScene_LoadSceneCallback)(String_fromFfi_nullable(p0));
+  } finally {
+    String_releaseFfiHandle_nullable(p0);
+  }
+  return 0;
+}
+Pointer<Void> smoke_MapScene_LoadSceneCallback_toFfi(MapScene_LoadSceneCallback value) {
+  final result = _smoke_MapScene_LoadSceneCallback_create_proxy(
+    __lib.cacheObject(value),
+    __lib.LibraryContext.isolateId,
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_MapScene_LoadSceneCallback_call_static, __lib.unknownError)
+  );
+  return result;
+}
+MapScene_LoadSceneCallback smoke_MapScene_LoadSceneCallback_fromFfi(Pointer<Void> handle) {
+  final _impl = MapScene_LoadSceneCallback$Impl(_smoke_MapScene_LoadSceneCallback_copy_handle(handle));
+  return (String p0) {
+    final _result =_impl.call(p0);
+    _impl.release();
+    return _result;
+  };
+}
+void smoke_MapScene_LoadSceneCallback_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_MapScene_LoadSceneCallback_release_handle(handle);
+// Nullable MapScene_LoadSceneCallback
+final _smoke_MapScene_LoadSceneCallback_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MapScene_LoadSceneCallback_create_handle_nullable'));
+final _smoke_MapScene_LoadSceneCallback_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MapScene_LoadSceneCallback_release_handle_nullable'));
+final _smoke_MapScene_LoadSceneCallback_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MapScene_LoadSceneCallback_get_value_nullable'));
+Pointer<Void> smoke_MapScene_LoadSceneCallback_toFfi_nullable(MapScene_LoadSceneCallback value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_MapScene_LoadSceneCallback_toFfi(value);
+  final result = _smoke_MapScene_LoadSceneCallback_create_handle_nullable(_handle);
+  smoke_MapScene_LoadSceneCallback_releaseFfiHandle(_handle);
+  return result;
+}
+MapScene_LoadSceneCallback smoke_MapScene_LoadSceneCallback_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_MapScene_LoadSceneCallback_get_value_nullable(handle);
+  final result = smoke_MapScene_LoadSceneCallback_fromFfi(_handle);
+  smoke_MapScene_LoadSceneCallback_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_MapScene_LoadSceneCallback_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_MapScene_LoadSceneCallback_release_handle_nullable(handle);
+// End of MapScene_LoadSceneCallback "private" section.
+// MapScene "private" section, not exported.
+final _smoke_MapScene_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MapScene_copy_handle'));
+final _smoke_MapScene_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MapScene_release_handle'));
+class MapScene$Impl implements MapScene {
+  @protected
+  Pointer<Void> handle;
+  MapScene$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.uncacheObject(this);
+    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
+    _smoke_MapScene_release_handle(handle);
+    handle = null;
+  }
+  @override
+  loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback callback) {
+    final _loadSceneWithInt_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int32, Pointer<Void>), void Function(Pointer<Void>, int, int, Pointer<Void>)>('library_smoke_MapScene_loadScene__Int_LoadSceneCallback'));
+    final _mapScheme_handle = (mapScheme);
+    final _callback_handle = smoke_MapScene_LoadSceneCallback_toFfi_nullable(callback);
+    final _handle = this.handle;
+    final __result_handle = _loadSceneWithInt_ffi(_handle, __lib.LibraryContext.isolateId, _mapScheme_handle, _callback_handle);
+    (_mapScheme_handle);
+    smoke_MapScene_LoadSceneCallback_releaseFfiHandle_nullable(_callback_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+  @override
+  loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback callback) {
+    final _loadSceneWithString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MapScene_loadScene__String_LoadSceneCallback'));
+    final _configurationFile_handle = String_toFfi(configurationFile);
+    final _callback_handle = smoke_MapScene_LoadSceneCallback_toFfi_nullable(callback);
+    final _handle = this.handle;
+    final __result_handle = _loadSceneWithString_ffi(_handle, __lib.LibraryContext.isolateId, _configurationFile_handle, _callback_handle);
+    String_releaseFfiHandle(_configurationFile_handle);
+    smoke_MapScene_LoadSceneCallback_releaseFfiHandle_nullable(_callback_handle);
+    try {
+      return (__result_handle);
+    } finally {
+      (__result_handle);
+    }
+  }
+}
+Pointer<Void> smoke_MapScene_toFfi(MapScene value) =>
+  _smoke_MapScene_copy_handle((value as MapScene$Impl).handle);
+MapScene smoke_MapScene_fromFfi(Pointer<Void> handle) {
+  final isolateId = __lib.LibraryContext.isolateId;
+  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final instance = __lib.instanceCache[token] as MapScene;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_MapScene_copy_handle(handle);
+  final result = MapScene$Impl(_copied_handle);
+  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  return result;
+}
+void smoke_MapScene_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_MapScene_release_handle(handle);
+Pointer<Void> smoke_MapScene_toFfi_nullable(MapScene value) =>
+  value != null ? smoke_MapScene_toFfi(value) : Pointer<Void>.fromAddress(0);
+MapScene smoke_MapScene_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_MapScene_fromFfi(handle) : null;
+void smoke_MapScene_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_MapScene_release_handle(handle);
+// End of MapScene "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MapScene.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MapScene.swift
@@ -1,0 +1,157 @@
+//
+//
+import Foundation
+/// Referencing some type `MapScene.loadScene(Int32, MapScene.LoadSceneCallback?)`.
+public class MapScene {
+    public typealias LoadSceneCallback = (String?) -> Void
+    let c_instance : _baseRef
+    init(cMapScene: _baseRef) {
+        guard cMapScene != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cMapScene
+    }
+    deinit {
+        smoke_MapScene_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_MapScene_release_handle(c_instance)
+    }
+    public func loadScene(mapScheme: Int32, callback: MapScene.LoadSceneCallback?) -> Void {
+        let c_mapScheme = moveToCType(mapScheme)
+        let c_callback = moveToCType(callback)
+        return moveFromCType(smoke_MapScene_loadScene_Int_LoadSceneCallback(self.c_instance, c_mapScheme.ref, c_callback.ref))
+    }
+    public func loadScene(configurationFile: String, callback: MapScene.LoadSceneCallback?) -> Void {
+        let c_configurationFile = moveToCType(configurationFile)
+        let c_callback = moveToCType(callback)
+        return moveFromCType(smoke_MapScene_loadScene_String_LoadSceneCallback(self.c_instance, c_configurationFile.ref, c_callback.ref))
+    }
+}
+internal func getRef(_ ref: MapScene?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_MapScene_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_MapScene_release_handle)
+        : RefHolder(handle_copy)
+}
+extension MapScene: NativeBase {
+    var c_handle: _baseRef { return c_instance }
+}
+extension MapScene: Hashable {
+    /// :nodoc:
+    public static func == (lhs: MapScene, rhs: MapScene) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    /// :nodoc:
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
+internal func MapScene_copyFromCType(_ handle: _baseRef) -> MapScene {
+    if let swift_pointer = smoke_MapScene_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MapScene {
+        return re_constructed
+    }
+    let result = MapScene(cMapScene: smoke_MapScene_copy_handle(handle))
+    smoke_MapScene_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func MapScene_moveFromCType(_ handle: _baseRef) -> MapScene {
+    if let swift_pointer = smoke_MapScene_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? MapScene {
+        smoke_MapScene_release_handle(handle)
+        return re_constructed
+    }
+    let result = MapScene(cMapScene: handle)
+    smoke_MapScene_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func MapScene_copyFromCType(_ handle: _baseRef) -> MapScene? {
+    guard handle != 0 else {
+        return nil
+    }
+    return MapScene_moveFromCType(handle) as MapScene
+}
+internal func MapScene_moveFromCType(_ handle: _baseRef) -> MapScene? {
+    guard handle != 0 else {
+        return nil
+    }
+    return MapScene_moveFromCType(handle) as MapScene
+}
+internal func copyToCType(_ swiftClass: MapScene) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: MapScene) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: MapScene?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: MapScene?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyFromCType(_ handle: _baseRef) -> MapScene.LoadSceneCallback {
+    return moveFromCType(smoke_MapScene_LoadSceneCallback_copy_handle(handle))
+}
+internal func moveFromCType(_ handle: _baseRef) -> MapScene.LoadSceneCallback {
+    let refHolder = RefHolder(ref: handle, release: smoke_MapScene_LoadSceneCallback_release_handle)
+    return { (p0: String?) -> Void in
+        let _p0 = moveToCType(p0)
+        return moveFromCType(smoke_MapScene_LoadSceneCallback_call(refHolder.ref, _p0.ref))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> MapScene.LoadSceneCallback? {
+    guard handle != 0 else {
+        return nil
+    }
+    return copyFromCType(handle) as MapScene.LoadSceneCallback
+}
+internal func moveFromCType(_ handle: _baseRef) -> MapScene.LoadSceneCallback? {
+    guard handle != 0 else {
+        return nil
+    }
+    return moveFromCType(handle) as MapScene.LoadSceneCallback
+}
+internal func createFunctionalTable(_ swiftType: @escaping MapScene.LoadSceneCallback) -> smoke_MapScene_LoadSceneCallback_FunctionTable {
+    class smoke_MapScene_LoadSceneCallback_Holder {
+        let closure: MapScene.LoadSceneCallback
+        init(_ closure: @escaping MapScene.LoadSceneCallback) {
+            self.closure = closure
+        }
+    }
+    var functions = smoke_MapScene_LoadSceneCallback_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(smoke_MapScene_LoadSceneCallback_Holder(swiftType)).toOpaque()
+    functions.release = { swift_closure_pointer in
+        if let swift_closure = swift_closure_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_closure).release()
+        }
+    }
+    functions.smoke_MapScene_LoadSceneCallback_call = { swift_closure_pointer, p0 in
+        let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_MapScene_LoadSceneCallback_Holder
+        return copyToCType(closure_holder.closure(moveFromCType(p0))).ref
+    }
+    return functions
+}
+internal func copyToCType(_ swiftType: @escaping MapScene.LoadSceneCallback) -> RefHolder {
+    let handle = smoke_MapScene_LoadSceneCallback_create_proxy(createFunctionalTable(swiftType))
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftType: @escaping MapScene.LoadSceneCallback) -> RefHolder {
+    let handle = smoke_MapScene_LoadSceneCallback_create_proxy(createFunctionalTable(swiftType))
+    return RefHolder(ref: handle, release: smoke_MapScene_LoadSceneCallback_release_handle)
+}
+internal func copyToCType(_ swiftType: MapScene.LoadSceneCallback?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let handle = smoke_MapScene_LoadSceneCallback_create_optional_proxy(createFunctionalTable(swiftType))
+    return RefHolder(handle)
+}
+internal func moveToCType(_ swiftType: MapScene.LoadSceneCallback?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let handle = smoke_MapScene_LoadSceneCallback_create_optional_proxy(createFunctionalTable(swiftType))
+    return RefHolder(ref: handle, release: smoke_MapScene_LoadSceneCallback_release_handle)
+}


### PR DESCRIPTION
Updated CommentsProcessor to normalize documentation references to functions  by reducing type names in the function
signature to a single name component. This only affects documentation references with full function signature (usually
used to disambiguate between different function overloads) and only for type names that are nested types.

Fixed initalization order of private fields in CppNameResolver to allow for properly resolving documentation references
to functions with parameters of nullable types.

Added smoke tests.

Resolves: #786
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>