### PR TITLE
Makes cmake API compatible with cmake < 3.19

### DIFF
--- a/cmake/modules/gluecodium/gluecodium/GetLinkedTargetsWithGeneratedSources.cmake
+++ b/cmake/modules/gluecodium/gluecodium/GetLinkedTargetsWithGeneratedSources.cmake
@@ -61,6 +61,15 @@ function(gluecodium_get_linked_targets_with_generated_sources result _target)
   endif()
 
   foreach(_linked_target IN LISTS _linked_targets)
+    if (CMAKE_VERSION VERSION_LESS 3.19)
+      get_target_property(_type ${_linked_target} TYPE)
+      if (_type STREQUAL "INTERFACE_LIBRARY")
+        # Prior CMake 3.19 interface libararies may have only whitelisted
+        # properties
+        continue()
+      endif()
+    endif()
+
     get_target_property(_generators ${_linked_target} GLUECODIUM_GENERATORS)
     if(_generators)
       list(APPEND _result ${_linked_target})

--- a/cmake/modules/gluecodium/gluecodium/details/GetLinkedTargets.cmake
+++ b/cmake/modules/gluecodium/gluecodium/details/GetLinkedTargets.cmake
@@ -55,11 +55,15 @@ function(gluecodium_get_linked_targets_rec result visited_targets _target only_s
 
     if(only_static)
       get_target_property(_linked_type ${_linked_lib} TYPE)
-      get_target_property(_framework ${_linked_lib} FRAMEWORK)
-      # Framework can be static, but it's still final target
-      if(_linked_type STREQUAL "SHARED_LIBRARY" OR _framework)
+      if(_linked_type STREQUAL "SHARED_LIBRARY")
         continue()
-      endif()
+      elseif (NOT _linked_type STREQUAL "INTERFACE_LIBRARY")
+        get_target_property(_framework ${_linked_lib} FRAMEWORK)
+        # Framework can be static, but it's still final target
+        if(_linked_type STREQUAL "SHARED_LIBRARY" OR _framework)
+          continue()
+        endif()
+      endif ()
     endif()
 
     list(APPEND _lib_targets ${_linked_lib})


### PR DESCRIPTION
Prior cmake 3.19 INTERFACE libraries may have only whitelisted
properties and cmake stops with error if tries read
non-whitelisted properties.
