### PR TITLE
Fix default ctor for structs with lists in C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Struct default constructor in C++ is no longer erroneously omitted if one of the fields is a
+    collection of immutable elements.
+
 ## 8.9.3
 Release date: 2021-02-24
 ### Bug fixes:

--- a/functional-tests/scripts/valgrind_suppressions
+++ b/functional-tests/scripts/valgrind_suppressions
@@ -224,3 +224,22 @@
    fun:_ZN11lorem_ipsum4test12OptionalBase*
    fun:*
 }
+{
+   leak in getAllTests()
+
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:$s14testfunctional11getAllTests*
+   fun:*
+}
+{
+   leak in instantiateConcreteTypeFromMangledName
+
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:__swift_instantiateConcreteTypeFromMangledName
+   fun:*
+}
+

--- a/gluecodium/src/test/resources/smoke/structs/input/ScalarKeyframe.lime
+++ b/gluecodium/src/test/resources/smoke/structs/input/ScalarKeyframe.lime
@@ -1,0 +1,32 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Immutable
+struct ScalarKeyframe
+{
+    value: Double
+    offsetInMs: Int
+}
+
+struct ScalarKeyframeTrack
+{
+    keyframes: List<ScalarKeyframe>
+    easingFunction: String
+    interpolationMode: String
+}

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/ScalarKeyframeTrack.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/ScalarKeyframeTrack.h
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/VectorHash.h"
+#include "smoke/ScalarKeyframe.h"
+#include <string>
+#include <vector>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT ScalarKeyframeTrack {
+    ::std::vector< ::smoke::ScalarKeyframe > keyframes;
+    ::std::string easing_function;
+    ::std::string interpolation_mode;
+    ScalarKeyframeTrack( );
+    ScalarKeyframeTrack( ::std::vector< ::smoke::ScalarKeyframe > keyframes, ::std::string easing_function, ::std::string interpolation_mode );
+};
+}

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/Structs.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/Structs.h
@@ -60,6 +60,7 @@ public:
     };
     struct _GLUECODIUM_CPP_EXPORT StructWithArrayOfImmutable {
         ::smoke::Structs::ArrayOfImmutable array_field;
+        StructWithArrayOfImmutable( );
         StructWithArrayOfImmutable( ::smoke::Structs::ArrayOfImmutable array_field );
     };
     struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithCppAccessors {

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/src/smoke/Structs.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/src/smoke/Structs.cpp
@@ -37,6 +37,10 @@ Structs::DoubleNestingImmutableStruct::DoubleNestingImmutableStruct( ::smoke::St
     : nesting_struct_field( std::move( nesting_struct_field ) )
 {
 }
+Structs::StructWithArrayOfImmutable::StructWithArrayOfImmutable( )
+    : array_field{ }
+{
+}
 Structs::StructWithArrayOfImmutable::StructWithArrayOfImmutable( ::smoke::Structs::ArrayOfImmutable array_field )
     : array_field( std::move( array_field ) )
 {

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypeHelper.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypeHelper.kt
@@ -21,25 +21,6 @@ package com.here.gluecodium.model.lime
 
 object LimeTypeHelper {
 
-    fun getAllFieldTypes(limeType: LimeType) = getAllFieldTypes(getLeafType(limeType), mutableSetOf())
-
-    private fun getAllFieldTypes(leafType: LimeType, visitedTypes: MutableSet<LimeType>): List<LimeType> {
-        if (leafType !is LimeStruct) return listOf(leafType)
-
-        visitedTypes += leafType
-        val typesToVisit = leafType.fields.map { getLeafType(it.typeRef.type.actualType) }.distinct() - visitedTypes
-        return typesToVisit.flatMap { getAllFieldTypes(it, visitedTypes) } + leafType
-    }
-
-    private fun getLeafType(limeType: LimeType): LimeType =
-        when (limeType) {
-            is LimeTypeAlias -> getLeafType(limeType.typeRef.type)
-            is LimeList -> getLeafType(limeType.elementType.type)
-            is LimeSet -> getLeafType(limeType.elementType.type)
-            is LimeMap -> getLeafType(limeType.valueType.type)
-            else -> limeType
-        }
-
     fun getAllTypes(limeElement: LimeNamedElement): List<LimeType> {
         val limeType = limeElement as? LimeType ?: return emptyList()
 


### PR DESCRIPTION
Updated C++ generator predicates to avoid erroneously omitting
default struct ctor if one of the fields is a collection of
immutable elements.

Moved field traversal predicate helpers to their respective
predicate classes to avoid misuse.

Added/updated smoke tests.

Resolves: #797
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>