### PR TITLE
Add "positional defaults" for Java structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added `@Java(PositionalDefaults)` attribute for structs. This attribute marks a struct to have an imitation of a
+    constructor with optional positional parameters in Java (only if the struct has any fields with default values).
+
 ## 8.9.4
 ### Bug fixes:
 Release date: 2021-02-26
@@ -51,7 +56,7 @@ Release date: 2021-01-18
 ## 8.7.0
 Release date: 2021-01-11
 ### Features:
-  * Added `@Dart(PositionalDefaults)` attribute for stucts. This attribute marks a struct to have a constructor with
+  * Added `@Dart(PositionalDefaults)` attribute for structs. This attribute marks a struct to have a constructor with
     optional positional parameters in Dart (only if the struct has at least one field with a default value).
 ### Bug fixes:
   * `@Deprecated` attribute specified on a property in IDL is now propagated to that property's accessors (but only if

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -504,6 +504,9 @@ for C++.
   generated code. _Annotation_ does not need to be prepended with `@`. _Annotation_ can contain parameters, e.g.
   `@Java(Attribute="Deprecated(\"It's deprecated.\")")`. If some of the parameters are string literals, their enclosing
   quotes need to be backslash-escaped, as in the example.
+  * **PositionalDefaults**: marks a struct to have additional constructors simulating optional positional parameters in
+  Java. Can only be applied to a struct that has at least one field with a default value. Please note that combining
+  this attribute with internal (see `Visibility` above) fields is not supported.
   * ~~**Builder**~~: **deprecated**. Marks a struct type to have a "builder" pattern generated in
   Java.
 * **@Swift**: marks an element with Swift-specific behaviors:

--- a/functional-tests/functional/android/app/src/test/java/com/here/android/test/DefaultsTest.java
+++ b/functional-tests/functional/android/app/src/test/java/com/here/android/test/DefaultsTest.java
@@ -196,4 +196,51 @@ public final class DefaultsTest {
     assertEquals(SomethingEnum.LAST, result.lastField);
     assertEquals(SomethingEnum.REALLY_FIRST, StructWithEnums.FIRST_CONSTANT);
   }
+
+  @Test
+  public void testPositionalDefaultsFreeArgsCtor() {
+    StructWithJavaPositionalDefaults result = new StructWithJavaPositionalDefaults("Foo", true);
+
+    assertEquals(42, result.firstInitField);
+    assertEquals("Foo", result.firstFreeField);
+    assertEquals(7.2f, result.secondInitField);
+    assertEquals(true, result.secondFreeField);
+    assertEquals("\\Jonny \"Magic\" Smith\n", result.thirdInitField);
+  }
+
+  @Test
+  public void testPositionalDefaultsOneInitArgCtor() {
+    StructWithJavaPositionalDefaults result =
+        new StructWithJavaPositionalDefaults("Foo", true, -17);
+
+    assertEquals(-17, result.firstInitField);
+    assertEquals("Foo", result.firstFreeField);
+    assertEquals(7.2f, result.secondInitField);
+    assertEquals(true, result.secondFreeField);
+    assertEquals("\\Jonny \"Magic\" Smith\n", result.thirdInitField);
+  }
+
+  @Test
+  public void testPositionalDefaultsTwoInitArgsCtor() {
+    StructWithJavaPositionalDefaults result =
+        new StructWithJavaPositionalDefaults("Foo", true, -17, 3.14f);
+
+    assertEquals(-17, result.firstInitField);
+    assertEquals("Foo", result.firstFreeField);
+    assertEquals(3.14f, result.secondInitField);
+    assertEquals(true, result.secondFreeField);
+    assertEquals("\\Jonny \"Magic\" Smith\n", result.thirdInitField);
+  }
+
+  @Test
+  public void testPositionalDefaultsThreeInitArgsCtor() {
+    StructWithJavaPositionalDefaults result =
+        new StructWithJavaPositionalDefaults("Foo", true, -17, 3.14f, "bar");
+
+    assertEquals(-17, result.firstInitField);
+    assertEquals("Foo", result.firstFreeField);
+    assertEquals(3.14f, result.secondInitField);
+    assertEquals(true, result.secondFreeField);
+    assertEquals("bar", result.thirdInitField);
+  }
 }

--- a/functional-tests/functional/input/lime/PositionalDefaults.lime
+++ b/functional-tests/functional/input/lime/PositionalDefaults.lime
@@ -30,3 +30,13 @@ struct StructWithAllDefaults {
     intField: Int = 42
     stringField: String = "\\Jonny \"Magic\" Smith\n"
 }
+
+@Java(PositionalDefaults)
+@Swift(Skip) @Dart(Skip)
+struct StructWithJavaPositionalDefaults {
+    firstInitField: Int = 42
+    firstFreeField: String
+    secondInitField: Float = 7.2
+    secondFreeField: Boolean
+    thirdInitField: String = "\\Jonny \"Magic\" Smith\n"
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/TemplateEngine.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/templates/TemplateEngine.kt
@@ -61,6 +61,7 @@ object TemplateEngine {
                     .addIsNotEqual()
                     .addInclude()
                     .addJoin()
+                    .addNumExpr()
                     .addSet()
                     .build()
             )

--- a/gluecodium/src/main/resources/templates/java/JavaStruct.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaStruct.mustache
@@ -53,8 +53,10 @@
 {{#fields}}        this.{{resolveName}} = {{#if defaultValue}}{{resolveName defaultValue}}{{/if}}{{!!
                    }}{{#unless defaultValue}}{{resolveName}}{{/unless}};
 {{/fields}}
-    }{{#if initializedFields}}
+    }
 
+{{#if initializedFields}}
+{{#unless attributes.java.positionalDefaults}}
 {{#unless constructorComment.isEmpty}}
     /**
 {{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
@@ -67,8 +69,37 @@
     }}({{joinPartial fields "java/JavaParameter" ", "}}) {
 {{#fields}}        this.{{resolveName}} = {{resolveName}};
 {{/fields}}
-    }{{/if}}
-{{/unless}}{{/if}}
+    }
+{{/unless}}{{!!
+
+}}{{#if attributes.java.positionalDefaults}}{{#set noAttributes=true struct=this}}
+{{#initializedFields}}{{#set fieldIndex=iter.index}}
+
+{{#unless constructorComment.isEmpty}}
+    /**
+{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
+{{#uninitializedFields}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/uninitializedFields}}
+{{#initializedFields}}{{#numExpr iter.index fieldIndex op="le"}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/numExpr}}{{/initializedFields}}
+     */
+{{/unless}}
+    {{#struct}}{{>structVisibility}}{{resolveName}}{{/struct}}{{!!
+    }}({{#uninitializedFields}}{{>java/JavaParameter}}, {{/uninitializedFields}}{{!!
+    }}{{#initializedFields}}{{#numExpr iter.index fieldIndex op="le"}}{{>java/JavaParameter}}{{/numExpr}}{{!!
+    }}{{#numExpr iter.index fieldIndex op="lt"}}, {{/numExpr}}{{/initializedFields}}) {
+{{#uninitializedFields}}        this.{{resolveName}} = {{resolveName}};
+{{/uninitializedFields}}
+{{#initializedFields}}        {{#numExpr iter.index fieldIndex op="le"}}this.{{resolveName}} = {{resolveName}};
+{{/numExpr}}{{!!
+}}{{#numExpr iter.index fieldIndex op="gt"}}this.{{resolveName}} = {{resolveName defaultValue}};
+{{/numExpr}}{{/initializedFields}}
+    }
+{{/set}}{{/initializedFields}}
+{{/set}}{{/if}}{{!!
+}}{{/if}}{{/unless}}{{/if}}
 {{#unless external.java.name}}{{#if attributes.serializable}}{{prefixPartial "java/ParcelableImpl" "    "}}
 
 {{/if}}

--- a/gluecodium/src/test/resources/smoke/defaults/input/PositionalDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/PositionalDefaults.lime
@@ -30,3 +30,20 @@ struct StructWithAllDefaults {
     intField: Int = 42
     stringField: String = "\\Jonny \"Magic\" Smith\n"
 }
+
+// Foo Bar this is a comment
+// @constructor buzz fizz
+@Java(PositionalDefaults)
+@Swift(Skip) @Dart(Skip)
+struct StructWithJavaPositionalDefaults {
+    // first init!
+    firstInitField: Int = 42
+    // first free!
+    firstFreeField: String
+    // second init yeah!
+    secondInitField: Float = 7.2
+    // second free here!
+    secondFreeField: Boolean
+    // third should be last!
+    thirdInitField: String = "\\Jonny \"Magic\" Smith\n"
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/StructWithJavaPositionalDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/StructWithJavaPositionalDefaults.java
@@ -1,0 +1,86 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+/**
+ * <p>Foo Bar this is a comment</p>
+ */
+public final class StructWithJavaPositionalDefaults {
+    /**
+     * <p>first init!</p>
+     */
+    public int firstInitField;
+    /**
+     * <p>first free!</p>
+     */
+    @NonNull
+    public String firstFreeField;
+    /**
+     * <p>second init yeah!</p>
+     */
+    public float secondInitField;
+    /**
+     * <p>second free here!</p>
+     */
+    public boolean secondFreeField;
+    /**
+     * <p>third should be last!</p>
+     */
+    @NonNull
+    public String thirdInitField;
+    /**
+     * <p>buzz fizz</p>
+     * @param firstFreeField <p>first free!</p>
+     * @param secondFreeField <p>second free here!</p>
+     */
+    public StructWithJavaPositionalDefaults(@NonNull final String firstFreeField, final boolean secondFreeField) {
+        this.firstInitField = 42;
+        this.firstFreeField = firstFreeField;
+        this.secondInitField = 7.2f;
+        this.secondFreeField = secondFreeField;
+        this.thirdInitField = "\\Jonny \"Magic\" Smith\n";
+    }
+    /**
+     * <p>buzz fizz</p>
+     * @param firstFreeField <p>first free!</p>
+     * @param secondFreeField <p>second free here!</p>
+     * @param firstInitField <p>first init!</p>
+     */
+    public StructWithJavaPositionalDefaults(@NonNull final String firstFreeField, final boolean secondFreeField, final int firstInitField) {
+        this.firstFreeField = firstFreeField;
+        this.secondFreeField = secondFreeField;
+        this.firstInitField = firstInitField;
+        this.secondInitField = 7.2f;
+        this.thirdInitField = "\\Jonny \"Magic\" Smith\n";
+    }
+    /**
+     * <p>buzz fizz</p>
+     * @param firstFreeField <p>first free!</p>
+     * @param secondFreeField <p>second free here!</p>
+     * @param firstInitField <p>first init!</p>
+     * @param secondInitField <p>second init yeah!</p>
+     */
+    public StructWithJavaPositionalDefaults(@NonNull final String firstFreeField, final boolean secondFreeField, final int firstInitField, final float secondInitField) {
+        this.firstFreeField = firstFreeField;
+        this.secondFreeField = secondFreeField;
+        this.firstInitField = firstInitField;
+        this.secondInitField = secondInitField;
+        this.thirdInitField = "\\Jonny \"Magic\" Smith\n";
+    }
+    /**
+     * <p>buzz fizz</p>
+     * @param firstFreeField <p>first free!</p>
+     * @param secondFreeField <p>second free here!</p>
+     * @param firstInitField <p>first init!</p>
+     * @param secondInitField <p>second init yeah!</p>
+     * @param thirdInitField <p>third should be last!</p>
+     */
+    public StructWithJavaPositionalDefaults(@NonNull final String firstFreeField, final boolean secondFreeField, final int firstInitField, final float secondInitField, @NonNull final String thirdInitField) {
+        this.firstFreeField = firstFreeField;
+        this.secondFreeField = secondFreeField;
+        this.firstInitField = firstInitField;
+        this.secondInitField = secondInitField;
+        this.thirdInitField = thirdInitField;
+    }
+}


### PR DESCRIPTION
Updated JavaStruct.mustache to add support for `@Java(PositionalDefaults)` attribute. Similar;y to what this attribute
already does for Dart, the generated code with this attributes imitates constructors with parameter default values in
Java. Given the limitations of Java language, this means generating as many separate constructors as there are
initialized fields.

Added smoke and functional tests.

Resolves: #795
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>