### PR TITLE
Autodiscover LIME loaders with SPI

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -29,7 +29,6 @@ import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.GeneratorSuite
 import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.generator.lime.LimeGeneratorSuite
-import com.here.gluecodium.loader.getLoader
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeModel
@@ -61,7 +60,7 @@ import kotlin.system.exitProcess
 
 class Gluecodium(
     private val options: Options,
-    private val modelLoader: LimeModelLoader = LimeModelLoader.getLoader()
+    private val modelLoader: LimeModelLoader = LimeModelLoader.getLoaders().first()
 ) {
     internal val cache = SplitSourceSetCache(
         options.outputDir,

--- a/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
@@ -27,7 +27,6 @@ import com.here.gluecodium.generator.dart.DartGeneratorSuite
 import com.here.gluecodium.generator.java.JavaGeneratorSuite
 import com.here.gluecodium.generator.lime.LimeGeneratorSuite
 import com.here.gluecodium.generator.swift.SwiftGeneratorSuite
-import com.here.gluecodium.loader.getLoader
 import com.here.gluecodium.model.lime.LimeModelLoader
 import com.here.gluecodium.test.NiceErrorCollector
 import io.mockk.every
@@ -148,7 +147,7 @@ class SmokeTest(
         )
         private val GENERATOR_DIRECTORIES = hashMapOf<String, List<String>>()
 
-        private val LOADER = LimeModelLoader.getLoader()
+        private val LOADER = LimeModelLoader.getLoaders().first()
 
         init {
             GENERATOR_DIRECTORIES[CppGeneratorSuite.GENERATOR_NAME] =

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/LimeBasedLimeModelLoader.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/LimeBasedLimeModelLoader.kt
@@ -35,7 +35,7 @@ import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.antlr.v4.runtime.tree.ParseTreeWalker
 
-internal class LimeBasedLimeModelLoader : LimeModelLoader {
+class LimeBasedLimeModelLoader : LimeModelLoader {
     private val logger = Logger.getLogger(LimeBasedLimeModelLoader::class.java.name)
 
     override fun loadModel(idlSources: List<String>, auxiliaryIdlSources: List<String>): LimeModel {
@@ -126,5 +126,3 @@ internal class LimeBasedLimeModelLoader : LimeModelLoader {
         }
     }
 }
-
-fun LimeModelLoader.Companion.getLoader(): LimeModelLoader = LimeBasedLimeModelLoader()

--- a/lime-loader/src/main/resources/META-INF/services/com.here.gluecodium.model.lime.LimeModelLoader
+++ b/lime-loader/src/main/resources/META-INF/services/com.here.gluecodium.model.lime.LimeModelLoader
@@ -1,0 +1,1 @@
+com.here.gluecodium.loader.LimeBasedLimeModelLoader

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeModelLoader.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeModelLoader.kt
@@ -19,14 +19,17 @@
 
 package com.here.gluecodium.model.lime
 
+import java.util.ServiceLoader
+
 /**
  * Abstraction for modules that load the LIME models from some source (usually files) into the
  * in-memory representation. The intent is to reduce the coupling between loader modules and the
- * rest of the binary to absolute minimum.
+ * rest of the binary to an absolute minimum.
  */
 interface LimeModelLoader {
     fun loadModel(idlSources: List<String>, auxiliaryIdlSources: List<String>): LimeModel
 
-    // Injection point for static "getLoader()" extensions.
-    companion object
+    companion object {
+        fun getLoaders() = ServiceLoader.load(LimeModelLoader::class.java).iterator().asSequence()
+    }
 }


### PR DESCRIPTION
Updated LimeModelLoader to be available through Java "Service Provider Interface" (SPI) mechanism. Updated Gluecodium
class to use SPI to locate the loader.

See: #804
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>