### PR TITLE
Rename "GeneratorSuite" to "Generator"

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -26,9 +26,9 @@ import com.here.gluecodium.cli.OptionReaderException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.common.LimeModelFilter
 import com.here.gluecodium.generator.common.GeneratedFile
-import com.here.gluecodium.generator.common.GeneratorSuite
+import com.here.gluecodium.generator.common.Generator
 import com.here.gluecodium.generator.common.templates.TemplateEngine
-import com.here.gluecodium.generator.lime.LimeGeneratorSuite
+import com.here.gluecodium.generator.lime.LimeGenerator
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeModel
@@ -106,7 +106,7 @@ class Gluecodium(
         var executionSucceeded = false
         try {
             executionSucceeded = discoverGenerators().all {
-                val model = if (it == LimeGeneratorSuite.GENERATOR_NAME) limeModel else filteredModel
+                val model = if (it == LimeGenerator.GENERATOR_NAME) limeModel else filteredModel
                 executeGenerator(it, model, fileNamesCache)
             }
         } finally {
@@ -122,7 +122,7 @@ class Gluecodium(
         fileNamesCache: MutableMap<String, String>
     ): Boolean {
         LOGGER.fine("Using generator '$generatorName'")
-        val generator = GeneratorSuite.instantiateByShortName(generatorName, options)
+        val generator = Generator.instantiateByShortName(generatorName, options)
         if (generator == null) {
             LOGGER.severe("Failed instantiation of generator '$generatorName'")
             return false
@@ -147,7 +147,7 @@ class Gluecodium(
         if (generators.isNotEmpty()) {
             LOGGER.fine("Following generators were specified on command line: $generators")
         } else {
-            generators = GeneratorSuite.generatorShortNames()
+            generators = Generator.generatorShortNames()
             LOGGER.fine("No generators specified, using all available generators: $generators")
         }
         return generators

--- a/gluecodium/src/main/java/com/here/gluecodium/cache/SplitSourceSetCache.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cache/SplitSourceSetCache.kt
@@ -22,7 +22,7 @@ package com.here.gluecodium.cache
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.GeneratedFile.SourceSet.COMMON
 import com.here.gluecodium.generator.common.GeneratedFile.SourceSet.MAIN
-import com.here.gluecodium.generator.common.GeneratorSuite
+import com.here.gluecodium.generator.common.Generator
 import java.io.File
 
 /**
@@ -65,7 +65,7 @@ class SplitSourceSetCache(
         mainCacheStrategy = CachingStrategyCreator.initializeCaching(
             isEnableCaching,
             outputDir,
-            GeneratorSuite.generatorShortNames()
+            Generator.generatorShortNames()
         )
     }
 
@@ -73,7 +73,7 @@ class SplitSourceSetCache(
         commonCacheStrategy = CachingStrategyCreator.initializeCaching(
             isEnableCaching,
             commonOutputDir,
-            GeneratorSuite.generatorShortNames()
+            Generator.generatorShortNames()
         )
     }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -21,7 +21,7 @@ package com.here.gluecodium.cli
 
 import com.here.gluecodium.Gluecodium
 import com.here.gluecodium.common.CaseInsensitiveSet
-import com.here.gluecodium.generator.common.GeneratorSuite
+import com.here.gluecodium.generator.common.Generator
 import com.natpryce.konfig.Configuration
 import com.natpryce.konfig.ConfigurationProperties
 import com.natpryce.konfig.Key
@@ -84,7 +84,7 @@ object OptionReader {
             "generators",
             true,
             "List of generators to use, separated by comma. If empty, all available generators are used. Available generators: " +
-                    GeneratorSuite.generatorShortNames().joinToString(", ") + "\n"
+                    Generator.generatorShortNames().joinToString(", ") + "\n"
         ).apply {
             valueSeparator = ','
             setOptionalArg(true)
@@ -180,7 +180,7 @@ object OptionReader {
         options.javaNonNullAnnotation = parseAnnotation(getStringValue("javanonnullannotation"))
         options.javaNullableAnnotation = parseAnnotation(getStringValue("javanullableannotation"))
         options.javaInternalPackages = getStringValue("intpackage")?.split(".") ?: emptyList()
-        options.generators = getStringListValue("generators")?.toSet() ?: GeneratorSuite.generatorShortNames()
+        options.generators = getStringListValue("generators")?.toSet() ?: Generator.generatorShortNames()
 
         options.isValidatingOnly = getFlagValue("validate")
         options.isEnableCaching = getFlagValue("output") && getFlagValue("cache")

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
@@ -23,7 +23,7 @@ import com.here.gluecodium.common.LimeTypeRefsVisitor
 import com.here.gluecodium.generator.cbridge.CBridgeNameRules.CBRIDGE_INTERNAL
 import com.here.gluecodium.generator.cbridge.CBridgeNameRules.CBRIDGE_PUBLIC
 import com.here.gluecodium.generator.common.GeneratedFile
-import com.here.gluecodium.generator.common.GeneratorSuite
+import com.here.gluecodium.generator.common.Generator
 import com.here.gluecodium.generator.common.Include
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.templates.TemplateEngine
@@ -224,14 +224,14 @@ internal class CBridgeGenerator(
         private val PROXY_CACHE_FILENAME = Paths.get(CBRIDGE_INTERNAL, INCLUDE_DIR, "CachedProxyBase.h").toString()
 
         val STATIC_FILES = listOf(
-            GeneratorSuite.copyCommonFile(BASE_HANDLE_FILE, ""),
-            GeneratorSuite.copyCommonFile(STRING_HANDLE_FILE, ""),
-            GeneratorSuite.copyCommonFile(DATE_HANDLE_FILE, ""),
-            GeneratorSuite.copyCommonFile(EXPORT_FILE, ""),
-            GeneratorSuite.copyCommonFile(Paths.get(CBRIDGE_PUBLIC, INCLUDE_DIR, "BuiltinHandle.h").toString(), ""),
-            GeneratorSuite.copyCommonFile(Paths.get(CBRIDGE_PUBLIC, INCLUDE_DIR, "ByteArrayHandle.h").toString(), ""),
-            GeneratorSuite.copyCommonFile(Paths.get(CBRIDGE_PUBLIC, INCLUDE_DIR, "LocaleHandle.h").toString(), ""),
-            GeneratorSuite.copyCommonFile(PROXY_CACHE_FILENAME, "")
+            Generator.copyCommonFile(BASE_HANDLE_FILE, ""),
+            Generator.copyCommonFile(STRING_HANDLE_FILE, ""),
+            Generator.copyCommonFile(DATE_HANDLE_FILE, ""),
+            Generator.copyCommonFile(EXPORT_FILE, ""),
+            Generator.copyCommonFile(Paths.get(CBRIDGE_PUBLIC, INCLUDE_DIR, "BuiltinHandle.h").toString(), ""),
+            Generator.copyCommonFile(Paths.get(CBRIDGE_PUBLIC, INCLUDE_DIR, "ByteArrayHandle.h").toString(), ""),
+            Generator.copyCommonFile(Paths.get(CBRIDGE_PUBLIC, INCLUDE_DIR, "LocaleHandle.h").toString(), ""),
+            Generator.copyCommonFile(PROXY_CACHE_FILENAME, "")
         )
 
         fun getAllParentTypes(allTypes: List<LimeType>): List<LimeType> {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/Generator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/Generator.kt
@@ -21,17 +21,17 @@ package com.here.gluecodium.generator.common
 
 import com.here.gluecodium.Gluecodium
 import com.here.gluecodium.cli.GluecodiumExecutionException
-import com.here.gluecodium.generator.cpp.CppGeneratorSuite
-import com.here.gluecodium.generator.dart.DartGeneratorSuite
-import com.here.gluecodium.generator.java.JavaGeneratorSuite
-import com.here.gluecodium.generator.lime.LimeGeneratorSuite
-import com.here.gluecodium.generator.swift.SwiftGeneratorSuite
+import com.here.gluecodium.generator.cpp.CppGenerator
+import com.here.gluecodium.generator.dart.DartGenerator
+import com.here.gluecodium.generator.java.JavaGenerator
+import com.here.gluecodium.generator.lime.LimeGenerator
+import com.here.gluecodium.generator.swift.SwiftGenerator
 import com.here.gluecodium.model.lime.LimeModel
 import java.io.File
 import java.io.IOException
 
 /** The base interface for all the generators.  */
-interface GeneratorSuite {
+interface Generator {
 
     /**
      * Triggers the generation. The model is assumed to be valid.
@@ -45,25 +45,25 @@ interface GeneratorSuite {
         /** Creates a new instance of a generator suite by its short identifier  */
         fun instantiateByShortName(shortName: String, options: Gluecodium.Options) =
             when (shortName) {
-                JavaGeneratorSuite.GENERATOR_NAME -> JavaGeneratorSuite(options)
-                CppGeneratorSuite.GENERATOR_NAME -> CppGeneratorSuite(options)
-                SwiftGeneratorSuite.GENERATOR_NAME -> SwiftGeneratorSuite(options)
-                LimeGeneratorSuite.GENERATOR_NAME -> LimeGeneratorSuite()
-                DartGeneratorSuite.GENERATOR_NAME -> DartGeneratorSuite(options)
+                JavaGenerator.GENERATOR_NAME -> JavaGenerator(options)
+                CppGenerator.GENERATOR_NAME -> CppGenerator(options)
+                SwiftGenerator.GENERATOR_NAME -> SwiftGenerator(options)
+                LimeGenerator.GENERATOR_NAME -> LimeGenerator()
+                DartGenerator.GENERATOR_NAME -> DartGenerator(options)
                 else -> null
             }
 
         /** @return all available generators */
         fun generatorShortNames() = setOf(
-                JavaGeneratorSuite.GENERATOR_NAME,
-                CppGeneratorSuite.GENERATOR_NAME,
-                SwiftGeneratorSuite.GENERATOR_NAME,
-                LimeGeneratorSuite.GENERATOR_NAME,
-                DartGeneratorSuite.GENERATOR_NAME
+                JavaGenerator.GENERATOR_NAME,
+                CppGenerator.GENERATOR_NAME,
+                SwiftGenerator.GENERATOR_NAME,
+                LimeGenerator.GENERATOR_NAME,
+                DartGenerator.GENERATOR_NAME
         )
 
         fun copyCommonFile(fileName: String, targetDir: String): GeneratedFile {
-            val stream = GeneratorSuite::class.java.classLoader.getResourceAsStream(fileName)
+            val stream = Generator::class.java.classLoader.getResourceAsStream(fileName)
                     ?: throw GluecodiumExecutionException(String.format("Failed loading resource %s.", fileName))
 
             return try {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGenerator.kt
@@ -23,7 +23,7 @@ import com.here.gluecodium.Gluecodium
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.generator.common.GeneratedFile
-import com.here.gluecodium.generator.common.GeneratorSuite
+import com.here.gluecodium.generator.common.Generator
 import com.here.gluecodium.generator.common.Include
 import com.here.gluecodium.generator.common.NameHelper
 import com.here.gluecodium.generator.common.NameResolver
@@ -60,7 +60,7 @@ import java.util.logging.Logger
  * Main class for the C++ generator. Collects the template data from the LIME model, applies the
  * templates to it and returns the list of generated files.
  */
-internal class CppGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
+internal class CppGenerator(options: Gluecodium.Options) : Generator {
 
     private val nameRules =
         CppNameRules(options.cppRootNamespace, nameRuleSetFromConfig(options.cppNameRules))
@@ -376,7 +376,7 @@ internal class CppGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
     companion object {
         const val GENERATOR_NAME = "cpp"
 
-        private val logger = Logger.getLogger(CppGeneratorSuite::class.java.name)
+        private val logger = Logger.getLogger(CppGenerator::class.java.name)
         private val COMMON_HEADERS = listOf(
             "Hash",
             "Locale",

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -27,7 +27,7 @@ import com.here.gluecodium.common.LimeTypeRefsVisitor
 import com.here.gluecodium.generator.common.CommonGeneratorPredicates
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.GeneratedFile.SourceSet.COMMON
-import com.here.gluecodium.generator.common.GeneratorSuite
+import com.here.gluecodium.generator.common.Generator
 import com.here.gluecodium.generator.common.Include
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.NameRules
@@ -67,7 +67,7 @@ import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeTypesCollection
 import java.util.logging.Logger
 
-class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
+class DartGenerator(options: Gluecodium.Options) : Generator {
 
     private val libraryName = options.libraryName
     private val lookupErrorMessage = options.dartLookupErrorMessage
@@ -500,7 +500,7 @@ class DartGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
     companion object {
         const val GENERATOR_NAME = "dart"
 
-        private val logger = Logger.getLogger(DartGeneratorSuite::class.java.name)
+        private val logger = Logger.getLogger(DartGenerator::class.java.name)
         private const val ROOT_DIR = GENERATOR_NAME
         private const val LIB_DIR = "$ROOT_DIR/lib"
         private const val SRC_DIR_SUFFIX = "src"

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -24,7 +24,7 @@ import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.common.LimeModelFilter
 import com.here.gluecodium.generator.common.GeneratedFile
-import com.here.gluecodium.generator.common.GeneratorSuite
+import com.here.gluecodium.generator.common.Generator
 import com.here.gluecodium.generator.common.nameRuleSetFromConfig
 import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.generator.cpp.CppNameCache
@@ -54,7 +54,7 @@ import java.util.logging.Logger
 /**
  * Combines Java and JNI templates to generate Java code and bindings to C++ layer for Java.
  */
-internal class JavaGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
+internal class JavaGenerator(options: Gluecodium.Options) : Generator {
 
     private val internalPackage = options.javaInternalPackages
     private val internalNamespace = options.cppInternalNamespace
@@ -230,7 +230,7 @@ internal class JavaGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite 
     companion object {
         const val GENERATOR_NAME = "android"
 
-        private val logger = Logger.getLogger(JavaGeneratorSuite::class.java.name)
+        private val logger = Logger.getLogger(JavaGenerator::class.java.name)
 
         private val UTILS_FILES = listOf(
             "CppProxyBase",

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/lime/LimeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/lime/LimeGenerator.kt
@@ -21,7 +21,7 @@ package com.here.gluecodium.generator.lime
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.generator.common.GeneratedFile
-import com.here.gluecodium.generator.common.GeneratorSuite
+import com.here.gluecodium.generator.common.Generator
 import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
@@ -45,7 +45,7 @@ import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeTypedElement
 import com.here.gluecodium.model.lime.LimeTypesCollection
 
-class LimeGeneratorSuite : GeneratorSuite {
+class LimeGenerator : Generator {
 
     override fun generate(limeModel: LimeModel) = limeModel.topElements.map { generate(it) }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -28,7 +28,7 @@ import com.here.gluecodium.generator.cbridge.CBridgeGenerator
 import com.here.gluecodium.generator.cbridge.CBridgeGenerator.Companion.getAllParentTypes
 import com.here.gluecodium.generator.cbridge.CBridgeNameResolver
 import com.here.gluecodium.generator.common.GeneratedFile
-import com.here.gluecodium.generator.common.GeneratorSuite
+import com.here.gluecodium.generator.common.Generator
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.nameRuleSetFromConfig
 import com.here.gluecodium.generator.common.templates.TemplateEngine
@@ -63,7 +63,7 @@ import java.util.logging.Logger
 /**
  * Generates Swift bindings on top of C++ API.
  */
-class SwiftGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
+class SwiftGenerator(options: Gluecodium.Options) : Generator {
 
     private val internalNamespace = options.cppInternalNamespace
     private val rootNamespace = options.cppRootNamespace
@@ -271,10 +271,10 @@ class SwiftGeneratorSuite(options: Gluecodium.Options) : GeneratorSuite {
         private const val CONVERSION_VISIBILITY_INTERNAL = "internal"
         private const val CONVERSION_VISIBILITY_PUBLIC = "/// :nodoc:\npublic"
 
-        private val logger = Logger.getLogger(SwiftGeneratorSuite::class.java.name)
+        private val logger = Logger.getLogger(SwiftGenerator::class.java.name)
         private val STATIC_FILES = listOf(
-            GeneratorSuite.copyCommonFile("swift/BuiltinConversions.swift", ""),
-            GeneratorSuite.copyCommonFile("swift/NativeBase.swift", "")
+            Generator.copyCommonFile("swift/BuiltinConversions.swift", ""),
+            Generator.copyCommonFile("swift/NativeBase.swift", "")
         )
     }
 }

--- a/gluecodium/src/test/java/com/here/gluecodium/GluecodiumTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/GluecodiumTest.kt
@@ -23,7 +23,7 @@ import com.here.gluecodium.Gluecodium.Options
 import com.here.gluecodium.cache.CachingStrategy
 import com.here.gluecodium.cache.CachingStrategyCreator
 import com.here.gluecodium.generator.common.GeneratedFile
-import com.here.gluecodium.generator.common.GeneratorSuite
+import com.here.gluecodium.generator.common.Generator
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeModelLoader
 import com.here.gluecodium.output.FileOutput
@@ -52,7 +52,7 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class GluecodiumTest {
     @MockK private lateinit var modelLoader: LimeModelLoader
-    @MockK private lateinit var generator: GeneratorSuite
+    @MockK private lateinit var generator: Generator
     @MockK private lateinit var cache: CachingStrategy
 
     @JvmField
@@ -65,7 +65,7 @@ class GluecodiumTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        mockkObject(GeneratorSuite.Companion)
+        mockkObject(Generator.Companion)
         mockkStatic(CachingStrategyCreator::class)
         mockkConstructor(FileOutput::class)
 
@@ -74,7 +74,7 @@ class GluecodiumTest {
         every { cache.write(true) } returns true
         every { cache.write(false) } returns false
 
-        every { GeneratorSuite.instantiateByShortName(any(), any()) } returns generator
+        every { Generator.instantiateByShortName(any(), any()) } returns generator
 
         every { modelLoader.loadModel(any(), any()) } returns LimeModel(emptyMap(), emptyList())
     }
@@ -87,7 +87,7 @@ class GluecodiumTest {
     @Test
     fun failedInstantiationOfGenerator() {
         // Arrange
-        every { GeneratorSuite.instantiateByShortName(any(), any()) } returns null
+        every { Generator.instantiateByShortName(any(), any()) } returns null
         val options = Options(
             idlSources = listOf(""),
             generators = setOf("invalidGenerator")

--- a/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
@@ -22,11 +22,11 @@ package com.here.gluecodium
 import com.here.gluecodium.Gluecodium.Options
 import com.here.gluecodium.cli.OptionReader
 import com.here.gluecodium.generator.common.GeneratedFile
-import com.here.gluecodium.generator.cpp.CppGeneratorSuite
-import com.here.gluecodium.generator.dart.DartGeneratorSuite
-import com.here.gluecodium.generator.java.JavaGeneratorSuite
-import com.here.gluecodium.generator.lime.LimeGeneratorSuite
-import com.here.gluecodium.generator.swift.SwiftGeneratorSuite
+import com.here.gluecodium.generator.cpp.CppGenerator
+import com.here.gluecodium.generator.dart.DartGenerator
+import com.here.gluecodium.generator.java.JavaGenerator
+import com.here.gluecodium.generator.lime.LimeGenerator
+import com.here.gluecodium.generator.swift.SwiftGenerator
 import com.here.gluecodium.model.lime.LimeModelLoader
 import com.here.gluecodium.test.NiceErrorCollector
 import io.mockk.every
@@ -102,7 +102,7 @@ class SmokeTest(
         val limeModel = LOADER.loadModel(listOf(inputDirectory.toString()), listOf(auxDirectory.toString()))
         assertTrue(gluecodium.validateModel(limeModel))
         val filteredModel =
-            if (generatorName == LimeGeneratorSuite.GENERATOR_NAME) limeModel else gluecodium.filterModel(limeModel)
+            if (generatorName == LimeGenerator.GENERATOR_NAME) limeModel else gluecodium.filterModel(limeModel)
         assertTrue(gluecodium.executeGenerator(generatorName, filteredModel, HashMap()))
 
         val generatedContents = results.associateBy({ it.targetFile.path }, { it.content })
@@ -139,27 +139,27 @@ class SmokeTest(
         private const val FEATURE_OUTPUT_FOLDER = "output"
         private const val IGNORE_PREFIX = "ignore"
         private val GENERATOR_NAMES = listOf(
-            CppGeneratorSuite.GENERATOR_NAME,
-            JavaGeneratorSuite.GENERATOR_NAME,
-            SwiftGeneratorSuite.GENERATOR_NAME,
-            LimeGeneratorSuite.GENERATOR_NAME,
-            DartGeneratorSuite.GENERATOR_NAME
+            CppGenerator.GENERATOR_NAME,
+            JavaGenerator.GENERATOR_NAME,
+            SwiftGenerator.GENERATOR_NAME,
+            LimeGenerator.GENERATOR_NAME,
+            DartGenerator.GENERATOR_NAME
         )
         private val GENERATOR_DIRECTORIES = hashMapOf<String, List<String>>()
 
         private val LOADER = LimeModelLoader.getLoaders().first()
 
         init {
-            GENERATOR_DIRECTORIES[CppGeneratorSuite.GENERATOR_NAME] =
-                listOf(CppGeneratorSuite.GENERATOR_NAME)
-            GENERATOR_DIRECTORIES[JavaGeneratorSuite.GENERATOR_NAME] =
-                listOf(JavaGeneratorSuite.GENERATOR_NAME)
-            GENERATOR_DIRECTORIES[SwiftGeneratorSuite.GENERATOR_NAME] =
-                listOf(SwiftGeneratorSuite.GENERATOR_NAME, "cbridge", "cbridge_internal")
-            GENERATOR_DIRECTORIES[LimeGeneratorSuite.GENERATOR_NAME] =
-                listOf(LimeGeneratorSuite.GENERATOR_NAME)
-            GENERATOR_DIRECTORIES[DartGeneratorSuite.GENERATOR_NAME] =
-                listOf(DartGeneratorSuite.GENERATOR_NAME)
+            GENERATOR_DIRECTORIES[CppGenerator.GENERATOR_NAME] =
+                listOf(CppGenerator.GENERATOR_NAME)
+            GENERATOR_DIRECTORIES[JavaGenerator.GENERATOR_NAME] =
+                listOf(JavaGenerator.GENERATOR_NAME)
+            GENERATOR_DIRECTORIES[SwiftGenerator.GENERATOR_NAME] =
+                listOf(SwiftGenerator.GENERATOR_NAME, "cbridge", "cbridge_internal")
+            GENERATOR_DIRECTORIES[LimeGenerator.GENERATOR_NAME] =
+                listOf(LimeGenerator.GENERATOR_NAME)
+            GENERATOR_DIRECTORIES[DartGenerator.GENERATOR_NAME] =
+                listOf(DartGenerator.GENERATOR_NAME)
         }
 
         private const val RESOURCE_PREFIX = "smoke"


### PR DESCRIPTION
"GeneratorSuite" name was a left-over from the old approach where JNI/CBridge were considered separate from Java/Swift
and thus were named "generators" and then grouped into "generator suites". This distinction no longer exists, so renamed
"GeneratorSuite" to "Generator". Renamed the implementing classes accordingly.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>