### PR TITLE
Split generator options from Gluecodium options

### DIFF
--- a/gluecodium-gradle/src/main/java/com/here/gluecodium/gradle/GluecodiumRunner.kt
+++ b/gluecodium-gradle/src/main/java/com/here/gluecodium/gradle/GluecodiumRunner.kt
@@ -22,16 +22,21 @@
 package com.here.gluecodium.gradle
 
 import com.here.gluecodium.Gluecodium
+import com.here.gluecodium.GluecodiumOptions
+import com.here.gluecodium.generator.common.GeneratorOptions
 import org.gradle.api.GradleException
 
 /**
  * Actual functionality of [GluecodiumTask], extracted into a standalone class for testability.
  */
 internal class GluecodiumRunner(
-    private val gluecodiumFactory: (Gluecodium.Options) -> Gluecodium = { Gluecodium(it) }
+    private val gluecodiumFactory: (GluecodiumOptions, GeneratorOptions) -> Gluecodium =
+        { gluecodiumOptions: GluecodiumOptions, generatorOptions: GeneratorOptions ->
+            Gluecodium(gluecodiumOptions, generatorOptions)
+        }
 ) {
-    fun run(options: Gluecodium.Options) {
-        val executionResult = gluecodiumFactory(options).execute()
+    fun run(gluecodiumOptions: GluecodiumOptions, generatorOptions: GeneratorOptions) {
+        val executionResult = gluecodiumFactory(gluecodiumOptions, generatorOptions).execute()
         if (!executionResult) {
             throw GradleException("Gluecodium code generation failed. See log for details.")
         }

--- a/gluecodium-gradle/src/test/java/com/here/gluecodium/gradle/GluecodiumRunnerTest.kt
+++ b/gluecodium-gradle/src/test/java/com/here/gluecodium/gradle/GluecodiumRunnerTest.kt
@@ -20,6 +20,8 @@
 package com.here.gluecodium.gradle
 
 import com.here.gluecodium.Gluecodium
+import com.here.gluecodium.GluecodiumOptions
+import com.here.gluecodium.generator.common.GeneratorOptions
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -38,7 +40,8 @@ internal class GluecodiumRunnerTest {
     val expectedException: ExpectedException = ExpectedException.none()
 
     @MockK lateinit var gluecodium: Gluecodium
-    private val defaultOptions = Gluecodium.Options()
+    private val defaultGluecodiumOptions = GluecodiumOptions()
+    private val defaultGeneratorOptions = GeneratorOptions()
 
     private lateinit var runner: GluecodiumRunner
 
@@ -46,14 +49,14 @@ internal class GluecodiumRunnerTest {
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
 
-        runner = GluecodiumRunner { gluecodium }
+        runner = GluecodiumRunner { _, _ -> gluecodium }
     }
 
     @Test
     fun executeReturningTrueDoesNotThrow() {
         every { gluecodium.execute() } returns true
 
-        runner.run(defaultOptions)
+        runner.run(defaultGluecodiumOptions, defaultGeneratorOptions)
     }
 
     @Test
@@ -61,6 +64,6 @@ internal class GluecodiumRunnerTest {
         every { gluecodium.execute() } returns false
         expectedException.expect(GradleException::class.java)
 
-        runner.run(defaultOptions)
+        runner.run(defaultGluecodiumOptions, defaultGeneratorOptions)
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -27,6 +27,7 @@ import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.common.LimeModelFilter
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.Generator
+import com.here.gluecodium.generator.common.GeneratorOptions
 import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
@@ -47,8 +48,6 @@ import com.here.gluecodium.validator.LimeSkipValidator
 import com.here.gluecodium.validator.LimeStructsValidator
 import com.here.gluecodium.validator.LimeTypeRefTargetValidator
 import com.here.gluecodium.validator.LimeTypeRefsValidator
-import com.natpryce.konfig.Configuration
-import com.natpryce.konfig.ConfigurationProperties
 import java.io.File
 import java.io.IOException
 import java.util.Properties
@@ -58,13 +57,14 @@ import java.util.logging.Logger
 import kotlin.system.exitProcess
 
 class Gluecodium(
-    private val options: Options,
+    private val gluecodiumOptions: GluecodiumOptions,
+    private val generatorOptions: GeneratorOptions,
     private val modelLoader: LimeModelLoader = LimeModelLoader.getLoaders().first()
 ) {
     internal val cache = SplitSourceSetCache(
-        options.outputDir,
-        options.commonOutputDir,
-        options.isEnableCaching
+        gluecodiumOptions.outputDir,
+        gluecodiumOptions.commonOutputDir,
+        gluecodiumOptions.isEnableCaching
     )
 
     init {
@@ -78,13 +78,13 @@ class Gluecodium(
     }
 
     fun execute(): Boolean {
-        if (options.idlSources.isEmpty()) {
+        if (gluecodiumOptions.idlSources.isEmpty()) {
             throw OptionReaderException("input option required")
         }
 
         val limeModel: LimeModel
         try {
-            limeModel = modelLoader.loadModel(options.idlSources, options.auxiliaryIdlSources)
+            limeModel = modelLoader.loadModel(gluecodiumOptions.idlSources, gluecodiumOptions.auxiliaryIdlSources)
         } catch (e: LimeModelLoaderException) {
             LOGGER.severe(e.message)
             return false
@@ -94,11 +94,11 @@ class Gluecodium(
             LOGGER.severe("Validation errors found, see log for details.")
             return false
         }
-        if (options.isValidatingOnly) {
+        if (gluecodiumOptions.isValidatingOnly) {
             return true
         }
 
-        TemplateEngine.initCopyrightHeaderContents(options.copyrightHeaderContents)
+        TemplateEngine.initCopyrightHeaderContents(generatorOptions.copyrightHeaderContents)
 
         val filteredModel = filterModel(limeModel)
         val fileNamesCache = hashMapOf<String, String>()
@@ -126,7 +126,7 @@ class Gluecodium(
         fileNamesCache: MutableMap<String, String>
     ): Boolean {
         LOGGER.fine("Using generator '$generatorName'")
-        val generator = Generator.initializeGenerator(generatorName, options)
+        val generator = Generator.initializeGenerator(generatorName, generatorOptions)
         if (generator == null) {
             LOGGER.severe("Failed initialization of generator '$generatorName'")
             return false
@@ -148,7 +148,7 @@ class Gluecodium(
     }
 
     private fun discoverGenerators(): Set<String> {
-        var generators = options.generators
+        var generators = gluecodiumOptions.generators
         if (generators.isNotEmpty()) {
             LOGGER.fine("Following generators were specified on command line: $generators")
         } else {
@@ -163,7 +163,7 @@ class Gluecodium(
         val mainFiles = filesToBeWritten.filter { it.sourceSet == GeneratedFile.SourceSet.MAIN }
         val commonFiles = filesToBeWritten.filter { it.sourceSet == GeneratedFile.SourceSet.COMMON }
 
-        return saveToDirectory(options.outputDir, mainFiles) && saveToDirectory(options.commonOutputDir, commonFiles)
+        return saveToDirectory(gluecodiumOptions.outputDir, mainFiles) && saveToDirectory(gluecodiumOptions.commonOutputDir, commonFiles)
     }
 
     internal fun validateModel(limeModel: LimeModel): Boolean {
@@ -176,7 +176,7 @@ class Gluecodium(
     }
 
     internal fun filterModel(limeModel: LimeModel) =
-        if (options.tags.isEmpty()) limeModel else LimeModelFilter.filter(limeModel) { !hasSkipTags(it, options.tags) }
+        if (gluecodiumOptions.tags.isEmpty()) limeModel else LimeModelFilter.filter(limeModel) { !hasSkipTags(it, gluecodiumOptions.tags) }
 
     private fun getTypeRefDependentValidators(limeLogger: LimeLogger) =
         listOf<(LimeModel) -> Boolean>(
@@ -195,64 +195,14 @@ class Gluecodium(
             { LimePropertiesValidator(limeLogger).validate(it) },
             { LimeDeprecationsValidator(
                 limeLogger,
-                options.werror.contains(Options.WARNING_DEPRECATED_ATTRIBUTES)
+                generatorOptions.werror.contains(GeneratorOptions.WARNING_DEPRECATED_ATTRIBUTES)
             ).validate(it.topElements) },
             { LimeFunctionsValidator(limeLogger).validate(it) },
             { LimeSkipValidator(limeLogger).validate(it) }
         )
 
-    data class Options(
-        var idlSources: List<String> = emptyList(),
-        var auxiliaryIdlSources: List<String> = emptyList(),
-        var outputDir: String = "",
-        var commonOutputDir: String = "",
-        var javaPackages: List<String> = listOf(),
-        var javaInternalPackages: List<String> = listOf(),
-        var javaNullableAnnotation: Pair<String, List<String>>? = null,
-        var javaNonNullAnnotation: Pair<String, List<String>>? = null,
-        var isValidatingOnly: Boolean = false,
-        var generators: Set<String> = setOf(),
-        var isEnableCaching: Boolean = false,
-        var copyrightHeaderContents: String? = null,
-        var cppInternalNamespace: List<String> = emptyList(),
-        var cppRootNamespace: List<String> = listOf(),
-        var cppExport: String = DEFAULT_CPP_EXPORT_MACRO_NAME,
-        var cppExportCommon: String? = null,
-        var internalPrefix: String? = null,
-        var libraryName: String = "library",
-        var dartLookupErrorMessage: String =
-            "Failed to resolve an FFI function. Perhaps `LibraryContext.init()` was not called.",
-        var werror: Set<String> = emptySet(),
-        var generateStubs: Boolean = false,
-        var tags: Set<String> = emptySet(),
-        var swiftExposeInternals: Boolean = false,
-        var cppNameRules: Configuration = ConfigurationProperties.fromResource(
-            Gluecodium::class.java,
-            "/namerules/cpp.properties"
-        ),
-        var javaNameRules: Configuration = ConfigurationProperties.fromResource(
-            Gluecodium::class.java,
-            "/namerules/java.properties"
-        ),
-        var swiftNameRules: Configuration = ConfigurationProperties.fromResource(
-            Gluecodium::class.java,
-            "/namerules/swift.properties"
-        ),
-        var dartNameRules: Configuration = ConfigurationProperties.fromResource(
-            Gluecodium::class.java,
-            "/namerules/dart.properties"
-        )
-    ) {
-        companion object {
-            const val WARNING_DOC_LINKS = "DocLinks"
-            const val WARNING_DEPRECATED_ATTRIBUTES = "DeprecatedAttributes"
-            const val WARNING_DART_OVERLOADS = "DartOverloads"
-        }
-    }
-
     companion object {
         private val LOGGER = Logger.getLogger(Gluecodium::class.java.name)
-        const val DEFAULT_CPP_EXPORT_MACRO_NAME = "_GLUECODIUM_CPP"
 
         private fun loadVersion(): String {
             val prop = Properties()
@@ -315,7 +265,7 @@ class Gluecodium(
             LOGGER.info("Version: ${loadVersion()}")
             try {
                 val options = OptionReader.read(args)
-                if (options == null || Gluecodium(options).execute()) {
+                if (options == null || Gluecodium(options.first, options.second).execute()) {
                     exitProcess(0)
                 }
             } catch (e: GluecodiumExecutionException) {

--- a/gluecodium/src/main/java/com/here/gluecodium/GluecodiumOptions.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/GluecodiumOptions.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium
+
+data class GluecodiumOptions(
+    var idlSources: List<String> = emptyList(),
+    var auxiliaryIdlSources: List<String> = emptyList(),
+    var outputDir: String = "",
+    var commonOutputDir: String = "",
+    var tags: Set<String> = emptySet(),
+    var generators: Set<String> = setOf(),
+    var isValidatingOnly: Boolean = false,
+    var isEnableCaching: Boolean = false
+)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/Generator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/Generator.kt
@@ -19,7 +19,6 @@
 
 package com.here.gluecodium.generator.common
 
-import com.here.gluecodium.Gluecodium
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.model.lime.LimeModel
 import java.io.File
@@ -37,7 +36,7 @@ interface Generator {
         get() = false
 
     /** Initialize the generator with given options. */
-    fun initialize(options: Gluecodium.Options) {}
+    fun initialize(options: GeneratorOptions) {}
 
     /**
      * Generate files in the output language based on given model. The model is assumed to be valid.
@@ -54,7 +53,7 @@ interface Generator {
         val allGeneratorShortNames
             get() = allGenerators.keys
 
-        fun initializeGenerator(shortName: String, options: Gluecodium.Options) =
+        fun initializeGenerator(shortName: String, options: GeneratorOptions) =
             allGenerators[shortName]?.also { it.initialize(options) }
 
         fun copyCommonFile(fileName: String, targetDir: String): GeneratedFile {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/GeneratorOptions.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/GeneratorOptions.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.common
+
+import com.here.gluecodium.Gluecodium
+import com.natpryce.konfig.Configuration
+import com.natpryce.konfig.ConfigurationProperties
+
+data class GeneratorOptions(
+    var werror: Set<String> = emptySet(),
+    var javaPackages: List<String> = listOf(),
+    var javaInternalPackages: List<String> = listOf(),
+    var javaNullableAnnotation: Pair<String, List<String>>? = null,
+    var javaNonNullAnnotation: Pair<String, List<String>>? = null,
+    var copyrightHeaderContents: String? = null,
+    var cppInternalNamespace: List<String> = emptyList(),
+    var cppRootNamespace: List<String> = listOf(),
+    var cppExport: String = DEFAULT_CPP_EXPORT_MACRO_NAME,
+    var cppExportCommon: String? = null,
+    var internalPrefix: String? = null,
+    var libraryName: String = "library",
+    var dartLookupErrorMessage: String =
+            "Failed to resolve an FFI function. Perhaps `LibraryContext.init()` was not called.",
+    var generateStubs: Boolean = false,
+    var swiftExposeInternals: Boolean = false,
+    var cppNameRules: Configuration = ConfigurationProperties.fromResource(
+            Gluecodium::class.java,
+            "/namerules/cpp.properties"
+        ),
+    var javaNameRules: Configuration = ConfigurationProperties.fromResource(
+            Gluecodium::class.java,
+            "/namerules/java.properties"
+        ),
+    var swiftNameRules: Configuration = ConfigurationProperties.fromResource(
+            Gluecodium::class.java,
+            "/namerules/swift.properties"
+        ),
+    var dartNameRules: Configuration = ConfigurationProperties.fromResource(
+            Gluecodium::class.java,
+            "/namerules/dart.properties"
+        )
+) {
+    companion object {
+        const val WARNING_DOC_LINKS = "DocLinks"
+        const val WARNING_DEPRECATED_ATTRIBUTES = "DeprecatedAttributes"
+        const val WARNING_DART_OVERLOADS = "DartOverloads"
+
+        const val DEFAULT_CPP_EXPORT_MACRO_NAME = "_GLUECODIUM_CPP"
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGenerator.kt
@@ -19,12 +19,12 @@
 
 package com.here.gluecodium.generator.cpp
 
-import com.here.gluecodium.Gluecodium
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.generator.common.CommentsProcessor
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.Generator
+import com.here.gluecodium.generator.common.GeneratorOptions
 import com.here.gluecodium.generator.common.Include
 import com.here.gluecodium.generator.common.NameHelper
 import com.here.gluecodium.generator.common.NameResolver
@@ -73,11 +73,11 @@ internal class CppGenerator : Generator {
 
     override val shortName = GENERATOR_NAME
 
-    override fun initialize(options: Gluecodium.Options) {
+    override fun initialize(options: GeneratorOptions) {
         nameRules = CppNameRules(options.cppRootNamespace, nameRuleSetFromConfig(options.cppNameRules))
         rootNamespace = options.cppRootNamespace
         internalNamespace = options.cppInternalNamespace
-        commentsProcessor = DoxygenCommentsProcessor(options.werror.contains(Gluecodium.Options.WARNING_DOC_LINKS))
+        commentsProcessor = DoxygenCommentsProcessor(options.werror.contains(GeneratorOptions.WARNING_DOC_LINKS))
         exportName = options.cppExport
         exportCommonName = options.cppExportCommon ?: options.cppExport
         exportInclude = Include.createInternalInclude(Paths.get(

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -19,7 +19,6 @@
 
 package com.here.gluecodium.generator.dart
 
-import com.here.gluecodium.Gluecodium
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.common.LimeModelFilter
@@ -29,6 +28,7 @@ import com.here.gluecodium.generator.common.CommonGeneratorPredicates
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.GeneratedFile.SourceSet.COMMON
 import com.here.gluecodium.generator.common.Generator
+import com.here.gluecodium.generator.common.GeneratorOptions
 import com.here.gluecodium.generator.common.Include
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.NameRules
@@ -83,7 +83,7 @@ internal class DartGenerator : Generator {
 
     override val shortName = "dart"
 
-    override fun initialize(options: Gluecodium.Options) {
+    override fun initialize(options: GeneratorOptions) {
         libraryName = options.libraryName
         lookupErrorMessage = options.dartLookupErrorMessage
         nameRules = NameRules(nameRuleSetFromConfig(options.dartNameRules))
@@ -91,8 +91,8 @@ internal class DartGenerator : Generator {
         rootNamespace = options.cppRootNamespace
         internalNamespace = options.cppInternalNamespace
         internalPrefix = options.internalPrefix ?: ""
-        commentsProcessor = DartCommentsProcessor(options.werror.contains(Gluecodium.Options.WARNING_DOC_LINKS))
-        overloadsWerror = options.werror.contains(Gluecodium.Options.WARNING_DART_OVERLOADS)
+        commentsProcessor = DartCommentsProcessor(options.werror.contains(GeneratorOptions.WARNING_DOC_LINKS))
+        overloadsWerror = options.werror.contains(GeneratorOptions.WARNING_DART_OVERLOADS)
         testableMode = options.generateStubs
     }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -19,13 +19,13 @@
 
 package com.here.gluecodium.generator.java
 
-import com.here.gluecodium.Gluecodium
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.common.LimeModelFilter
 import com.here.gluecodium.generator.common.CommentsProcessor
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.Generator
+import com.here.gluecodium.generator.common.GeneratorOptions
 import com.here.gluecodium.generator.common.nameRuleSetFromConfig
 import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.generator.cpp.CppNameCache
@@ -70,11 +70,11 @@ internal class JavaGenerator : Generator {
 
     override val shortName = GENERATOR_NAME
 
-    override fun initialize(options: Gluecodium.Options) {
+    override fun initialize(options: GeneratorOptions) {
         internalPackage = options.javaInternalPackages
         internalNamespace = options.cppInternalNamespace
         rootNamespace = options.cppRootNamespace
-        commentsProcessor = JavaDocProcessor(options.werror.contains(Gluecodium.Options.WARNING_DOC_LINKS))
+        commentsProcessor = JavaDocProcessor(options.werror.contains(GeneratorOptions.WARNING_DOC_LINKS))
         cppNameRules = CppNameRules(rootNamespace, nameRuleSetFromConfig(options.cppNameRules))
         javaNameRules = JavaNameRules(nameRuleSetFromConfig(options.javaNameRules))
         nonNullAnnotation = annotationFromOption(options.javaNonNullAnnotation)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -19,7 +19,6 @@
 
 package com.here.gluecodium.generator.swift
 
-import com.here.gluecodium.Gluecodium
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.common.LimeModelFilter
@@ -30,6 +29,7 @@ import com.here.gluecodium.generator.cbridge.CBridgeNameResolver
 import com.here.gluecodium.generator.common.CommentsProcessor
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.Generator
+import com.here.gluecodium.generator.common.GeneratorOptions
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.nameRuleSetFromConfig
 import com.here.gluecodium.generator.common.templates.TemplateEngine
@@ -76,10 +76,10 @@ internal class SwiftGenerator : Generator {
 
     override val shortName = "swift"
 
-    override fun initialize(options: Gluecodium.Options) {
+    override fun initialize(options: GeneratorOptions) {
         internalNamespace = options.cppInternalNamespace
         rootNamespace = options.cppRootNamespace
-        commentsProcessor = SwiftCommentsProcessor(options.werror.contains(Gluecodium.Options.WARNING_DOC_LINKS))
+        commentsProcessor = SwiftCommentsProcessor(options.werror.contains(GeneratorOptions.WARNING_DOC_LINKS))
         cppNameRules = CppNameRules(rootNamespace, nameRuleSetFromConfig(options.cppNameRules))
         nameRules = SwiftNameRules(nameRuleSetFromConfig(options.swiftNameRules))
         internalPrefix = options.internalPrefix

--- a/gluecodium/src/test/java/com/here/gluecodium/GluecodiumIntegrationTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/GluecodiumIntegrationTest.kt
@@ -19,8 +19,8 @@
 
 package com.here.gluecodium
 
-import com.here.gluecodium.Gluecodium.Options
 import com.here.gluecodium.generator.common.GeneratedFile
+import com.here.gluecodium.generator.common.GeneratorOptions
 import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -51,15 +51,17 @@ class GluecodiumIntegrationTest {
         val expectedMainFile = File("$mainDir/${mainFile.targetFile}")
         val expectedCommonFile = File("$commonDir/${commonFile.targetFile}")
 
-        val options = Options(
-            cppInternalNamespace = listOf("gluecodium"),
-            javaNonNullAnnotation = Pair("NonNull", listOf("android", "support", "annotation")),
-            javaNullableAnnotation = Pair("Nullable", listOf("android", "support", "annotation")),
+        val gluecodiumOptions = GluecodiumOptions(
             outputDir = mainDir,
             commonOutputDir = commonDir,
             isEnableCaching = true
         )
-        val gluecodium = Gluecodium(options)
+        val generatorOptions = GeneratorOptions(
+            cppInternalNamespace = listOf("gluecodium"),
+            javaNonNullAnnotation = Pair("NonNull", listOf("android", "support", "annotation")),
+            javaNullableAnnotation = Pair("Nullable", listOf("android", "support", "annotation"))
+        )
+        val gluecodium = Gluecodium(gluecodiumOptions, generatorOptions)
 
         gluecodium.output("cpp", listOf(mainFile, commonFile))
         gluecodium.cache.write(true)

--- a/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
@@ -19,10 +19,10 @@
 
 package com.here.gluecodium
 
-import com.here.gluecodium.Gluecodium.Options
 import com.here.gluecodium.cli.OptionReader
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.Generator
+import com.here.gluecodium.generator.common.GeneratorOptions
 import com.here.gluecodium.model.lime.LimeModelLoader
 import com.here.gluecodium.test.NiceErrorCollector
 import io.mockk.every
@@ -54,7 +54,7 @@ class SmokeTest(
 
     private val results = mutableListOf<GeneratedFile>()
 
-    private fun getGluecodiumOptions(): Options {
+    private fun getOptions(): Pair<GluecodiumOptions, GeneratorOptions> {
         val inputDirectory = File(featureDirectory, FEATURE_INPUT_FOLDER)
         val auxDirectory = File(featureDirectory, FEATURE_AUX_FOLDER)
         val commandLineOptions = File(inputDirectory, "commandlineoptions.txt")
@@ -69,12 +69,13 @@ class SmokeTest(
             return options!!
         }
 
-        return TEST_OPTIONS
+        return Pair(GluecodiumOptions(), TEST_OPTIONS)
     }
 
     @Before
     fun setUp() {
-        gluecodium = spyk(Gluecodium(getGluecodiumOptions()))
+        val options = getOptions()
+        gluecodium = spyk(Gluecodium(options.first, options.second))
         every { gluecodium.output(any(), any()) }.answers {
             @Suppress("UNCHECKED_CAST")
             results.addAll(it.invocation.args[1] as List<GeneratedFile>)
@@ -127,7 +128,7 @@ class SmokeTest(
     }
 
     companion object {
-        private val TEST_OPTIONS = Options(
+        private val TEST_OPTIONS = GeneratorOptions(
             cppInternalNamespace = listOf("gluecodium"),
             internalPrefix = "foobar_",
             javaNonNullAnnotation = Pair("NonNull", listOf("android", "support", "annotation")),

--- a/gluecodium/src/test/java/com/here/gluecodium/cli/OptionReaderTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/cli/OptionReaderTest.kt
@@ -76,9 +76,9 @@ class OptionReaderTest {
         val options = OptionReader.read(arrayOf("-input", TEST_INPUT_SINGLE_FOLDER[0]))
 
         // Assert
-        assertNotNull(options!!.idlSources)
-        assertEquals(1, options.idlSources.size)
-        assertEquals(TEST_INPUT_SINGLE_FOLDER[0], options.idlSources[0])
+        assertNotNull(options!!.first.idlSources)
+        assertEquals(1, options.first.idlSources.size)
+        assertEquals(TEST_INPUT_SINGLE_FOLDER[0], options.first.idlSources[0])
     }
 
     @Test
@@ -90,10 +90,10 @@ class OptionReaderTest {
         )
 
         // Assert
-        assertNotNull(options!!.idlSources)
-        assertEquals(2, options.idlSources.size)
-        assertEquals(TEST_INPUT_TWO_FOLDERS[0], options.idlSources[0])
-        assertEquals(TEST_INPUT_TWO_FOLDERS[1], options.idlSources[1])
+        assertNotNull(options!!.first.idlSources)
+        assertEquals(2, options.first.idlSources.size)
+        assertEquals(TEST_INPUT_TWO_FOLDERS[0], options.first.idlSources[0])
+        assertEquals(TEST_INPUT_TWO_FOLDERS[1], options.first.idlSources[1])
     }
 
     @Test
@@ -106,7 +106,7 @@ class OptionReaderTest {
         val options = OptionReader.read(toRead)
 
         // Assert
-        assertEquals(TEST_OUTPUT, options!!.outputDir)
+        assertEquals(TEST_OUTPUT, options!!.first.outputDir)
     }
 
     @Test
@@ -119,7 +119,7 @@ class OptionReaderTest {
         val options = OptionReader.read(toRead)
 
         // Assert
-        val generators = options?.generators
+        val generators = options?.first?.generators
         assertTrue(generators?.contains("cpp") ?: false)
         assertTrue(generators?.contains("java") ?: false)
     }
@@ -134,7 +134,7 @@ class OptionReaderTest {
         val options = OptionReader.read(toRead)
 
         // Assert
-        assertEquals(listOf(TEST_JAVA_PACKAGE_LIST), options!!.javaPackages)
+        assertEquals(listOf(TEST_JAVA_PACKAGE_LIST), options!!.second.javaPackages)
     }
 
     @Test
@@ -159,7 +159,7 @@ class OptionReaderTest {
         val options = OptionReader.read(toRead)
 
         // Assert
-        assertEquals("", options!!.copyrightHeaderContents)
+        assertEquals("", options!!.second.copyrightHeaderContents)
     }
 
     private fun prepareToRead(optionName: String, optionValue: String): Array<String> =


### PR DESCRIPTION
Split Gluecodium.Options class into two separate classes. GluecodiumOptions (moved out of Gluecodium class to the top
level) contains options regarding input and output of Gluecodium as a whole, which are handled by Gluecodium's top level
code. GeneratorOptions contains the rest of the options: both options common to all generators and options for the
individual generators.

This reduces coupling between Gluecodium's top level code and individual generators.

See: #804
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>