### PR TITLE
Update Dart generator to support null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Gluecodium project Release Notes
 
 ## Unreleased
+### Features:
+  * Generated Dart code now supports null safety.
+### Breaking changes:
+  * Generated Dart code now requires minimum Dart version 2.12.0.
 ### Bug fixes:
-  * Fixed missing includes types referenced through type aliases in Dart FFI.
+  * Fixed missing includes for types referenced through type aliases in Dart FFI.
 
 ## 8.13.1
-Release date: 2021-04-28
 ### Bug fixes:
   * Fixed Dart runtime issue when passing a child class of an interface from C++ to Dart and then back to C++.
 

--- a/functional-tests/functional/dart/main.dart
+++ b/functional-tests/functional/dart/main.dart
@@ -121,5 +121,5 @@ void main(List<String> arguments) {
   _allTests.forEach((testCase) => testCase());
   __lib.LibraryContext.release();
 
-  CallbacksMultithreadedTests.main(libraryName);
+  CallbacksMultithreadedTests.main([libraryName]);
 }

--- a/functional-tests/functional/dart/pubspec.yaml.in
+++ b/functional-tests/functional/dart/pubspec.yaml.in
@@ -1,6 +1,6 @@
 name: FunctionalDartTests
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
   test:
   functional:

--- a/functional-tests/functional/dart/test/Blobs_test.dart
+++ b/functional-tests/functional/dart/test/Blobs_test.dart
@@ -52,8 +52,8 @@ void main() {
     expect(result.image, Uint8List.fromList([255, 42, 0]));
   });
   _testSuite.test("methodThatExplodes() throws", () {
-    Uint8List result = null;
-    ExplosiveException exception = null;
+    Uint8List? result = null;
+    ExplosiveException? exception = null;
 
     try {
       result = ArraysByteBuffer.methodThatExplodes(true);
@@ -62,12 +62,11 @@ void main() {
     }
 
     expect(result, isNull);
-    expect(exception, isNotNull);
-    expect(exception.error, ExplosiveErrorCode.exploded);
+    expect(exception?.error, ExplosiveErrorCode.exploded);
   });
   _testSuite.test("methodThatExplodes() does not throw", () {
-    Uint8List result = null;
-    ExplosiveException exception = null;
+    Uint8List? result = null;
+    ExplosiveException? exception = null;
 
     try {
       result = ArraysByteBuffer.methodThatExplodes(false);

--- a/functional-tests/functional/dart/test/CallbacksMultithreaded_test.dart
+++ b/functional-tests/functional/dart/test/CallbacksMultithreaded_test.dart
@@ -34,6 +34,7 @@ class ThreadedListenerImpl implements ThreadedListener {
   @override
   int onEvent(String message) {
     completer.complete(message);
+    return 0;
   }
 
   @override
@@ -46,9 +47,9 @@ class ThreadedListenerImpl implements ThreadedListener {
   void release() {}
 }
 
-void main(String library_name) {
+void main(List<String> args) {
   setUp(() {
-    LibraryContext.init(IsolateOrigin.main, nativeLibraryPath: library_name);
+    LibraryContext.init(IsolateOrigin.main, nativeLibraryPath: args[0]);
   });
   tearDown(() {
     LibraryContext.release();

--- a/functional-tests/functional/dart/test/Dates_test.dart
+++ b/functional-tests/functional/dart/test/Dates_test.dart
@@ -55,11 +55,11 @@ void main() {
 
     final result = Dates.increaseDateMaybe(input);
 
-    expect(result.year, 1971);
-    expect(result.month, 3);
-    expect(result.day, 6);
-    expect(result.hour, 8);
-    expect(result.minute, 10);
-    expect(result.second, 12);
+    expect(result?.year, 1971);
+    expect(result?.month, 3);
+    expect(result?.day, 6);
+    expect(result?.hour, 8);
+    expect(result?.minute, 10);
+    expect(result?.second, 12);
   });
 }

--- a/functional-tests/functional/dart/test/EquatableStructs_test.dart
+++ b/functional-tests/functional/dart/test/EquatableStructs_test.dart
@@ -34,7 +34,7 @@ EquatableStruct createEquatableStruct() {
 }
 
 void main() {
-  EquatableStruct struct;
+  late EquatableStruct struct;
   setUp(() {
     struct = createEquatableStruct();
   });

--- a/functional-tests/functional/dart/test/Exceptions_test.dart
+++ b/functional-tests/functional/dart/test/Exceptions_test.dart
@@ -27,7 +27,7 @@ final _testSuite = TestSuite("Exceptions");
 
 void main() {
   _testSuite.test("methodWithError() throws", () {
-    ErrorsInternalException exception = null;
+    ErrorsInternalException? exception = null;
 
     try {
       Errors.methodWithError(true);
@@ -35,11 +35,10 @@ void main() {
       exception = e;
     }
 
-    expect(exception, isNotNull);
-    expect(exception.error, ErrorsInternalErrorCode.crashed);
+    expect(exception?.error, ErrorsInternalErrorCode.crashed);
   });
   _testSuite.test("methodWithError() does not throw", () {
-    ErrorsInternalException exception = null;
+    ErrorsInternalException? exception = null;
 
     try {
       Errors.methodWithError(false);
@@ -50,8 +49,8 @@ void main() {
     expect(exception, isNull);
   });
   _testSuite.test("methodWithErrorAndString() throws", () {
-    String result = null;
-    AdditionalErrorsExternalException exception = null;
+    String? result = null;
+    AdditionalErrorsExternalException? exception = null;
 
     try {
       result = Errors.methodWithErrorAndString(true);
@@ -60,12 +59,11 @@ void main() {
     }
 
     expect(result, isNull);
-    expect(exception, isNotNull);
-    expect(exception.error, AdditionalErrorsExternalErrorCode.failed);
+    expect(exception?.error, AdditionalErrorsExternalErrorCode.failed);
   });
   _testSuite.test("methodWithErrorAndString() does not throw", () {
-    String result = null;
-    AdditionalErrorsExternalException exception = null;
+    String? result = null;
+    AdditionalErrorsExternalException? exception = null;
 
     try {
       result = Errors.methodWithErrorAndString(false);
@@ -77,7 +75,7 @@ void main() {
     expect(exception, isNull);
   });
   _testSuite.test("methodWithExternalError() throws", () {
-    ErrorsExternalException exception = null;
+    ErrorsExternalException? exception = null;
 
     try {
       Errors.methodWithExternalError(true);
@@ -85,11 +83,10 @@ void main() {
       exception = e;
     }
 
-    expect(exception, isNotNull);
-    expect(exception.error, ErrorsExternalErrorCode.boom);
+    expect(exception?.error, ErrorsExternalErrorCode.boom);
   });
   _testSuite.test("methodWithExternalError() does not throw", () {
-    ErrorsExternalException exception = null;
+    ErrorsExternalException? exception = null;
 
     try {
       Errors.methodWithExternalError(false);
@@ -100,7 +97,7 @@ void main() {
     expect(exception, isNull);
   });
   _testSuite.test("methodWithPayloadError() throws", () {
-    WithPayloadException exception = null;
+    WithPayloadException? exception = null;
 
     try {
       Errors.methodWithPayloadError(true);
@@ -108,12 +105,11 @@ void main() {
       exception = e;
     }
 
-    expect(exception, isNotNull);
-    expect(exception.error.errorCode, 42);
-    expect(exception.error.message, "foo error");
+    expect(exception?.error.errorCode, 42);
+    expect(exception?.error.message, "foo error");
   });
   _testSuite.test("methodWithPayloadError() does not throw", () {
-    WithPayloadException exception = null;
+    WithPayloadException? exception = null;
 
     try {
       Errors.methodWithPayloadError(false);
@@ -124,8 +120,8 @@ void main() {
     expect(exception, isNull);
   });
   _testSuite.test("methodWithPayloadErrorAndReturnValue() throws", () {
-    String result = null;
-    WithPayloadException exception = null;
+    String? result = null;
+    WithPayloadException? exception = null;
 
     try {
       result = Errors.methodWithPayloadErrorAndReturnValue(true);
@@ -134,13 +130,12 @@ void main() {
     }
 
     expect(result, isNull);
-    expect(exception, isNotNull);
-    expect(exception.error.errorCode, 42);
-    expect(exception.error.message, "foo error");
+    expect(exception?.error.errorCode, 42);
+    expect(exception?.error.message, "foo error");
   });
   _testSuite.test("methodWithPayloadErrorAndReturnValue() does not throw", () {
-    String result = null;
-    WithPayloadException exception = null;
+    String? result = null;
+    WithPayloadException? exception = null;
 
     try {
       result = Errors.methodWithPayloadErrorAndReturnValue(false);
@@ -152,8 +147,8 @@ void main() {
     expect(exception, isNull);
   });
   _testSuite.test("Throwing constructor throws", () {
-    ThrowingConstructor result = null;
-    ThrowingConstructorSomeException exception = null;
+    ThrowingConstructor? result = null;
+    ThrowingConstructorSomeException? exception = null;
 
     try {
       result = new ThrowingConstructor(1.0);
@@ -162,12 +157,11 @@ void main() {
     }
 
     expect(result, isNull);
-    expect(exception, isNotNull);
-    expect(exception.error, ThrowingConstructorErrorEnum.crashed);
+    expect(exception?.error, ThrowingConstructorErrorEnum.crashed);
   });
   _testSuite.test("Throwing constructor does not throw", () {
-    ThrowingConstructor result = null;
-    ThrowingConstructorSomeException exception = null;
+    ThrowingConstructor? result = null;
+    ThrowingConstructorSomeException? exception = null;
 
     try {
       result = new ThrowingConstructor(0.0);
@@ -178,6 +172,6 @@ void main() {
     expect(result, isNotNull);
     expect(exception, isNull);
 
-    result.release();
+    result?.release();
   });
 }

--- a/functional-tests/functional/dart/test/Interfaces_test.dart
+++ b/functional-tests/functional/dart/test/Interfaces_test.dart
@@ -124,7 +124,7 @@ void main() {
     result2.release();
   });
   _testSuite.test("Delegator with functions", () {
-    String stringValue;
+    String stringValue = "";
     final delegator = SimpleInterfaceOne.fromLambdas(
       lambda_setStringValue: (value) { stringValue = value; },
       lambda_getStringValue: () => stringValue
@@ -136,7 +136,7 @@ void main() {
     expect(result, "foo");
   });
   _testSuite.test("Delegator with property", () {
-    String stringValue;
+    String stringValue = "";
     final delegator = InterfaceWithProperty.fromLambdas(
       lambda_stringProperty_set: (value) { stringValue = value; },
       lambda_stringProperty_get: () => stringValue

--- a/functional-tests/functional/dart/test/Lambdas_test.dart
+++ b/functional-tests/functional/dart/test/Lambdas_test.dart
@@ -70,7 +70,7 @@ void main() {
   _testSuite.test("Call nullable C++ lambda in Dart", () {
     final lambda = Lambdas.getConcatenatorOrNull(">.<");
 
-    final result = lambda("foo", "bar");
+    final result = lambda!("foo", "bar");
 
     expect(result, "foo>.<bar");
   });
@@ -107,7 +107,7 @@ void main() {
 
     final result = lambda("foo");
 
-    expect(result(), "foo");
+    expect(result!(), "foo");
   });
   _testSuite.test("Call nullable C++ lambda in Dart with null", () {
     final lambda = Lambdas.getNullableConfuser();
@@ -117,14 +117,14 @@ void main() {
     expect(result, isNull);
   });
   _testSuite.test("Call nullable Dart lambda in C++ with value", () {
-    final lambda = (String s1) => s1 != null ? () => s1 : null;
+    final lambda = (String? s1) => s1 != null ? () => s1 : null;
 
     final result = Lambdas.applyNullableConfuser(lambda, "foo");
 
-    expect(result(), "foo");
+    expect(result!(), "foo");
   });
   _testSuite.test("Call nullable Dart lambda in C++ with null", () {
-    final lambda = (String s1) => s1 != null ? () => s1 : null;
+    final lambda = (String? s1) => s1 != null ? () => s1 : null;
 
     final result = Lambdas.applyNullableConfuser(lambda, null);
 

--- a/functional-tests/functional/dart/test/ListenersWithAttributes_test.dart
+++ b/functional-tests/functional/dart/test/ListenersWithAttributes_test.dart
@@ -36,17 +36,16 @@ class TestListener implements ListenerWithAttributes {
   String message = "Doesn't work";
 
   @override
-  MessagePackage packedMessage = null;
+  MessagePackage? packedMessage = null;
 
   @override
-  MessageBox boxedMessage = null;
+  MessageBox? boxedMessage = null;
 
   @override
-  ListenerWithReturnMessageStruct structuredMessage = null;
+  late ListenerWithReturnMessageStruct structuredMessage;
 
   @override
-  ListenerWithReturnMessageEnum enumeratedMessage =
-      ListenerWithReturnMessageEnum.no;
+  ListenerWithReturnMessageEnum enumeratedMessage = ListenerWithReturnMessageEnum.no;
 
   @override
   List<String> arrayedMessage = ["Doesn't work"];
@@ -59,14 +58,14 @@ class TestListener implements ListenerWithAttributes {
 
   @override
   void release() {
-    if (packedMessage != null) packedMessage.release();
-    if (boxedMessage != null) boxedMessage.release();
+    packedMessage?.release();
+    boxedMessage?.release();
   }
 }
 
 void main() {
-  ListenerWithAttributes envelope;
-  AttributedMessageDelivery delivery;
+  late ListenerWithAttributes envelope;
+  late AttributedMessageDelivery delivery;
   setUp(() {
     envelope = TestListener();
     delivery = AttributedMessageDelivery();

--- a/functional-tests/functional/dart/test/ListenersWithErrors_test.dart
+++ b/functional-tests/functional/dart/test/ListenersWithErrors_test.dart
@@ -70,7 +70,7 @@ class ThrowingListener extends ErrorsInInterface {
 }
 
 void main() {
-  ErrorMessenger messenger;
+  late ErrorMessenger messenger;
   setUp(() {
     messenger = ErrorMessenger();
   });
@@ -87,7 +87,7 @@ void main() {
     expect(result, "Works");
   });
   _testSuite.test("getMessage() error rethrown", () {
-    AdditionalErrorsExternalException exception = null;
+    AdditionalErrorsExternalException? exception = null;
     final ErrorsInInterface listener = ThrowingListener();
 
     try {
@@ -96,13 +96,12 @@ void main() {
       exception = e;
     }
 
-    expect(exception, isNotNull);
-    expect(exception.error, AdditionalErrorsExternalErrorCode.failed);
+    expect(exception?.error, AdditionalErrorsExternalErrorCode.failed);
 
     listener.release();
   });
   _testSuite.test("setMessage() error rethrown", () {
-    AdditionalErrorsExternalException exception = null;
+    AdditionalErrorsExternalException? exception = null;
     final ErrorsInInterface listener = ThrowingListener();
 
     try {
@@ -111,13 +110,12 @@ void main() {
       exception = e;
     }
 
-    expect(exception, isNotNull);
-    expect(exception.error, AdditionalErrorsExternalErrorCode.failed);
+    expect(exception?.error, AdditionalErrorsExternalErrorCode.failed);
 
     listener.release();
   });
   _testSuite.test("getMessageWithPayload() error rethrown", () {
-    WithPayloadException exception = null;
+    WithPayloadException? exception = null;
     final ErrorsInInterface listener = ThrowingListener();
 
     try {
@@ -126,13 +124,12 @@ void main() {
       exception = e;
     }
 
-    expect(exception, isNotNull);
-    expect(exception.error, Payload(42, "foo"));
+    expect(exception?.error, Payload(42, "foo"));
 
     listener.release();
   });
   _testSuite.test("setMessageWithPayload() error rethrown", () {
-    WithPayloadException exception = null;
+    WithPayloadException? exception = null;
     final ErrorsInInterface listener = ThrowingListener();
 
     try {
@@ -141,8 +138,7 @@ void main() {
       exception = e;
     }
 
-    expect(exception, isNotNull);
-    expect(exception.error, Payload(42, "foo"));
+    expect(exception?.error, Payload(42, "foo"));
 
     listener.release();
   });

--- a/functional-tests/functional/dart/test/ListenersWithReturnValues_test.dart
+++ b/functional-tests/functional/dart/test/ListenersWithReturnValues_test.dart
@@ -60,8 +60,8 @@ class TestListener extends ListenerWithReturn {
 }
 
 void main() {
-  ListenerWithReturn envelope;
-  MessageDelivery delivery;
+  late ListenerWithReturn envelope;
+  late MessageDelivery delivery;
   setUp(() {
     envelope = TestListener();
     delivery = MessageDelivery();

--- a/functional-tests/functional/dart/test/Maps_test.dart
+++ b/functional-tests/functional/dart/test/Maps_test.dart
@@ -51,8 +51,8 @@ void main() {
 
     final result = Maps.methodWithMapToStruct(input);
 
-    expect(result[31].value, equals("FOO"));
-    expect(result[42].value, equals("BAR"));
+    expect(result[31]?.value, equals("FOO"));
+    expect(result[42]?.value, equals("BAR"));
   });
   _testSuite.test("Empty nested Map round trip", () {
     final input = <int, Map<int, MapsSomeStruct>>{};
@@ -66,8 +66,8 @@ void main() {
 
     final result = Maps.methodWithNestedMap(input);
 
-    expect(result[31][77].value, equals("FOO"));
-    expect(result[42][199].value, equals("BAR"));
+    expect(result[31]?[77]?.value, equals("FOO"));
+    expect(result[42]?[199]?.value, equals("BAR"));
   });
   _testSuite.test("Empty Map in Struct round trip", () {
     final input = MapsStructWithMap({});
@@ -101,12 +101,12 @@ void main() {
 
     final result = Maps.methodWithMapOfInstances(input);
 
-    expect(result["One"].getStringValue(), equals("Functional One"));
-    expect(result["Two"].getStringValue(), equals("Functional Two"));
+    expect(result["One"]?.getStringValue(), equals("Functional One"));
+    expect(result["Two"]?.getStringValue(), equals("Functional Two"));
 
     instance1.release();
     instance2.release();
-    result["One"].release();
-    result["Two"].release();
+    result["One"]?.release();
+    result["Two"]?.release();
   });
 }

--- a/functional-tests/functional/dart/test/MultiListener_test.dart
+++ b/functional-tests/functional/dart/test/MultiListener_test.dart
@@ -25,7 +25,7 @@ import "../test_suite.dart";
 final _testSuite = TestSuite("MultiListener");
 
 class MultiReceiver implements ReceiverA, ReceiverB {
-  final log = List<String>();
+  final log = List<String>.empty(growable: true);
 
   @override
   void receiveA(String message) {

--- a/functional-tests/functional/dart/test/Nesting_test.dart
+++ b/functional-tests/functional/dart/test/Nesting_test.dart
@@ -31,7 +31,7 @@ void main() {
     expect(result.first, 42);
   });
   _testSuite.test("Call a method throwing an exception nested in a struct", () {
-    OuterStructInstantiationException exception = null;
+    OuterStructInstantiationException? exception = null;
 
     try {
       OuterStruct.doNothing();

--- a/functional-tests/functional/dart/test/Nullable_test.dart
+++ b/functional-tests/functional/dart/test/Nullable_test.dart
@@ -26,7 +26,7 @@ import "../test_suite.dart";
 final _testSuite = TestSuite("Nullable");
 
 void main() {
-  NullableInterface instance;
+  late NullableInterface instance;
   setUp(() {
     instance = NullableInterface();
   });
@@ -80,7 +80,7 @@ void main() {
     expect(result.stringField, "");
     expect(result.boolField, isFalse);
     expect(result.doubleField, 0.0);
-    expect(result.structField.stringField, "");
+    expect(result.structField?.stringField, "");
     expect(result.enumField, NullableInterfaceSomeEnum.off);
     expect(result.arrayField, isEmpty);
     expect(result.inlineArrayField, isEmpty);
@@ -105,7 +105,7 @@ void main() {
     expect(result.stringField, "Foo");
     expect(result.boolField, isTrue);
     expect(result.doubleField, 3.14);
-    expect(result.structField.stringField, "Bar");
+    expect(result.structField?.stringField, "Bar");
     expect(result.enumField, NullableInterfaceSomeEnum.on);
     expect(result.arrayField, ["Baz"]);
     expect(result.inlineArrayField, ["Fizz"]);
@@ -234,16 +234,14 @@ void main() {
     expect(result, isNull);
   });
   _testSuite.test("Nullable Struct round trip with zero", () {
-    final result =
-        instance.methodWithSomeStruct(NullableInterfaceSomeStruct(""));
+    final result = instance.methodWithSomeStruct(NullableInterfaceSomeStruct(""));
 
-    expect(result.stringField, "");
+    expect(result?.stringField, "");
   });
   _testSuite.test("Nullable Struct round trip with non-zero", () {
-    final result =
-        instance.methodWithSomeStruct(NullableInterfaceSomeStruct("Foo"));
+    final result = instance.methodWithSomeStruct(NullableInterfaceSomeStruct("Foo"));
 
-    expect(result.stringField, "Foo");
+    expect(result?.stringField, "Foo");
   });
   _testSuite.test("Nullable Enum round trip with null", () {
     final result = instance.methodWithSomeEnum(null);

--- a/functional-tests/functional/dart/test/Properties_test.dart
+++ b/functional-tests/functional/dart/test/Properties_test.dart
@@ -27,7 +27,7 @@ import "../test_suite.dart";
 final _testSuite = TestSuite("Properties");
 
 void main() {
-  Attributes attributes;
+  late Attributes attributes;
   setUp(() {
     attributes = Attributes();
   });
@@ -99,11 +99,11 @@ void main() {
   _testSuite.test("Property in a nested class", () {
     final geometry = VenueGeometry();
     final internalAddress = geometry.internalAddress;
-    final result = internalAddress.longAddress;
+    final result = internalAddress?.longAddress;
 
     expect(result, "foobar");
 
     geometry.release();
-    internalAddress.release();
+    internalAddress?.release();
   });
 }

--- a/functional-tests/functional/dart/test/SimpleEquality_test.dart
+++ b/functional-tests/functional/dart/test/SimpleEquality_test.dart
@@ -25,10 +25,10 @@ import "../test_suite.dart";
 final _testSuite = TestSuite("SimpleEquality");
 
 void main() {
-  NonEquatableClass class1;
-  NonEquatableClass class2;
-  NonEquatableInterface interface1;
-  NonEquatableInterface interface2;
+  late NonEquatableClass class1;
+  late NonEquatableClass class2;
+  late NonEquatableInterface interface1;
+  late NonEquatableInterface interface2;
 
   setUp(() {
     class1 = NonEquatableFactory.createNonEquatableClass();

--- a/functional-tests/functional/dart/test/StructsWithMethods_test.dart
+++ b/functional-tests/functional/dart/test/StructsWithMethods_test.dart
@@ -66,8 +66,8 @@ void main() {
     expect(result, isFalse);
   });
   _testSuite.test("Vector copy constructor does not throw", () {
-    Vector result = null;
-    ValidationException exception = null;
+    Vector? result = null;
+    ValidationException? exception = null;
 
     try {
       result = new Vector.createCopy(vector);
@@ -76,12 +76,12 @@ void main() {
     }
 
     expect(exception, isNull);
-    expect(result.x, 1);
-    expect(result.y, 2);
+    expect(result?.x, 1);
+    expect(result?.y, 2);
   });
   _testSuite.test("Vector copy constructor throws", () {
-    Vector result = null;
-    ValidationException exception = null;
+    Vector? result = null;
+    ValidationException? exception = null;
 
     try {
       result = new Vector.createCopy(new Vector.create(1, double.nan));
@@ -90,8 +90,7 @@ void main() {
     }
 
     expect(result, isNull);
-    expect(exception, isNotNull);
-    expect(exception.error, ValidationErrorCode.validationFailed);
+    expect(exception?.error, ValidationErrorCode.validationFailed);
   });
   _testSuite.test("Vector3 distance to self", () {
     final result = vector3.distanceTo(vector3);
@@ -134,8 +133,8 @@ void main() {
     expect(result, isFalse);
   });
   _testSuite.test("Vector3 copy constructor does not throw", () {
-    StructsWithMethodsInterfaceVector3 result = null;
-    ValidationException exception = null;
+    StructsWithMethodsInterfaceVector3? result = null;
+    ValidationException? exception = null;
 
     try {
       result = new StructsWithMethodsInterfaceVector3.createCopy(vector3);
@@ -144,13 +143,13 @@ void main() {
     }
 
     expect(exception, isNull);
-    expect(result.x, 1);
-    expect(result.y, 2);
-    expect(result.z, 3);
+    expect(result?.x, 1);
+    expect(result?.y, 2);
+    expect(result?.z, 3);
   });
   _testSuite.test("Vector3 copy constructor throws", () {
-    StructsWithMethodsInterfaceVector3 result = null;
-    ValidationException exception = null;
+    StructsWithMethodsInterfaceVector3? result = null;
+    ValidationException? exception = null;
 
     try {
       result = new StructsWithMethodsInterfaceVector3.createCopy(
@@ -161,7 +160,6 @@ void main() {
     }
 
     expect(result, isNull);
-    expect(exception, isNotNull);
-    expect(exception.error, ValidationErrorCode.validationFailed);
+    expect(exception?.error, ValidationErrorCode.validationFailed);
   });
 }

--- a/functional-tests/functional/input/src/dart/season_converter.dart
+++ b/functional-tests/functional/input/src/dart/season_converter.dart
@@ -31,6 +31,8 @@ class SeasonConverter {
         return "summer";
       case String_internal.autumn:
         return "autumn";
+      default:
+        return "";
     }
   }
 
@@ -44,6 +46,8 @@ class SeasonConverter {
         return String_internal.summer;
       case "autumn":
         return String_internal.autumn;
+      default:
+        return String_internal.winter;
     }
   }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -205,7 +205,8 @@ internal class DartNameResolver(
     private fun resolveTypeRefName(limeTypeRef: LimeTypeRef): String {
         val typeName = resolveName(limeTypeRef.type)
         val alias = limeTypeRef.type.actualType.external?.dart?.get(IMPORT_PATH_NAME)?.let { computeAlias(it) }
-        return listOfNotNull(alias, typeName).joinToString(".")
+        val suffix = if (limeTypeRef.isNullable) "?" else ""
+        return listOfNotNull(alias, typeName).joinToString(".") + suffix
     }
 
     private fun buildPathMap(): Map<String, String> {

--- a/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
@@ -89,13 +89,16 @@ final _String_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.loo
   >('{{libraryName}}_std_string_get_value'));
 
 Pointer<Void> String_toFfi(String value) {
-  final cValue = Utf8.toUtf8(value);
+  final cValue = value.toNativeUtf8();
   final result = _String_create_handle(cValue);
-  free(cValue);
+  malloc.free(cValue);
   return result;
 }
 
-String String_fromFfi(Pointer<Void> handle) => Utf8.fromUtf8(_String_get_value(handle));
+String String_fromFfi(Pointer<Void> handle) {
+  final Pointer<Utf8> cString = _String_get_value(handle);
+  return cString.toDartString();
+}
 
 void String_releaseFfiHandle(Pointer<Void> handle) => _String_release_handle(handle);
 
@@ -127,38 +130,36 @@ final _Locale_get_language_tag = __lib.catchArgumentError(() => __lib.nativeLibr
 >('{{libraryName}}_locale_get_language_tag'));
 
 Pointer<Void> Locale_toFfi(Locale locale) {
-  final cLanguageCode = Utf8.toUtf8(locale.languageCode);
-  final cCountryCode =
-    locale.countryCode != null ? Utf8.toUtf8(locale.countryCode) : Pointer<Utf8>.fromAddress(0);
-  final cScriptCode =
-    locale.scriptCode != null ? Utf8.toUtf8(locale.scriptCode) : Pointer<Utf8>.fromAddress(0);
-  final cLanguageTag = Utf8.toUtf8(locale.toLanguageTag());
+  final cLanguageCode = locale.languageCode.toNativeUtf8();
+  final cCountryCode = locale.countryCode?.toNativeUtf8() ?? Pointer<Utf8>.fromAddress(0);
+  final cScriptCode = locale.scriptCode?.toNativeUtf8() ?? Pointer<Utf8>.fromAddress(0);
+  final cLanguageTag = locale.toLanguageTag().toNativeUtf8();
 
   final result = _Locale_create_handle(cLanguageCode, cCountryCode, cScriptCode, cLanguageTag);
 
-  free(cLanguageCode);
-  if (cCountryCode.address != 0) free(cCountryCode);
-  if (cScriptCode.address != 0) free(cScriptCode);
-  free(cLanguageTag);
+  malloc.free(cLanguageCode);
+  if (cCountryCode.address != 0) malloc.free(cCountryCode);
+  if (cScriptCode.address != 0) malloc.free(cScriptCode);
+  malloc.free(cLanguageTag);
 
   return result;
 }
 
 Locale Locale_fromFfi(Pointer<Void> handle) {
-  final languageTagCstring = _Locale_get_language_tag(handle);
+  final Pointer<Utf8> languageTagCstring = _Locale_get_language_tag(handle);
   if (languageTagCstring.address != 0) {
     // BCP 47 language tag takes precedence if present.
-    return Locale.parse(Utf8.fromUtf8(languageTagCstring));
+    return Locale.parse(languageTagCstring.toDartString());
   }
 
-  final languageCodeCstring = _Locale_get_language_code(handle);
-  final countryCodeCstring = _Locale_get_country_code(handle);
-  final scriptCodeCstring = _Locale_get_script_code(handle);
+  final Pointer<Utf8> languageCodeCstring = _Locale_get_language_code(handle);
+  final Pointer<Utf8> countryCodeCstring = _Locale_get_country_code(handle);
+  final Pointer<Utf8> scriptCodeCstring = _Locale_get_script_code(handle);
 
   return Locale.fromSubtags(
-    languageCode: languageCodeCstring.address != 0 ? Utf8.fromUtf8(languageCodeCstring) : null,
-    countryCode: countryCodeCstring.address != 0 ? Utf8.fromUtf8(countryCodeCstring) : null,
-    scriptCode: scriptCodeCstring.address != 0 ? Utf8.fromUtf8(scriptCodeCstring) : null
+    languageCode: languageCodeCstring.address != 0 ? languageCodeCstring.toDartString() : "und",
+    countryCode: countryCodeCstring.address != 0 ? countryCodeCstring.toDartString() : null,
+    scriptCode: scriptCodeCstring.address != 0 ? scriptCodeCstring.toDartString() : null
   );
 }
 
@@ -180,7 +181,7 @@ final _{{this}}_get_value_nullable = __lib.catchArgumentError(() => __lib.native
     {{resolveName "FfiDartTypes"}} Function(Pointer<Void>)
   >('{{libraryName}}_{{this}}_get_value_nullable'));
 
-Pointer<Void> {{this}}_toFfi_nullable({{resolveName}} value) {
+Pointer<Void> {{this}}_toFfi_nullable({{resolveName}}? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = {{#unless isNumericType}}{{this}}_toFfi{{/unless}}(value);
   final result = _{{this}}_create_handle_nullable(_handle);{{#unless isNumericType}}
@@ -188,7 +189,7 @@ Pointer<Void> {{this}}_toFfi_nullable({{resolveName}} value) {
   return result;
 }
 
-{{resolveName}} {{this}}_fromFfi_nullable(Pointer<Void> handle) {
+{{resolveName}}? {{this}}_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _{{this}}_get_value_nullable(handle);
   final result = {{#unless isNumericType}}{{this}}_fromFfi{{/unless}}(_handle);{{#unless isNumericType}}

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -93,11 +93,11 @@ class {{resolveName}}$Impl extends {{#if hasClassParent}}{{resolveName parent}}$
 
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _{{resolveName "Ffi"}}_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 
 {{#set inheritanceParent=this.parent parent=this container=this ignoreStatic=testableMode}}{{#constructors}}
@@ -133,8 +133,8 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) =>
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as {{resolveName}};
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is {{resolveName}}) return instance;
 
 {{#if this.parent visibility.isOpen logic="or"}}
   final _type_id_handle = _{{resolveName "Ffi"}}_get_type_id(handle);
@@ -153,10 +153,10 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) =>
 void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) =>
   _{{resolveName "Ffi"}}_release_handle(handle);
 
-Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}} value) =>
+Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}}? value) =>
   value != null ? {{resolveName "Ffi"}}_toFfi(value) : Pointer<Void>.fromAddress(0);
 
-{{resolveName}} {{resolveName "Ffi"}}_fromFfi_nullable(Pointer<Void> handle) =>
+{{resolveName}}? {{resolveName "Ffi"}}_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? {{resolveName "Ffi"}}_fromFfi(handle) : null;
 
 void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
@@ -182,7 +182,7 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 {{/unless}}{{/dartConstructor}}{{!!
 
 }}{{+dartCachedProperty}}
-{{#if isStatic}}{{#unless testableMode}}static {{/unless}}{{/if}}{{resolveName typeRef}} _cache_{{resolveName}};
+{{#if isStatic}}{{#unless testableMode}}static {{/unless}}{{/if}}late {{resolveName typeRef}} _cache_{{resolveName}};
 {{#if isStatic}}{{#unless testableMode}}static {{/unless}}{{/if}}bool _is_cached_{{resolveName}} = false;
 {{#unless isStatic}}@override
 {{/unless}}

--- a/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
@@ -105,7 +105,8 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
 }
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
-  final result = {{resolveName}}();
+  final result = {{resolveName}}{{#instanceOf this "LimeList"}}.empty(growable: true){{/instanceOf}}{{!!
+  }}{{#notInstanceOf this "LimeList"}}(){{/notInstanceOf}};
   final _iterator_handle = _{{resolveName "Ffi"}}_iterator(handle);
   while (_{{resolveName "Ffi"}}_iterator_is_valid(handle, _iterator_handle) != 0) {
 {{#instanceOf this "LimeMap"}}

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -25,11 +25,11 @@ abstract class {{resolveName}} {{#if this.parent}}implements {{resolveName this.
 
   factory {{resolveName}}.fromLambdas({
 {{#each inheritedFunctions functions}}{{#unless isStatic}}
-    @required {{>dart/DartLambdaType}} lambda_{{resolveName}},
+    required {{>dart/DartLambdaType}} lambda_{{resolveName}},
 {{/unless}}{{/each}}{{#each inheritedProperties properties}}{{#unless isStatic}}{{#set property=this}}{{#getter}}
-    @required {{>dart/DartLambdaType}} lambda_{{resolveName property}}_get{{#if setter}},
+    required {{>dart/DartLambdaType}} lambda_{{resolveName property}}_get{{#if setter}},
 {{/if}}{{/getter}}{{#setter}}
-    @required {{>dart/DartLambdaType}} lambda_{{resolveName property}}_set{{/setter}}{{#if iter.hasNext}},
+    required {{>dart/DartLambdaType}} lambda_{{resolveName property}}_set{{/setter}}{{#if iter.hasNext}},
 {{/if}}{{/set}}{{/unless}}{{/each}}
 
   }) => {{resolveName}}$Lambdas(
@@ -149,11 +149,11 @@ class {{resolveName}}$Impl extends __lib.NativeBase implements {{resolveName}} {
 
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _{{resolveName "Ffi"}}_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 
 {{#set parent=this}}{{#each inheritedFunctions functions}}
@@ -177,7 +177,7 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 {{#if thrownType}}
   bool _error_flag = false;
 {{/if}}{{#unless returnType.isVoid}}
-  {{resolveName returnType.typeRef}} _result_object = null;{{/unless}}
+  {{resolveName returnType.typeRef}}{{#unless returnType.typeRef.isNullable}}?{{/unless}} _result_object = null;{{/unless}}
   try {
     {{#unless returnType.isVoid}}_result_object = {{/unless}}{{!!
   }}(__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}}({{#parameters}}{{!!
@@ -190,9 +190,9 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
     final _error_object = e.error;
     _error.value = {{#set typeRef=exception.errorType call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_error_object);
 {{#instanceOf exception.errorType.type.actualType "LimeClass"}}
-    if (_error_object != null) _error_object.release();
+    _error_object.release();
 {{/instanceOf}}{{#instanceOf exception.errorType.type.actualType "LimeInterface"}}
-    if (_error_object != null) _error_object.release();
+    _error_object.release();
 {{/instanceOf}}
 {{/if}}
   } finally {
@@ -200,9 +200,9 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
     {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
 {{/parameters}}{{!!
 }}{{#instanceOf returnType.typeRef.type.actualType "LimeClass"}}
-    if (_result_object != null) _result_object.release();
+    _result_object?.release();
 {{/instanceOf}}{{#instanceOf returnType.typeRef.type.actualType "LimeInterface"}}
-    if (_result_object != null) _result_object.release();
+    _result_object?.release();
 {{/instanceOf}}
   }
   return{{#if thrownType}} _error_flag ? 1 :{{/if}} 0;
@@ -249,8 +249,8 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as {{resolveName}};
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is {{resolveName}}) return instance;
 
   final _type_id_handle = _{{resolveName "Ffi"}}_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
@@ -267,10 +267,10 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
 void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) =>
   _{{resolveName "Ffi"}}_release_handle(handle);
 
-Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}} value) =>
+Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}}? value) =>
   value != null ? {{resolveName "Ffi"}}_toFfi(value) : Pointer<Void>.fromAddress(0);
 
-{{resolveName}} {{resolveName "Ffi"}}_fromFfi_nullable(Pointer<Void> handle) =>
+{{resolveName}}? {{resolveName "Ffi"}}_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? {{resolveName "Ffi"}}_fromFfi(handle) : null;
 
 void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -53,7 +53,8 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 }}int _token{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
 }}{{#unless returnType.isVoid}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/unless}}) {
-  {{#unless returnType.isVoid}}{{resolveName returnType.typeRef}} _result_object;{{/unless}}
+  {{#unless returnType.isVoid}}{{resolveName returnType.typeRef}}{{!!
+  }}{{#unless returnType.typeRef.isNullable}}?{{/unless}} _result_object = null;{{/unless}}
   try {
     {{#unless returnType.isVoid}}_result_object = {{/unless}}{{!!
   }}(__lib.instanceCache[_token] as {{resolveName parent}})({{#parameters}}{{!!
@@ -64,9 +65,9 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 {{#parameters}}
     {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
 {{/parameters}}{{#instanceOf returnType.typeRef.type.actualType "LimeClass"}}
-    if (_result_object != null) _result_object.release();
+    _result_object?.release();
 {{/instanceOf}}{{#instanceOf returnType.typeRef.type.actualType "LimeInterface"}}
-    if (_result_object != null) _result_object.release();
+    _result_object?.release();
 {{/instanceOf}}
   }
   return 0;

--- a/gluecodium/src/main/resources/templates/dart/DartLazyList.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLazyList.mustache
@@ -74,7 +74,7 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   int indexOf(E element, [int start = 0]) => indexWhere((it) => element == it, start);
 
   int indexWhere(bool test(E element), [int start = 0]) {
-    final iterator = _LazyIterator(this, start ?? -1, 1);
+    final iterator = _LazyIterator(this, start - 1, 1);
     while (iterator.moveNext()) {
       if (test(iterator.current)) return iterator.position;
     }

--- a/gluecodium/src/main/resources/templates/dart/DartLazyList.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLazyList.mustache
@@ -66,7 +66,7 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   List<E> operator +(List<E> other) => cast<E>() + other;
   Map<int, E> asMap() => cast<E>().asMap();
   Iterable<E> getRange(int start, int end) => cast<E>().getRange(start, end);
-  List<E> sublist(int start, [int end = null]) => cast<E>().sublist(start, end);
+  List<E> sublist(int start, [int? end]) => cast<E>().sublist(start, end);
   Iterable<E> get reversed => cast<E>().reversed;
 
   // Methods relying on the iterator
@@ -81,9 +81,9 @@ class LazyList<E> extends Iterable<E> implements List<E> {
     return -1;
   }
 
-  int lastIndexOf(E element, [int start = null]) => lastIndexWhere((it) => element == it, start);
+  int lastIndexOf(E element, [int? start]) => lastIndexWhere((it) => element == it, start);
 
-  int lastIndexWhere(bool test(E element), [int start = null]) {
+  int lastIndexWhere(bool test(E element), [int? start]) {
     final iterator = _LazyIterator(this, start ?? length, -1);
     while (iterator.moveNext()) {
       if (test(iterator.current)) return iterator.position;
@@ -97,10 +97,10 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   void add(E value) => throw UnsupportedError(_cannotModify);
   void addAll(Iterable<E> iterable) => throw UnsupportedError(_cannotModify);
   void clear() => throw UnsupportedError(_cannotModify);
-  void fillRange(int start, int end, [E fillValue]) => throw UnsupportedError(_cannotModify);
+  void fillRange(int start, int end, [E? fillValue]) => throw UnsupportedError(_cannotModify);
   void insert(int index, E element) => throw UnsupportedError(_cannotModify);
   void insertAll(int index, Iterable<E> iterable) => throw UnsupportedError(_cannotModify);
-  bool remove(Object value) => throw UnsupportedError(_cannotModify);
+  bool remove(Object? value) => throw UnsupportedError(_cannotModify);
   E removeAt(int index) => throw UnsupportedError(_cannotModify);
   E removeLast() => throw UnsupportedError(_cannotModify);
   void removeRange(int start, int end) => throw UnsupportedError(_cannotModify);
@@ -109,8 +109,8 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   void retainWhere(bool test(E element)) => throw UnsupportedError(_cannotModify);
   void setAll(int index, Iterable<E> iterable) => throw UnsupportedError(_cannotModify);
   void setRange(int start, int end, Iterable<E> iterable, [int skipCount = 0]) => throw UnsupportedError(_cannotModify);
-  void shuffle([Random random]) => throw UnsupportedError(_cannotModify);
-  void sort([int compare(E a, E b)]) => throw UnsupportedError(_cannotModify);
+  void shuffle([Random? random]) => throw UnsupportedError(_cannotModify);
+  void sort([int compare(E a, E b)?]) => throw UnsupportedError(_cannotModify);
   void set first(E value) => throw UnsupportedError(_cannotModify);
   void set last(E value) => throw UnsupportedError(_cannotModify);
   set length(int newLength) => throw UnsupportedError(_cannotModify);

--- a/gluecodium/src/main/resources/templates/dart/DartLibraryContext.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLibraryContext.mustache
@@ -26,7 +26,7 @@ import 'dart:io';
 import 'dart:isolate';
 
 final nativeLibrary = _nativeLibrary ?? _loadNativeLibrary(_getLibraryPath("{{libraryName}}"));
-/*late*/ DynamicLibrary _nativeLibrary;
+DynamicLibrary? _nativeLibrary = null;
 
 DynamicLibrary _loadNativeLibrary(String nativeLibraryPath) {
   try {
@@ -71,7 +71,7 @@ class _SentryIsolateMessage {
   _SentryIsolateMessage(this.port, this.isolateId, this.nativeLibraryPath);
   final SendPort port;
   final int isolateId;
-  final String nativeLibraryPath;
+  final String? nativeLibraryPath;
 }
 
 enum IsolateOrigin {
@@ -89,12 +89,12 @@ class LibraryContext {
   static int get isolateId => _isolateId;
 
   static int _isolateId = -1;
-  /*late*/ static StreamSubscription _callbackStream;
+  static late StreamSubscription _callbackStream;
 
   /// [nativeLibraryPath] is an optional parameter specifying a path to native shared library
   /// binary. If omitted (null) automatic library loading is attempted as a fallback. If loading
   /// fails, current process is used as a native library instead.
-  static void init(IsolateOrigin isolateOrigin, {String nativeLibraryPath}) {
+  static void init(IsolateOrigin isolateOrigin, {String? nativeLibraryPath}) {
     _loadCustomLibrary(nativeLibraryPath);
     _isolateId = _library_callbacks_queue_init(isolateOrigin == IsolateOrigin.main ? 1 : 0);
 
@@ -121,7 +121,7 @@ class LibraryContext {
     message.port.send(0);
   }
 
-  static DynamicLibrary _loadCustomLibrary(String nativeLibraryPath) {
+  static void _loadCustomLibrary(String? nativeLibraryPath) {
     if (nativeLibraryPath != null) _nativeLibrary = _loadNativeLibrary(nativeLibraryPath);
   }
 }

--- a/gluecodium/src/main/resources/templates/dart/DartNativeBase.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartNativeBase.mustache
@@ -27,7 +27,7 @@ import 'package:meta/meta.dart';
 /// @nodoc
 class NativeBase {
   @protected
-  Pointer<Void> handle;
+  Pointer<Void> handle = Pointer<Void>.fromAddress(0);
 
   NativeBase(this.handle);
 }

--- a/gluecodium/src/main/resources/templates/dart/DartNullableTypeConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartNullableTypeConversion.mustache
@@ -31,7 +31,7 @@ final _{{resolveName "Ffi"}}_get_value_nullable = __lib.catchArgumentError(() =>
     {{resolveName "FfiDartTypes"}} Function(Pointer<Void>)
   >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_get_value_nullable'));
 
-Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName this "" "ref"}} value) {
+Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName this "" "ref"}}? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = {{resolveName "Ffi"}}_toFfi(value);
   final result = _{{resolveName "Ffi"}}_create_handle_nullable(_handle);
@@ -39,7 +39,7 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName this "" "ref"}}
   return result;
 }
 
-{{resolveName this "" "ref"}} {{resolveName "Ffi"}}_fromFfi_nullable(Pointer<Void> handle) {
+{{resolveName this "" "ref"}}? {{resolveName "Ffi"}}_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _{{resolveName "Ffi"}}_get_value_nullable(handle);
   final result = {{resolveName "Ffi"}}_fromFfi(_handle);

--- a/gluecodium/src/main/resources/templates/dart/DartPubspec.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartPubspec.mustache
@@ -20,8 +20,8 @@
   !}}
 name: {{libraryName}}
 environment:
-  sdk: '>=2.5.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  ffi: ^0.1.3
+  ffi:
   intl:
   meta:

--- a/gluecodium/src/main/resources/templates/dart/DartTokenCache.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartTokenCache.mustache
@@ -32,7 +32,7 @@ final Map<int, Object> instanceCache = {};
 final Map<Object, int> tokenCache = {};
 
 int cacheObject(Object obj) {
-  int token = tokenCache[obj];
+  int? token = tokenCache[obj];
   if (token == null) {
     token = _instanceCounter++;
     instanceCache[token] = obj;

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -34,11 +34,11 @@ class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
   AttributesClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_AttributesClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   veryFun(@OnParameterInClass String param) {
@@ -85,8 +85,8 @@ Pointer<Void> smoke_AttributesClass_toFfi(AttributesClass value) =>
 AttributesClass smoke_AttributesClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as AttributesClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is AttributesClass) return instance;
   final _copied_handle = _smoke_AttributesClass_copy_handle(handle);
   final result = AttributesClass$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -94,9 +94,9 @@ AttributesClass smoke_AttributesClass_fromFfi(Pointer<Void> handle) {
 }
 void smoke_AttributesClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_AttributesClass_release_handle(handle);
-Pointer<Void> smoke_AttributesClass_toFfi_nullable(AttributesClass value) =>
+Pointer<Void> smoke_AttributesClass_toFfi_nullable(AttributesClass? value) =>
   value != null ? smoke_AttributesClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-AttributesClass smoke_AttributesClass_fromFfi_nullable(Pointer<Void> handle) =>
+AttributesClass? smoke_AttributesClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_AttributesClass_fromFfi(handle) : null;
 void smoke_AttributesClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_AttributesClass_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_enum.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_enum.dart
@@ -39,14 +39,14 @@ final _smoke_AttributesEnum_get_value_nullable = __lib.catchArgumentError(() => 
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_AttributesEnum_get_value_nullable'));
-Pointer<Void> smoke_AttributesEnum_toFfi_nullable(AttributesEnum value) {
+Pointer<Void> smoke_AttributesEnum_toFfi_nullable(AttributesEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_AttributesEnum_toFfi(value);
   final result = _smoke_AttributesEnum_create_handle_nullable(_handle);
   smoke_AttributesEnum_releaseFfiHandle(_handle);
   return result;
 }
-AttributesEnum smoke_AttributesEnum_fromFfi_nullable(Pointer<Void> handle) {
+AttributesEnum? smoke_AttributesEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_AttributesEnum_get_value_nullable(handle);
   final result = smoke_AttributesEnum_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -10,9 +10,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class AttributesInterface {
   AttributesInterface() {}
   factory AttributesInterface.fromLambdas({
-    @required void Function(String) lambda_veryFun,
-    @required String Function() lambda_prop_get,
-    @required void Function(String) lambda_prop_set
+    required void Function(String) lambda_veryFun,
+    required String Function() lambda_prop_get,
+    required void Function(String) lambda_prop_set
   }) => AttributesInterface$Lambdas(
     lambda_veryFun,
     lambda_prop_get,
@@ -72,11 +72,11 @@ class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInt
   AttributesInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_AttributesInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   veryFun(@OnParameterInInterface String param) {
@@ -152,8 +152,8 @@ Pointer<Void> smoke_AttributesInterface_toFfi(AttributesInterface value) {
 AttributesInterface smoke_AttributesInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as AttributesInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is AttributesInterface) return instance;
   final _type_id_handle = _smoke_AttributesInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -166,9 +166,9 @@ AttributesInterface smoke_AttributesInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_AttributesInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_AttributesInterface_release_handle(handle);
-Pointer<Void> smoke_AttributesInterface_toFfi_nullable(AttributesInterface value) =>
+Pointer<Void> smoke_AttributesInterface_toFfi_nullable(AttributesInterface? value) =>
   value != null ? smoke_AttributesInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-AttributesInterface smoke_AttributesInterface_fromFfi_nullable(Pointer<Void> handle) =>
+AttributesInterface? smoke_AttributesInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_AttributesInterface_fromFfi(handle) : null;
 void smoke_AttributesInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_AttributesInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
@@ -74,14 +74,14 @@ final _smoke_AttributesLambda_get_value_nullable = __lib.catchArgumentError(() =
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesLambda_get_value_nullable'));
-Pointer<Void> smoke_AttributesLambda_toFfi_nullable(AttributesLambda value) {
+Pointer<Void> smoke_AttributesLambda_toFfi_nullable(AttributesLambda? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_AttributesLambda_toFfi(value);
   final result = _smoke_AttributesLambda_create_handle_nullable(_handle);
   smoke_AttributesLambda_releaseFfiHandle(_handle);
   return result;
 }
-AttributesLambda smoke_AttributesLambda_fromFfi_nullable(Pointer<Void> handle) {
+AttributesLambda? smoke_AttributesLambda_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_AttributesLambda_get_value_nullable(handle);
   final result = smoke_AttributesLambda_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
@@ -68,14 +68,14 @@ final _smoke_AttributesStruct_get_value_nullable = __lib.catchArgumentError(() =
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesStruct_get_value_nullable'));
-Pointer<Void> smoke_AttributesStruct_toFfi_nullable(AttributesStruct value) {
+Pointer<Void> smoke_AttributesStruct_toFfi_nullable(AttributesStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_AttributesStruct_toFfi(value);
   final result = _smoke_AttributesStruct_create_handle_nullable(_handle);
   smoke_AttributesStruct_releaseFfiHandle(_handle);
   return result;
 }
-AttributesStruct smoke_AttributesStruct_fromFfi_nullable(Pointer<Void> handle) {
+AttributesStruct? smoke_AttributesStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_AttributesStruct_get_value_nullable(handle);
   final result = smoke_AttributesStruct_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -76,14 +76,14 @@ final _smoke_AttributesWithComments_SomeStruct_get_value_nullable = __lib.catchA
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_AttributesWithComments_SomeStruct_toFfi_nullable(AttributesWithComments_SomeStruct value) {
+Pointer<Void> smoke_AttributesWithComments_SomeStruct_toFfi_nullable(AttributesWithComments_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_AttributesWithComments_SomeStruct_toFfi(value);
   final result = _smoke_AttributesWithComments_SomeStruct_create_handle_nullable(_handle);
   smoke_AttributesWithComments_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-AttributesWithComments_SomeStruct smoke_AttributesWithComments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+AttributesWithComments_SomeStruct? smoke_AttributesWithComments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_AttributesWithComments_SomeStruct_get_value_nullable(handle);
   final result = smoke_AttributesWithComments_SomeStruct_fromFfi(_handle);
@@ -106,11 +106,11 @@ class AttributesWithComments$Impl extends __lib.NativeBase implements Attributes
   AttributesWithComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_AttributesWithComments_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   veryFun() {
@@ -155,8 +155,8 @@ Pointer<Void> smoke_AttributesWithComments_toFfi(AttributesWithComments value) =
 AttributesWithComments smoke_AttributesWithComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as AttributesWithComments;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is AttributesWithComments) return instance;
   final _copied_handle = _smoke_AttributesWithComments_copy_handle(handle);
   final result = AttributesWithComments$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -164,9 +164,9 @@ AttributesWithComments smoke_AttributesWithComments_fromFfi(Pointer<Void> handle
 }
 void smoke_AttributesWithComments_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_AttributesWithComments_release_handle(handle);
-Pointer<Void> smoke_AttributesWithComments_toFfi_nullable(AttributesWithComments value) =>
+Pointer<Void> smoke_AttributesWithComments_toFfi_nullable(AttributesWithComments? value) =>
   value != null ? smoke_AttributesWithComments_toFfi(value) : Pointer<Void>.fromAddress(0);
-AttributesWithComments smoke_AttributesWithComments_fromFfi_nullable(Pointer<Void> handle) =>
+AttributesWithComments? smoke_AttributesWithComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_AttributesWithComments_fromFfi(handle) : null;
 void smoke_AttributesWithComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_AttributesWithComments_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -75,14 +75,14 @@ final _smoke_AttributesWithDeprecated_SomeStruct_get_value_nullable = __lib.catc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_AttributesWithDeprecated_SomeStruct_toFfi_nullable(AttributesWithDeprecated_SomeStruct value) {
+Pointer<Void> smoke_AttributesWithDeprecated_SomeStruct_toFfi_nullable(AttributesWithDeprecated_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_AttributesWithDeprecated_SomeStruct_toFfi(value);
   final result = _smoke_AttributesWithDeprecated_SomeStruct_create_handle_nullable(_handle);
   smoke_AttributesWithDeprecated_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-AttributesWithDeprecated_SomeStruct smoke_AttributesWithDeprecated_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+AttributesWithDeprecated_SomeStruct? smoke_AttributesWithDeprecated_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_AttributesWithDeprecated_SomeStruct_get_value_nullable(handle);
   final result = smoke_AttributesWithDeprecated_SomeStruct_fromFfi(_handle);
@@ -105,11 +105,11 @@ class AttributesWithDeprecated$Impl extends __lib.NativeBase implements Attribut
   AttributesWithDeprecated$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_AttributesWithDeprecated_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   veryFun() {
@@ -154,8 +154,8 @@ Pointer<Void> smoke_AttributesWithDeprecated_toFfi(AttributesWithDeprecated valu
 AttributesWithDeprecated smoke_AttributesWithDeprecated_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as AttributesWithDeprecated;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is AttributesWithDeprecated) return instance;
   final _copied_handle = _smoke_AttributesWithDeprecated_copy_handle(handle);
   final result = AttributesWithDeprecated$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -163,9 +163,9 @@ AttributesWithDeprecated smoke_AttributesWithDeprecated_fromFfi(Pointer<Void> ha
 }
 void smoke_AttributesWithDeprecated_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_AttributesWithDeprecated_release_handle(handle);
-Pointer<Void> smoke_AttributesWithDeprecated_toFfi_nullable(AttributesWithDeprecated value) =>
+Pointer<Void> smoke_AttributesWithDeprecated_toFfi_nullable(AttributesWithDeprecated? value) =>
   value != null ? smoke_AttributesWithDeprecated_toFfi(value) : Pointer<Void>.fromAddress(0);
-AttributesWithDeprecated smoke_AttributesWithDeprecated_fromFfi_nullable(Pointer<Void> handle) =>
+AttributesWithDeprecated? smoke_AttributesWithDeprecated_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_AttributesWithDeprecated_fromFfi(handle) : null;
 void smoke_AttributesWithDeprecated_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_AttributesWithDeprecated_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -45,11 +45,11 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
   MultipleAttributesDart$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_MultipleAttributesDart_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   noLists2() {
@@ -112,8 +112,8 @@ Pointer<Void> smoke_MultipleAttributesDart_toFfi(MultipleAttributesDart value) =
 MultipleAttributesDart smoke_MultipleAttributesDart_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as MultipleAttributesDart;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is MultipleAttributesDart) return instance;
   final _copied_handle = _smoke_MultipleAttributesDart_copy_handle(handle);
   final result = MultipleAttributesDart$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -121,9 +121,9 @@ MultipleAttributesDart smoke_MultipleAttributesDart_fromFfi(Pointer<Void> handle
 }
 void smoke_MultipleAttributesDart_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_MultipleAttributesDart_release_handle(handle);
-Pointer<Void> smoke_MultipleAttributesDart_toFfi_nullable(MultipleAttributesDart value) =>
+Pointer<Void> smoke_MultipleAttributesDart_toFfi_nullable(MultipleAttributesDart? value) =>
   value != null ? smoke_MultipleAttributesDart_toFfi(value) : Pointer<Void>.fromAddress(0);
-MultipleAttributesDart smoke_MultipleAttributesDart_fromFfi_nullable(Pointer<Void> handle) =>
+MultipleAttributesDart? smoke_MultipleAttributesDart_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_MultipleAttributesDart_fromFfi(handle) : null;
 void smoke_MultipleAttributesDart_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_MultipleAttributesDart_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -29,11 +29,11 @@ class SpecialAttributes$Impl extends __lib.NativeBase implements SpecialAttribut
   SpecialAttributes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_SpecialAttributes_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   withEscaping() {
@@ -63,8 +63,8 @@ Pointer<Void> smoke_SpecialAttributes_toFfi(SpecialAttributes value) =>
 SpecialAttributes smoke_SpecialAttributes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as SpecialAttributes;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is SpecialAttributes) return instance;
   final _copied_handle = _smoke_SpecialAttributes_copy_handle(handle);
   final result = SpecialAttributes$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -72,9 +72,9 @@ SpecialAttributes smoke_SpecialAttributes_fromFfi(Pointer<Void> handle) {
 }
 void smoke_SpecialAttributes_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SpecialAttributes_release_handle(handle);
-Pointer<Void> smoke_SpecialAttributes_toFfi_nullable(SpecialAttributes value) =>
+Pointer<Void> smoke_SpecialAttributes_toFfi_nullable(SpecialAttributes? value) =>
   value != null ? smoke_SpecialAttributes_toFfi(value) : Pointer<Void>.fromAddress(0);
-SpecialAttributes smoke_SpecialAttributes_fromFfi_nullable(Pointer<Void> handle) =>
+SpecialAttributes? smoke_SpecialAttributes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SpecialAttributes_fromFfi(handle) : null;
 void smoke_SpecialAttributes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SpecialAttributes_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/builtin_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/builtin_types__conversion.dart
@@ -50,12 +50,15 @@ final _String_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.loo
     Pointer<Utf8> Function(Pointer<Void>)
   >('library_std_string_get_value'));
 Pointer<Void> String_toFfi(String value) {
-  final cValue = Utf8.toUtf8(value);
+  final cValue = value.toNativeUtf8();
   final result = _String_create_handle(cValue);
-  free(cValue);
+  malloc.free(cValue);
   return result;
 }
-String String_fromFfi(Pointer<Void> handle) => Utf8.fromUtf8(_String_get_value(handle));
+String String_fromFfi(Pointer<Void> handle) {
+  final Pointer<Utf8> cString = _String_get_value(handle);
+  return cString.toDartString();
+}
 void String_releaseFfiHandle(Pointer<Void> handle) => _String_release_handle(handle);
 // Locale
 final _Locale_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -83,32 +86,30 @@ final _Locale_get_language_tag = __lib.catchArgumentError(() => __lib.nativeLibr
     Pointer<Utf8> Function(Pointer<Void>)
 >('library_locale_get_language_tag'));
 Pointer<Void> Locale_toFfi(Locale locale) {
-  final cLanguageCode = Utf8.toUtf8(locale.languageCode);
-  final cCountryCode =
-    locale.countryCode != null ? Utf8.toUtf8(locale.countryCode) : Pointer<Utf8>.fromAddress(0);
-  final cScriptCode =
-    locale.scriptCode != null ? Utf8.toUtf8(locale.scriptCode) : Pointer<Utf8>.fromAddress(0);
-  final cLanguageTag = Utf8.toUtf8(locale.toLanguageTag());
+  final cLanguageCode = locale.languageCode.toNativeUtf8();
+  final cCountryCode = locale.countryCode?.toNativeUtf8() ?? Pointer<Utf8>.fromAddress(0);
+  final cScriptCode = locale.scriptCode?.toNativeUtf8() ?? Pointer<Utf8>.fromAddress(0);
+  final cLanguageTag = locale.toLanguageTag().toNativeUtf8();
   final result = _Locale_create_handle(cLanguageCode, cCountryCode, cScriptCode, cLanguageTag);
-  free(cLanguageCode);
-  if (cCountryCode.address != 0) free(cCountryCode);
-  if (cScriptCode.address != 0) free(cScriptCode);
-  free(cLanguageTag);
+  malloc.free(cLanguageCode);
+  if (cCountryCode.address != 0) malloc.free(cCountryCode);
+  if (cScriptCode.address != 0) malloc.free(cScriptCode);
+  malloc.free(cLanguageTag);
   return result;
 }
 Locale Locale_fromFfi(Pointer<Void> handle) {
-  final languageTagCstring = _Locale_get_language_tag(handle);
+  final Pointer<Utf8> languageTagCstring = _Locale_get_language_tag(handle);
   if (languageTagCstring.address != 0) {
     // BCP 47 language tag takes precedence if present.
-    return Locale.parse(Utf8.fromUtf8(languageTagCstring));
+    return Locale.parse(languageTagCstring.toDartString());
   }
-  final languageCodeCstring = _Locale_get_language_code(handle);
-  final countryCodeCstring = _Locale_get_country_code(handle);
-  final scriptCodeCstring = _Locale_get_script_code(handle);
+  final Pointer<Utf8> languageCodeCstring = _Locale_get_language_code(handle);
+  final Pointer<Utf8> countryCodeCstring = _Locale_get_country_code(handle);
+  final Pointer<Utf8> scriptCodeCstring = _Locale_get_script_code(handle);
   return Locale.fromSubtags(
-    languageCode: languageCodeCstring.address != 0 ? Utf8.fromUtf8(languageCodeCstring) : null,
-    countryCode: countryCodeCstring.address != 0 ? Utf8.fromUtf8(countryCodeCstring) : null,
-    scriptCode: scriptCodeCstring.address != 0 ? Utf8.fromUtf8(scriptCodeCstring) : null
+    languageCode: languageCodeCstring.address != 0 ? languageCodeCstring.toDartString() : "und",
+    countryCode: countryCodeCstring.address != 0 ? countryCodeCstring.toDartString() : null,
+    scriptCode: scriptCodeCstring.address != 0 ? scriptCodeCstring.toDartString() : null
   );
 }
 void Locale_releaseFfiHandle(Pointer<Void> handle) => _Locale_release_handle(handle);
@@ -125,13 +126,13 @@ final _Byte_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibr
     Int8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_Byte_get_value_nullable'));
-Pointer<Void> Byte_toFfi_nullable(int value) {
+Pointer<Void> Byte_toFfi_nullable(int? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
   final result = _Byte_create_handle_nullable(_handle);
   return result;
 }
-int Byte_fromFfi_nullable(Pointer<Void> handle) {
+int? Byte_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _Byte_get_value_nullable(handle);
   final result = (_handle);
@@ -151,13 +152,13 @@ final _UByte_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLib
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_UByte_get_value_nullable'));
-Pointer<Void> UByte_toFfi_nullable(int value) {
+Pointer<Void> UByte_toFfi_nullable(int? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
   final result = _UByte_create_handle_nullable(_handle);
   return result;
 }
-int UByte_fromFfi_nullable(Pointer<Void> handle) {
+int? UByte_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _UByte_get_value_nullable(handle);
   final result = (_handle);
@@ -177,13 +178,13 @@ final _Short_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLib
     Int16 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_Short_get_value_nullable'));
-Pointer<Void> Short_toFfi_nullable(int value) {
+Pointer<Void> Short_toFfi_nullable(int? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
   final result = _Short_create_handle_nullable(_handle);
   return result;
 }
-int Short_fromFfi_nullable(Pointer<Void> handle) {
+int? Short_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _Short_get_value_nullable(handle);
   final result = (_handle);
@@ -203,13 +204,13 @@ final _UShort_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLi
     Uint16 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_UShort_get_value_nullable'));
-Pointer<Void> UShort_toFfi_nullable(int value) {
+Pointer<Void> UShort_toFfi_nullable(int? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
   final result = _UShort_create_handle_nullable(_handle);
   return result;
 }
-int UShort_fromFfi_nullable(Pointer<Void> handle) {
+int? UShort_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _UShort_get_value_nullable(handle);
   final result = (_handle);
@@ -229,13 +230,13 @@ final _Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibra
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_Int_get_value_nullable'));
-Pointer<Void> Int_toFfi_nullable(int value) {
+Pointer<Void> Int_toFfi_nullable(int? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
   final result = _Int_create_handle_nullable(_handle);
   return result;
 }
-int Int_fromFfi_nullable(Pointer<Void> handle) {
+int? Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _Int_get_value_nullable(handle);
   final result = (_handle);
@@ -255,13 +256,13 @@ final _UInt_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibr
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_UInt_get_value_nullable'));
-Pointer<Void> UInt_toFfi_nullable(int value) {
+Pointer<Void> UInt_toFfi_nullable(int? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
   final result = _UInt_create_handle_nullable(_handle);
   return result;
 }
-int UInt_fromFfi_nullable(Pointer<Void> handle) {
+int? UInt_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _UInt_get_value_nullable(handle);
   final result = (_handle);
@@ -281,13 +282,13 @@ final _Long_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibr
     Int64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_Long_get_value_nullable'));
-Pointer<Void> Long_toFfi_nullable(int value) {
+Pointer<Void> Long_toFfi_nullable(int? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
   final result = _Long_create_handle_nullable(_handle);
   return result;
 }
-int Long_fromFfi_nullable(Pointer<Void> handle) {
+int? Long_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _Long_get_value_nullable(handle);
   final result = (_handle);
@@ -307,13 +308,13 @@ final _ULong_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLib
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_ULong_get_value_nullable'));
-Pointer<Void> ULong_toFfi_nullable(int value) {
+Pointer<Void> ULong_toFfi_nullable(int? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
   final result = _ULong_create_handle_nullable(_handle);
   return result;
 }
-int ULong_fromFfi_nullable(Pointer<Void> handle) {
+int? ULong_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _ULong_get_value_nullable(handle);
   final result = (_handle);
@@ -333,13 +334,13 @@ final _Float_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLib
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_Float_get_value_nullable'));
-Pointer<Void> Float_toFfi_nullable(double value) {
+Pointer<Void> Float_toFfi_nullable(double? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
   final result = _Float_create_handle_nullable(_handle);
   return result;
 }
-double Float_fromFfi_nullable(Pointer<Void> handle) {
+double? Float_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _Float_get_value_nullable(handle);
   final result = (_handle);
@@ -359,13 +360,13 @@ final _Double_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLi
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_Double_get_value_nullable'));
-Pointer<Void> Double_toFfi_nullable(double value) {
+Pointer<Void> Double_toFfi_nullable(double? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
   final result = _Double_create_handle_nullable(_handle);
   return result;
 }
-double Double_fromFfi_nullable(Pointer<Void> handle) {
+double? Double_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _Double_get_value_nullable(handle);
   final result = (_handle);
@@ -385,14 +386,14 @@ final _Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeL
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_Boolean_get_value_nullable'));
-Pointer<Void> Boolean_toFfi_nullable(bool value) {
+Pointer<Void> Boolean_toFfi_nullable(bool? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = Boolean_toFfi(value);
   final result = _Boolean_create_handle_nullable(_handle);
   Boolean_releaseFfiHandle(_handle);
   return result;
 }
-bool Boolean_fromFfi_nullable(Pointer<Void> handle) {
+bool? Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _Boolean_get_value_nullable(handle);
   final result = Boolean_fromFfi(_handle);
@@ -413,14 +414,14 @@ final _String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLi
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_String_get_value_nullable'));
-Pointer<Void> String_toFfi_nullable(String value) {
+Pointer<Void> String_toFfi_nullable(String? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = String_toFfi(value);
   final result = _String_create_handle_nullable(_handle);
   String_releaseFfiHandle(_handle);
   return result;
 }
-String String_fromFfi_nullable(Pointer<Void> handle) {
+String? String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _String_get_value_nullable(handle);
   final result = String_fromFfi(_handle);
@@ -441,14 +442,14 @@ final _Blob_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_Blob_get_value_nullable'));
-Pointer<Void> Blob_toFfi_nullable(Uint8List value) {
+Pointer<Void> Blob_toFfi_nullable(Uint8List? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = Blob_toFfi(value);
   final result = _Blob_create_handle_nullable(_handle);
   Blob_releaseFfiHandle(_handle);
   return result;
 }
-Uint8List Blob_fromFfi_nullable(Pointer<Void> handle) {
+Uint8List? Blob_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _Blob_get_value_nullable(handle);
   final result = Blob_fromFfi(_handle);
@@ -469,14 +470,14 @@ final _Date_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibr
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_Date_get_value_nullable'));
-Pointer<Void> Date_toFfi_nullable(DateTime value) {
+Pointer<Void> Date_toFfi_nullable(DateTime? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = Date_toFfi(value);
   final result = _Date_create_handle_nullable(_handle);
   Date_releaseFfiHandle(_handle);
   return result;
 }
-DateTime Date_fromFfi_nullable(Pointer<Void> handle) {
+DateTime? Date_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _Date_get_value_nullable(handle);
   final result = Date_fromFfi(_handle);
@@ -497,14 +498,14 @@ final _Locale_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLi
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_Locale_get_value_nullable'));
-Pointer<Void> Locale_toFfi_nullable(Locale value) {
+Pointer<Void> Locale_toFfi_nullable(Locale? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = Locale_toFfi(value);
   final result = _Locale_create_handle_nullable(_handle);
   Locale_releaseFfiHandle(_handle);
   return result;
 }
-Locale Locale_fromFfi_nullable(Pointer<Void> handle) {
+Locale? Locale_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _Locale_get_value_nullable(handle);
   final result = Locale_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -37,11 +37,11 @@ class BasicTypes$Impl extends __lib.NativeBase implements BasicTypes {
   BasicTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_BasicTypes_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static String stringFunction(String input) {
     final _stringFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_BasicTypes_stringFunction__String'));
@@ -181,8 +181,8 @@ Pointer<Void> smoke_BasicTypes_toFfi(BasicTypes value) =>
 BasicTypes smoke_BasicTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as BasicTypes;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is BasicTypes) return instance;
   final _copied_handle = _smoke_BasicTypes_copy_handle(handle);
   final result = BasicTypes$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -190,9 +190,9 @@ BasicTypes smoke_BasicTypes_fromFfi(Pointer<Void> handle) {
 }
 void smoke_BasicTypes_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_BasicTypes_release_handle(handle);
-Pointer<Void> smoke_BasicTypes_toFfi_nullable(BasicTypes value) =>
+Pointer<Void> smoke_BasicTypes_toFfi_nullable(BasicTypes? value) =>
   value != null ? smoke_BasicTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
-BasicTypes smoke_BasicTypes_fromFfi_nullable(Pointer<Void> handle) =>
+BasicTypes? smoke_BasicTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_BasicTypes_fromFfi(handle) : null;
 void smoke_BasicTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_BasicTypes_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -112,14 +112,14 @@ final _smoke_Comments_SomeEnum_get_value_nullable = __lib.catchArgumentError(() 
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_Comments_SomeEnum_toFfi_nullable(Comments_SomeEnum value) {
+Pointer<Void> smoke_Comments_SomeEnum_toFfi_nullable(Comments_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Comments_SomeEnum_toFfi(value);
   final result = _smoke_Comments_SomeEnum_create_handle_nullable(_handle);
   smoke_Comments_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-Comments_SomeEnum smoke_Comments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+Comments_SomeEnum? smoke_Comments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Comments_SomeEnum_get_value_nullable(handle);
   final result = smoke_Comments_SomeEnum_fromFfi(_handle);
@@ -140,7 +140,7 @@ class Comments_SomeStruct {
   /// remains to be seen
   bool someField;
   /// Can be `null`
-  String nullableField;
+  String? nullableField;
   /// This is how easy it is to construct.
   /// [someField] How useful this struct is
   /// remains to be seen
@@ -199,14 +199,14 @@ final _smoke_Comments_SomeStruct_get_value_nullable = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Comments_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_Comments_SomeStruct_toFfi_nullable(Comments_SomeStruct value) {
+Pointer<Void> smoke_Comments_SomeStruct_toFfi_nullable(Comments_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Comments_SomeStruct_toFfi(value);
   final result = _smoke_Comments_SomeStruct_create_handle_nullable(_handle);
   smoke_Comments_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-Comments_SomeStruct smoke_Comments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+Comments_SomeStruct? smoke_Comments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Comments_SomeStruct_get_value_nullable(handle);
   final result = smoke_Comments_SomeStruct_fromFfi(_handle);
@@ -252,7 +252,7 @@ class Comments_SomeLambda$Impl {
   }
 }
 int _Comments_SomeLambda_call_static(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
-  double _result_object;
+  double? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as Comments_SomeLambda)(String_fromFfi(p0), (p1));
     _result.value = (_result_object);
@@ -294,14 +294,14 @@ final _smoke_Comments_SomeLambda_get_value_nullable = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Comments_SomeLambda_get_value_nullable'));
-Pointer<Void> smoke_Comments_SomeLambda_toFfi_nullable(Comments_SomeLambda value) {
+Pointer<Void> smoke_Comments_SomeLambda_toFfi_nullable(Comments_SomeLambda? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Comments_SomeLambda_toFfi(value);
   final result = _smoke_Comments_SomeLambda_create_handle_nullable(_handle);
   smoke_Comments_SomeLambda_releaseFfiHandle(_handle);
   return result;
 }
-Comments_SomeLambda smoke_Comments_SomeLambda_fromFfi_nullable(Pointer<Void> handle) {
+Comments_SomeLambda? smoke_Comments_SomeLambda_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Comments_SomeLambda_get_value_nullable(handle);
   final result = smoke_Comments_SomeLambda_fromFfi(_handle);
@@ -340,11 +340,11 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
   Comments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_Comments_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   bool someMethodWithAllComments(String inputParameter) {
@@ -537,8 +537,8 @@ Pointer<Void> smoke_Comments_toFfi(Comments value) =>
 Comments smoke_Comments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Comments;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Comments) return instance;
   final _copied_handle = _smoke_Comments_copy_handle(handle);
   final result = Comments$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -546,9 +546,9 @@ Comments smoke_Comments_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Comments_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Comments_release_handle(handle);
-Pointer<Void> smoke_Comments_toFfi_nullable(Comments value) =>
+Pointer<Void> smoke_Comments_toFfi_nullable(Comments? value) =>
   value != null ? smoke_Comments_toFfi(value) : Pointer<Void>.fromAddress(0);
-Comments smoke_Comments_fromFfi_nullable(Pointer<Void> handle) =>
+Comments? smoke_Comments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Comments_fromFfi(handle) : null;
 void smoke_Comments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Comments_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -10,18 +10,18 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class CommentsInterface {
   CommentsInterface() {}
   factory CommentsInterface.fromLambdas({
-    @required bool Function(String) lambda_someMethodWithAllComments,
-    @required bool Function(String) lambda_someMethodWithInputComments,
-    @required bool Function(String) lambda_someMethodWithOutputComments,
-    @required bool Function(String) lambda_someMethodWithNoComments,
-    @required void Function(String) lambda_someMethodWithoutReturnTypeWithAllComments,
-    @required void Function(String) lambda_someMethodWithoutReturnTypeWithNoComments,
-    @required bool Function() lambda_someMethodWithoutInputParametersWithAllComments,
-    @required bool Function() lambda_someMethodWithoutInputParametersWithNoComments,
-    @required void Function() lambda_someMethodWithNothing,
-    @required void Function() lambda_someMethodWithoutReturnTypeOrInputParameters,
-    @required bool Function() lambda_isSomeProperty_get,
-    @required void Function(bool) lambda_isSomeProperty_set
+    required bool Function(String) lambda_someMethodWithAllComments,
+    required bool Function(String) lambda_someMethodWithInputComments,
+    required bool Function(String) lambda_someMethodWithOutputComments,
+    required bool Function(String) lambda_someMethodWithNoComments,
+    required void Function(String) lambda_someMethodWithoutReturnTypeWithAllComments,
+    required void Function(String) lambda_someMethodWithoutReturnTypeWithNoComments,
+    required bool Function() lambda_someMethodWithoutInputParametersWithAllComments,
+    required bool Function() lambda_someMethodWithoutInputParametersWithNoComments,
+    required void Function() lambda_someMethodWithNothing,
+    required void Function() lambda_someMethodWithoutReturnTypeOrInputParameters,
+    required bool Function() lambda_isSomeProperty_get,
+    required void Function(bool) lambda_isSomeProperty_set
   }) => CommentsInterface$Lambdas(
     lambda_someMethodWithAllComments,
     lambda_someMethodWithInputComments,
@@ -133,14 +133,14 @@ final _smoke_CommentsInterface_SomeEnum_get_value_nullable = __lib.catchArgument
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_CommentsInterface_SomeEnum_toFfi_nullable(CommentsInterface_SomeEnum value) {
+Pointer<Void> smoke_CommentsInterface_SomeEnum_toFfi_nullable(CommentsInterface_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CommentsInterface_SomeEnum_toFfi(value);
   final result = _smoke_CommentsInterface_SomeEnum_create_handle_nullable(_handle);
   smoke_CommentsInterface_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-CommentsInterface_SomeEnum smoke_CommentsInterface_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+CommentsInterface_SomeEnum? smoke_CommentsInterface_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_CommentsInterface_SomeEnum_get_value_nullable(handle);
   final result = smoke_CommentsInterface_SomeEnum_fromFfi(_handle);
@@ -199,14 +199,14 @@ final _smoke_CommentsInterface_SomeStruct_get_value_nullable = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_CommentsInterface_SomeStruct_toFfi_nullable(CommentsInterface_SomeStruct value) {
+Pointer<Void> smoke_CommentsInterface_SomeStruct_toFfi_nullable(CommentsInterface_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CommentsInterface_SomeStruct_toFfi(value);
   final result = _smoke_CommentsInterface_SomeStruct_create_handle_nullable(_handle);
   smoke_CommentsInterface_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-CommentsInterface_SomeStruct smoke_CommentsInterface_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+CommentsInterface_SomeStruct? smoke_CommentsInterface_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_CommentsInterface_SomeStruct_get_value_nullable(handle);
   final result = smoke_CommentsInterface_SomeStruct_fromFfi(_handle);
@@ -301,11 +301,11 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   CommentsInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_CommentsInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   bool someMethodWithAllComments(String input) {
@@ -455,7 +455,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   }
 }
 int _CommentsInterface_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithAllComments(String_fromFfi(input));
     _result.value = Boolean_toFfi(_result_object);
@@ -465,7 +465,7 @@ int _CommentsInterface_someMethodWithAllComments_static(int _token, Pointer<Void
   return 0;
 }
 int _CommentsInterface_someMethodWithInputComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithInputComments(String_fromFfi(input));
     _result.value = Boolean_toFfi(_result_object);
@@ -475,7 +475,7 @@ int _CommentsInterface_someMethodWithInputComments_static(int _token, Pointer<Vo
   return 0;
 }
 int _CommentsInterface_someMethodWithOutputComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithOutputComments(String_fromFfi(input));
     _result.value = Boolean_toFfi(_result_object);
@@ -485,7 +485,7 @@ int _CommentsInterface_someMethodWithOutputComments_static(int _token, Pointer<V
   return 0;
 }
 int _CommentsInterface_someMethodWithNoComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithNoComments(String_fromFfi(input));
     _result.value = Boolean_toFfi(_result_object);
@@ -511,7 +511,7 @@ int _CommentsInterface_someMethodWithoutReturnTypeWithNoComments_static(int _tok
   return 0;
 }
 int _CommentsInterface_someMethodWithoutInputParametersWithAllComments_static(int _token, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithAllComments();
     _result.value = Boolean_toFfi(_result_object);
@@ -520,7 +520,7 @@ int _CommentsInterface_someMethodWithoutInputParametersWithAllComments_static(in
   return 0;
 }
 int _CommentsInterface_someMethodWithoutInputParametersWithNoComments_static(int _token, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithNoComments();
     _result.value = Boolean_toFfi(_result_object);
@@ -579,8 +579,8 @@ Pointer<Void> smoke_CommentsInterface_toFfi(CommentsInterface value) {
 CommentsInterface smoke_CommentsInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as CommentsInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is CommentsInterface) return instance;
   final _type_id_handle = _smoke_CommentsInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -593,9 +593,9 @@ CommentsInterface smoke_CommentsInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_CommentsInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_CommentsInterface_release_handle(handle);
-Pointer<Void> smoke_CommentsInterface_toFfi_nullable(CommentsInterface value) =>
+Pointer<Void> smoke_CommentsInterface_toFfi_nullable(CommentsInterface? value) =>
   value != null ? smoke_CommentsInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-CommentsInterface smoke_CommentsInterface_fromFfi_nullable(Pointer<Void> handle) =>
+CommentsInterface? smoke_CommentsInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_CommentsInterface_fromFfi(handle) : null;
 void smoke_CommentsInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_CommentsInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -116,14 +116,14 @@ final _smoke_CommentsLinks_RandomStruct_get_value_nullable = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_RandomStruct_get_value_nullable'));
-Pointer<Void> smoke_CommentsLinks_RandomStruct_toFfi_nullable(CommentsLinks_RandomStruct value) {
+Pointer<Void> smoke_CommentsLinks_RandomStruct_toFfi_nullable(CommentsLinks_RandomStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CommentsLinks_RandomStruct_toFfi(value);
   final result = _smoke_CommentsLinks_RandomStruct_create_handle_nullable(_handle);
   smoke_CommentsLinks_RandomStruct_releaseFfiHandle(_handle);
   return result;
 }
-CommentsLinks_RandomStruct smoke_CommentsLinks_RandomStruct_fromFfi_nullable(Pointer<Void> handle) {
+CommentsLinks_RandomStruct? smoke_CommentsLinks_RandomStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_CommentsLinks_RandomStruct_get_value_nullable(handle);
   final result = smoke_CommentsLinks_RandomStruct_fromFfi(_handle);
@@ -162,11 +162,11 @@ class CommentsLinks$Impl extends __lib.NativeBase implements CommentsLinks {
   CommentsLinks$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_CommentsLinks_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   Comments_SomeEnum randomMethod(Comments_SomeEnum inputParameter) {
@@ -213,8 +213,8 @@ Pointer<Void> smoke_CommentsLinks_toFfi(CommentsLinks value) =>
 CommentsLinks smoke_CommentsLinks_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as CommentsLinks;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is CommentsLinks) return instance;
   final _copied_handle = _smoke_CommentsLinks_copy_handle(handle);
   final result = CommentsLinks$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -222,9 +222,9 @@ CommentsLinks smoke_CommentsLinks_fromFfi(Pointer<Void> handle) {
 }
 void smoke_CommentsLinks_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_CommentsLinks_release_handle(handle);
-Pointer<Void> smoke_CommentsLinks_toFfi_nullable(CommentsLinks value) =>
+Pointer<Void> smoke_CommentsLinks_toFfi_nullable(CommentsLinks? value) =>
   value != null ? smoke_CommentsLinks_toFfi(value) : Pointer<Void>.fromAddress(0);
-CommentsLinks smoke_CommentsLinks_fromFfi_nullable(Pointer<Void> handle) =>
+CommentsLinks? smoke_CommentsLinks_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_CommentsLinks_fromFfi(handle) : null;
 void smoke_CommentsLinks_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_CommentsLinks_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
@@ -51,14 +51,14 @@ final _smoke_DeprecatedWithNoMessage_get_value_nullable = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecatedWithNoMessage_get_value_nullable'));
-Pointer<Void> smoke_DeprecatedWithNoMessage_toFfi_nullable(DeprecatedWithNoMessage value) {
+Pointer<Void> smoke_DeprecatedWithNoMessage_toFfi_nullable(DeprecatedWithNoMessage? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecatedWithNoMessage_toFfi(value);
   final result = _smoke_DeprecatedWithNoMessage_create_handle_nullable(_handle);
   smoke_DeprecatedWithNoMessage_releaseFfiHandle(_handle);
   return result;
 }
-DeprecatedWithNoMessage smoke_DeprecatedWithNoMessage_fromFfi_nullable(Pointer<Void> handle) {
+DeprecatedWithNoMessage? smoke_DeprecatedWithNoMessage_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DeprecatedWithNoMessage_get_value_nullable(handle);
   final result = smoke_DeprecatedWithNoMessage_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -11,11 +11,11 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class DeprecationComments {
   DeprecationComments() {}
   factory DeprecationComments.fromLambdas({
-    @required bool Function(String) lambda_someMethodWithAllComments,
-    @required bool Function() lambda_isSomeProperty_get,
-    @required void Function(bool) lambda_isSomeProperty_set,
-    @required String Function() lambda_propertyButNotAccessors_get,
-    @required void Function(String) lambda_propertyButNotAccessors_set
+    required bool Function(String) lambda_someMethodWithAllComments,
+    required bool Function() lambda_isSomeProperty_get,
+    required void Function(bool) lambda_isSomeProperty_set,
+    required String Function() lambda_propertyButNotAccessors_get,
+    required void Function(String) lambda_propertyButNotAccessors_set
   }) => DeprecationComments$Lambdas(
     lambda_someMethodWithAllComments,
     lambda_isSomeProperty_get,
@@ -90,14 +90,14 @@ final _smoke_DeprecationComments_SomeEnum_get_value_nullable = __lib.catchArgume
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_DeprecationComments_SomeEnum_toFfi_nullable(DeprecationComments_SomeEnum value) {
+Pointer<Void> smoke_DeprecationComments_SomeEnum_toFfi_nullable(DeprecationComments_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecationComments_SomeEnum_toFfi(value);
   final result = _smoke_DeprecationComments_SomeEnum_create_handle_nullable(_handle);
   smoke_DeprecationComments_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-DeprecationComments_SomeEnum smoke_DeprecationComments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+DeprecationComments_SomeEnum? smoke_DeprecationComments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DeprecationComments_SomeEnum_get_value_nullable(handle);
   final result = smoke_DeprecationComments_SomeEnum_fromFfi(_handle);
@@ -163,14 +163,14 @@ final _smoke_DeprecationComments_SomeStruct_get_value_nullable = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_DeprecationComments_SomeStruct_toFfi_nullable(DeprecationComments_SomeStruct value) {
+Pointer<Void> smoke_DeprecationComments_SomeStruct_toFfi_nullable(DeprecationComments_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecationComments_SomeStruct_toFfi(value);
   final result = _smoke_DeprecationComments_SomeStruct_create_handle_nullable(_handle);
   smoke_DeprecationComments_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-DeprecationComments_SomeStruct smoke_DeprecationComments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+DeprecationComments_SomeStruct? smoke_DeprecationComments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DeprecationComments_SomeStruct_get_value_nullable(handle);
   final result = smoke_DeprecationComments_SomeStruct_fromFfi(_handle);
@@ -228,11 +228,11 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
   DeprecationComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_DeprecationComments_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   bool someMethodWithAllComments(String input) {
@@ -300,7 +300,7 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
   }
 }
 int _DeprecationComments_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as DeprecationComments).someMethodWithAllComments(String_fromFfi(input));
     _result.value = Boolean_toFfi(_result_object);
@@ -352,8 +352,8 @@ Pointer<Void> smoke_DeprecationComments_toFfi(DeprecationComments value) {
 DeprecationComments smoke_DeprecationComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as DeprecationComments;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is DeprecationComments) return instance;
   final _type_id_handle = _smoke_DeprecationComments_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -366,9 +366,9 @@ DeprecationComments smoke_DeprecationComments_fromFfi(Pointer<Void> handle) {
 }
 void smoke_DeprecationComments_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_DeprecationComments_release_handle(handle);
-Pointer<Void> smoke_DeprecationComments_toFfi_nullable(DeprecationComments value) =>
+Pointer<Void> smoke_DeprecationComments_toFfi_nullable(DeprecationComments? value) =>
   value != null ? smoke_DeprecationComments_toFfi(value) : Pointer<Void>.fromAddress(0);
-DeprecationComments smoke_DeprecationComments_fromFfi_nullable(Pointer<Void> handle) =>
+DeprecationComments? smoke_DeprecationComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_DeprecationComments_fromFfi(handle) : null;
 void smoke_DeprecationComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_DeprecationComments_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -10,9 +10,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class DeprecationCommentsOnly {
   DeprecationCommentsOnly() {}
   factory DeprecationCommentsOnly.fromLambdas({
-    @required bool Function(String) lambda_someMethodWithAllComments,
-    @required bool Function() lambda_isSomeProperty_get,
-    @required void Function(bool) lambda_isSomeProperty_set
+    required bool Function(String) lambda_someMethodWithAllComments,
+    required bool Function() lambda_isSomeProperty_get,
+    required void Function(bool) lambda_isSomeProperty_set
   }) => DeprecationCommentsOnly$Lambdas(
     lambda_someMethodWithAllComments,
     lambda_isSomeProperty_get,
@@ -73,14 +73,14 @@ final _smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable = __lib.catchAr
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_DeprecationCommentsOnly_SomeEnum_toFfi_nullable(DeprecationCommentsOnly_SomeEnum value) {
+Pointer<Void> smoke_DeprecationCommentsOnly_SomeEnum_toFfi_nullable(DeprecationCommentsOnly_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecationCommentsOnly_SomeEnum_toFfi(value);
   final result = _smoke_DeprecationCommentsOnly_SomeEnum_create_handle_nullable(_handle);
   smoke_DeprecationCommentsOnly_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-DeprecationCommentsOnly_SomeEnum smoke_DeprecationCommentsOnly_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+DeprecationCommentsOnly_SomeEnum? smoke_DeprecationCommentsOnly_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable(handle);
   final result = smoke_DeprecationCommentsOnly_SomeEnum_fromFfi(_handle);
@@ -139,14 +139,14 @@ final _smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable = __lib.catch
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_DeprecationCommentsOnly_SomeStruct_toFfi_nullable(DeprecationCommentsOnly_SomeStruct value) {
+Pointer<Void> smoke_DeprecationCommentsOnly_SomeStruct_toFfi_nullable(DeprecationCommentsOnly_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecationCommentsOnly_SomeStruct_toFfi(value);
   final result = _smoke_DeprecationCommentsOnly_SomeStruct_create_handle_nullable(_handle);
   smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-DeprecationCommentsOnly_SomeStruct smoke_DeprecationCommentsOnly_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+DeprecationCommentsOnly_SomeStruct? smoke_DeprecationCommentsOnly_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable(handle);
   final result = smoke_DeprecationCommentsOnly_SomeStruct_fromFfi(_handle);
@@ -196,11 +196,11 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
   DeprecationCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_DeprecationCommentsOnly_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   bool someMethodWithAllComments(String input) {
@@ -241,7 +241,7 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
   }
 }
 int _DeprecationCommentsOnly_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as DeprecationCommentsOnly).someMethodWithAllComments(String_fromFfi(input));
     _result.value = Boolean_toFfi(_result_object);
@@ -278,8 +278,8 @@ Pointer<Void> smoke_DeprecationCommentsOnly_toFfi(DeprecationCommentsOnly value)
 DeprecationCommentsOnly smoke_DeprecationCommentsOnly_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as DeprecationCommentsOnly;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is DeprecationCommentsOnly) return instance;
   final _type_id_handle = _smoke_DeprecationCommentsOnly_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -292,9 +292,9 @@ DeprecationCommentsOnly smoke_DeprecationCommentsOnly_fromFfi(Pointer<Void> hand
 }
 void smoke_DeprecationCommentsOnly_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_DeprecationCommentsOnly_release_handle(handle);
-Pointer<Void> smoke_DeprecationCommentsOnly_toFfi_nullable(DeprecationCommentsOnly value) =>
+Pointer<Void> smoke_DeprecationCommentsOnly_toFfi_nullable(DeprecationCommentsOnly? value) =>
   value != null ? smoke_DeprecationCommentsOnly_toFfi(value) : Pointer<Void>.fromAddress(0);
-DeprecationCommentsOnly smoke_DeprecationCommentsOnly_fromFfi_nullable(Pointer<Void> handle) =>
+DeprecationCommentsOnly? smoke_DeprecationCommentsOnly_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_DeprecationCommentsOnly_fromFfi(handle) : null;
 void smoke_DeprecationCommentsOnly_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_DeprecationCommentsOnly_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -76,14 +76,14 @@ final _smoke_ExcludedComments_SomeEnum_get_value_nullable = __lib.catchArgumentE
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_ExcludedComments_SomeEnum_toFfi_nullable(ExcludedComments_SomeEnum value) {
+Pointer<Void> smoke_ExcludedComments_SomeEnum_toFfi_nullable(ExcludedComments_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExcludedComments_SomeEnum_toFfi(value);
   final result = _smoke_ExcludedComments_SomeEnum_create_handle_nullable(_handle);
   smoke_ExcludedComments_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-ExcludedComments_SomeEnum smoke_ExcludedComments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+ExcludedComments_SomeEnum? smoke_ExcludedComments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ExcludedComments_SomeEnum_get_value_nullable(handle);
   final result = smoke_ExcludedComments_SomeEnum_fromFfi(_handle);
@@ -154,14 +154,14 @@ final _smoke_ExcludedComments_SomeStruct_get_value_nullable = __lib.catchArgumen
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_ExcludedComments_SomeStruct_toFfi_nullable(ExcludedComments_SomeStruct value) {
+Pointer<Void> smoke_ExcludedComments_SomeStruct_toFfi_nullable(ExcludedComments_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExcludedComments_SomeStruct_toFfi(value);
   final result = _smoke_ExcludedComments_SomeStruct_create_handle_nullable(_handle);
   smoke_ExcludedComments_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-ExcludedComments_SomeStruct smoke_ExcludedComments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+ExcludedComments_SomeStruct? smoke_ExcludedComments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ExcludedComments_SomeStruct_get_value_nullable(handle);
   final result = smoke_ExcludedComments_SomeStruct_fromFfi(_handle);
@@ -208,7 +208,7 @@ class ExcludedComments_SomeLambda$Impl {
   }
 }
 int _ExcludedComments_SomeLambda_call_static(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
-  double _result_object;
+  double? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as ExcludedComments_SomeLambda)(String_fromFfi(p0), (p1));
     _result.value = (_result_object);
@@ -250,14 +250,14 @@ final _smoke_ExcludedComments_SomeLambda_get_value_nullable = __lib.catchArgumen
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeLambda_get_value_nullable'));
-Pointer<Void> smoke_ExcludedComments_SomeLambda_toFfi_nullable(ExcludedComments_SomeLambda value) {
+Pointer<Void> smoke_ExcludedComments_SomeLambda_toFfi_nullable(ExcludedComments_SomeLambda? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExcludedComments_SomeLambda_toFfi(value);
   final result = _smoke_ExcludedComments_SomeLambda_create_handle_nullable(_handle);
   smoke_ExcludedComments_SomeLambda_releaseFfiHandle(_handle);
   return result;
 }
-ExcludedComments_SomeLambda smoke_ExcludedComments_SomeLambda_fromFfi_nullable(Pointer<Void> handle) {
+ExcludedComments_SomeLambda? smoke_ExcludedComments_SomeLambda_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ExcludedComments_SomeLambda_get_value_nullable(handle);
   final result = smoke_ExcludedComments_SomeLambda_fromFfi(_handle);
@@ -296,11 +296,11 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
   ExcludedComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ExcludedComments_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   bool someMethodWithAllComments(String inputParameter) {
@@ -367,8 +367,8 @@ Pointer<Void> smoke_ExcludedComments_toFfi(ExcludedComments value) =>
 ExcludedComments smoke_ExcludedComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ExcludedComments;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ExcludedComments) return instance;
   final _copied_handle = _smoke_ExcludedComments_copy_handle(handle);
   final result = ExcludedComments$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -376,9 +376,9 @@ ExcludedComments smoke_ExcludedComments_fromFfi(Pointer<Void> handle) {
 }
 void smoke_ExcludedComments_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ExcludedComments_release_handle(handle);
-Pointer<Void> smoke_ExcludedComments_toFfi_nullable(ExcludedComments value) =>
+Pointer<Void> smoke_ExcludedComments_toFfi_nullable(ExcludedComments? value) =>
   value != null ? smoke_ExcludedComments_toFfi(value) : Pointer<Void>.fromAddress(0);
-ExcludedComments smoke_ExcludedComments_fromFfi_nullable(Pointer<Void> handle) =>
+ExcludedComments? smoke_ExcludedComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ExcludedComments_fromFfi(handle) : null;
 void smoke_ExcludedComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ExcludedComments_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
@@ -36,11 +36,11 @@ class ExcludedCommentsInterface$Impl extends __lib.NativeBase implements Exclude
   ExcludedCommentsInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ExcludedCommentsInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 }
 Pointer<Void> smoke_ExcludedCommentsInterface_toFfi(ExcludedCommentsInterface value) {
@@ -55,8 +55,8 @@ Pointer<Void> smoke_ExcludedCommentsInterface_toFfi(ExcludedCommentsInterface va
 ExcludedCommentsInterface smoke_ExcludedCommentsInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ExcludedCommentsInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ExcludedCommentsInterface) return instance;
   final _type_id_handle = _smoke_ExcludedCommentsInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -69,9 +69,9 @@ ExcludedCommentsInterface smoke_ExcludedCommentsInterface_fromFfi(Pointer<Void> 
 }
 void smoke_ExcludedCommentsInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ExcludedCommentsInterface_release_handle(handle);
-Pointer<Void> smoke_ExcludedCommentsInterface_toFfi_nullable(ExcludedCommentsInterface value) =>
+Pointer<Void> smoke_ExcludedCommentsInterface_toFfi_nullable(ExcludedCommentsInterface? value) =>
   value != null ? smoke_ExcludedCommentsInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-ExcludedCommentsInterface smoke_ExcludedCommentsInterface_fromFfi_nullable(Pointer<Void> handle) =>
+ExcludedCommentsInterface? smoke_ExcludedCommentsInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ExcludedCommentsInterface_fromFfi(handle) : null;
 void smoke_ExcludedCommentsInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ExcludedCommentsInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -60,14 +60,14 @@ final _smoke_ExcludedCommentsOnly_SomeEnum_get_value_nullable = __lib.catchArgum
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_ExcludedCommentsOnly_SomeEnum_toFfi_nullable(ExcludedCommentsOnly_SomeEnum value) {
+Pointer<Void> smoke_ExcludedCommentsOnly_SomeEnum_toFfi_nullable(ExcludedCommentsOnly_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExcludedCommentsOnly_SomeEnum_toFfi(value);
   final result = _smoke_ExcludedCommentsOnly_SomeEnum_create_handle_nullable(_handle);
   smoke_ExcludedCommentsOnly_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-ExcludedCommentsOnly_SomeEnum smoke_ExcludedCommentsOnly_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+ExcludedCommentsOnly_SomeEnum? smoke_ExcludedCommentsOnly_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ExcludedCommentsOnly_SomeEnum_get_value_nullable(handle);
   final result = smoke_ExcludedCommentsOnly_SomeEnum_fromFfi(_handle);
@@ -131,14 +131,14 @@ final _smoke_ExcludedCommentsOnly_SomeStruct_get_value_nullable = __lib.catchArg
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_ExcludedCommentsOnly_SomeStruct_toFfi_nullable(ExcludedCommentsOnly_SomeStruct value) {
+Pointer<Void> smoke_ExcludedCommentsOnly_SomeStruct_toFfi_nullable(ExcludedCommentsOnly_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExcludedCommentsOnly_SomeStruct_toFfi(value);
   final result = _smoke_ExcludedCommentsOnly_SomeStruct_create_handle_nullable(_handle);
   smoke_ExcludedCommentsOnly_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-ExcludedCommentsOnly_SomeStruct smoke_ExcludedCommentsOnly_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+ExcludedCommentsOnly_SomeStruct? smoke_ExcludedCommentsOnly_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ExcludedCommentsOnly_SomeStruct_get_value_nullable(handle);
   final result = smoke_ExcludedCommentsOnly_SomeStruct_fromFfi(_handle);
@@ -184,7 +184,7 @@ class ExcludedCommentsOnly_SomeLambda$Impl {
   }
 }
 int _ExcludedCommentsOnly_SomeLambda_call_static(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
-  double _result_object;
+  double? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as ExcludedCommentsOnly_SomeLambda)(String_fromFfi(p0), (p1));
     _result.value = (_result_object);
@@ -226,14 +226,14 @@ final _smoke_ExcludedCommentsOnly_SomeLambda_get_value_nullable = __lib.catchArg
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeLambda_get_value_nullable'));
-Pointer<Void> smoke_ExcludedCommentsOnly_SomeLambda_toFfi_nullable(ExcludedCommentsOnly_SomeLambda value) {
+Pointer<Void> smoke_ExcludedCommentsOnly_SomeLambda_toFfi_nullable(ExcludedCommentsOnly_SomeLambda? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExcludedCommentsOnly_SomeLambda_toFfi(value);
   final result = _smoke_ExcludedCommentsOnly_SomeLambda_create_handle_nullable(_handle);
   smoke_ExcludedCommentsOnly_SomeLambda_releaseFfiHandle(_handle);
   return result;
 }
-ExcludedCommentsOnly_SomeLambda smoke_ExcludedCommentsOnly_SomeLambda_fromFfi_nullable(Pointer<Void> handle) {
+ExcludedCommentsOnly_SomeLambda? smoke_ExcludedCommentsOnly_SomeLambda_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ExcludedCommentsOnly_SomeLambda_get_value_nullable(handle);
   final result = smoke_ExcludedCommentsOnly_SomeLambda_fromFfi(_handle);
@@ -272,11 +272,11 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
   ExcludedCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ExcludedCommentsOnly_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   bool someMethodWithAllComments(String inputParameter) {
@@ -343,8 +343,8 @@ Pointer<Void> smoke_ExcludedCommentsOnly_toFfi(ExcludedCommentsOnly value) =>
 ExcludedCommentsOnly smoke_ExcludedCommentsOnly_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ExcludedCommentsOnly;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ExcludedCommentsOnly) return instance;
   final _copied_handle = _smoke_ExcludedCommentsOnly_copy_handle(handle);
   final result = ExcludedCommentsOnly$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -352,9 +352,9 @@ ExcludedCommentsOnly smoke_ExcludedCommentsOnly_fromFfi(Pointer<Void> handle) {
 }
 void smoke_ExcludedCommentsOnly_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ExcludedCommentsOnly_release_handle(handle);
-Pointer<Void> smoke_ExcludedCommentsOnly_toFfi_nullable(ExcludedCommentsOnly value) =>
+Pointer<Void> smoke_ExcludedCommentsOnly_toFfi_nullable(ExcludedCommentsOnly? value) =>
   value != null ? smoke_ExcludedCommentsOnly_toFfi(value) : Pointer<Void>.fromAddress(0);
-ExcludedCommentsOnly smoke_ExcludedCommentsOnly_fromFfi_nullable(Pointer<Void> handle) =>
+ExcludedCommentsOnly? smoke_ExcludedCommentsOnly_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ExcludedCommentsOnly_fromFfi(handle) : null;
 void smoke_ExcludedCommentsOnly_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ExcludedCommentsOnly_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -31,11 +31,11 @@ class InternalClassWithComments$Impl extends __lib.NativeBase implements Interna
   InternalClassWithComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_InternalClassWithComments_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   internal_doNothing() {
@@ -54,8 +54,8 @@ Pointer<Void> smoke_InternalClassWithComments_toFfi(InternalClassWithComments va
 InternalClassWithComments smoke_InternalClassWithComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as InternalClassWithComments;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is InternalClassWithComments) return instance;
   final _copied_handle = _smoke_InternalClassWithComments_copy_handle(handle);
   final result = InternalClassWithComments$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -63,9 +63,9 @@ InternalClassWithComments smoke_InternalClassWithComments_fromFfi(Pointer<Void> 
 }
 void smoke_InternalClassWithComments_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_InternalClassWithComments_release_handle(handle);
-Pointer<Void> smoke_InternalClassWithComments_toFfi_nullable(InternalClassWithComments value) =>
+Pointer<Void> smoke_InternalClassWithComments_toFfi_nullable(InternalClassWithComments? value) =>
   value != null ? smoke_InternalClassWithComments_toFfi(value) : Pointer<Void>.fromAddress(0);
-InternalClassWithComments smoke_InternalClassWithComments_fromFfi_nullable(Pointer<Void> handle) =>
+InternalClassWithComments? smoke_InternalClassWithComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InternalClassWithComments_fromFfi(handle) : null;
 void smoke_InternalClassWithComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_InternalClassWithComments_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -12,10 +12,10 @@ abstract class MapScene {
   /// Call this to free memory when you no longer need this instance.
   /// Note that setting the instance to null will not destroy the underlying native object.
   void release();
-  loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback callback);
-  loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback callback);
+  loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback? callback);
+  loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback? callback);
 }
-typedef MapScene_LoadSceneCallback = void Function(String);
+typedef MapScene_LoadSceneCallback = void Function(String?);
 // MapScene_LoadSceneCallback "private" section, not exported.
 final _smoke_MapScene_LoadSceneCallback_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
@@ -34,7 +34,7 @@ class MapScene_LoadSceneCallback$Impl {
   final Pointer<Void> handle;
   MapScene_LoadSceneCallback$Impl(this.handle);
   void release() => _smoke_MapScene_LoadSceneCallback_release_handle(handle);
-  call(String p0) {
+  call(String? p0) {
     final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MapScene_LoadSceneCallback_call__String'));
     final _p0_handle = String_toFfi_nullable(p0);
     final _handle = this.handle;
@@ -66,7 +66,7 @@ Pointer<Void> smoke_MapScene_LoadSceneCallback_toFfi(MapScene_LoadSceneCallback 
 }
 MapScene_LoadSceneCallback smoke_MapScene_LoadSceneCallback_fromFfi(Pointer<Void> handle) {
   final _impl = MapScene_LoadSceneCallback$Impl(_smoke_MapScene_LoadSceneCallback_copy_handle(handle));
-  return (String p0) {
+  return (String? p0) {
     final _result =_impl.call(p0);
     _impl.release();
     return _result;
@@ -87,14 +87,14 @@ final _smoke_MapScene_LoadSceneCallback_get_value_nullable = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MapScene_LoadSceneCallback_get_value_nullable'));
-Pointer<Void> smoke_MapScene_LoadSceneCallback_toFfi_nullable(MapScene_LoadSceneCallback value) {
+Pointer<Void> smoke_MapScene_LoadSceneCallback_toFfi_nullable(MapScene_LoadSceneCallback? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_MapScene_LoadSceneCallback_toFfi(value);
   final result = _smoke_MapScene_LoadSceneCallback_create_handle_nullable(_handle);
   smoke_MapScene_LoadSceneCallback_releaseFfiHandle(_handle);
   return result;
 }
-MapScene_LoadSceneCallback smoke_MapScene_LoadSceneCallback_fromFfi_nullable(Pointer<Void> handle) {
+MapScene_LoadSceneCallback? smoke_MapScene_LoadSceneCallback_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_MapScene_LoadSceneCallback_get_value_nullable(handle);
   final result = smoke_MapScene_LoadSceneCallback_fromFfi(_handle);
@@ -117,14 +117,14 @@ class MapScene$Impl extends __lib.NativeBase implements MapScene {
   MapScene$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_MapScene_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
-  loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback callback) {
+  loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback? callback) {
     final _loadSceneWithInt_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int32, Pointer<Void>), void Function(Pointer<Void>, int, int, Pointer<Void>)>('library_smoke_MapScene_loadScene__Int_LoadSceneCallback'));
     final _mapScheme_handle = (mapScheme);
     final _callback_handle = smoke_MapScene_LoadSceneCallback_toFfi_nullable(callback);
@@ -139,7 +139,7 @@ class MapScene$Impl extends __lib.NativeBase implements MapScene {
     }
   }
   @override
-  loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback callback) {
+  loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback? callback) {
     final _loadSceneWithString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MapScene_loadScene__String_LoadSceneCallback'));
     final _configurationFile_handle = String_toFfi(configurationFile);
     final _callback_handle = smoke_MapScene_LoadSceneCallback_toFfi_nullable(callback);
@@ -159,8 +159,8 @@ Pointer<Void> smoke_MapScene_toFfi(MapScene value) =>
 MapScene smoke_MapScene_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as MapScene;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is MapScene) return instance;
   final _copied_handle = _smoke_MapScene_copy_handle(handle);
   final result = MapScene$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -168,9 +168,9 @@ MapScene smoke_MapScene_fromFfi(Pointer<Void> handle) {
 }
 void smoke_MapScene_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_MapScene_release_handle(handle);
-Pointer<Void> smoke_MapScene_toFfi_nullable(MapScene value) =>
+Pointer<Void> smoke_MapScene_toFfi_nullable(MapScene? value) =>
   value != null ? smoke_MapScene_toFfi(value) : Pointer<Void>.fromAddress(0);
-MapScene smoke_MapScene_fromFfi_nullable(Pointer<Void> handle) =>
+MapScene? smoke_MapScene_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_MapScene_fromFfi(handle) : null;
 void smoke_MapScene_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_MapScene_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -58,11 +58,11 @@ class MultiLineComments$Impl extends __lib.NativeBase implements MultiLineCommen
   MultiLineComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_MultiLineComments_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   double someMethodWithLongComment(String input, double ratio) {
@@ -85,8 +85,8 @@ Pointer<Void> smoke_MultiLineComments_toFfi(MultiLineComments value) =>
 MultiLineComments smoke_MultiLineComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as MultiLineComments;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is MultiLineComments) return instance;
   final _copied_handle = _smoke_MultiLineComments_copy_handle(handle);
   final result = MultiLineComments$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -94,9 +94,9 @@ MultiLineComments smoke_MultiLineComments_fromFfi(Pointer<Void> handle) {
 }
 void smoke_MultiLineComments_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_MultiLineComments_release_handle(handle);
-Pointer<Void> smoke_MultiLineComments_toFfi_nullable(MultiLineComments value) =>
+Pointer<Void> smoke_MultiLineComments_toFfi_nullable(MultiLineComments? value) =>
   value != null ? smoke_MultiLineComments_toFfi(value) : Pointer<Void>.fromAddress(0);
-MultiLineComments smoke_MultiLineComments_fromFfi_nullable(Pointer<Void> handle) =>
+MultiLineComments? smoke_MultiLineComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_MultiLineComments_fromFfi(handle) : null;
 void smoke_MultiLineComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_MultiLineComments_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -71,14 +71,14 @@ final _smoke_PlatformComments_SomeEnum_get_value_nullable = __lib.catchArgumentE
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformComments_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_PlatformComments_SomeEnum_toFfi_nullable(PlatformComments_SomeEnum value) {
+Pointer<Void> smoke_PlatformComments_SomeEnum_toFfi_nullable(PlatformComments_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PlatformComments_SomeEnum_toFfi(value);
   final result = _smoke_PlatformComments_SomeEnum_create_handle_nullable(_handle);
   smoke_PlatformComments_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-PlatformComments_SomeEnum smoke_PlatformComments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+PlatformComments_SomeEnum? smoke_PlatformComments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_PlatformComments_SomeEnum_get_value_nullable(handle);
   final result = smoke_PlatformComments_SomeEnum_fromFfi(_handle);
@@ -141,14 +141,14 @@ final _smoke_PlatformComments_Something_get_value_nullable = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformComments_Something_get_value_nullable'));
-Pointer<Void> smoke_PlatformComments_Something_toFfi_nullable(PlatformComments_Something value) {
+Pointer<Void> smoke_PlatformComments_Something_toFfi_nullable(PlatformComments_Something? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PlatformComments_Something_toFfi(value);
   final result = _smoke_PlatformComments_Something_create_handle_nullable(_handle);
   smoke_PlatformComments_Something_releaseFfiHandle(_handle);
   return result;
 }
-PlatformComments_Something smoke_PlatformComments_Something_fromFfi_nullable(Pointer<Void> handle) {
+PlatformComments_Something? smoke_PlatformComments_Something_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_PlatformComments_Something_get_value_nullable(handle);
   final result = smoke_PlatformComments_Something_fromFfi(_handle);
@@ -187,11 +187,11 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
   PlatformComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_PlatformComments_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   doNothing() {
@@ -256,8 +256,8 @@ Pointer<Void> smoke_PlatformComments_toFfi(PlatformComments value) =>
 PlatformComments smoke_PlatformComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as PlatformComments;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is PlatformComments) return instance;
   final _copied_handle = _smoke_PlatformComments_copy_handle(handle);
   final result = PlatformComments$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -265,9 +265,9 @@ PlatformComments smoke_PlatformComments_fromFfi(Pointer<Void> handle) {
 }
 void smoke_PlatformComments_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_PlatformComments_release_handle(handle);
-Pointer<Void> smoke_PlatformComments_toFfi_nullable(PlatformComments value) =>
+Pointer<Void> smoke_PlatformComments_toFfi_nullable(PlatformComments? value) =>
   value != null ? smoke_PlatformComments_toFfi(value) : Pointer<Void>.fromAddress(0);
-PlatformComments smoke_PlatformComments_fromFfi_nullable(Pointer<Void> handle) =>
+PlatformComments? smoke_PlatformComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_PlatformComments_fromFfi(handle) : null;
 void smoke_PlatformComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_PlatformComments_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -51,11 +51,11 @@ class UnicodeComments$Impl extends __lib.NativeBase implements UnicodeComments {
   UnicodeComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_UnicodeComments_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   bool someMethodWithAllComments(String input) {
@@ -87,8 +87,8 @@ Pointer<Void> smoke_UnicodeComments_toFfi(UnicodeComments value) =>
 UnicodeComments smoke_UnicodeComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as UnicodeComments;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is UnicodeComments) return instance;
   final _copied_handle = _smoke_UnicodeComments_copy_handle(handle);
   final result = UnicodeComments$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -96,9 +96,9 @@ UnicodeComments smoke_UnicodeComments_fromFfi(Pointer<Void> handle) {
 }
 void smoke_UnicodeComments_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_UnicodeComments_release_handle(handle);
-Pointer<Void> smoke_UnicodeComments_toFfi_nullable(UnicodeComments value) =>
+Pointer<Void> smoke_UnicodeComments_toFfi_nullable(UnicodeComments? value) =>
   value != null ? smoke_UnicodeComments_toFfi(value) : Pointer<Void>.fromAddress(0);
-UnicodeComments smoke_UnicodeComments_fromFfi_nullable(Pointer<Void> handle) =>
+UnicodeComments? smoke_UnicodeComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_UnicodeComments_fromFfi(handle) : null;
 void smoke_UnicodeComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_UnicodeComments_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
@@ -28,11 +28,11 @@ class CollectionConstants$Impl extends __lib.NativeBase implements CollectionCon
   CollectionConstants$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_CollectionConstants_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 }
 Pointer<Void> smoke_CollectionConstants_toFfi(CollectionConstants value) =>
@@ -40,8 +40,8 @@ Pointer<Void> smoke_CollectionConstants_toFfi(CollectionConstants value) =>
 CollectionConstants smoke_CollectionConstants_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as CollectionConstants;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is CollectionConstants) return instance;
   final _copied_handle = _smoke_CollectionConstants_copy_handle(handle);
   final result = CollectionConstants$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -49,9 +49,9 @@ CollectionConstants smoke_CollectionConstants_fromFfi(Pointer<Void> handle) {
 }
 void smoke_CollectionConstants_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_CollectionConstants_release_handle(handle);
-Pointer<Void> smoke_CollectionConstants_toFfi_nullable(CollectionConstants value) =>
+Pointer<Void> smoke_CollectionConstants_toFfi_nullable(CollectionConstants? value) =>
   value != null ? smoke_CollectionConstants_toFfi(value) : Pointer<Void>.fromAddress(0);
-CollectionConstants smoke_CollectionConstants_fromFfi_nullable(Pointer<Void> handle) =>
+CollectionConstants? smoke_CollectionConstants_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_CollectionConstants_fromFfi(handle) : null;
 void smoke_CollectionConstants_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_CollectionConstants_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants.dart
@@ -2,7 +2,6 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 enum StateEnum {
     off,
     on
@@ -45,14 +44,14 @@ final _smoke_Constants_StateEnum_get_value_nullable = __lib.catchArgumentError((
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constants_StateEnum_get_value_nullable'));
-Pointer<Void> smoke_Constants_StateEnum_toFfi_nullable(StateEnum value) {
+Pointer<Void> smoke_Constants_StateEnum_toFfi_nullable(StateEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Constants_StateEnum_toFfi(value);
   final result = _smoke_Constants_StateEnum_create_handle_nullable(_handle);
   smoke_Constants_StateEnum_releaseFfiHandle(_handle);
   return result;
 }
-StateEnum smoke_Constants_StateEnum_fromFfi_nullable(Pointer<Void> handle) {
+StateEnum? smoke_Constants_StateEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Constants_StateEnum_get_value_nullable(handle);
   final result = smoke_Constants_StateEnum_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
@@ -60,14 +60,14 @@ final _smoke_ConstantsInterface_StateEnum_get_value_nullable = __lib.catchArgume
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ConstantsInterface_StateEnum_get_value_nullable'));
-Pointer<Void> smoke_ConstantsInterface_StateEnum_toFfi_nullable(ConstantsInterface_StateEnum value) {
+Pointer<Void> smoke_ConstantsInterface_StateEnum_toFfi_nullable(ConstantsInterface_StateEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ConstantsInterface_StateEnum_toFfi(value);
   final result = _smoke_ConstantsInterface_StateEnum_create_handle_nullable(_handle);
   smoke_ConstantsInterface_StateEnum_releaseFfiHandle(_handle);
   return result;
 }
-ConstantsInterface_StateEnum smoke_ConstantsInterface_StateEnum_fromFfi_nullable(Pointer<Void> handle) {
+ConstantsInterface_StateEnum? smoke_ConstantsInterface_StateEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ConstantsInterface_StateEnum_get_value_nullable(handle);
   final result = smoke_ConstantsInterface_StateEnum_fromFfi(_handle);
@@ -90,11 +90,11 @@ class ConstantsInterface$Impl extends __lib.NativeBase implements ConstantsInter
   ConstantsInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ConstantsInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 }
 Pointer<Void> smoke_ConstantsInterface_toFfi(ConstantsInterface value) =>
@@ -102,8 +102,8 @@ Pointer<Void> smoke_ConstantsInterface_toFfi(ConstantsInterface value) =>
 ConstantsInterface smoke_ConstantsInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ConstantsInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ConstantsInterface) return instance;
   final _copied_handle = _smoke_ConstantsInterface_copy_handle(handle);
   final result = ConstantsInterface$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -111,9 +111,9 @@ ConstantsInterface smoke_ConstantsInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_ConstantsInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ConstantsInterface_release_handle(handle);
-Pointer<Void> smoke_ConstantsInterface_toFfi_nullable(ConstantsInterface value) =>
+Pointer<Void> smoke_ConstantsInterface_toFfi_nullable(ConstantsInterface? value) =>
   value != null ? smoke_ConstantsInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-ConstantsInterface smoke_ConstantsInterface_fromFfi_nullable(Pointer<Void> handle) =>
+ConstantsInterface? smoke_ConstantsInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ConstantsInterface_fromFfi(handle) : null;
 void smoke_ConstantsInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ConstantsInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
@@ -71,14 +71,14 @@ final _smoke_StructConstants_SomeStruct_get_value_nullable = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_StructConstants_SomeStruct_toFfi_nullable(StructConstants_SomeStruct value) {
+Pointer<Void> smoke_StructConstants_SomeStruct_toFfi_nullable(StructConstants_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructConstants_SomeStruct_toFfi(value);
   final result = _smoke_StructConstants_SomeStruct_create_handle_nullable(_handle);
   smoke_StructConstants_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-StructConstants_SomeStruct smoke_StructConstants_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+StructConstants_SomeStruct? smoke_StructConstants_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructConstants_SomeStruct_get_value_nullable(handle);
   final result = smoke_StructConstants_SomeStruct_fromFfi(_handle);
@@ -135,14 +135,14 @@ final _smoke_StructConstants_NestingStruct_get_value_nullable = __lib.catchArgum
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_NestingStruct_get_value_nullable'));
-Pointer<Void> smoke_StructConstants_NestingStruct_toFfi_nullable(StructConstants_NestingStruct value) {
+Pointer<Void> smoke_StructConstants_NestingStruct_toFfi_nullable(StructConstants_NestingStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructConstants_NestingStruct_toFfi(value);
   final result = _smoke_StructConstants_NestingStruct_create_handle_nullable(_handle);
   smoke_StructConstants_NestingStruct_releaseFfiHandle(_handle);
   return result;
 }
-StructConstants_NestingStruct smoke_StructConstants_NestingStruct_fromFfi_nullable(Pointer<Void> handle) {
+StructConstants_NestingStruct? smoke_StructConstants_NestingStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructConstants_NestingStruct_get_value_nullable(handle);
   final result = smoke_StructConstants_NestingStruct_fromFfi(_handle);
@@ -165,11 +165,11 @@ class StructConstants$Impl extends __lib.NativeBase implements StructConstants {
   StructConstants$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_StructConstants_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 }
 Pointer<Void> smoke_StructConstants_toFfi(StructConstants value) =>
@@ -177,8 +177,8 @@ Pointer<Void> smoke_StructConstants_toFfi(StructConstants value) =>
 StructConstants smoke_StructConstants_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as StructConstants;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is StructConstants) return instance;
   final _copied_handle = _smoke_StructConstants_copy_handle(handle);
   final result = StructConstants$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -186,9 +186,9 @@ StructConstants smoke_StructConstants_fromFfi(Pointer<Void> handle) {
 }
 void smoke_StructConstants_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_StructConstants_release_handle(handle);
-Pointer<Void> smoke_StructConstants_toFfi_nullable(StructConstants value) =>
+Pointer<Void> smoke_StructConstants_toFfi_nullable(StructConstants? value) =>
   value != null ? smoke_StructConstants_toFfi(value) : Pointer<Void>.fromAddress(0);
-StructConstants smoke_StructConstants_fromFfi_nullable(Pointer<Void> handle) =>
+StructConstants? smoke_StructConstants_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_StructConstants_fromFfi(handle) : null;
 void smoke_StructConstants_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_StructConstants_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -62,14 +62,14 @@ final _smoke_Constructors_ErrorEnum_get_value_nullable = __lib.catchArgumentErro
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constructors_ErrorEnum_get_value_nullable'));
-Pointer<Void> smoke_Constructors_ErrorEnum_toFfi_nullable(Constructors_ErrorEnum value) {
+Pointer<Void> smoke_Constructors_ErrorEnum_toFfi_nullable(Constructors_ErrorEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Constructors_ErrorEnum_toFfi(value);
   final result = _smoke_Constructors_ErrorEnum_create_handle_nullable(_handle);
   smoke_Constructors_ErrorEnum_releaseFfiHandle(_handle);
   return result;
 }
-Constructors_ErrorEnum smoke_Constructors_ErrorEnum_fromFfi_nullable(Pointer<Void> handle) {
+Constructors_ErrorEnum? smoke_Constructors_ErrorEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Constructors_ErrorEnum_get_value_nullable(handle);
   final result = smoke_Constructors_ErrorEnum_fromFfi(_handle);
@@ -116,11 +116,11 @@ class Constructors$Impl extends __lib.NativeBase implements Constructors {
   Constructors$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_Constructors_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   Constructors$Impl.$init() : super(_$init()) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
@@ -199,8 +199,8 @@ Pointer<Void> smoke_Constructors_toFfi(Constructors value) =>
 Constructors smoke_Constructors_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Constructors;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Constructors) return instance;
   final _type_id_handle = _smoke_Constructors_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -213,9 +213,9 @@ Constructors smoke_Constructors_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Constructors_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Constructors_release_handle(handle);
-Pointer<Void> smoke_Constructors_toFfi_nullable(Constructors value) =>
+Pointer<Void> smoke_Constructors_toFfi_nullable(Constructors? value) =>
   value != null ? smoke_Constructors_toFfi(value) : Pointer<Void>.fromAddress(0);
-Constructors smoke_Constructors_fromFfi_nullable(Pointer<Void> handle) =>
+Constructors? smoke_Constructors_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Constructors_fromFfi(handle) : null;
 void smoke_Constructors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Constructors_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
@@ -25,11 +25,11 @@ class SingleNamedConstructor$Impl extends __lib.NativeBase implements SingleName
   SingleNamedConstructor$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_SingleNamedConstructor_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   SingleNamedConstructor$Impl.fooBar() : super(_fooBar()) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
@@ -45,8 +45,8 @@ Pointer<Void> smoke_SingleNamedConstructor_toFfi(SingleNamedConstructor value) =
 SingleNamedConstructor smoke_SingleNamedConstructor_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as SingleNamedConstructor;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is SingleNamedConstructor) return instance;
   final _copied_handle = _smoke_SingleNamedConstructor_copy_handle(handle);
   final result = SingleNamedConstructor$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -54,9 +54,9 @@ SingleNamedConstructor smoke_SingleNamedConstructor_fromFfi(Pointer<Void> handle
 }
 void smoke_SingleNamedConstructor_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SingleNamedConstructor_release_handle(handle);
-Pointer<Void> smoke_SingleNamedConstructor_toFfi_nullable(SingleNamedConstructor value) =>
+Pointer<Void> smoke_SingleNamedConstructor_toFfi_nullable(SingleNamedConstructor? value) =>
   value != null ? smoke_SingleNamedConstructor_toFfi(value) : Pointer<Void>.fromAddress(0);
-SingleNamedConstructor smoke_SingleNamedConstructor_fromFfi_nullable(Pointer<Void> handle) =>
+SingleNamedConstructor? smoke_SingleNamedConstructor_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SingleNamedConstructor_fromFfi(handle) : null;
 void smoke_SingleNamedConstructor_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SingleNamedConstructor_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
@@ -25,11 +25,11 @@ class SingleNamelessConstructor$Impl extends __lib.NativeBase implements SingleN
   SingleNamelessConstructor$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_SingleNamelessConstructor_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   SingleNamelessConstructor$Impl.create() : super(_create()) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
@@ -45,8 +45,8 @@ Pointer<Void> smoke_SingleNamelessConstructor_toFfi(SingleNamelessConstructor va
 SingleNamelessConstructor smoke_SingleNamelessConstructor_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as SingleNamelessConstructor;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is SingleNamelessConstructor) return instance;
   final _copied_handle = _smoke_SingleNamelessConstructor_copy_handle(handle);
   final result = SingleNamelessConstructor$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -54,9 +54,9 @@ SingleNamelessConstructor smoke_SingleNamelessConstructor_fromFfi(Pointer<Void> 
 }
 void smoke_SingleNamelessConstructor_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SingleNamelessConstructor_release_handle(handle);
-Pointer<Void> smoke_SingleNamelessConstructor_toFfi_nullable(SingleNamelessConstructor value) =>
+Pointer<Void> smoke_SingleNamelessConstructor_toFfi_nullable(SingleNamelessConstructor? value) =>
   value != null ? smoke_SingleNamelessConstructor_toFfi(value) : Pointer<Void>.fromAddress(0);
-SingleNamelessConstructor smoke_SingleNamelessConstructor_fromFfi_nullable(Pointer<Void> handle) =>
+SingleNamelessConstructor? smoke_SingleNamelessConstructor_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SingleNamelessConstructor_fromFfi(handle) : null;
 void smoke_SingleNamelessConstructor_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SingleNamelessConstructor_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -62,14 +62,14 @@ final _smoke_Dates_DateStruct_get_value_nullable = __lib.catchArgumentError(() =
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Dates_DateStruct_get_value_nullable'));
-Pointer<Void> smoke_Dates_DateStruct_toFfi_nullable(Dates_DateStruct value) {
+Pointer<Void> smoke_Dates_DateStruct_toFfi_nullable(Dates_DateStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Dates_DateStruct_toFfi(value);
   final result = _smoke_Dates_DateStruct_create_handle_nullable(_handle);
   smoke_Dates_DateStruct_releaseFfiHandle(_handle);
   return result;
 }
-Dates_DateStruct smoke_Dates_DateStruct_fromFfi_nullable(Pointer<Void> handle) {
+Dates_DateStruct? smoke_Dates_DateStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Dates_DateStruct_get_value_nullable(handle);
   final result = smoke_Dates_DateStruct_fromFfi(_handle);
@@ -92,11 +92,11 @@ class Dates$Impl extends __lib.NativeBase implements Dates {
   Dates$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_Dates_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   DateTime dateMethod(DateTime input) {
@@ -141,8 +141,8 @@ Pointer<Void> smoke_Dates_toFfi(Dates value) =>
 Dates smoke_Dates_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Dates;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Dates) return instance;
   final _copied_handle = _smoke_Dates_copy_handle(handle);
   final result = Dates$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -150,9 +150,9 @@ Dates smoke_Dates_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Dates_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Dates_release_handle(handle);
-Pointer<Void> smoke_Dates_toFfi_nullable(Dates value) =>
+Pointer<Void> smoke_Dates_toFfi_nullable(Dates? value) =>
   value != null ? smoke_Dates_toFfi(value) : Pointer<Void>.fromAddress(0);
-Dates smoke_Dates_fromFfi_nullable(Pointer<Void> handle) =>
+Dates? smoke_Dates_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Dates_fromFfi(handle) : null;
 void smoke_Dates_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Dates_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -56,14 +56,14 @@ final _smoke_DefaultValues_SomeEnum_get_value_nullable = __lib.catchArgumentErro
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DefaultValues_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_DefaultValues_SomeEnum_toFfi_nullable(DefaultValues_SomeEnum value) {
+Pointer<Void> smoke_DefaultValues_SomeEnum_toFfi_nullable(DefaultValues_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_SomeEnum_toFfi(value);
   final result = _smoke_DefaultValues_SomeEnum_create_handle_nullable(_handle);
   smoke_DefaultValues_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-DefaultValues_SomeEnum smoke_DefaultValues_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+DefaultValues_SomeEnum? smoke_DefaultValues_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DefaultValues_SomeEnum_get_value_nullable(handle);
   final result = smoke_DefaultValues_SomeEnum_fromFfi(_handle);
@@ -115,14 +115,14 @@ final _smoke_DefaultValues_ExternalEnum_get_value_nullable = __lib.catchArgument
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DefaultValues_ExternalEnum_get_value_nullable'));
-Pointer<Void> smoke_DefaultValues_ExternalEnum_toFfi_nullable(DefaultValues_ExternalEnum value) {
+Pointer<Void> smoke_DefaultValues_ExternalEnum_toFfi_nullable(DefaultValues_ExternalEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_ExternalEnum_toFfi(value);
   final result = _smoke_DefaultValues_ExternalEnum_create_handle_nullable(_handle);
   smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
-DefaultValues_ExternalEnum smoke_DefaultValues_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
+DefaultValues_ExternalEnum? smoke_DefaultValues_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DefaultValues_ExternalEnum_get_value_nullable(handle);
   final result = smoke_DefaultValues_ExternalEnum_fromFfi(_handle);
@@ -251,14 +251,14 @@ final _smoke_DefaultValues_StructWithDefaults_get_value_nullable = __lib.catchAr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_get_value_nullable'));
-Pointer<Void> smoke_DefaultValues_StructWithDefaults_toFfi_nullable(DefaultValues_StructWithDefaults value) {
+Pointer<Void> smoke_DefaultValues_StructWithDefaults_toFfi_nullable(DefaultValues_StructWithDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_StructWithDefaults_toFfi(value);
   final result = _smoke_DefaultValues_StructWithDefaults_create_handle_nullable(_handle);
   smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_handle);
   return result;
 }
-DefaultValues_StructWithDefaults smoke_DefaultValues_StructWithDefaults_fromFfi_nullable(Pointer<Void> handle) {
+DefaultValues_StructWithDefaults? smoke_DefaultValues_StructWithDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DefaultValues_StructWithDefaults_get_value_nullable(handle);
   final result = smoke_DefaultValues_StructWithDefaults_fromFfi(_handle);
@@ -269,12 +269,12 @@ void smoke_DefaultValues_StructWithDefaults_releaseFfiHandle_nullable(Pointer<Vo
   _smoke_DefaultValues_StructWithDefaults_release_handle_nullable(handle);
 // End of DefaultValues_StructWithDefaults "private" section.
 class DefaultValues_NullableStructWithDefaults {
-  int intField;
-  int uintField;
-  double floatField;
-  bool boolField;
-  String stringField;
-  DefaultValues_SomeEnum enumField;
+  int? intField;
+  int? uintField;
+  double? floatField;
+  bool? boolField;
+  String? stringField;
+  DefaultValues_SomeEnum? enumField;
   DefaultValues_NullableStructWithDefaults(this.intField, this.uintField, this.floatField, this.boolField, this.stringField, this.enumField);
   DefaultValues_NullableStructWithDefaults.withDefaults()
     : intField = null, uintField = null, floatField = null, boolField = null, stringField = null, enumField = null;
@@ -367,14 +367,14 @@ final _smoke_DefaultValues_NullableStructWithDefaults_get_value_nullable = __lib
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_get_value_nullable'));
-Pointer<Void> smoke_DefaultValues_NullableStructWithDefaults_toFfi_nullable(DefaultValues_NullableStructWithDefaults value) {
+Pointer<Void> smoke_DefaultValues_NullableStructWithDefaults_toFfi_nullable(DefaultValues_NullableStructWithDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_NullableStructWithDefaults_toFfi(value);
   final result = _smoke_DefaultValues_NullableStructWithDefaults_create_handle_nullable(_handle);
   smoke_DefaultValues_NullableStructWithDefaults_releaseFfiHandle(_handle);
   return result;
 }
-DefaultValues_NullableStructWithDefaults smoke_DefaultValues_NullableStructWithDefaults_fromFfi_nullable(Pointer<Void> handle) {
+DefaultValues_NullableStructWithDefaults? smoke_DefaultValues_NullableStructWithDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DefaultValues_NullableStructWithDefaults_get_value_nullable(handle);
   final result = smoke_DefaultValues_NullableStructWithDefaults_fromFfi(_handle);
@@ -483,14 +483,14 @@ final _smoke_DefaultValues_StructWithSpecialDefaults_get_value_nullable = __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_value_nullable'));
-Pointer<Void> smoke_DefaultValues_StructWithSpecialDefaults_toFfi_nullable(DefaultValues_StructWithSpecialDefaults value) {
+Pointer<Void> smoke_DefaultValues_StructWithSpecialDefaults_toFfi_nullable(DefaultValues_StructWithSpecialDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_StructWithSpecialDefaults_toFfi(value);
   final result = _smoke_DefaultValues_StructWithSpecialDefaults_create_handle_nullable(_handle);
   smoke_DefaultValues_StructWithSpecialDefaults_releaseFfiHandle(_handle);
   return result;
 }
-DefaultValues_StructWithSpecialDefaults smoke_DefaultValues_StructWithSpecialDefaults_fromFfi_nullable(Pointer<Void> handle) {
+DefaultValues_StructWithSpecialDefaults? smoke_DefaultValues_StructWithSpecialDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_value_nullable(handle);
   final result = smoke_DefaultValues_StructWithSpecialDefaults_fromFfi(_handle);
@@ -589,14 +589,14 @@ final _smoke_DefaultValues_StructWithEmptyDefaults_get_value_nullable = __lib.ca
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_value_nullable'));
-Pointer<Void> smoke_DefaultValues_StructWithEmptyDefaults_toFfi_nullable(DefaultValues_StructWithEmptyDefaults value) {
+Pointer<Void> smoke_DefaultValues_StructWithEmptyDefaults_toFfi_nullable(DefaultValues_StructWithEmptyDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_StructWithEmptyDefaults_toFfi(value);
   final result = _smoke_DefaultValues_StructWithEmptyDefaults_create_handle_nullable(_handle);
   smoke_DefaultValues_StructWithEmptyDefaults_releaseFfiHandle(_handle);
   return result;
 }
-DefaultValues_StructWithEmptyDefaults smoke_DefaultValues_StructWithEmptyDefaults_fromFfi_nullable(Pointer<Void> handle) {
+DefaultValues_StructWithEmptyDefaults? smoke_DefaultValues_StructWithEmptyDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_value_nullable(handle);
   final result = smoke_DefaultValues_StructWithEmptyDefaults_fromFfi(_handle);
@@ -685,14 +685,14 @@ final _smoke_DefaultValues_StructWithTypedefDefaults_get_value_nullable = __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_value_nullable'));
-Pointer<Void> smoke_DefaultValues_StructWithTypedefDefaults_toFfi_nullable(DefaultValues_StructWithTypedefDefaults value) {
+Pointer<Void> smoke_DefaultValues_StructWithTypedefDefaults_toFfi_nullable(DefaultValues_StructWithTypedefDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_StructWithTypedefDefaults_toFfi(value);
   final result = _smoke_DefaultValues_StructWithTypedefDefaults_create_handle_nullable(_handle);
   smoke_DefaultValues_StructWithTypedefDefaults_releaseFfiHandle(_handle);
   return result;
 }
-DefaultValues_StructWithTypedefDefaults smoke_DefaultValues_StructWithTypedefDefaults_fromFfi_nullable(Pointer<Void> handle) {
+DefaultValues_StructWithTypedefDefaults? smoke_DefaultValues_StructWithTypedefDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_value_nullable(handle);
   final result = smoke_DefaultValues_StructWithTypedefDefaults_fromFfi(_handle);
@@ -715,11 +715,11 @@ class DefaultValues$Impl extends __lib.NativeBase implements DefaultValues {
   DefaultValues$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_DefaultValues_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) {
     final _processStructWithDefaults_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_DefaultValues_processStructWithDefaults__StructWithDefaults'));
@@ -738,8 +738,8 @@ Pointer<Void> smoke_DefaultValues_toFfi(DefaultValues value) =>
 DefaultValues smoke_DefaultValues_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as DefaultValues;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is DefaultValues) return instance;
   final _copied_handle = _smoke_DefaultValues_copy_handle(handle);
   final result = DefaultValues$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -747,9 +747,9 @@ DefaultValues smoke_DefaultValues_fromFfi(Pointer<Void> handle) {
 }
 void smoke_DefaultValues_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_DefaultValues_release_handle(handle);
-Pointer<Void> smoke_DefaultValues_toFfi_nullable(DefaultValues value) =>
+Pointer<Void> smoke_DefaultValues_toFfi_nullable(DefaultValues? value) =>
   value != null ? smoke_DefaultValues_toFfi(value) : Pointer<Void>.fromAddress(0);
-DefaultValues smoke_DefaultValues_fromFfi_nullable(Pointer<Void> handle) =>
+DefaultValues? smoke_DefaultValues_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_DefaultValues_fromFfi(handle) : null;
 void smoke_DefaultValues_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_DefaultValues_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_all_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_all_defaults.dart
@@ -63,14 +63,14 @@ final _smoke_StructWithAllDefaults_get_value_nullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithAllDefaults_get_value_nullable'));
-Pointer<Void> smoke_StructWithAllDefaults_toFfi_nullable(StructWithAllDefaults value) {
+Pointer<Void> smoke_StructWithAllDefaults_toFfi_nullable(StructWithAllDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithAllDefaults_toFfi(value);
   final result = _smoke_StructWithAllDefaults_create_handle_nullable(_handle);
   smoke_StructWithAllDefaults_releaseFfiHandle(_handle);
   return result;
 }
-StructWithAllDefaults smoke_StructWithAllDefaults_fromFfi_nullable(Pointer<Void> handle) {
+StructWithAllDefaults? smoke_StructWithAllDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructWithAllDefaults_get_value_nullable(handle);
   final result = smoke_StructWithAllDefaults_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
@@ -104,14 +104,14 @@ final _smoke_StructWithCollectionDefaults_get_value_nullable = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithCollectionDefaults_get_value_nullable'));
-Pointer<Void> smoke_StructWithCollectionDefaults_toFfi_nullable(StructWithCollectionDefaults value) {
+Pointer<Void> smoke_StructWithCollectionDefaults_toFfi_nullable(StructWithCollectionDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithCollectionDefaults_toFfi(value);
   final result = _smoke_StructWithCollectionDefaults_create_handle_nullable(_handle);
   smoke_StructWithCollectionDefaults_releaseFfiHandle(_handle);
   return result;
 }
-StructWithCollectionDefaults smoke_StructWithCollectionDefaults_fromFfi_nullable(Pointer<Void> handle) {
+StructWithCollectionDefaults? smoke_StructWithCollectionDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructWithCollectionDefaults_get_value_nullable(handle);
   final result = smoke_StructWithCollectionDefaults_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_enums.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_enums.dart
@@ -73,14 +73,14 @@ final _smoke_StructWithEnums_get_value_nullable = __lib.catchArgumentError(() =>
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithEnums_get_value_nullable'));
-Pointer<Void> smoke_StructWithEnums_toFfi_nullable(StructWithEnums value) {
+Pointer<Void> smoke_StructWithEnums_toFfi_nullable(StructWithEnums? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithEnums_toFfi(value);
   final result = _smoke_StructWithEnums_create_handle_nullable(_handle);
   smoke_StructWithEnums_releaseFfiHandle(_handle);
   return result;
 }
-StructWithEnums smoke_StructWithEnums_fromFfi_nullable(Pointer<Void> handle) {
+StructWithEnums? smoke_StructWithEnums_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructWithEnums_get_value_nullable(handle);
   final result = smoke_StructWithEnums_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
@@ -94,14 +94,14 @@ final _smoke_StructWithInitializerDefaults_get_value_nullable = __lib.catchArgum
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_get_value_nullable'));
-Pointer<Void> smoke_StructWithInitializerDefaults_toFfi_nullable(StructWithInitializerDefaults value) {
+Pointer<Void> smoke_StructWithInitializerDefaults_toFfi_nullable(StructWithInitializerDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithInitializerDefaults_toFfi(value);
   final result = _smoke_StructWithInitializerDefaults_create_handle_nullable(_handle);
   smoke_StructWithInitializerDefaults_releaseFfiHandle(_handle);
   return result;
 }
-StructWithInitializerDefaults smoke_StructWithInitializerDefaults_fromFfi_nullable(Pointer<Void> handle) {
+StructWithInitializerDefaults? smoke_StructWithInitializerDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructWithInitializerDefaults_get_value_nullable(handle);
   final result = smoke_StructWithInitializerDefaults_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_some_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_some_defaults.dart
@@ -63,14 +63,14 @@ final _smoke_StructWithSomeDefaults_get_value_nullable = __lib.catchArgumentErro
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithSomeDefaults_get_value_nullable'));
-Pointer<Void> smoke_StructWithSomeDefaults_toFfi_nullable(StructWithSomeDefaults value) {
+Pointer<Void> smoke_StructWithSomeDefaults_toFfi_nullable(StructWithSomeDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithSomeDefaults_toFfi(value);
   final result = _smoke_StructWithSomeDefaults_create_handle_nullable(_handle);
   smoke_StructWithSomeDefaults_releaseFfiHandle(_handle);
   return result;
 }
-StructWithSomeDefaults smoke_StructWithSomeDefaults_fromFfi_nullable(Pointer<Void> handle) {
+StructWithSomeDefaults? smoke_StructWithSomeDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructWithSomeDefaults_get_value_nullable(handle);
   final result = smoke_StructWithSomeDefaults_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -47,14 +47,14 @@ final _smoke_TypesWithDefaults_SomeEnum_get_value_nullable = __lib.catchArgument
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_TypesWithDefaults_SomeEnum_toFfi_nullable(SomeEnum value) {
+Pointer<Void> smoke_TypesWithDefaults_SomeEnum_toFfi_nullable(SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypesWithDefaults_SomeEnum_toFfi(value);
   final result = _smoke_TypesWithDefaults_SomeEnum_create_handle_nullable(_handle);
   smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-SomeEnum smoke_TypesWithDefaults_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+SomeEnum? smoke_TypesWithDefaults_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_TypesWithDefaults_SomeEnum_get_value_nullable(handle);
   final result = smoke_TypesWithDefaults_SomeEnum_fromFfi(_handle);
@@ -173,14 +173,14 @@ final _smoke_TypesWithDefaults_StructWithDefaults_get_value_nullable = __lib.cat
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_get_value_nullable'));
-Pointer<Void> smoke_TypesWithDefaults_StructWithDefaults_toFfi_nullable(StructWithDefaults value) {
+Pointer<Void> smoke_TypesWithDefaults_StructWithDefaults_toFfi_nullable(StructWithDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypesWithDefaults_StructWithDefaults_toFfi(value);
   final result = _smoke_TypesWithDefaults_StructWithDefaults_create_handle_nullable(_handle);
   smoke_TypesWithDefaults_StructWithDefaults_releaseFfiHandle(_handle);
   return result;
 }
-StructWithDefaults smoke_TypesWithDefaults_StructWithDefaults_fromFfi_nullable(Pointer<Void> handle) {
+StructWithDefaults? smoke_TypesWithDefaults_StructWithDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_TypesWithDefaults_StructWithDefaults_get_value_nullable(handle);
   final result = smoke_TypesWithDefaults_StructWithDefaults_fromFfi(_handle);
@@ -310,14 +310,14 @@ final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_value_nullable = 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_value_nullable'));
-Pointer<Void> smoke_TypesWithDefaults_ImmutableStructWithDefaults_toFfi_nullable(ImmutableStructWithDefaults value) {
+Pointer<Void> smoke_TypesWithDefaults_ImmutableStructWithDefaults_toFfi_nullable(ImmutableStructWithDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypesWithDefaults_ImmutableStructWithDefaults_toFfi(value);
   final result = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle_nullable(_handle);
   smoke_TypesWithDefaults_ImmutableStructWithDefaults_releaseFfiHandle(_handle);
   return result;
 }
-ImmutableStructWithDefaults smoke_TypesWithDefaults_ImmutableStructWithDefaults_fromFfi_nullable(Pointer<Void> handle) {
+ImmutableStructWithDefaults? smoke_TypesWithDefaults_ImmutableStructWithDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_value_nullable(handle);
   final result = smoke_TypesWithDefaults_ImmutableStructWithDefaults_fromFfi(_handle);
@@ -376,14 +376,14 @@ final _smoke_TypesWithDefaults_StructWithAnEnum_get_value_nullable = __lib.catch
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithAnEnum_get_value_nullable'));
-Pointer<Void> smoke_TypesWithDefaults_StructWithAnEnum_toFfi_nullable(StructWithAnEnum value) {
+Pointer<Void> smoke_TypesWithDefaults_StructWithAnEnum_toFfi_nullable(StructWithAnEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypesWithDefaults_StructWithAnEnum_toFfi(value);
   final result = _smoke_TypesWithDefaults_StructWithAnEnum_create_handle_nullable(_handle);
   smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_handle);
   return result;
 }
-StructWithAnEnum smoke_TypesWithDefaults_StructWithAnEnum_fromFfi_nullable(Pointer<Void> handle) {
+StructWithAnEnum? smoke_TypesWithDefaults_StructWithAnEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_TypesWithDefaults_StructWithAnEnum_get_value_nullable(handle);
   final result = smoke_TypesWithDefaults_StructWithAnEnum_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_starts_with_one.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_starts_with_one.dart
@@ -44,14 +44,14 @@ final _smoke_EnumStartsWithOne_get_value_nullable = __lib.catchArgumentError(() 
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_EnumStartsWithOne_get_value_nullable'));
-Pointer<Void> smoke_EnumStartsWithOne_toFfi_nullable(EnumStartsWithOne value) {
+Pointer<Void> smoke_EnumStartsWithOne_toFfi_nullable(EnumStartsWithOne? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_EnumStartsWithOne_toFfi(value);
   final result = _smoke_EnumStartsWithOne_create_handle_nullable(_handle);
   smoke_EnumStartsWithOne_releaseFfiHandle(_handle);
   return result;
 }
-EnumStartsWithOne smoke_EnumStartsWithOne_fromFfi_nullable(Pointer<Void> handle) {
+EnumStartsWithOne? smoke_EnumStartsWithOne_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_EnumStartsWithOne_get_value_nullable(handle);
   final result = smoke_EnumStartsWithOne_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -58,14 +58,14 @@ final _smoke_Enums_SimpleEnum_get_value_nullable = __lib.catchArgumentError(() =
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_SimpleEnum_get_value_nullable'));
-Pointer<Void> smoke_Enums_SimpleEnum_toFfi_nullable(Enums_SimpleEnum value) {
+Pointer<Void> smoke_Enums_SimpleEnum_toFfi_nullable(Enums_SimpleEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_SimpleEnum_toFfi(value);
   final result = _smoke_Enums_SimpleEnum_create_handle_nullable(_handle);
   smoke_Enums_SimpleEnum_releaseFfiHandle(_handle);
   return result;
 }
-Enums_SimpleEnum smoke_Enums_SimpleEnum_fromFfi_nullable(Pointer<Void> handle) {
+Enums_SimpleEnum? smoke_Enums_SimpleEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Enums_SimpleEnum_get_value_nullable(handle);
   final result = smoke_Enums_SimpleEnum_fromFfi(_handle);
@@ -117,14 +117,14 @@ final _smoke_Enums_InternalErrorCode_get_value_nullable = __lib.catchArgumentErr
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_InternalErrorCode_get_value_nullable'));
-Pointer<Void> smoke_Enums_InternalErrorCode_toFfi_nullable(Enums_InternalErrorCode value) {
+Pointer<Void> smoke_Enums_InternalErrorCode_toFfi_nullable(Enums_InternalErrorCode? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_InternalErrorCode_toFfi(value);
   final result = _smoke_Enums_InternalErrorCode_create_handle_nullable(_handle);
   smoke_Enums_InternalErrorCode_releaseFfiHandle(_handle);
   return result;
 }
-Enums_InternalErrorCode smoke_Enums_InternalErrorCode_fromFfi_nullable(Pointer<Void> handle) {
+Enums_InternalErrorCode? smoke_Enums_InternalErrorCode_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Enums_InternalErrorCode_get_value_nullable(handle);
   final result = smoke_Enums_InternalErrorCode_fromFfi(_handle);
@@ -191,14 +191,14 @@ final _smoke_Enums_ErrorStruct_get_value_nullable = __lib.catchArgumentError(() 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Enums_ErrorStruct_get_value_nullable'));
-Pointer<Void> smoke_Enums_ErrorStruct_toFfi_nullable(Enums_ErrorStruct value) {
+Pointer<Void> smoke_Enums_ErrorStruct_toFfi_nullable(Enums_ErrorStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_ErrorStruct_toFfi(value);
   final result = _smoke_Enums_ErrorStruct_create_handle_nullable(_handle);
   smoke_Enums_ErrorStruct_releaseFfiHandle(_handle);
   return result;
 }
-Enums_ErrorStruct smoke_Enums_ErrorStruct_fromFfi_nullable(Pointer<Void> handle) {
+Enums_ErrorStruct? smoke_Enums_ErrorStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Enums_ErrorStruct_get_value_nullable(handle);
   final result = smoke_Enums_ErrorStruct_fromFfi(_handle);
@@ -221,11 +221,11 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
   Enums$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_Enums_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static Enums_SimpleEnum methodWithEnumeration(Enums_SimpleEnum input) {
     final _methodWithEnumeration_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_Enums_methodWithEnumeration__SimpleEnum'));
@@ -279,8 +279,8 @@ Pointer<Void> smoke_Enums_toFfi(Enums value) =>
 Enums smoke_Enums_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Enums;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Enums) return instance;
   final _copied_handle = _smoke_Enums_copy_handle(handle);
   final result = Enums$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -288,9 +288,9 @@ Enums smoke_Enums_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Enums_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Enums_release_handle(handle);
-Pointer<Void> smoke_Enums_toFfi_nullable(Enums value) =>
+Pointer<Void> smoke_Enums_toFfi_nullable(Enums? value) =>
   value != null ? smoke_Enums_toFfi(value) : Pointer<Void>.fromAddress(0);
-Enums smoke_Enums_fromFfi_nullable(Pointer<Void> handle) =>
+Enums? smoke_Enums_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Enums_fromFfi(handle) : null;
 void smoke_Enums_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Enums_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
@@ -48,14 +48,14 @@ final _smoke_Equatable_SomeEnum_get_value_nullable = __lib.catchArgumentError(()
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Equatable_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_Equatable_SomeEnum_toFfi_nullable(SomeEnum value) {
+Pointer<Void> smoke_Equatable_SomeEnum_toFfi_nullable(SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Equatable_SomeEnum_toFfi(value);
   final result = _smoke_Equatable_SomeEnum_create_handle_nullable(_handle);
   smoke_Equatable_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-SomeEnum smoke_Equatable_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+SomeEnum? smoke_Equatable_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Equatable_SomeEnum_get_value_nullable(handle);
   final result = smoke_Equatable_SomeEnum_fromFfi(_handle);
@@ -233,14 +233,14 @@ final _smoke_Equatable_EquatableStruct_get_value_nullable = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_value_nullable'));
-Pointer<Void> smoke_Equatable_EquatableStruct_toFfi_nullable(EquatableStruct value) {
+Pointer<Void> smoke_Equatable_EquatableStruct_toFfi_nullable(EquatableStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Equatable_EquatableStruct_toFfi(value);
   final result = _smoke_Equatable_EquatableStruct_create_handle_nullable(_handle);
   smoke_Equatable_EquatableStruct_releaseFfiHandle(_handle);
   return result;
 }
-EquatableStruct smoke_Equatable_EquatableStruct_fromFfi_nullable(Pointer<Void> handle) {
+EquatableStruct? smoke_Equatable_EquatableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Equatable_EquatableStruct_get_value_nullable(handle);
   final result = smoke_Equatable_EquatableStruct_fromFfi(_handle);
@@ -251,15 +251,15 @@ void smoke_Equatable_EquatableStruct_releaseFfiHandle_nullable(Pointer<Void> han
   _smoke_Equatable_EquatableStruct_release_handle_nullable(handle);
 // End of EquatableStruct "private" section.
 class EquatableNullableStruct {
-  bool boolField;
-  int intField;
-  int uintField;
-  double floatField;
-  String stringField;
-  NestedEquatableStruct structField;
-  SomeEnum enumField;
-  List<String> arrayField;
-  Map<int, String> mapField;
+  bool? boolField;
+  int? intField;
+  int? uintField;
+  double? floatField;
+  String? stringField;
+  NestedEquatableStruct? structField;
+  SomeEnum? enumField;
+  List<String>? arrayField;
+  Map<int, String>? mapField;
   EquatableNullableStruct(this.boolField, this.intField, this.uintField, this.floatField, this.stringField, this.structField, this.enumField, this.arrayField, this.mapField);
   @override
   bool operator ==(dynamic other) {
@@ -406,14 +406,14 @@ final _smoke_Equatable_EquatableNullableStruct_get_value_nullable = __lib.catchA
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_value_nullable'));
-Pointer<Void> smoke_Equatable_EquatableNullableStruct_toFfi_nullable(EquatableNullableStruct value) {
+Pointer<Void> smoke_Equatable_EquatableNullableStruct_toFfi_nullable(EquatableNullableStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Equatable_EquatableNullableStruct_toFfi(value);
   final result = _smoke_Equatable_EquatableNullableStruct_create_handle_nullable(_handle);
   smoke_Equatable_EquatableNullableStruct_releaseFfiHandle(_handle);
   return result;
 }
-EquatableNullableStruct smoke_Equatable_EquatableNullableStruct_fromFfi_nullable(Pointer<Void> handle) {
+EquatableNullableStruct? smoke_Equatable_EquatableNullableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Equatable_EquatableNullableStruct_get_value_nullable(handle);
   final result = smoke_Equatable_EquatableNullableStruct_fromFfi(_handle);
@@ -483,14 +483,14 @@ final _smoke_Equatable_NestedEquatableStruct_get_value_nullable = __lib.catchArg
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_NestedEquatableStruct_get_value_nullable'));
-Pointer<Void> smoke_Equatable_NestedEquatableStruct_toFfi_nullable(NestedEquatableStruct value) {
+Pointer<Void> smoke_Equatable_NestedEquatableStruct_toFfi_nullable(NestedEquatableStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Equatable_NestedEquatableStruct_toFfi(value);
   final result = _smoke_Equatable_NestedEquatableStruct_create_handle_nullable(_handle);
   smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(_handle);
   return result;
 }
-NestedEquatableStruct smoke_Equatable_NestedEquatableStruct_fromFfi_nullable(Pointer<Void> handle) {
+NestedEquatableStruct? smoke_Equatable_NestedEquatableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Equatable_NestedEquatableStruct_get_value_nullable(handle);
   final result = smoke_Equatable_NestedEquatableStruct_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
@@ -37,11 +37,11 @@ class EquatableInterface$Impl extends __lib.NativeBase implements EquatableInter
   EquatableInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_EquatableInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   bool operator ==(dynamic other) {
@@ -62,8 +62,8 @@ Pointer<Void> smoke_EquatableInterface_toFfi(EquatableInterface value) {
 EquatableInterface smoke_EquatableInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as EquatableInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is EquatableInterface) return instance;
   final _type_id_handle = _smoke_EquatableInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -76,9 +76,9 @@ EquatableInterface smoke_EquatableInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_EquatableInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_EquatableInterface_release_handle(handle);
-Pointer<Void> smoke_EquatableInterface_toFfi_nullable(EquatableInterface value) =>
+Pointer<Void> smoke_EquatableInterface_toFfi_nullable(EquatableInterface? value) =>
   value != null ? smoke_EquatableInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-EquatableInterface smoke_EquatableInterface_fromFfi_nullable(Pointer<Void> handle) =>
+EquatableInterface? smoke_EquatableInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_EquatableInterface_fromFfi(handle) : null;
 void smoke_EquatableInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_EquatableInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
@@ -118,14 +118,14 @@ final _smoke_EquatableStructWithInternalFields_get_value_nullable = __lib.catchA
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EquatableStructWithInternalFields_get_value_nullable'));
-Pointer<Void> smoke_EquatableStructWithInternalFields_toFfi_nullable(EquatableStructWithInternalFields value) {
+Pointer<Void> smoke_EquatableStructWithInternalFields_toFfi_nullable(EquatableStructWithInternalFields? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_EquatableStructWithInternalFields_toFfi(value);
   final result = _smoke_EquatableStructWithInternalFields_create_handle_nullable(_handle);
   smoke_EquatableStructWithInternalFields_releaseFfiHandle(_handle);
   return result;
 }
-EquatableStructWithInternalFields smoke_EquatableStructWithInternalFields_fromFfi_nullable(Pointer<Void> handle) {
+EquatableStructWithInternalFields? smoke_EquatableStructWithInternalFields_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_EquatableStructWithInternalFields_get_value_nullable(handle);
   final result = smoke_EquatableStructWithInternalFields_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/simple_equatable_struct.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/simple_equatable_struct.dart
@@ -9,8 +9,8 @@ import 'package:library/src/_library_context.dart' as __lib;
 class SimpleEquatableStruct {
   NonEquatableClass classField;
   NonEquatableInterface interfaceField;
-  NonEquatableClass nullableClassField;
-  NonEquatableInterface nullableInterfaceField;
+  NonEquatableClass? nullableClassField;
+  NonEquatableInterface? nullableInterfaceField;
   SimpleEquatableStruct(this.classField, this.interfaceField, this.nullableClassField, this.nullableInterfaceField);
   @override
   bool operator ==(dynamic other) {
@@ -102,14 +102,14 @@ final _smoke_SimpleEquatableStruct_get_value_nullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleEquatableStruct_get_value_nullable'));
-Pointer<Void> smoke_SimpleEquatableStruct_toFfi_nullable(SimpleEquatableStruct value) {
+Pointer<Void> smoke_SimpleEquatableStruct_toFfi_nullable(SimpleEquatableStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SimpleEquatableStruct_toFfi(value);
   final result = _smoke_SimpleEquatableStruct_create_handle_nullable(_handle);
   smoke_SimpleEquatableStruct_releaseFfiHandle(_handle);
   return result;
 }
-SimpleEquatableStruct smoke_SimpleEquatableStruct_fromFfi_nullable(Pointer<Void> handle) {
+SimpleEquatableStruct? smoke_SimpleEquatableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_SimpleEquatableStruct_get_value_nullable(handle);
   final result = smoke_SimpleEquatableStruct_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -61,14 +61,14 @@ final _smoke_Errors_InternalErrorCode_get_value_nullable = __lib.catchArgumentEr
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_InternalErrorCode_get_value_nullable'));
-Pointer<Void> smoke_Errors_InternalErrorCode_toFfi_nullable(Errors_InternalErrorCode value) {
+Pointer<Void> smoke_Errors_InternalErrorCode_toFfi_nullable(Errors_InternalErrorCode? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Errors_InternalErrorCode_toFfi(value);
   final result = _smoke_Errors_InternalErrorCode_create_handle_nullable(_handle);
   smoke_Errors_InternalErrorCode_releaseFfiHandle(_handle);
   return result;
 }
-Errors_InternalErrorCode smoke_Errors_InternalErrorCode_fromFfi_nullable(Pointer<Void> handle) {
+Errors_InternalErrorCode? smoke_Errors_InternalErrorCode_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Errors_InternalErrorCode_get_value_nullable(handle);
   final result = smoke_Errors_InternalErrorCode_fromFfi(_handle);
@@ -127,14 +127,14 @@ final _smoke_Errors_ExternalErrors_get_value_nullable = __lib.catchArgumentError
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_ExternalErrors_get_value_nullable'));
-Pointer<Void> smoke_Errors_ExternalErrors_toFfi_nullable(Errors_ExternalErrors value) {
+Pointer<Void> smoke_Errors_ExternalErrors_toFfi_nullable(Errors_ExternalErrors? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Errors_ExternalErrors_toFfi(value);
   final result = _smoke_Errors_ExternalErrors_create_handle_nullable(_handle);
   smoke_Errors_ExternalErrors_releaseFfiHandle(_handle);
   return result;
 }
-Errors_ExternalErrors smoke_Errors_ExternalErrors_fromFfi_nullable(Pointer<Void> handle) {
+Errors_ExternalErrors? smoke_Errors_ExternalErrors_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Errors_ExternalErrors_get_value_nullable(handle);
   final result = smoke_Errors_ExternalErrors_fromFfi(_handle);
@@ -236,11 +236,11 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
   Errors$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_Errors_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static methodWithErrors() {
     final _methodWithErrors_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrors'));
@@ -348,8 +348,8 @@ Pointer<Void> smoke_Errors_toFfi(Errors value) =>
 Errors smoke_Errors_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Errors;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Errors) return instance;
   final _copied_handle = _smoke_Errors_copy_handle(handle);
   final result = Errors$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -357,9 +357,9 @@ Errors smoke_Errors_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Errors_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Errors_release_handle(handle);
-Pointer<Void> smoke_Errors_toFfi_nullable(Errors value) =>
+Pointer<Void> smoke_Errors_toFfi_nullable(Errors? value) =>
   value != null ? smoke_Errors_toFfi(value) : Pointer<Void>.fromAddress(0);
-Errors smoke_Errors_fromFfi_nullable(Pointer<Void> handle) =>
+Errors? smoke_Errors_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Errors_fromFfi(handle) : null;
 void smoke_Errors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Errors_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -11,9 +11,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class ErrorsInterface {
   ErrorsInterface() {}
   factory ErrorsInterface.fromLambdas({
-    @required void Function() lambda_methodWithErrors,
-    @required void Function() lambda_methodWithExternalErrors,
-    @required String Function() lambda_methodWithErrorsAndReturnValue,
+    required void Function() lambda_methodWithErrors,
+    required void Function() lambda_methodWithExternalErrors,
+    required String Function() lambda_methodWithErrorsAndReturnValue,
   }) => ErrorsInterface$Lambdas(
     lambda_methodWithErrors,
     lambda_methodWithExternalErrors,
@@ -72,14 +72,14 @@ final _smoke_ErrorsInterface_InternalError_get_value_nullable = __lib.catchArgum
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_InternalError_get_value_nullable'));
-Pointer<Void> smoke_ErrorsInterface_InternalError_toFfi_nullable(ErrorsInterface_InternalError value) {
+Pointer<Void> smoke_ErrorsInterface_InternalError_toFfi_nullable(ErrorsInterface_InternalError? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ErrorsInterface_InternalError_toFfi(value);
   final result = _smoke_ErrorsInterface_InternalError_create_handle_nullable(_handle);
   smoke_ErrorsInterface_InternalError_releaseFfiHandle(_handle);
   return result;
 }
-ErrorsInterface_InternalError smoke_ErrorsInterface_InternalError_fromFfi_nullable(Pointer<Void> handle) {
+ErrorsInterface_InternalError? smoke_ErrorsInterface_InternalError_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ErrorsInterface_InternalError_get_value_nullable(handle);
   final result = smoke_ErrorsInterface_InternalError_fromFfi(_handle);
@@ -138,14 +138,14 @@ final _smoke_ErrorsInterface_ExternalErrors_get_value_nullable = __lib.catchArgu
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_ExternalErrors_get_value_nullable'));
-Pointer<Void> smoke_ErrorsInterface_ExternalErrors_toFfi_nullable(ErrorsInterface_ExternalErrors value) {
+Pointer<Void> smoke_ErrorsInterface_ExternalErrors_toFfi_nullable(ErrorsInterface_ExternalErrors? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ErrorsInterface_ExternalErrors_toFfi(value);
   final result = _smoke_ErrorsInterface_ExternalErrors_create_handle_nullable(_handle);
   smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(_handle);
   return result;
 }
-ErrorsInterface_ExternalErrors smoke_ErrorsInterface_ExternalErrors_fromFfi_nullable(Pointer<Void> handle) {
+ErrorsInterface_ExternalErrors? smoke_ErrorsInterface_ExternalErrors_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ErrorsInterface_ExternalErrors_get_value_nullable(handle);
   final result = smoke_ErrorsInterface_ExternalErrors_fromFfi(_handle);
@@ -276,11 +276,11 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
   ErrorsInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ErrorsInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   methodWithErrors() {
@@ -417,7 +417,7 @@ int _ErrorsInterface_methodWithExternalErrors_static(int _token, Pointer<Uint32>
 }
 int _ErrorsInterface_methodWithErrorsAndReturnValue_static(int _token, Pointer<Pointer<Void>> _result, Pointer<Uint32> _error) {
   bool _error_flag = false;
-  String _result_object = null;
+  String? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as ErrorsInterface).methodWithErrorsAndReturnValue();
     _result.value = String_toFfi(_result_object);
@@ -444,8 +444,8 @@ Pointer<Void> smoke_ErrorsInterface_toFfi(ErrorsInterface value) {
 ErrorsInterface smoke_ErrorsInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ErrorsInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ErrorsInterface) return instance;
   final _type_id_handle = _smoke_ErrorsInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -458,9 +458,9 @@ ErrorsInterface smoke_ErrorsInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_ErrorsInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ErrorsInterface_release_handle(handle);
-Pointer<Void> smoke_ErrorsInterface_toFfi_nullable(ErrorsInterface value) =>
+Pointer<Void> smoke_ErrorsInterface_toFfi_nullable(ErrorsInterface? value) =>
   value != null ? smoke_ErrorsInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-ErrorsInterface smoke_ErrorsInterface_fromFfi_nullable(Pointer<Void> handle) =>
+ErrorsInterface? smoke_ErrorsInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ErrorsInterface_fromFfi(handle) : null;
 void smoke_ErrorsInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ErrorsInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -53,11 +53,11 @@ class Class$Impl extends __lib.NativeBase implements Class {
   Class$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _package_Class_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   Class$Impl.constructor() : super(_constructor()) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
@@ -121,8 +121,8 @@ Pointer<Void> package_Class_toFfi(Class value) =>
 Class package_Class_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Class;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Class) return instance;
   final _type_id_handle = _package_Class_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -135,9 +135,9 @@ Class package_Class_fromFfi(Pointer<Void> handle) {
 }
 void package_Class_releaseFfiHandle(Pointer<Void> handle) =>
   _package_Class_release_handle(handle);
-Pointer<Void> package_Class_toFfi_nullable(Class value) =>
+Pointer<Void> package_Class_toFfi_nullable(Class? value) =>
   value != null ? package_Class_toFfi(value) : Pointer<Void>.fromAddress(0);
-Class package_Class_fromFfi_nullable(Pointer<Void> handle) =>
+Class? package_Class_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? package_Class_fromFfi(handle) : null;
 void package_Class_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _package_Class_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
@@ -34,11 +34,11 @@ class Interface$Impl extends __lib.NativeBase implements Interface {
   Interface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _package_Interface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 }
 Pointer<Void> package_Interface_toFfi(Interface value) {
@@ -53,8 +53,8 @@ Pointer<Void> package_Interface_toFfi(Interface value) {
 Interface package_Interface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Interface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Interface) return instance;
   final _type_id_handle = _package_Interface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -67,9 +67,9 @@ Interface package_Interface_fromFfi(Pointer<Void> handle) {
 }
 void package_Interface_releaseFfiHandle(Pointer<Void> handle) =>
   _package_Interface_release_handle(handle);
-Pointer<Void> package_Interface_toFfi_nullable(Interface value) =>
+Pointer<Void> package_Interface_toFfi_nullable(Interface? value) =>
   value != null ? package_Interface_toFfi(value) : Pointer<Void>.fromAddress(0);
-Interface package_Interface_fromFfi_nullable(Pointer<Void> handle) =>
+Interface? package_Interface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? package_Interface_fromFfi(handle) : null;
 void package_Interface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _package_Interface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
@@ -37,14 +37,14 @@ final _package_Types_Enum_get_value_nullable = __lib.catchArgumentError(() => __
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_package_Types_Enum_get_value_nullable'));
-Pointer<Void> package_Types_Enum_toFfi_nullable(Enum value) {
+Pointer<Void> package_Types_Enum_toFfi_nullable(Enum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = package_Types_Enum_toFfi(value);
   final result = _package_Types_Enum_create_handle_nullable(_handle);
   package_Types_Enum_releaseFfiHandle(_handle);
   return result;
 }
-Enum package_Types_Enum_fromFfi_nullable(Pointer<Void> handle) {
+Enum? package_Types_Enum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _package_Types_Enum_get_value_nullable(handle);
   final result = package_Types_Enum_fromFfi(_handle);
@@ -107,14 +107,14 @@ final _package_Types_Struct_get_value_nullable = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Types_Struct_get_value_nullable'));
-Pointer<Void> package_Types_Struct_toFfi_nullable(Struct value) {
+Pointer<Void> package_Types_Struct_toFfi_nullable(Struct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = package_Types_Struct_toFfi(value);
   final result = _package_Types_Struct_create_handle_nullable(_handle);
   package_Types_Struct_releaseFfiHandle(_handle);
   return result;
 }
-Struct package_Types_Struct_fromFfi_nullable(Pointer<Void> handle) {
+Struct? package_Types_Struct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _package_Types_Struct_get_value_nullable(handle);
   final result = package_Types_Struct_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
@@ -49,7 +49,7 @@ Pointer<Void> foobar_ListOf_Byte_toFfi(List<int> value) {
   return _result;
 }
 List<int> foobar_ListOf_Byte_fromFfi(Pointer<Void> handle) {
-  final result = List<int>();
+  final result = List<int>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_Byte_iterator(handle);
   while (_foobar_ListOf_Byte_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_Byte_iterator_get(_iterator_handle);
@@ -76,14 +76,14 @@ final _foobar_ListOf_Byte_get_value_nullable = __lib.catchArgumentError(() => __
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Byte_get_value_nullable'));
-Pointer<Void> foobar_ListOf_Byte_toFfi_nullable(List<int> value) {
+Pointer<Void> foobar_ListOf_Byte_toFfi_nullable(List<int>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_Byte_toFfi(value);
   final result = _foobar_ListOf_Byte_create_handle_nullable(_handle);
   foobar_ListOf_Byte_releaseFfiHandle(_handle);
   return result;
 }
-List<int> foobar_ListOf_Byte_fromFfi_nullable(Pointer<Void> handle) {
+List<int>? foobar_ListOf_Byte_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_Byte_get_value_nullable(handle);
   final result = foobar_ListOf_Byte_fromFfi(_handle);
@@ -134,7 +134,7 @@ Pointer<Void> foobar_ListOf_String_toFfi(List<String> value) {
   return _result;
 }
 List<String> foobar_ListOf_String_fromFfi(Pointer<Void> handle) {
-  final result = List<String>();
+  final result = List<String>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_String_iterator(handle);
   while (_foobar_ListOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_String_iterator_get(_iterator_handle);
@@ -161,14 +161,14 @@ final _foobar_ListOf_String_get_value_nullable = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_String_get_value_nullable'));
-Pointer<Void> foobar_ListOf_String_toFfi_nullable(List<String> value) {
+Pointer<Void> foobar_ListOf_String_toFfi_nullable(List<String>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_String_toFfi(value);
   final result = _foobar_ListOf_String_create_handle_nullable(_handle);
   foobar_ListOf_String_releaseFfiHandle(_handle);
   return result;
 }
-List<String> foobar_ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
+List<String>? foobar_ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_String_get_value_nullable(handle);
   final result = foobar_ListOf_String_fromFfi(_handle);
@@ -219,7 +219,7 @@ Pointer<Void> foobar_ListOf_smoke_Rectangle_toFfi(List<math.Rectangle<int>> valu
   return _result;
 }
 List<math.Rectangle<int>> foobar_ListOf_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
-  final result = List<math.Rectangle<int>>();
+  final result = List<math.Rectangle<int>>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_smoke_Rectangle_iterator(handle);
   while (_foobar_ListOf_smoke_Rectangle_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_Rectangle_iterator_get(_iterator_handle);
@@ -246,14 +246,14 @@ final _foobar_ListOf_smoke_Rectangle_get_value_nullable = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_Rectangle_get_value_nullable'));
-Pointer<Void> foobar_ListOf_smoke_Rectangle_toFfi_nullable(List<math.Rectangle<int>> value) {
+Pointer<Void> foobar_ListOf_smoke_Rectangle_toFfi_nullable(List<math.Rectangle<int>>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_Rectangle_toFfi(value);
   final result = _foobar_ListOf_smoke_Rectangle_create_handle_nullable(_handle);
   foobar_ListOf_smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
-List<math.Rectangle<int>> foobar_ListOf_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
+List<math.Rectangle<int>>? foobar_ListOf_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_smoke_Rectangle_get_value_nullable(handle);
   final result = foobar_ListOf_smoke_Rectangle_fromFfi(_handle);
@@ -340,14 +340,14 @@ final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable'));
-Pointer<Void> foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi_nullable(Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> value) {
+Pointer<Void> foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi_nullable(Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi(value);
   final result = _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle_nullable(_handle);
   foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
-Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
+Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>>? foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable(handle);
   final result = foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi(_handle);
@@ -425,14 +425,14 @@ final _foobar_SetOf_smoke_CompressionState_get_value_nullable = __lib.catchArgum
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_CompressionState_get_value_nullable'));
-Pointer<Void> foobar_SetOf_smoke_CompressionState_toFfi_nullable(Set<bar.HttpClientResponseCompressionState> value) {
+Pointer<Void> foobar_SetOf_smoke_CompressionState_toFfi_nullable(Set<bar.HttpClientResponseCompressionState>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_smoke_CompressionState_toFfi(value);
   final result = _foobar_SetOf_smoke_CompressionState_create_handle_nullable(_handle);
   foobar_SetOf_smoke_CompressionState_releaseFfiHandle(_handle);
   return result;
 }
-Set<bar.HttpClientResponseCompressionState> foobar_SetOf_smoke_CompressionState_fromFfi_nullable(Pointer<Void> handle) {
+Set<bar.HttpClientResponseCompressionState>? foobar_SetOf_smoke_CompressionState_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_SetOf_smoke_CompressionState_get_value_nullable(handle);
   final result = foobar_SetOf_smoke_CompressionState_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -55,14 +55,14 @@ final _smoke_Enums_ExternalEnum_get_value_nullable = __lib.catchArgumentError(()
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_ExternalEnum_get_value_nullable'));
-Pointer<Void> smoke_Enums_ExternalEnum_toFfi_nullable(Enums_ExternalEnum value) {
+Pointer<Void> smoke_Enums_ExternalEnum_toFfi_nullable(Enums_ExternalEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_ExternalEnum_toFfi(value);
   final result = _smoke_Enums_ExternalEnum_create_handle_nullable(_handle);
   smoke_Enums_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
-Enums_ExternalEnum smoke_Enums_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
+Enums_ExternalEnum? smoke_Enums_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Enums_ExternalEnum_get_value_nullable(handle);
   final result = smoke_Enums_ExternalEnum_fromFfi(_handle);
@@ -114,14 +114,14 @@ final _smoke_Enums_VeryExternalEnum_get_value_nullable = __lib.catchArgumentErro
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_VeryExternalEnum_get_value_nullable'));
-Pointer<Void> smoke_Enums_VeryExternalEnum_toFfi_nullable(Enums_VeryExternalEnum value) {
+Pointer<Void> smoke_Enums_VeryExternalEnum_toFfi_nullable(Enums_VeryExternalEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_VeryExternalEnum_toFfi(value);
   final result = _smoke_Enums_VeryExternalEnum_create_handle_nullable(_handle);
   smoke_Enums_VeryExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
-Enums_VeryExternalEnum smoke_Enums_VeryExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
+Enums_VeryExternalEnum? smoke_Enums_VeryExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Enums_VeryExternalEnum_get_value_nullable(handle);
   final result = smoke_Enums_VeryExternalEnum_fromFfi(_handle);
@@ -144,11 +144,11 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
   Enums$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_Enums_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static methodWithExternalEnum(Enums_ExternalEnum input) {
     final _methodWithExternalEnum_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Uint32), void Function(int, int)>('library_smoke_Enums_methodWithExternalEnum__External_1Enum'));
@@ -167,8 +167,8 @@ Pointer<Void> smoke_Enums_toFfi(Enums value) =>
 Enums smoke_Enums_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Enums;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Enums) return instance;
   final _copied_handle = _smoke_Enums_copy_handle(handle);
   final result = Enums$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -176,9 +176,9 @@ Enums smoke_Enums_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Enums_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Enums_release_handle(handle);
-Pointer<Void> smoke_Enums_toFfi_nullable(Enums value) =>
+Pointer<Void> smoke_Enums_toFfi_nullable(Enums? value) =>
   value != null ? smoke_Enums_toFfi(value) : Pointer<Void>.fromAddress(0);
-Enums smoke_Enums_fromFfi_nullable(Pointer<Void> handle) =>
+Enums? smoke_Enums_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Enums_fromFfi(handle) : null;
 void smoke_Enums_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Enums_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -49,14 +49,14 @@ final _smoke_ExternalClass_SomeEnum_get_value_nullable = __lib.catchArgumentErro
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_ExternalClass_SomeEnum_toFfi_nullable(ExternalClass_SomeEnum value) {
+Pointer<Void> smoke_ExternalClass_SomeEnum_toFfi_nullable(ExternalClass_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExternalClass_SomeEnum_toFfi(value);
   final result = _smoke_ExternalClass_SomeEnum_create_handle_nullable(_handle);
   smoke_ExternalClass_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-ExternalClass_SomeEnum smoke_ExternalClass_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+ExternalClass_SomeEnum? smoke_ExternalClass_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ExternalClass_SomeEnum_get_value_nullable(handle);
   final result = smoke_ExternalClass_SomeEnum_fromFfi(_handle);
@@ -113,14 +113,14 @@ final _smoke_ExternalClass_SomeStruct_get_value_nullable = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_ExternalClass_SomeStruct_toFfi_nullable(ExternalClass_SomeStruct value) {
+Pointer<Void> smoke_ExternalClass_SomeStruct_toFfi_nullable(ExternalClass_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExternalClass_SomeStruct_toFfi(value);
   final result = _smoke_ExternalClass_SomeStruct_create_handle_nullable(_handle);
   smoke_ExternalClass_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-ExternalClass_SomeStruct smoke_ExternalClass_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+ExternalClass_SomeStruct? smoke_ExternalClass_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ExternalClass_SomeStruct_get_value_nullable(handle);
   final result = smoke_ExternalClass_SomeStruct_fromFfi(_handle);
@@ -143,11 +143,11 @@ class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
   ExternalClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ExternalClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   someMethod(int someParameter) {
@@ -179,8 +179,8 @@ Pointer<Void> smoke_ExternalClass_toFfi(ExternalClass value) =>
 ExternalClass smoke_ExternalClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ExternalClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ExternalClass) return instance;
   final _copied_handle = _smoke_ExternalClass_copy_handle(handle);
   final result = ExternalClass$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -188,9 +188,9 @@ ExternalClass smoke_ExternalClass_fromFfi(Pointer<Void> handle) {
 }
 void smoke_ExternalClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ExternalClass_release_handle(handle);
-Pointer<Void> smoke_ExternalClass_toFfi_nullable(ExternalClass value) =>
+Pointer<Void> smoke_ExternalClass_toFfi_nullable(ExternalClass? value) =>
   value != null ? smoke_ExternalClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-ExternalClass smoke_ExternalClass_fromFfi_nullable(Pointer<Void> handle) =>
+ExternalClass? smoke_ExternalClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ExternalClass_fromFfi(handle) : null;
 void smoke_ExternalClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ExternalClass_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -9,8 +9,8 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class ExternalInterface {
   ExternalInterface() {}
   factory ExternalInterface.fromLambdas({
-    @required void Function(int) lambda_someMethod,
-    @required String Function() lambda_someProperty_get
+    required void Function(int) lambda_someMethod,
+    required String Function() lambda_someProperty_get
   }) => ExternalInterface$Lambdas(
     lambda_someMethod,
     lambda_someProperty_get
@@ -58,14 +58,14 @@ final _smoke_ExternalInterface_SomeEnum_get_value_nullable = __lib.catchArgument
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_ExternalInterface_SomeEnum_toFfi_nullable(ExternalInterface_SomeEnum value) {
+Pointer<Void> smoke_ExternalInterface_SomeEnum_toFfi_nullable(ExternalInterface_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExternalInterface_SomeEnum_toFfi(value);
   final result = _smoke_ExternalInterface_SomeEnum_create_handle_nullable(_handle);
   smoke_ExternalInterface_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-ExternalInterface_SomeEnum smoke_ExternalInterface_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+ExternalInterface_SomeEnum? smoke_ExternalInterface_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ExternalInterface_SomeEnum_get_value_nullable(handle);
   final result = smoke_ExternalInterface_SomeEnum_fromFfi(_handle);
@@ -122,14 +122,14 @@ final _smoke_ExternalInterface_SomeStruct_get_value_nullable = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_ExternalInterface_SomeStruct_toFfi_nullable(ExternalInterface_SomeStruct value) {
+Pointer<Void> smoke_ExternalInterface_SomeStruct_toFfi_nullable(ExternalInterface_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExternalInterface_SomeStruct_toFfi(value);
   final result = _smoke_ExternalInterface_SomeStruct_create_handle_nullable(_handle);
   smoke_ExternalInterface_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-ExternalInterface_SomeStruct smoke_ExternalInterface_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+ExternalInterface_SomeStruct? smoke_ExternalInterface_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ExternalInterface_SomeStruct_get_value_nullable(handle);
   final result = smoke_ExternalInterface_SomeStruct_fromFfi(_handle);
@@ -175,11 +175,11 @@ class ExternalInterface$Impl extends __lib.NativeBase implements ExternalInterfa
   ExternalInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ExternalInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   someMethod(int someParameter) {
@@ -231,8 +231,8 @@ Pointer<Void> smoke_ExternalInterface_toFfi(ExternalInterface value) {
 ExternalInterface smoke_ExternalInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ExternalInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ExternalInterface) return instance;
   final _type_id_handle = _smoke_ExternalInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -245,9 +245,9 @@ ExternalInterface smoke_ExternalInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_ExternalInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ExternalInterface_release_handle(handle);
-Pointer<Void> smoke_ExternalInterface_toFfi_nullable(ExternalInterface value) =>
+Pointer<Void> smoke_ExternalInterface_toFfi_nullable(ExternalInterface? value) =>
   value != null ? smoke_ExternalInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-ExternalInterface smoke_ExternalInterface_fromFfi_nullable(Pointer<Void> handle) =>
+ExternalInterface? smoke_ExternalInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ExternalInterface_fromFfi(handle) : null;
 void smoke_ExternalInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ExternalInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
@@ -47,14 +47,14 @@ final _smoke_CompressionState_get_value_nullable = __lib.catchArgumentError(() =
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CompressionState_get_value_nullable'));
-Pointer<Void> smoke_CompressionState_toFfi_nullable(bar.HttpClientResponseCompressionState value) {
+Pointer<Void> smoke_CompressionState_toFfi_nullable(bar.HttpClientResponseCompressionState? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CompressionState_toFfi(value);
   final result = _smoke_CompressionState_create_handle_nullable(_handle);
   smoke_CompressionState_releaseFfiHandle(_handle);
   return result;
 }
-bar.HttpClientResponseCompressionState smoke_CompressionState_fromFfi_nullable(Pointer<Void> handle) {
+bar.HttpClientResponseCompressionState? smoke_CompressionState_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_CompressionState_get_value_nullable(handle);
   final result = smoke_CompressionState_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
@@ -85,14 +85,14 @@ final _smoke_DartColor_get_value_nullable = __lib.catchArgumentError(() => __lib
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DartColor_get_value_nullable'));
-Pointer<Void> smoke_DartColor_toFfi_nullable(int value) {
+Pointer<Void> smoke_DartColor_toFfi_nullable(int? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DartColor_toFfi(value);
   final result = _smoke_DartColor_create_handle_nullable(_handle);
   smoke_DartColor_releaseFfiHandle(_handle);
   return result;
 }
-int smoke_DartColor_fromFfi_nullable(Pointer<Void> handle) {
+int? smoke_DartColor_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DartColor_get_value_nullable(handle);
   final result = smoke_DartColor_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
@@ -74,14 +74,14 @@ final _smoke_Rectangle_get_value_nullable = __lib.catchArgumentError(() => __lib
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Rectangle_get_value_nullable'));
-Pointer<Void> smoke_Rectangle_toFfi_nullable(math.Rectangle<int> value) {
+Pointer<Void> smoke_Rectangle_toFfi_nullable(math.Rectangle<int>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Rectangle_toFfi(value);
   final result = _smoke_Rectangle_create_handle_nullable(_handle);
   smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
-math.Rectangle<int> smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
+math.Rectangle<int>? smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Rectangle_get_value_nullable(handle);
   final result = smoke_Rectangle_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
@@ -60,14 +60,14 @@ final _smoke_DartSeason_get_value_nullable = __lib.catchArgumentError(() => __li
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DartSeason_get_value_nullable'));
-Pointer<Void> smoke_DartSeason_toFfi_nullable(String value) {
+Pointer<Void> smoke_DartSeason_toFfi_nullable(String? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DartSeason_toFfi(value);
   final result = _smoke_DartSeason_create_handle_nullable(_handle);
   smoke_DartSeason_releaseFfiHandle(_handle);
   return result;
 }
-String smoke_DartSeason_fromFfi_nullable(Pointer<Void> handle) {
+String? smoke_DartSeason_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_DartSeason_get_value_nullable(handle);
   final result = smoke_DartSeason_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
@@ -92,14 +92,14 @@ final _smoke_Structs_ExternalStruct_get_value_nullable = __lib.catchArgumentErro
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ExternalStruct_get_value_nullable'));
-Pointer<Void> smoke_Structs_ExternalStruct_toFfi_nullable(Structs_ExternalStruct value) {
+Pointer<Void> smoke_Structs_ExternalStruct_toFfi_nullable(Structs_ExternalStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_ExternalStruct_toFfi(value);
   final result = _smoke_Structs_ExternalStruct_create_handle_nullable(_handle);
   smoke_Structs_ExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
-Structs_ExternalStruct smoke_Structs_ExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
+Structs_ExternalStruct? smoke_Structs_ExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Structs_ExternalStruct_get_value_nullable(handle);
   final result = smoke_Structs_ExternalStruct_fromFfi(_handle);
@@ -156,14 +156,14 @@ final _smoke_Structs_AnotherExternalStruct_get_value_nullable = __lib.catchArgum
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_AnotherExternalStruct_get_value_nullable'));
-Pointer<Void> smoke_Structs_AnotherExternalStruct_toFfi_nullable(Structs_AnotherExternalStruct value) {
+Pointer<Void> smoke_Structs_AnotherExternalStruct_toFfi_nullable(Structs_AnotherExternalStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_AnotherExternalStruct_toFfi(value);
   final result = _smoke_Structs_AnotherExternalStruct_create_handle_nullable(_handle);
   smoke_Structs_AnotherExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
-Structs_AnotherExternalStruct smoke_Structs_AnotherExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
+Structs_AnotherExternalStruct? smoke_Structs_AnotherExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Structs_AnotherExternalStruct_get_value_nullable(handle);
   final result = smoke_Structs_AnotherExternalStruct_fromFfi(_handle);
@@ -186,11 +186,11 @@ class Structs$Impl extends __lib.NativeBase implements Structs {
   Structs$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_Structs_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static Structs_ExternalStruct getExternalStruct() {
     final _getExternalStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getExternalStruct'));
@@ -216,8 +216,8 @@ Pointer<Void> smoke_Structs_toFfi(Structs value) =>
 Structs smoke_Structs_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Structs;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Structs) return instance;
   final _copied_handle = _smoke_Structs_copy_handle(handle);
   final result = Structs$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -225,9 +225,9 @@ Structs smoke_Structs_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Structs_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Structs_release_handle(handle);
-Pointer<Void> smoke_Structs_toFfi_nullable(Structs value) =>
+Pointer<Void> smoke_Structs_toFfi_nullable(Structs? value) =>
   value != null ? smoke_Structs_toFfi(value) : Pointer<Void>.fromAddress(0);
-Structs smoke_Structs_fromFfi_nullable(Pointer<Void> handle) =>
+Structs? smoke_Structs_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Structs_fromFfi(handle) : null;
 void smoke_Structs_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Structs_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -34,11 +34,11 @@ class UseDartExternalTypes$Impl extends __lib.NativeBase implements UseDartExter
   UseDartExternalTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_UseDartExternalTypes_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static math.Rectangle<int> rectangleRoundTrip(math.Rectangle<int> input) {
     final _rectangleRoundTrip_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_rectangleRoundTrip__Rectangle'));
@@ -90,8 +90,8 @@ Pointer<Void> smoke_UseDartExternalTypes_toFfi(UseDartExternalTypes value) =>
 UseDartExternalTypes smoke_UseDartExternalTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as UseDartExternalTypes;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is UseDartExternalTypes) return instance;
   final _copied_handle = _smoke_UseDartExternalTypes_copy_handle(handle);
   final result = UseDartExternalTypes$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -99,9 +99,9 @@ UseDartExternalTypes smoke_UseDartExternalTypes_fromFfi(Pointer<Void> handle) {
 }
 void smoke_UseDartExternalTypes_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_UseDartExternalTypes_release_handle(handle);
-Pointer<Void> smoke_UseDartExternalTypes_toFfi_nullable(UseDartExternalTypes value) =>
+Pointer<Void> smoke_UseDartExternalTypes_toFfi_nullable(UseDartExternalTypes? value) =>
   value != null ? smoke_UseDartExternalTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
-UseDartExternalTypes smoke_UseDartExternalTypes_fromFfi_nullable(Pointer<Void> handle) =>
+UseDartExternalTypes? smoke_UseDartExternalTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_UseDartExternalTypes_fromFfi(handle) : null;
 void smoke_UseDartExternalTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_UseDartExternalTypes_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/_lazy_list.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/_lazy_list.dart
@@ -30,19 +30,19 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   List<E> operator +(List<E> other) => cast<E>() + other;
   Map<int, E> asMap() => cast<E>().asMap();
   Iterable<E> getRange(int start, int end) => cast<E>().getRange(start, end);
-  List<E> sublist(int start, [int end = null]) => cast<E>().sublist(start, end);
+  List<E> sublist(int start, [int? end]) => cast<E>().sublist(start, end);
   Iterable<E> get reversed => cast<E>().reversed;
   // Methods relying on the iterator
   int indexOf(E element, [int start = 0]) => indexWhere((it) => element == it, start);
   int indexWhere(bool test(E element), [int start = 0]) {
-    final iterator = _LazyIterator(this, start ?? -1, 1);
+    final iterator = _LazyIterator(this, start - 1, 1);
     while (iterator.moveNext()) {
       if (test(iterator.current)) return iterator.position;
     }
     return -1;
   }
-  int lastIndexOf(E element, [int start = null]) => lastIndexWhere((it) => element == it, start);
-  int lastIndexWhere(bool test(E element), [int start = null]) {
+  int lastIndexOf(E element, [int? start]) => lastIndexWhere((it) => element == it, start);
+  int lastIndexWhere(bool test(E element), [int? start]) {
     final iterator = _LazyIterator(this, start ?? length, -1);
     while (iterator.moveNext()) {
       if (test(iterator.current)) return iterator.position;
@@ -54,10 +54,10 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   void add(E value) => throw UnsupportedError(_cannotModify);
   void addAll(Iterable<E> iterable) => throw UnsupportedError(_cannotModify);
   void clear() => throw UnsupportedError(_cannotModify);
-  void fillRange(int start, int end, [E fillValue]) => throw UnsupportedError(_cannotModify);
+  void fillRange(int start, int end, [E? fillValue]) => throw UnsupportedError(_cannotModify);
   void insert(int index, E element) => throw UnsupportedError(_cannotModify);
   void insertAll(int index, Iterable<E> iterable) => throw UnsupportedError(_cannotModify);
-  bool remove(Object value) => throw UnsupportedError(_cannotModify);
+  bool remove(Object? value) => throw UnsupportedError(_cannotModify);
   E removeAt(int index) => throw UnsupportedError(_cannotModify);
   E removeLast() => throw UnsupportedError(_cannotModify);
   void removeRange(int start, int end) => throw UnsupportedError(_cannotModify);
@@ -66,8 +66,8 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   void retainWhere(bool test(E element)) => throw UnsupportedError(_cannotModify);
   void setAll(int index, Iterable<E> iterable) => throw UnsupportedError(_cannotModify);
   void setRange(int start, int end, Iterable<E> iterable, [int skipCount = 0]) => throw UnsupportedError(_cannotModify);
-  void shuffle([Random random]) => throw UnsupportedError(_cannotModify);
-  void sort([int compare(E a, E b)]) => throw UnsupportedError(_cannotModify);
+  void shuffle([Random? random]) => throw UnsupportedError(_cannotModify);
+  void sort([int compare(E a, E b)?]) => throw UnsupportedError(_cannotModify);
   void set first(E value) => throw UnsupportedError(_cannotModify);
   void set last(E value) => throw UnsupportedError(_cannotModify);
   set length(int newLength) => throw UnsupportedError(_cannotModify);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/generic_types__conversion.dart
@@ -52,7 +52,7 @@ Pointer<Void> foobar_ListOf_Float_toFfi(List<double> value) {
   return _result;
 }
 List<double> foobar_ListOf_Float_fromFfi(Pointer<Void> handle) {
-  final result = List<double>();
+  final result = List<double>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_Float_iterator(handle);
   while (_foobar_ListOf_Float_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_Float_iterator_get(_iterator_handle);
@@ -79,14 +79,14 @@ final _foobar_ListOf_Float_get_value_nullable = __lib.catchArgumentError(() => _
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Float_get_value_nullable'));
-Pointer<Void> foobar_ListOf_Float_toFfi_nullable(List<double> value) {
+Pointer<Void> foobar_ListOf_Float_toFfi_nullable(List<double>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_Float_toFfi(value);
   final result = _foobar_ListOf_Float_create_handle_nullable(_handle);
   foobar_ListOf_Float_releaseFfiHandle(_handle);
   return result;
 }
-List<double> foobar_ListOf_Float_fromFfi_nullable(Pointer<Void> handle) {
+List<double>? foobar_ListOf_Float_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_Float_get_value_nullable(handle);
   final result = foobar_ListOf_Float_fromFfi(_handle);
@@ -137,7 +137,7 @@ Pointer<Void> foobar_ListOf_Int_toFfi(List<int> value) {
   return _result;
 }
 List<int> foobar_ListOf_Int_fromFfi(Pointer<Void> handle) {
-  final result = List<int>();
+  final result = List<int>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_Int_iterator(handle);
   while (_foobar_ListOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_Int_iterator_get(_iterator_handle);
@@ -164,14 +164,14 @@ final _foobar_ListOf_Int_get_value_nullable = __lib.catchArgumentError(() => __l
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Int_get_value_nullable'));
-Pointer<Void> foobar_ListOf_Int_toFfi_nullable(List<int> value) {
+Pointer<Void> foobar_ListOf_Int_toFfi_nullable(List<int>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_Int_toFfi(value);
   final result = _foobar_ListOf_Int_create_handle_nullable(_handle);
   foobar_ListOf_Int_releaseFfiHandle(_handle);
   return result;
 }
-List<int> foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
+List<int>? foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_Int_get_value_nullable(handle);
   final result = foobar_ListOf_Int_fromFfi(_handle);
@@ -222,7 +222,7 @@ Pointer<Void> foobar_ListOf_String_toFfi(List<String> value) {
   return _result;
 }
 List<String> foobar_ListOf_String_fromFfi(Pointer<Void> handle) {
-  final result = List<String>();
+  final result = List<String>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_String_iterator(handle);
   while (_foobar_ListOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_String_iterator_get(_iterator_handle);
@@ -249,14 +249,14 @@ final _foobar_ListOf_String_get_value_nullable = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_String_get_value_nullable'));
-Pointer<Void> foobar_ListOf_String_toFfi_nullable(List<String> value) {
+Pointer<Void> foobar_ListOf_String_toFfi_nullable(List<String>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_String_toFfi(value);
   final result = _foobar_ListOf_String_create_handle_nullable(_handle);
   foobar_ListOf_String_releaseFfiHandle(_handle);
   return result;
 }
-List<String> foobar_ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
+List<String>? foobar_ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_String_get_value_nullable(handle);
   final result = foobar_ListOf_String_fromFfi(_handle);
@@ -307,7 +307,7 @@ Pointer<Void> foobar_ListOf_UByte_toFfi(List<int> value) {
   return _result;
 }
 List<int> foobar_ListOf_UByte_fromFfi(Pointer<Void> handle) {
-  final result = List<int>();
+  final result = List<int>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_UByte_iterator(handle);
   while (_foobar_ListOf_UByte_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_UByte_iterator_get(_iterator_handle);
@@ -334,14 +334,14 @@ final _foobar_ListOf_UByte_get_value_nullable = __lib.catchArgumentError(() => _
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_UByte_get_value_nullable'));
-Pointer<Void> foobar_ListOf_UByte_toFfi_nullable(List<int> value) {
+Pointer<Void> foobar_ListOf_UByte_toFfi_nullable(List<int>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_UByte_toFfi(value);
   final result = _foobar_ListOf_UByte_create_handle_nullable(_handle);
   foobar_ListOf_UByte_releaseFfiHandle(_handle);
   return result;
 }
-List<int> foobar_ListOf_UByte_fromFfi_nullable(Pointer<Void> handle) {
+List<int>? foobar_ListOf_UByte_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_UByte_get_value_nullable(handle);
   final result = foobar_ListOf_UByte_fromFfi(_handle);
@@ -392,7 +392,7 @@ Pointer<Void> foobar_ListOf_foobar_ListOf_Int_toFfi(List<List<int>> value) {
   return _result;
 }
 List<List<int>> foobar_ListOf_foobar_ListOf_Int_fromFfi(Pointer<Void> handle) {
-  final result = List<List<int>>();
+  final result = List<List<int>>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_foobar_ListOf_Int_iterator(handle);
   while (_foobar_ListOf_foobar_ListOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_foobar_ListOf_Int_iterator_get(_iterator_handle);
@@ -419,14 +419,14 @@ final _foobar_ListOf_foobar_ListOf_Int_get_value_nullable = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_ListOf_Int_get_value_nullable'));
-Pointer<Void> foobar_ListOf_foobar_ListOf_Int_toFfi_nullable(List<List<int>> value) {
+Pointer<Void> foobar_ListOf_foobar_ListOf_Int_toFfi_nullable(List<List<int>>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_foobar_ListOf_Int_toFfi(value);
   final result = _foobar_ListOf_foobar_ListOf_Int_create_handle_nullable(_handle);
   foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(_handle);
   return result;
 }
-List<List<int>> foobar_ListOf_foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
+List<List<int>>? foobar_ListOf_foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_foobar_ListOf_Int_get_value_nullable(handle);
   final result = foobar_ListOf_foobar_ListOf_Int_fromFfi(_handle);
@@ -477,7 +477,7 @@ Pointer<Void> foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi(List<Map<int, bool
   return _result;
 }
 List<Map<int, bool>> foobar_ListOf_foobar_MapOf_Int_to_Boolean_fromFfi(Pointer<Void> handle) {
-  final result = List<Map<int, bool>>();
+  final result = List<Map<int, bool>>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator(handle);
   while (_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_get(_iterator_handle);
@@ -504,14 +504,14 @@ final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.catc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_get_value_nullable'));
-Pointer<Void> foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi_nullable(List<Map<int, bool>> value) {
+Pointer<Void> foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi_nullable(List<Map<int, bool>>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi(value);
   final result = _foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable(_handle);
   foobar_ListOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
-List<Map<int, bool>> foobar_ListOf_foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
+List<Map<int, bool>>? foobar_ListOf_foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_foobar_MapOf_Int_to_Boolean_get_value_nullable(handle);
   final result = foobar_ListOf_foobar_MapOf_Int_to_Boolean_fromFfi(_handle);
@@ -562,7 +562,7 @@ Pointer<Void> foobar_ListOf_foobar_SetOf_Int_toFfi(List<Set<int>> value) {
   return _result;
 }
 List<Set<int>> foobar_ListOf_foobar_SetOf_Int_fromFfi(Pointer<Void> handle) {
-  final result = List<Set<int>>();
+  final result = List<Set<int>>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_foobar_SetOf_Int_iterator(handle);
   while (_foobar_ListOf_foobar_SetOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_foobar_SetOf_Int_iterator_get(_iterator_handle);
@@ -589,14 +589,14 @@ final _foobar_ListOf_foobar_SetOf_Int_get_value_nullable = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_SetOf_Int_get_value_nullable'));
-Pointer<Void> foobar_ListOf_foobar_SetOf_Int_toFfi_nullable(List<Set<int>> value) {
+Pointer<Void> foobar_ListOf_foobar_SetOf_Int_toFfi_nullable(List<Set<int>>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_foobar_SetOf_Int_toFfi(value);
   final result = _foobar_ListOf_foobar_SetOf_Int_create_handle_nullable(_handle);
   foobar_ListOf_foobar_SetOf_Int_releaseFfiHandle(_handle);
   return result;
 }
-List<Set<int>> foobar_ListOf_foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
+List<Set<int>>? foobar_ListOf_foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_foobar_SetOf_Int_get_value_nullable(handle);
   final result = foobar_ListOf_foobar_SetOf_Int_fromFfi(_handle);
@@ -647,7 +647,7 @@ Pointer<Void> foobar_ListOf_smoke_AnotherDummyClass_toFfi(List<AnotherDummyClass
   return _result;
 }
 List<AnotherDummyClass> foobar_ListOf_smoke_AnotherDummyClass_fromFfi(Pointer<Void> handle) {
-  final result = List<AnotherDummyClass>();
+  final result = List<AnotherDummyClass>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_smoke_AnotherDummyClass_iterator(handle);
   while (_foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_AnotherDummyClass_iterator_get(_iterator_handle);
@@ -674,14 +674,14 @@ final _foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable = __lib.catchArg
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable'));
-Pointer<Void> foobar_ListOf_smoke_AnotherDummyClass_toFfi_nullable(List<AnotherDummyClass> value) {
+Pointer<Void> foobar_ListOf_smoke_AnotherDummyClass_toFfi_nullable(List<AnotherDummyClass>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_AnotherDummyClass_toFfi(value);
   final result = _foobar_ListOf_smoke_AnotherDummyClass_create_handle_nullable(_handle);
   foobar_ListOf_smoke_AnotherDummyClass_releaseFfiHandle(_handle);
   return result;
 }
-List<AnotherDummyClass> foobar_ListOf_smoke_AnotherDummyClass_fromFfi_nullable(Pointer<Void> handle) {
+List<AnotherDummyClass>? foobar_ListOf_smoke_AnotherDummyClass_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable(handle);
   final result = foobar_ListOf_smoke_AnotherDummyClass_fromFfi(_handle);
@@ -732,7 +732,7 @@ Pointer<Void> foobar_ListOf_smoke_DummyClass_toFfi(List<DummyClass> value) {
   return _result;
 }
 List<DummyClass> foobar_ListOf_smoke_DummyClass_fromFfi(Pointer<Void> handle) {
-  final result = List<DummyClass>();
+  final result = List<DummyClass>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_smoke_DummyClass_iterator(handle);
   while (_foobar_ListOf_smoke_DummyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_DummyClass_iterator_get(_iterator_handle);
@@ -759,14 +759,14 @@ final _foobar_ListOf_smoke_DummyClass_get_value_nullable = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_DummyClass_get_value_nullable'));
-Pointer<Void> foobar_ListOf_smoke_DummyClass_toFfi_nullable(List<DummyClass> value) {
+Pointer<Void> foobar_ListOf_smoke_DummyClass_toFfi_nullable(List<DummyClass>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_DummyClass_toFfi(value);
   final result = _foobar_ListOf_smoke_DummyClass_create_handle_nullable(_handle);
   foobar_ListOf_smoke_DummyClass_releaseFfiHandle(_handle);
   return result;
 }
-List<DummyClass> foobar_ListOf_smoke_DummyClass_fromFfi_nullable(Pointer<Void> handle) {
+List<DummyClass>? foobar_ListOf_smoke_DummyClass_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_smoke_DummyClass_get_value_nullable(handle);
   final result = foobar_ListOf_smoke_DummyClass_fromFfi(_handle);
@@ -817,7 +817,7 @@ Pointer<Void> foobar_ListOf_smoke_DummyInterface_toFfi(List<DummyInterface> valu
   return _result;
 }
 List<DummyInterface> foobar_ListOf_smoke_DummyInterface_fromFfi(Pointer<Void> handle) {
-  final result = List<DummyInterface>();
+  final result = List<DummyInterface>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_smoke_DummyInterface_iterator(handle);
   while (_foobar_ListOf_smoke_DummyInterface_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_DummyInterface_iterator_get(_iterator_handle);
@@ -844,14 +844,14 @@ final _foobar_ListOf_smoke_DummyInterface_get_value_nullable = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_DummyInterface_get_value_nullable'));
-Pointer<Void> foobar_ListOf_smoke_DummyInterface_toFfi_nullable(List<DummyInterface> value) {
+Pointer<Void> foobar_ListOf_smoke_DummyInterface_toFfi_nullable(List<DummyInterface>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_DummyInterface_toFfi(value);
   final result = _foobar_ListOf_smoke_DummyInterface_create_handle_nullable(_handle);
   foobar_ListOf_smoke_DummyInterface_releaseFfiHandle(_handle);
   return result;
 }
-List<DummyInterface> foobar_ListOf_smoke_DummyInterface_fromFfi_nullable(Pointer<Void> handle) {
+List<DummyInterface>? foobar_ListOf_smoke_DummyInterface_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_smoke_DummyInterface_get_value_nullable(handle);
   final result = foobar_ListOf_smoke_DummyInterface_fromFfi(_handle);
@@ -902,7 +902,7 @@ Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFf
   return _result;
 }
 List<GenericTypesWithCompoundTypes_BasicStruct> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(Pointer<Void> handle) {
-  final result = List<GenericTypesWithCompoundTypes_BasicStruct>();
+  final result = List<GenericTypesWithCompoundTypes_BasicStruct>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator(handle);
   while (_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get(_iterator_handle);
@@ -929,14 +929,14 @@ final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_n
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable'));
-Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi_nullable(List<GenericTypesWithCompoundTypes_BasicStruct> value) {
+Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi_nullable(List<GenericTypesWithCompoundTypes_BasicStruct>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(value);
   final result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable(_handle);
   foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_handle);
   return result;
 }
-List<GenericTypesWithCompoundTypes_BasicStruct> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
+List<GenericTypesWithCompoundTypes_BasicStruct>? foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable(handle);
   final result = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_handle);
@@ -987,7 +987,7 @@ Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toF
   return _result;
 }
 List<GenericTypesWithCompoundTypes_ExternalEnum> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(Pointer<Void> handle) {
-  final result = List<GenericTypesWithCompoundTypes_ExternalEnum>();
+  final result = List<GenericTypesWithCompoundTypes_ExternalEnum>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(handle);
   while (_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get(_iterator_handle);
@@ -1014,14 +1014,14 @@ final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
-Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(List<GenericTypesWithCompoundTypes_ExternalEnum> value) {
+Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(List<GenericTypesWithCompoundTypes_ExternalEnum>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(value);
   final result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(_handle);
   foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
-List<GenericTypesWithCompoundTypes_ExternalEnum> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
+List<GenericTypesWithCompoundTypes_ExternalEnum>? foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(handle);
   final result = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_handle);
@@ -1072,7 +1072,7 @@ Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_t
   return _result;
 }
 List<GenericTypesWithCompoundTypes_ExternalStruct> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(Pointer<Void> handle) {
-  final result = List<GenericTypesWithCompoundTypes_ExternalStruct>();
+  final result = List<GenericTypesWithCompoundTypes_ExternalStruct>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator(handle);
   while (_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get(_iterator_handle);
@@ -1099,14 +1099,14 @@ final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_valu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable'));
-Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi_nullable(List<GenericTypesWithCompoundTypes_ExternalStruct> value) {
+Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi_nullable(List<GenericTypesWithCompoundTypes_ExternalStruct>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(value);
   final result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable(_handle);
   foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
-List<GenericTypesWithCompoundTypes_ExternalStruct> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
+List<GenericTypesWithCompoundTypes_ExternalStruct>? foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable(handle);
   final result = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_handle);
@@ -1157,7 +1157,7 @@ Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(L
   return _result;
 }
 List<GenericTypesWithCompoundTypes_SomeEnum> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(Pointer<Void> handle) {
-  final result = List<GenericTypesWithCompoundTypes_SomeEnum>();
+  final result = List<GenericTypesWithCompoundTypes_SomeEnum>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(handle);
   while (_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get(_iterator_handle);
@@ -1184,14 +1184,14 @@ final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_null
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
-Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(List<GenericTypesWithCompoundTypes_SomeEnum> value) {
+Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(List<GenericTypesWithCompoundTypes_SomeEnum>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(value);
   final result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(_handle);
   foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-List<GenericTypesWithCompoundTypes_SomeEnum> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+List<GenericTypesWithCompoundTypes_SomeEnum>? foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(handle);
   final result = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_handle);
@@ -1242,7 +1242,7 @@ Pointer<Void> foobar_ListOf_smoke_UnreasonablyLazyClass_toFfi(List<UnreasonablyL
   return _result;
 }
 List<UnreasonablyLazyClass> foobar_ListOf_smoke_UnreasonablyLazyClass_fromFfi(Pointer<Void> handle) {
-  final result = List<UnreasonablyLazyClass>();
+  final result = List<UnreasonablyLazyClass>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_smoke_UnreasonablyLazyClass_iterator(handle);
   while (_foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_get(_iterator_handle);
@@ -1269,14 +1269,14 @@ final _foobar_ListOf_smoke_UnreasonablyLazyClass_get_value_nullable = __lib.catc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_UnreasonablyLazyClass_get_value_nullable'));
-Pointer<Void> foobar_ListOf_smoke_UnreasonablyLazyClass_toFfi_nullable(List<UnreasonablyLazyClass> value) {
+Pointer<Void> foobar_ListOf_smoke_UnreasonablyLazyClass_toFfi_nullable(List<UnreasonablyLazyClass>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_UnreasonablyLazyClass_toFfi(value);
   final result = _foobar_ListOf_smoke_UnreasonablyLazyClass_create_handle_nullable(_handle);
   foobar_ListOf_smoke_UnreasonablyLazyClass_releaseFfiHandle(_handle);
   return result;
 }
-List<UnreasonablyLazyClass> foobar_ListOf_smoke_UnreasonablyLazyClass_fromFfi_nullable(Pointer<Void> handle) {
+List<UnreasonablyLazyClass>? foobar_ListOf_smoke_UnreasonablyLazyClass_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_smoke_UnreasonablyLazyClass_get_value_nullable(handle);
   final result = foobar_ListOf_smoke_UnreasonablyLazyClass_fromFfi(_handle);
@@ -1327,7 +1327,7 @@ Pointer<Void> foobar_ListOf_smoke_VeryBigStruct_toFfi(List<VeryBigStruct> value)
   return _result;
 }
 List<VeryBigStruct> foobar_ListOf_smoke_VeryBigStruct_fromFfi(Pointer<Void> handle) {
-  final result = List<VeryBigStruct>();
+  final result = List<VeryBigStruct>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_smoke_VeryBigStruct_iterator(handle);
   while (_foobar_ListOf_smoke_VeryBigStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_VeryBigStruct_iterator_get(_iterator_handle);
@@ -1354,14 +1354,14 @@ final _foobar_ListOf_smoke_VeryBigStruct_get_value_nullable = __lib.catchArgumen
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_VeryBigStruct_get_value_nullable'));
-Pointer<Void> foobar_ListOf_smoke_VeryBigStruct_toFfi_nullable(List<VeryBigStruct> value) {
+Pointer<Void> foobar_ListOf_smoke_VeryBigStruct_toFfi_nullable(List<VeryBigStruct>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_VeryBigStruct_toFfi(value);
   final result = _foobar_ListOf_smoke_VeryBigStruct_create_handle_nullable(_handle);
   foobar_ListOf_smoke_VeryBigStruct_releaseFfiHandle(_handle);
   return result;
 }
-List<VeryBigStruct> foobar_ListOf_smoke_VeryBigStruct_fromFfi_nullable(Pointer<Void> handle) {
+List<VeryBigStruct>? foobar_ListOf_smoke_VeryBigStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_smoke_VeryBigStruct_get_value_nullable(handle);
   final result = foobar_ListOf_smoke_VeryBigStruct_fromFfi(_handle);
@@ -1412,7 +1412,7 @@ Pointer<Void> foobar_ListOf_smoke_YetAnotherDummyClass_toFfi(List<YetAnotherDumm
   return _result;
 }
 List<YetAnotherDummyClass> foobar_ListOf_smoke_YetAnotherDummyClass_fromFfi(Pointer<Void> handle) {
-  final result = List<YetAnotherDummyClass>();
+  final result = List<YetAnotherDummyClass>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_smoke_YetAnotherDummyClass_iterator(handle);
   while (_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_get(_iterator_handle);
@@ -1439,14 +1439,14 @@ final _foobar_ListOf_smoke_YetAnotherDummyClass_get_value_nullable = __lib.catch
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_YetAnotherDummyClass_get_value_nullable'));
-Pointer<Void> foobar_ListOf_smoke_YetAnotherDummyClass_toFfi_nullable(List<YetAnotherDummyClass> value) {
+Pointer<Void> foobar_ListOf_smoke_YetAnotherDummyClass_toFfi_nullable(List<YetAnotherDummyClass>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_YetAnotherDummyClass_toFfi(value);
   final result = _foobar_ListOf_smoke_YetAnotherDummyClass_create_handle_nullable(_handle);
   foobar_ListOf_smoke_YetAnotherDummyClass_releaseFfiHandle(_handle);
   return result;
 }
-List<YetAnotherDummyClass> foobar_ListOf_smoke_YetAnotherDummyClass_fromFfi_nullable(Pointer<Void> handle) {
+List<YetAnotherDummyClass>? foobar_ListOf_smoke_YetAnotherDummyClass_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_smoke_YetAnotherDummyClass_get_value_nullable(handle);
   final result = foobar_ListOf_smoke_YetAnotherDummyClass_fromFfi(_handle);
@@ -1533,14 +1533,14 @@ final _foobar_MapOf_Float_to_Double_get_value_nullable = __lib.catchArgumentErro
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Float_to_Double_get_value_nullable'));
-Pointer<Void> foobar_MapOf_Float_to_Double_toFfi_nullable(Map<double, double> value) {
+Pointer<Void> foobar_MapOf_Float_to_Double_toFfi_nullable(Map<double, double>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Float_to_Double_toFfi(value);
   final result = _foobar_MapOf_Float_to_Double_create_handle_nullable(_handle);
   foobar_MapOf_Float_to_Double_releaseFfiHandle(_handle);
   return result;
 }
-Map<double, double> foobar_MapOf_Float_to_Double_fromFfi_nullable(Pointer<Void> handle) {
+Map<double, double>? foobar_MapOf_Float_to_Double_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_Float_to_Double_get_value_nullable(handle);
   final result = foobar_MapOf_Float_to_Double_fromFfi(_handle);
@@ -1627,14 +1627,14 @@ final _foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_Boolean_get_value_nullable'));
-Pointer<Void> foobar_MapOf_Int_to_Boolean_toFfi_nullable(Map<int, bool> value) {
+Pointer<Void> foobar_MapOf_Int_to_Boolean_toFfi_nullable(Map<int, bool>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_Boolean_toFfi(value);
   final result = _foobar_MapOf_Int_to_Boolean_create_handle_nullable(_handle);
   foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, bool> foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, bool>? foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_Int_to_Boolean_get_value_nullable(handle);
   final result = foobar_MapOf_Int_to_Boolean_fromFfi(_handle);
@@ -1721,14 +1721,14 @@ final _foobar_MapOf_Int_to_foobar_ListOf_Int_get_value_nullable = __lib.catchArg
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_get_value_nullable'));
-Pointer<Void> foobar_MapOf_Int_to_foobar_ListOf_Int_toFfi_nullable(Map<int, List<int>> value) {
+Pointer<Void> foobar_MapOf_Int_to_foobar_ListOf_Int_toFfi_nullable(Map<int, List<int>>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_foobar_ListOf_Int_toFfi(value);
   final result = _foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle_nullable(_handle);
   foobar_MapOf_Int_to_foobar_ListOf_Int_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, List<int>> foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, List<int>>? foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_Int_to_foobar_ListOf_Int_get_value_nullable(handle);
   final result = foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi(_handle);
@@ -1815,14 +1815,14 @@ final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_get_value_nullable = __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_get_value_nullable'));
-Pointer<Void> foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_toFfi_nullable(Map<int, Map<int, bool>> value) {
+Pointer<Void> foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_toFfi_nullable(Map<int, Map<int, bool>>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_toFfi(value);
   final result = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle_nullable(_handle);
   foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, Map<int, bool>> foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, Map<int, bool>>? foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_get_value_nullable(handle);
   final result = foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_fromFfi(_handle);
@@ -1909,14 +1909,14 @@ final _foobar_MapOf_Int_to_foobar_SetOf_Int_get_value_nullable = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_get_value_nullable'));
-Pointer<Void> foobar_MapOf_Int_to_foobar_SetOf_Int_toFfi_nullable(Map<int, Set<int>> value) {
+Pointer<Void> foobar_MapOf_Int_to_foobar_SetOf_Int_toFfi_nullable(Map<int, Set<int>>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_foobar_SetOf_Int_toFfi(value);
   final result = _foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle_nullable(_handle);
   foobar_MapOf_Int_to_foobar_SetOf_Int_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, Set<int>> foobar_MapOf_Int_to_foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, Set<int>>? foobar_MapOf_Int_to_foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_Int_to_foobar_SetOf_Int_get_value_nullable(handle);
   final result = foobar_MapOf_Int_to_foobar_SetOf_Int_fromFfi(_handle);
@@ -2003,14 +2003,14 @@ final _foobar_MapOf_Int_to_smoke_DummyClass_get_value_nullable = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_DummyClass_get_value_nullable'));
-Pointer<Void> foobar_MapOf_Int_to_smoke_DummyClass_toFfi_nullable(Map<int, DummyClass> value) {
+Pointer<Void> foobar_MapOf_Int_to_smoke_DummyClass_toFfi_nullable(Map<int, DummyClass>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_smoke_DummyClass_toFfi(value);
   final result = _foobar_MapOf_Int_to_smoke_DummyClass_create_handle_nullable(_handle);
   foobar_MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, DummyClass> foobar_MapOf_Int_to_smoke_DummyClass_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, DummyClass>? foobar_MapOf_Int_to_smoke_DummyClass_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_Int_to_smoke_DummyClass_get_value_nullable(handle);
   final result = foobar_MapOf_Int_to_smoke_DummyClass_fromFfi(_handle);
@@ -2097,14 +2097,14 @@ final _foobar_MapOf_Int_to_smoke_DummyInterface_get_value_nullable = __lib.catch
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_DummyInterface_get_value_nullable'));
-Pointer<Void> foobar_MapOf_Int_to_smoke_DummyInterface_toFfi_nullable(Map<int, DummyInterface> value) {
+Pointer<Void> foobar_MapOf_Int_to_smoke_DummyInterface_toFfi_nullable(Map<int, DummyInterface>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_smoke_DummyInterface_toFfi(value);
   final result = _foobar_MapOf_Int_to_smoke_DummyInterface_create_handle_nullable(_handle);
   foobar_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, DummyInterface> foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, DummyInterface>? foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_Int_to_smoke_DummyInterface_get_value_nullable(handle);
   final result = foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi(_handle);
@@ -2191,14 +2191,14 @@ final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
-Pointer<Void> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(Map<int, GenericTypesWithCompoundTypes_ExternalEnum> value) {
+Pointer<Void> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(Map<int, GenericTypesWithCompoundTypes_ExternalEnum>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(value);
   final result = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(_handle);
   foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, GenericTypesWithCompoundTypes_ExternalEnum> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, GenericTypesWithCompoundTypes_ExternalEnum>? foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(handle);
   final result = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_handle);
@@ -2285,14 +2285,14 @@ final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_valu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
-Pointer<Void> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(Map<int, GenericTypesWithCompoundTypes_SomeEnum> value) {
+Pointer<Void> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(Map<int, GenericTypesWithCompoundTypes_SomeEnum>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(value);
   final result = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(_handle);
   foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, GenericTypesWithCompoundTypes_SomeEnum> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, GenericTypesWithCompoundTypes_SomeEnum>? foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(handle);
   final result = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_handle);
@@ -2379,14 +2379,14 @@ final _foobar_MapOf_String_to_String_get_value_nullable = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_String_get_value_nullable'));
-Pointer<Void> foobar_MapOf_String_to_String_toFfi_nullable(Map<String, String> value) {
+Pointer<Void> foobar_MapOf_String_to_String_toFfi_nullable(Map<String, String>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_String_to_String_toFfi(value);
   final result = _foobar_MapOf_String_to_String_create_handle_nullable(_handle);
   foobar_MapOf_String_to_String_releaseFfiHandle(_handle);
   return result;
 }
-Map<String, String> foobar_MapOf_String_to_String_fromFfi_nullable(Pointer<Void> handle) {
+Map<String, String>? foobar_MapOf_String_to_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_String_to_String_get_value_nullable(handle);
   final result = foobar_MapOf_String_to_String_fromFfi(_handle);
@@ -2473,14 +2473,14 @@ final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_ge
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable'));
-Pointer<Void> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi_nullable(Map<String, GenericTypesWithCompoundTypes_BasicStruct> value) {
+Pointer<Void> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi_nullable(Map<String, GenericTypesWithCompoundTypes_BasicStruct>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(value);
   final result = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable(_handle);
   foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_handle);
   return result;
 }
-Map<String, GenericTypesWithCompoundTypes_BasicStruct> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
+Map<String, GenericTypesWithCompoundTypes_BasicStruct>? foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable(handle);
   final result = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_handle);
@@ -2567,14 +2567,14 @@ final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable'));
-Pointer<Void> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi_nullable(Map<String, GenericTypesWithCompoundTypes_ExternalStruct> value) {
+Pointer<Void> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi_nullable(Map<String, GenericTypesWithCompoundTypes_ExternalStruct>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(value);
   final result = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable(_handle);
   foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
-Map<String, GenericTypesWithCompoundTypes_ExternalStruct> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
+Map<String, GenericTypesWithCompoundTypes_ExternalStruct>? foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable(handle);
   final result = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_handle);
@@ -2661,14 +2661,14 @@ final _foobar_MapOf_UByte_to_String_get_value_nullable = __lib.catchArgumentErro
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_UByte_to_String_get_value_nullable'));
-Pointer<Void> foobar_MapOf_UByte_to_String_toFfi_nullable(Map<int, String> value) {
+Pointer<Void> foobar_MapOf_UByte_to_String_toFfi_nullable(Map<int, String>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_UByte_to_String_toFfi(value);
   final result = _foobar_MapOf_UByte_to_String_create_handle_nullable(_handle);
   foobar_MapOf_UByte_to_String_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, String> foobar_MapOf_UByte_to_String_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, String>? foobar_MapOf_UByte_to_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_UByte_to_String_get_value_nullable(handle);
   final result = foobar_MapOf_UByte_to_String_fromFfi(_handle);
@@ -2755,14 +2755,14 @@ final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_get_value_nullable = __lib.catc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_get_value_nullable'));
-Pointer<Void> foobar_MapOf_foobar_ListOf_Int_to_Boolean_toFfi_nullable(Map<List<int>, bool> value) {
+Pointer<Void> foobar_MapOf_foobar_ListOf_Int_to_Boolean_toFfi_nullable(Map<List<int>, bool>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_foobar_ListOf_Int_to_Boolean_toFfi(value);
   final result = _foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle_nullable(_handle);
   foobar_MapOf_foobar_ListOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
-Map<List<int>, bool> foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
+Map<List<int>, bool>? foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_foobar_ListOf_Int_to_Boolean_get_value_nullable(handle);
   final result = foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi(_handle);
@@ -2849,14 +2849,14 @@ final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_get_value_nullable = 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_get_value_nullable'));
-Pointer<Void> foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_toFfi_nullable(Map<Map<int, bool>, bool> value) {
+Pointer<Void> foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_toFfi_nullable(Map<Map<int, bool>, bool>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_toFfi(value);
   final result = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle_nullable(_handle);
   foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
-Map<Map<int, bool>, bool> foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
+Map<Map<int, bool>, bool>? foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_get_value_nullable(handle);
   final result = foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fromFfi(_handle);
@@ -2943,14 +2943,14 @@ final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_get_value_nullable = __lib.catch
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_get_value_nullable'));
-Pointer<Void> foobar_MapOf_foobar_SetOf_Int_to_Boolean_toFfi_nullable(Map<Set<int>, bool> value) {
+Pointer<Void> foobar_MapOf_foobar_SetOf_Int_to_Boolean_toFfi_nullable(Map<Set<int>, bool>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_foobar_SetOf_Int_to_Boolean_toFfi(value);
   final result = _foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle_nullable(_handle);
   foobar_MapOf_foobar_SetOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
-Map<Set<int>, bool> foobar_MapOf_foobar_SetOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
+Map<Set<int>, bool>? foobar_MapOf_foobar_SetOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_foobar_SetOf_Int_to_Boolean_get_value_nullable(handle);
   final result = foobar_MapOf_foobar_SetOf_Int_to_Boolean_fromFfi(_handle);
@@ -3037,14 +3037,14 @@ final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_get_value_nullable'));
-Pointer<Void> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_toFfi_nullable(Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> value) {
+Pointer<Void> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_toFfi_nullable(Map<GenericTypesWithCompoundTypes_ExternalEnum, bool>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_toFfi(value);
   final result = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle_nullable(_handle);
   foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
-Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
+Map<GenericTypesWithCompoundTypes_ExternalEnum, bool>? foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_get_value_nullable(handle);
   final result = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi(_handle);
@@ -3131,14 +3131,14 @@ final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_get_
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_get_value_nullable'));
-Pointer<Void> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi_nullable(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> value) {
+Pointer<Void> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi_nullable(Map<GenericTypesWithCompoundTypes_SomeEnum, bool>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(value);
   final result = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle_nullable(_handle);
   foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
-Map<GenericTypesWithCompoundTypes_SomeEnum, bool> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
+Map<GenericTypesWithCompoundTypes_SomeEnum, bool>? foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_get_value_nullable(handle);
   final result = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_fromFfi(_handle);
@@ -3216,14 +3216,14 @@ final _foobar_SetOf_Float_get_value_nullable = __lib.catchArgumentError(() => __
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_Float_get_value_nullable'));
-Pointer<Void> foobar_SetOf_Float_toFfi_nullable(Set<double> value) {
+Pointer<Void> foobar_SetOf_Float_toFfi_nullable(Set<double>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_Float_toFfi(value);
   final result = _foobar_SetOf_Float_create_handle_nullable(_handle);
   foobar_SetOf_Float_releaseFfiHandle(_handle);
   return result;
 }
-Set<double> foobar_SetOf_Float_fromFfi_nullable(Pointer<Void> handle) {
+Set<double>? foobar_SetOf_Float_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_SetOf_Float_get_value_nullable(handle);
   final result = foobar_SetOf_Float_fromFfi(_handle);
@@ -3301,14 +3301,14 @@ final _foobar_SetOf_Int_get_value_nullable = __lib.catchArgumentError(() => __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_Int_get_value_nullable'));
-Pointer<Void> foobar_SetOf_Int_toFfi_nullable(Set<int> value) {
+Pointer<Void> foobar_SetOf_Int_toFfi_nullable(Set<int>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_Int_toFfi(value);
   final result = _foobar_SetOf_Int_create_handle_nullable(_handle);
   foobar_SetOf_Int_releaseFfiHandle(_handle);
   return result;
 }
-Set<int> foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
+Set<int>? foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_SetOf_Int_get_value_nullable(handle);
   final result = foobar_SetOf_Int_fromFfi(_handle);
@@ -3386,14 +3386,14 @@ final _foobar_SetOf_String_get_value_nullable = __lib.catchArgumentError(() => _
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_String_get_value_nullable'));
-Pointer<Void> foobar_SetOf_String_toFfi_nullable(Set<String> value) {
+Pointer<Void> foobar_SetOf_String_toFfi_nullable(Set<String>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_String_toFfi(value);
   final result = _foobar_SetOf_String_create_handle_nullable(_handle);
   foobar_SetOf_String_releaseFfiHandle(_handle);
   return result;
 }
-Set<String> foobar_SetOf_String_fromFfi_nullable(Pointer<Void> handle) {
+Set<String>? foobar_SetOf_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_SetOf_String_get_value_nullable(handle);
   final result = foobar_SetOf_String_fromFfi(_handle);
@@ -3471,14 +3471,14 @@ final _foobar_SetOf_UByte_get_value_nullable = __lib.catchArgumentError(() => __
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_UByte_get_value_nullable'));
-Pointer<Void> foobar_SetOf_UByte_toFfi_nullable(Set<int> value) {
+Pointer<Void> foobar_SetOf_UByte_toFfi_nullable(Set<int>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_UByte_toFfi(value);
   final result = _foobar_SetOf_UByte_create_handle_nullable(_handle);
   foobar_SetOf_UByte_releaseFfiHandle(_handle);
   return result;
 }
-Set<int> foobar_SetOf_UByte_fromFfi_nullable(Pointer<Void> handle) {
+Set<int>? foobar_SetOf_UByte_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_SetOf_UByte_get_value_nullable(handle);
   final result = foobar_SetOf_UByte_fromFfi(_handle);
@@ -3556,14 +3556,14 @@ final _foobar_SetOf_foobar_ListOf_Int_get_value_nullable = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_ListOf_Int_get_value_nullable'));
-Pointer<Void> foobar_SetOf_foobar_ListOf_Int_toFfi_nullable(Set<List<int>> value) {
+Pointer<Void> foobar_SetOf_foobar_ListOf_Int_toFfi_nullable(Set<List<int>>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_foobar_ListOf_Int_toFfi(value);
   final result = _foobar_SetOf_foobar_ListOf_Int_create_handle_nullable(_handle);
   foobar_SetOf_foobar_ListOf_Int_releaseFfiHandle(_handle);
   return result;
 }
-Set<List<int>> foobar_SetOf_foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
+Set<List<int>>? foobar_SetOf_foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_SetOf_foobar_ListOf_Int_get_value_nullable(handle);
   final result = foobar_SetOf_foobar_ListOf_Int_fromFfi(_handle);
@@ -3641,14 +3641,14 @@ final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.catch
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_get_value_nullable'));
-Pointer<Void> foobar_SetOf_foobar_MapOf_Int_to_Boolean_toFfi_nullable(Set<Map<int, bool>> value) {
+Pointer<Void> foobar_SetOf_foobar_MapOf_Int_to_Boolean_toFfi_nullable(Set<Map<int, bool>>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_foobar_MapOf_Int_to_Boolean_toFfi(value);
   final result = _foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable(_handle);
   foobar_SetOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
-Set<Map<int, bool>> foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
+Set<Map<int, bool>>? foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_SetOf_foobar_MapOf_Int_to_Boolean_get_value_nullable(handle);
   final result = foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi(_handle);
@@ -3726,14 +3726,14 @@ final _foobar_SetOf_foobar_SetOf_Int_get_value_nullable = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_SetOf_Int_get_value_nullable'));
-Pointer<Void> foobar_SetOf_foobar_SetOf_Int_toFfi_nullable(Set<Set<int>> value) {
+Pointer<Void> foobar_SetOf_foobar_SetOf_Int_toFfi_nullable(Set<Set<int>>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_foobar_SetOf_Int_toFfi(value);
   final result = _foobar_SetOf_foobar_SetOf_Int_create_handle_nullable(_handle);
   foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(_handle);
   return result;
 }
-Set<Set<int>> foobar_SetOf_foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
+Set<Set<int>>? foobar_SetOf_foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_SetOf_foobar_SetOf_Int_get_value_nullable(handle);
   final result = foobar_SetOf_foobar_SetOf_Int_fromFfi(_handle);
@@ -3811,14 +3811,14 @@ final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_n
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
-Pointer<Void> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(Set<GenericTypesWithCompoundTypes_ExternalEnum> value) {
+Pointer<Void> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(Set<GenericTypesWithCompoundTypes_ExternalEnum>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(value);
   final result = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(_handle);
   foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
-Set<GenericTypesWithCompoundTypes_ExternalEnum> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
+Set<GenericTypesWithCompoundTypes_ExternalEnum>? foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(handle);
   final result = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_handle);
@@ -3896,14 +3896,14 @@ final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nulla
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
-Pointer<Void> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(Set<GenericTypesWithCompoundTypes_SomeEnum> value) {
+Pointer<Void> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(Set<GenericTypesWithCompoundTypes_SomeEnum>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(value);
   final result = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(_handle);
   foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-Set<GenericTypesWithCompoundTypes_SomeEnum> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+Set<GenericTypesWithCompoundTypes_SomeEnum>? foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(handle);
   final result = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -92,14 +92,14 @@ final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_value_nullable = 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_value_nullable'));
-Pointer<Void> smoke_GenericTypesWithBasicTypes_StructWithGenerics_toFfi_nullable(GenericTypesWithBasicTypes_StructWithGenerics value) {
+Pointer<Void> smoke_GenericTypesWithBasicTypes_StructWithGenerics_toFfi_nullable(GenericTypesWithBasicTypes_StructWithGenerics? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithBasicTypes_StructWithGenerics_toFfi(value);
   final result = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle_nullable(_handle);
   smoke_GenericTypesWithBasicTypes_StructWithGenerics_releaseFfiHandle(_handle);
   return result;
 }
-GenericTypesWithBasicTypes_StructWithGenerics smoke_GenericTypesWithBasicTypes_StructWithGenerics_fromFfi_nullable(Pointer<Void> handle) {
+GenericTypesWithBasicTypes_StructWithGenerics? smoke_GenericTypesWithBasicTypes_StructWithGenerics_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_value_nullable(handle);
   final result = smoke_GenericTypesWithBasicTypes_StructWithGenerics_fromFfi(_handle);
@@ -122,11 +122,11 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
   GenericTypesWithBasicTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_GenericTypesWithBasicTypes_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   List<int> methodWithList(List<int> input) {
@@ -284,8 +284,8 @@ Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi(GenericTypesWithBasicTypes 
 GenericTypesWithBasicTypes smoke_GenericTypesWithBasicTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as GenericTypesWithBasicTypes;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is GenericTypesWithBasicTypes) return instance;
   final _copied_handle = _smoke_GenericTypesWithBasicTypes_copy_handle(handle);
   final result = GenericTypesWithBasicTypes$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -293,9 +293,9 @@ GenericTypesWithBasicTypes smoke_GenericTypesWithBasicTypes_fromFfi(Pointer<Void
 }
 void smoke_GenericTypesWithBasicTypes_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_GenericTypesWithBasicTypes_release_handle(handle);
-Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi_nullable(GenericTypesWithBasicTypes value) =>
+Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi_nullable(GenericTypesWithBasicTypes? value) =>
   value != null ? smoke_GenericTypesWithBasicTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
-GenericTypesWithBasicTypes smoke_GenericTypesWithBasicTypes_fromFfi_nullable(Pointer<Void> handle) =>
+GenericTypesWithBasicTypes? smoke_GenericTypesWithBasicTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_GenericTypesWithBasicTypes_fromFfi(handle) : null;
 void smoke_GenericTypesWithBasicTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_GenericTypesWithBasicTypes_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -65,14 +65,14 @@ final _smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.c
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(GenericTypesWithCompoundTypes_SomeEnum value) {
+Pointer<Void> smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(GenericTypesWithCompoundTypes_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(value);
   final result = _smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(_handle);
   smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-GenericTypesWithCompoundTypes_SomeEnum smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+GenericTypesWithCompoundTypes_SomeEnum? smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(handle);
   final result = smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_handle);
@@ -124,14 +124,14 @@ final _smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __l
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
-Pointer<Void> smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(GenericTypesWithCompoundTypes_ExternalEnum value) {
+Pointer<Void> smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(GenericTypesWithCompoundTypes_ExternalEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(value);
   final result = _smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(_handle);
   smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
-GenericTypesWithCompoundTypes_ExternalEnum smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
+GenericTypesWithCompoundTypes_ExternalEnum? smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(handle);
   final result = smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_handle);
@@ -188,14 +188,14 @@ final _smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable = __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable'));
-Pointer<Void> smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi_nullable(GenericTypesWithCompoundTypes_BasicStruct value) {
+Pointer<Void> smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi_nullable(GenericTypesWithCompoundTypes_BasicStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(value);
   final result = _smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable(_handle);
   smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_handle);
   return result;
 }
-GenericTypesWithCompoundTypes_BasicStruct smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
+GenericTypesWithCompoundTypes_BasicStruct? smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable(handle);
   final result = smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_handle);
@@ -252,14 +252,14 @@ final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable = _
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable'));
-Pointer<Void> smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi_nullable(GenericTypesWithCompoundTypes_ExternalStruct value) {
+Pointer<Void> smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi_nullable(GenericTypesWithCompoundTypes_ExternalStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(value);
   final result = _smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable(_handle);
   smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
-GenericTypesWithCompoundTypes_ExternalStruct smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
+GenericTypesWithCompoundTypes_ExternalStruct? smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable(handle);
   final result = smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_handle);
@@ -282,11 +282,11 @@ class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements Gen
   GenericTypesWithCompoundTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_GenericTypesWithCompoundTypes_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   List<GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructList(List<GenericTypesWithCompoundTypes_BasicStruct> input) {
@@ -398,8 +398,8 @@ Pointer<Void> smoke_GenericTypesWithCompoundTypes_toFfi(GenericTypesWithCompound
 GenericTypesWithCompoundTypes smoke_GenericTypesWithCompoundTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as GenericTypesWithCompoundTypes;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is GenericTypesWithCompoundTypes) return instance;
   final _copied_handle = _smoke_GenericTypesWithCompoundTypes_copy_handle(handle);
   final result = GenericTypesWithCompoundTypes$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -407,9 +407,9 @@ GenericTypesWithCompoundTypes smoke_GenericTypesWithCompoundTypes_fromFfi(Pointe
 }
 void smoke_GenericTypesWithCompoundTypes_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_GenericTypesWithCompoundTypes_release_handle(handle);
-Pointer<Void> smoke_GenericTypesWithCompoundTypes_toFfi_nullable(GenericTypesWithCompoundTypes value) =>
+Pointer<Void> smoke_GenericTypesWithCompoundTypes_toFfi_nullable(GenericTypesWithCompoundTypes? value) =>
   value != null ? smoke_GenericTypesWithCompoundTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
-GenericTypesWithCompoundTypes smoke_GenericTypesWithCompoundTypes_fromFfi_nullable(Pointer<Void> handle) =>
+GenericTypesWithCompoundTypes? smoke_GenericTypesWithCompoundTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_GenericTypesWithCompoundTypes_fromFfi(handle) : null;
 void smoke_GenericTypesWithCompoundTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_GenericTypesWithCompoundTypes_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -33,11 +33,11 @@ class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements Gene
   GenericTypesWithGenericTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_GenericTypesWithGenericTypes_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   List<List<int>> methodWithListOfLists(List<List<int>> input) {
@@ -136,8 +136,8 @@ Pointer<Void> smoke_GenericTypesWithGenericTypes_toFfi(GenericTypesWithGenericTy
 GenericTypesWithGenericTypes smoke_GenericTypesWithGenericTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as GenericTypesWithGenericTypes;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is GenericTypesWithGenericTypes) return instance;
   final _copied_handle = _smoke_GenericTypesWithGenericTypes_copy_handle(handle);
   final result = GenericTypesWithGenericTypes$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -145,9 +145,9 @@ GenericTypesWithGenericTypes smoke_GenericTypesWithGenericTypes_fromFfi(Pointer<
 }
 void smoke_GenericTypesWithGenericTypes_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_GenericTypesWithGenericTypes_release_handle(handle);
-Pointer<Void> smoke_GenericTypesWithGenericTypes_toFfi_nullable(GenericTypesWithGenericTypes value) =>
+Pointer<Void> smoke_GenericTypesWithGenericTypes_toFfi_nullable(GenericTypesWithGenericTypes? value) =>
   value != null ? smoke_GenericTypesWithGenericTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
-GenericTypesWithGenericTypes smoke_GenericTypesWithGenericTypes_fromFfi_nullable(Pointer<Void> handle) =>
+GenericTypesWithGenericTypes? smoke_GenericTypesWithGenericTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_GenericTypesWithGenericTypes_fromFfi(handle) : null;
 void smoke_GenericTypesWithGenericTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_GenericTypesWithGenericTypes_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
@@ -54,11 +54,11 @@ class UseOptimizedList$Impl extends __lib.NativeBase implements UseOptimizedList
   UseOptimizedList$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_UseOptimizedList_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static List<VeryBigStruct> fetchTheBigOnes() {
     final _fetchTheBigOnes_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_UseOptimizedList_fetchTheBigOnes'));
@@ -96,8 +96,8 @@ Pointer<Void> smoke_UseOptimizedList_toFfi(UseOptimizedList value) =>
 UseOptimizedList smoke_UseOptimizedList_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as UseOptimizedList;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is UseOptimizedList) return instance;
   final _copied_handle = _smoke_UseOptimizedList_copy_handle(handle);
   final result = UseOptimizedList$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -105,9 +105,9 @@ UseOptimizedList smoke_UseOptimizedList_fromFfi(Pointer<Void> handle) {
 }
 void smoke_UseOptimizedList_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_UseOptimizedList_release_handle(handle);
-Pointer<Void> smoke_UseOptimizedList_toFfi_nullable(UseOptimizedList value) =>
+Pointer<Void> smoke_UseOptimizedList_toFfi_nullable(UseOptimizedList? value) =>
   value != null ? smoke_UseOptimizedList_toFfi(value) : Pointer<Void>.fromAddress(0);
-UseOptimizedList smoke_UseOptimizedList_fromFfi_nullable(Pointer<Void> handle) =>
+UseOptimizedList? smoke_UseOptimizedList_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_UseOptimizedList_fromFfi(handle) : null;
 void smoke_UseOptimizedList_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_UseOptimizedList_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list_struct.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list_struct.dart
@@ -104,14 +104,14 @@ final _smoke_UseOptimizedListStruct_get_value_nullable = __lib.catchArgumentErro
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_UseOptimizedListStruct_get_value_nullable'));
-Pointer<Void> smoke_UseOptimizedListStruct_toFfi_nullable(UseOptimizedListStruct value) {
+Pointer<Void> smoke_UseOptimizedListStruct_toFfi_nullable(UseOptimizedListStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_UseOptimizedListStruct_toFfi(value);
   final result = _smoke_UseOptimizedListStruct_create_handle_nullable(_handle);
   smoke_UseOptimizedListStruct_releaseFfiHandle(_handle);
   return result;
 }
-UseOptimizedListStruct smoke_UseOptimizedListStruct_fromFfi_nullable(Pointer<Void> handle) {
+UseOptimizedListStruct? smoke_UseOptimizedListStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_UseOptimizedListStruct_get_value_nullable(handle);
   final result = smoke_UseOptimizedListStruct_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -32,11 +32,11 @@ class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFro
   ChildClassFromClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ChildClassFromClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   childClassMethod() {
@@ -55,8 +55,8 @@ Pointer<Void> smoke_ChildClassFromClass_toFfi(ChildClassFromClass value) =>
 ChildClassFromClass smoke_ChildClassFromClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ChildClassFromClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ChildClassFromClass) return instance;
   final _type_id_handle = _smoke_ChildClassFromClass_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -69,9 +69,9 @@ ChildClassFromClass smoke_ChildClassFromClass_fromFfi(Pointer<Void> handle) {
 }
 void smoke_ChildClassFromClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ChildClassFromClass_release_handle(handle);
-Pointer<Void> smoke_ChildClassFromClass_toFfi_nullable(ChildClassFromClass value) =>
+Pointer<Void> smoke_ChildClassFromClass_toFfi_nullable(ChildClassFromClass? value) =>
   value != null ? smoke_ChildClassFromClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-ChildClassFromClass smoke_ChildClassFromClass_fromFfi_nullable(Pointer<Void> handle) =>
+ChildClassFromClass? smoke_ChildClassFromClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ChildClassFromClass_fromFfi(handle) : null;
 void smoke_ChildClassFromClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ChildClassFromClass_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -32,11 +32,11 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
   ChildClassFromInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ChildClassFromInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   childClassMethod() {
@@ -90,8 +90,8 @@ Pointer<Void> smoke_ChildClassFromInterface_toFfi(ChildClassFromInterface value)
 ChildClassFromInterface smoke_ChildClassFromInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ChildClassFromInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ChildClassFromInterface) return instance;
   final _type_id_handle = _smoke_ChildClassFromInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -104,9 +104,9 @@ ChildClassFromInterface smoke_ChildClassFromInterface_fromFfi(Pointer<Void> hand
 }
 void smoke_ChildClassFromInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ChildClassFromInterface_release_handle(handle);
-Pointer<Void> smoke_ChildClassFromInterface_toFfi_nullable(ChildClassFromInterface value) =>
+Pointer<Void> smoke_ChildClassFromInterface_toFfi_nullable(ChildClassFromInterface? value) =>
   value != null ? smoke_ChildClassFromInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-ChildClassFromInterface smoke_ChildClassFromInterface_fromFfi_nullable(Pointer<Void> handle) =>
+ChildClassFromInterface? smoke_ChildClassFromInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ChildClassFromInterface_fromFfi(handle) : null;
 void smoke_ChildClassFromInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ChildClassFromInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -10,10 +10,10 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildInterface implements ParentInterface {
   ChildInterface() {}
   factory ChildInterface.fromLambdas({
-    @required void Function() lambda_rootMethod,
-    @required void Function() lambda_childMethod,
-    @required String Function() lambda_rootProperty_get,
-    @required void Function(String) lambda_rootProperty_set
+    required void Function() lambda_rootMethod,
+    required void Function() lambda_childMethod,
+    required String Function() lambda_rootProperty_get,
+    required void Function(String) lambda_rootProperty_set
   }) => ChildInterface$Lambdas(
     lambda_rootMethod,
     lambda_childMethod,
@@ -72,11 +72,11 @@ class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
   ChildInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ChildInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   rootMethod() {
@@ -166,8 +166,8 @@ Pointer<Void> smoke_ChildInterface_toFfi(ChildInterface value) {
 ChildInterface smoke_ChildInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ChildInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ChildInterface) return instance;
   final _type_id_handle = _smoke_ChildInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -180,9 +180,9 @@ ChildInterface smoke_ChildInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_ChildInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ChildInterface_release_handle(handle);
-Pointer<Void> smoke_ChildInterface_toFfi_nullable(ChildInterface value) =>
+Pointer<Void> smoke_ChildInterface_toFfi_nullable(ChildInterface? value) =>
   value != null ? smoke_ChildInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-ChildInterface smoke_ChildInterface_fromFfi_nullable(Pointer<Void> handle) =>
+ChildInterface? smoke_ChildInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ChildInterface_fromFfi(handle) : null;
 void smoke_ChildInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ChildInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -33,11 +33,11 @@ class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements Ch
   ChildWithParentClassReferences$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ChildWithParentClassReferences_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   ChildClassFromClass classFunction() {
@@ -80,8 +80,8 @@ Pointer<Void> smoke_ChildWithParentClassReferences_toFfi(ChildWithParentClassRef
 ChildWithParentClassReferences smoke_ChildWithParentClassReferences_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ChildWithParentClassReferences;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ChildWithParentClassReferences) return instance;
   final _type_id_handle = _smoke_ChildWithParentClassReferences_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -94,9 +94,9 @@ ChildWithParentClassReferences smoke_ChildWithParentClassReferences_fromFfi(Poin
 }
 void smoke_ChildWithParentClassReferences_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ChildWithParentClassReferences_release_handle(handle);
-Pointer<Void> smoke_ChildWithParentClassReferences_toFfi_nullable(ChildWithParentClassReferences value) =>
+Pointer<Void> smoke_ChildWithParentClassReferences_toFfi_nullable(ChildWithParentClassReferences? value) =>
   value != null ? smoke_ChildWithParentClassReferences_toFfi(value) : Pointer<Void>.fromAddress(0);
-ChildWithParentClassReferences smoke_ChildWithParentClassReferences_fromFfi_nullable(Pointer<Void> handle) =>
+ChildWithParentClassReferences? smoke_ChildWithParentClassReferences_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ChildWithParentClassReferences_fromFfi(handle) : null;
 void smoke_ChildWithParentClassReferences_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ChildWithParentClassReferences_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -33,11 +33,11 @@ class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
   ParentClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ParentClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   rootMethod() {
@@ -80,8 +80,8 @@ Pointer<Void> smoke_ParentClass_toFfi(ParentClass value) =>
 ParentClass smoke_ParentClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ParentClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ParentClass) return instance;
   final _type_id_handle = _smoke_ParentClass_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -94,9 +94,9 @@ ParentClass smoke_ParentClass_fromFfi(Pointer<Void> handle) {
 }
 void smoke_ParentClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ParentClass_release_handle(handle);
-Pointer<Void> smoke_ParentClass_toFfi_nullable(ParentClass value) =>
+Pointer<Void> smoke_ParentClass_toFfi_nullable(ParentClass? value) =>
   value != null ? smoke_ParentClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-ParentClass smoke_ParentClass_fromFfi_nullable(Pointer<Void> handle) =>
+ParentClass? smoke_ParentClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ParentClass_fromFfi(handle) : null;
 void smoke_ParentClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ParentClass_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -9,9 +9,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class ParentInterface {
   ParentInterface() {}
   factory ParentInterface.fromLambdas({
-    @required void Function() lambda_rootMethod,
-    @required String Function() lambda_rootProperty_get,
-    @required void Function(String) lambda_rootProperty_set
+    required void Function() lambda_rootMethod,
+    required String Function() lambda_rootProperty_get,
+    required void Function(String) lambda_rootProperty_set
   }) => ParentInterface$Lambdas(
     lambda_rootMethod,
     lambda_rootProperty_get,
@@ -66,11 +66,11 @@ class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
   ParentInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ParentInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   rootMethod() {
@@ -141,8 +141,8 @@ Pointer<Void> smoke_ParentInterface_toFfi(ParentInterface value) {
 ParentInterface smoke_ParentInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ParentInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ParentInterface) return instance;
   final _type_id_handle = _smoke_ParentInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -155,9 +155,9 @@ ParentInterface smoke_ParentInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_ParentInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ParentInterface_release_handle(handle);
-Pointer<Void> smoke_ParentInterface_toFfi_nullable(ParentInterface value) =>
+Pointer<Void> smoke_ParentInterface_toFfi_nullable(ParentInterface? value) =>
   value != null ? smoke_ParentInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-ParentInterface smoke_ParentInterface_fromFfi_nullable(Pointer<Void> handle) =>
+ParentInterface? smoke_ParentInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ParentInterface_fromFfi(handle) : null;
 void smoke_ParentInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ParentInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/_native_base.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/_native_base.dart
@@ -4,6 +4,6 @@ import 'package:meta/meta.dart';
 /// @nodoc
 class NativeBase {
   @protected
-  Pointer<Void> handle;
+  Pointer<Void> handle = Pointer<Void>.fromAddress(0);
   NativeBase(this.handle);
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
@@ -27,11 +27,11 @@ class SimpleClass$Impl extends __lib.NativeBase implements SimpleClass {
   SimpleClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_SimpleClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String getStringValue() {
@@ -63,8 +63,8 @@ Pointer<Void> smoke_SimpleClass_toFfi(SimpleClass value) =>
 SimpleClass smoke_SimpleClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as SimpleClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is SimpleClass) return instance;
   final _copied_handle = _smoke_SimpleClass_copy_handle(handle);
   final result = SimpleClass$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -72,9 +72,9 @@ SimpleClass smoke_SimpleClass_fromFfi(Pointer<Void> handle) {
 }
 void smoke_SimpleClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SimpleClass_release_handle(handle);
-Pointer<Void> smoke_SimpleClass_toFfi_nullable(SimpleClass value) =>
+Pointer<Void> smoke_SimpleClass_toFfi_nullable(SimpleClass? value) =>
   value != null ? smoke_SimpleClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-SimpleClass smoke_SimpleClass_fromFfi_nullable(Pointer<Void> handle) =>
+SimpleClass? smoke_SimpleClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SimpleClass_fromFfi(handle) : null;
 void smoke_SimpleClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SimpleClass_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -9,8 +9,8 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class SimpleInterface {
   SimpleInterface() {}
   factory SimpleInterface.fromLambdas({
-    @required String Function() lambda_getStringValue,
-    @required SimpleInterface Function(SimpleInterface) lambda_useSimpleInterface,
+    required String Function() lambda_getStringValue,
+    required SimpleInterface Function(SimpleInterface) lambda_useSimpleInterface,
   }) => SimpleInterface$Lambdas(
     lambda_getStringValue,
     lambda_useSimpleInterface,
@@ -60,11 +60,11 @@ class SimpleInterface$Impl extends __lib.NativeBase implements SimpleInterface {
   SimpleInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_SimpleInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String getStringValue() {
@@ -92,7 +92,7 @@ class SimpleInterface$Impl extends __lib.NativeBase implements SimpleInterface {
   }
 }
 int _SimpleInterface_getStringValue_static(int _token, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as SimpleInterface).getStringValue();
     _result.value = String_toFfi(_result_object);
@@ -101,13 +101,13 @@ int _SimpleInterface_getStringValue_static(int _token, Pointer<Pointer<Void>> _r
   return 0;
 }
 int _SimpleInterface_useSimpleInterface_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  SimpleInterface _result_object = null;
+  SimpleInterface? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as SimpleInterface).useSimpleInterface(smoke_SimpleInterface_fromFfi(input));
     _result.value = smoke_SimpleInterface_toFfi(_result_object);
   } finally {
     smoke_SimpleInterface_releaseFfiHandle(input);
-    if (_result_object != null) _result_object.release();
+    _result_object?.release();
   }
   return 0;
 }
@@ -125,8 +125,8 @@ Pointer<Void> smoke_SimpleInterface_toFfi(SimpleInterface value) {
 SimpleInterface smoke_SimpleInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as SimpleInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is SimpleInterface) return instance;
   final _type_id_handle = _smoke_SimpleInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -139,9 +139,9 @@ SimpleInterface smoke_SimpleInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_SimpleInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SimpleInterface_release_handle(handle);
-Pointer<Void> smoke_SimpleInterface_toFfi_nullable(SimpleInterface value) =>
+Pointer<Void> smoke_SimpleInterface_toFfi_nullable(SimpleInterface? value) =>
   value != null ? smoke_SimpleInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-SimpleInterface smoke_SimpleInterface_fromFfi_nullable(Pointer<Void> handle) =>
+SimpleInterface? smoke_SimpleInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SimpleInterface_fromFfi(handle) : null;
 void smoke_SimpleInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SimpleInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_class.dart
@@ -50,14 +50,14 @@ final _smoke_StructWithClass_get_value_nullable = __lib.catchArgumentError(() =>
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithClass_get_value_nullable'));
-Pointer<Void> smoke_StructWithClass_toFfi_nullable(StructWithClass value) {
+Pointer<Void> smoke_StructWithClass_toFfi_nullable(StructWithClass? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithClass_toFfi(value);
   final result = _smoke_StructWithClass_create_handle_nullable(_handle);
   smoke_StructWithClass_releaseFfiHandle(_handle);
   return result;
 }
-StructWithClass smoke_StructWithClass_fromFfi_nullable(Pointer<Void> handle) {
+StructWithClass? smoke_StructWithClass_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructWithClass_get_value_nullable(handle);
   final result = smoke_StructWithClass_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_interface.dart
@@ -50,14 +50,14 @@ final _smoke_StructWithInterface_get_value_nullable = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInterface_get_value_nullable'));
-Pointer<Void> smoke_StructWithInterface_toFfi_nullable(StructWithInterface value) {
+Pointer<Void> smoke_StructWithInterface_toFfi_nullable(StructWithInterface? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithInterface_toFfi(value);
   final result = _smoke_StructWithInterface_create_handle_nullable(_handle);
   smoke_StructWithInterface_releaseFfiHandle(_handle);
   return result;
 }
-StructWithInterface smoke_StructWithInterface_fromFfi_nullable(Pointer<Void> handle) {
+StructWithInterface? smoke_StructWithInterface_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructWithInterface_get_value_nullable(handle);
   final result = smoke_StructWithInterface_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -47,7 +47,7 @@ class ClassWithInternalLambda_InternalLambda$Impl {
   }
 }
 int _ClassWithInternalLambda_InternalLambda_call_static(int _token, Pointer<Void> p0, Pointer<Uint8> _result) {
-  bool _result_object;
+  bool? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as ClassWithInternalLambda_InternalLambda)(String_fromFfi(p0));
     _result.value = Boolean_toFfi(_result_object);
@@ -88,14 +88,14 @@ final _smoke_ClassWithInternalLambda_InternalLambda_get_value_nullable = __lib.c
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ClassWithInternalLambda_InternalLambda_get_value_nullable'));
-Pointer<Void> smoke_ClassWithInternalLambda_InternalLambda_toFfi_nullable(ClassWithInternalLambda_InternalLambda value) {
+Pointer<Void> smoke_ClassWithInternalLambda_InternalLambda_toFfi_nullable(ClassWithInternalLambda_InternalLambda? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ClassWithInternalLambda_InternalLambda_toFfi(value);
   final result = _smoke_ClassWithInternalLambda_InternalLambda_create_handle_nullable(_handle);
   smoke_ClassWithInternalLambda_InternalLambda_releaseFfiHandle(_handle);
   return result;
 }
-ClassWithInternalLambda_InternalLambda smoke_ClassWithInternalLambda_InternalLambda_fromFfi_nullable(Pointer<Void> handle) {
+ClassWithInternalLambda_InternalLambda? smoke_ClassWithInternalLambda_InternalLambda_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ClassWithInternalLambda_InternalLambda_get_value_nullable(handle);
   final result = smoke_ClassWithInternalLambda_InternalLambda_fromFfi(_handle);
@@ -118,11 +118,11 @@ class ClassWithInternalLambda$Impl extends __lib.NativeBase implements ClassWith
   ClassWithInternalLambda$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ClassWithInternalLambda_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static bool invokeInternalLambda(ClassWithInternalLambda_InternalLambda lambda, String value) {
     final _invokeInternalLambda_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Pointer<Void>, Pointer<Void>), int Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_invokeInternalLambda__InternalLambda_String'));
@@ -143,8 +143,8 @@ Pointer<Void> smoke_ClassWithInternalLambda_toFfi(ClassWithInternalLambda value)
 ClassWithInternalLambda smoke_ClassWithInternalLambda_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ClassWithInternalLambda;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ClassWithInternalLambda) return instance;
   final _copied_handle = _smoke_ClassWithInternalLambda_copy_handle(handle);
   final result = ClassWithInternalLambda$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -152,9 +152,9 @@ ClassWithInternalLambda smoke_ClassWithInternalLambda_fromFfi(Pointer<Void> hand
 }
 void smoke_ClassWithInternalLambda_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ClassWithInternalLambda_release_handle(handle);
-Pointer<Void> smoke_ClassWithInternalLambda_toFfi_nullable(ClassWithInternalLambda value) =>
+Pointer<Void> smoke_ClassWithInternalLambda_toFfi_nullable(ClassWithInternalLambda? value) =>
   value != null ? smoke_ClassWithInternalLambda_toFfi(value) : Pointer<Void>.fromAddress(0);
-ClassWithInternalLambda smoke_ClassWithInternalLambda_fromFfi_nullable(Pointer<Void> handle) =>
+ClassWithInternalLambda? smoke_ClassWithInternalLambda_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ClassWithInternalLambda_fromFfi(handle) : null;
 void smoke_ClassWithInternalLambda_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ClassWithInternalLambda_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -46,7 +46,7 @@ class Lambdas_Producer$Impl {
   }
 }
 int _Lambdas_Producer_call_static(int _token, Pointer<Pointer<Void>> _result) {
-  String _result_object;
+  String? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as Lambdas_Producer)();
     _result.value = String_toFfi(_result_object);
@@ -86,14 +86,14 @@ final _smoke_Lambdas_Producer_get_value_nullable = __lib.catchArgumentError(() =
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Producer_get_value_nullable'));
-Pointer<Void> smoke_Lambdas_Producer_toFfi_nullable(Lambdas_Producer value) {
+Pointer<Void> smoke_Lambdas_Producer_toFfi_nullable(Lambdas_Producer? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_Producer_toFfi(value);
   final result = _smoke_Lambdas_Producer_create_handle_nullable(_handle);
   smoke_Lambdas_Producer_releaseFfiHandle(_handle);
   return result;
 }
-Lambdas_Producer smoke_Lambdas_Producer_fromFfi_nullable(Pointer<Void> handle) {
+Lambdas_Producer? smoke_Lambdas_Producer_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Lambdas_Producer_get_value_nullable(handle);
   final result = smoke_Lambdas_Producer_fromFfi(_handle);
@@ -137,7 +137,7 @@ class Lambdas_Confuser$Impl {
   }
 }
 int _Lambdas_Confuser_call_static(int _token, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
-  Lambdas_Producer _result_object;
+  Lambdas_Producer? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as Lambdas_Confuser)(String_fromFfi(p0));
     _result.value = smoke_Lambdas_Producer_toFfi(_result_object);
@@ -178,14 +178,14 @@ final _smoke_Lambdas_Confuser_get_value_nullable = __lib.catchArgumentError(() =
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Confuser_get_value_nullable'));
-Pointer<Void> smoke_Lambdas_Confuser_toFfi_nullable(Lambdas_Confuser value) {
+Pointer<Void> smoke_Lambdas_Confuser_toFfi_nullable(Lambdas_Confuser? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_Confuser_toFfi(value);
   final result = _smoke_Lambdas_Confuser_create_handle_nullable(_handle);
   smoke_Lambdas_Confuser_releaseFfiHandle(_handle);
   return result;
 }
-Lambdas_Confuser smoke_Lambdas_Confuser_fromFfi_nullable(Pointer<Void> handle) {
+Lambdas_Confuser? smoke_Lambdas_Confuser_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Lambdas_Confuser_get_value_nullable(handle);
   final result = smoke_Lambdas_Confuser_fromFfi(_handle);
@@ -267,14 +267,14 @@ final _smoke_Lambdas_Consumer_get_value_nullable = __lib.catchArgumentError(() =
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Consumer_get_value_nullable'));
-Pointer<Void> smoke_Lambdas_Consumer_toFfi_nullable(Lambdas_Consumer value) {
+Pointer<Void> smoke_Lambdas_Consumer_toFfi_nullable(Lambdas_Consumer? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_Consumer_toFfi(value);
   final result = _smoke_Lambdas_Consumer_create_handle_nullable(_handle);
   smoke_Lambdas_Consumer_releaseFfiHandle(_handle);
   return result;
 }
-Lambdas_Consumer smoke_Lambdas_Consumer_fromFfi_nullable(Pointer<Void> handle) {
+Lambdas_Consumer? smoke_Lambdas_Consumer_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Lambdas_Consumer_get_value_nullable(handle);
   final result = smoke_Lambdas_Consumer_fromFfi(_handle);
@@ -319,7 +319,7 @@ class Lambdas_Indexer$Impl {
   }
 }
 int _Lambdas_Indexer_call_static(int _token, Pointer<Void> p0, double p1, Pointer<Int32> _result) {
-  int _result_object;
+  int? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as Lambdas_Indexer)(String_fromFfi(p0), (p1));
     _result.value = (_result_object);
@@ -361,14 +361,14 @@ final _smoke_Lambdas_Indexer_get_value_nullable = __lib.catchArgumentError(() =>
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Indexer_get_value_nullable'));
-Pointer<Void> smoke_Lambdas_Indexer_toFfi_nullable(Lambdas_Indexer value) {
+Pointer<Void> smoke_Lambdas_Indexer_toFfi_nullable(Lambdas_Indexer? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_Indexer_toFfi(value);
   final result = _smoke_Lambdas_Indexer_create_handle_nullable(_handle);
   smoke_Lambdas_Indexer_releaseFfiHandle(_handle);
   return result;
 }
-Lambdas_Indexer smoke_Lambdas_Indexer_fromFfi_nullable(Pointer<Void> handle) {
+Lambdas_Indexer? smoke_Lambdas_Indexer_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Lambdas_Indexer_get_value_nullable(handle);
   final result = smoke_Lambdas_Indexer_fromFfi(_handle);
@@ -378,7 +378,7 @@ Lambdas_Indexer smoke_Lambdas_Indexer_fromFfi_nullable(Pointer<Void> handle) {
 void smoke_Lambdas_Indexer_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Lambdas_Indexer_release_handle_nullable(handle);
 // End of Lambdas_Indexer "private" section.
-typedef Lambdas_NullableConfuser = Lambdas_Producer Function(String);
+typedef Lambdas_NullableConfuser = Lambdas_Producer? Function(String?);
 // Lambdas_NullableConfuser "private" section, not exported.
 final _smoke_Lambdas_NullableConfuser_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
@@ -397,7 +397,7 @@ class Lambdas_NullableConfuser$Impl {
   final Pointer<Void> handle;
   Lambdas_NullableConfuser$Impl(this.handle);
   void release() => _smoke_Lambdas_NullableConfuser_release_handle(handle);
-  Lambdas_Producer call(String p0) {
+  Lambdas_Producer? call(String? p0) {
     final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_NullableConfuser_call__String'));
     final _p0_handle = String_toFfi_nullable(p0);
     final _handle = this.handle;
@@ -411,7 +411,7 @@ class Lambdas_NullableConfuser$Impl {
   }
 }
 int _Lambdas_NullableConfuser_call_static(int _token, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
-  Lambdas_Producer _result_object;
+  Lambdas_Producer? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as Lambdas_NullableConfuser)(String_fromFfi_nullable(p0));
     _result.value = smoke_Lambdas_Producer_toFfi_nullable(_result_object);
@@ -431,7 +431,7 @@ Pointer<Void> smoke_Lambdas_NullableConfuser_toFfi(Lambdas_NullableConfuser valu
 }
 Lambdas_NullableConfuser smoke_Lambdas_NullableConfuser_fromFfi(Pointer<Void> handle) {
   final _impl = Lambdas_NullableConfuser$Impl(_smoke_Lambdas_NullableConfuser_copy_handle(handle));
-  return (String p0) {
+  return (String? p0) {
     final _result =_impl.call(p0);
     _impl.release();
     return _result;
@@ -452,14 +452,14 @@ final _smoke_Lambdas_NullableConfuser_get_value_nullable = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_NullableConfuser_get_value_nullable'));
-Pointer<Void> smoke_Lambdas_NullableConfuser_toFfi_nullable(Lambdas_NullableConfuser value) {
+Pointer<Void> smoke_Lambdas_NullableConfuser_toFfi_nullable(Lambdas_NullableConfuser? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_NullableConfuser_toFfi(value);
   final result = _smoke_Lambdas_NullableConfuser_create_handle_nullable(_handle);
   smoke_Lambdas_NullableConfuser_releaseFfiHandle(_handle);
   return result;
 }
-Lambdas_NullableConfuser smoke_Lambdas_NullableConfuser_fromFfi_nullable(Pointer<Void> handle) {
+Lambdas_NullableConfuser? smoke_Lambdas_NullableConfuser_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Lambdas_NullableConfuser_get_value_nullable(handle);
   final result = smoke_Lambdas_NullableConfuser_fromFfi(_handle);
@@ -482,11 +482,11 @@ class Lambdas$Impl extends __lib.NativeBase implements Lambdas {
   Lambdas$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_Lambdas_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   Lambdas_Producer deconfuse(String value, Lambdas_Confuser confuser) {
@@ -522,8 +522,8 @@ Pointer<Void> smoke_Lambdas_toFfi(Lambdas value) =>
 Lambdas smoke_Lambdas_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Lambdas;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Lambdas) return instance;
   final _copied_handle = _smoke_Lambdas_copy_handle(handle);
   final result = Lambdas$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -531,9 +531,9 @@ Lambdas smoke_Lambdas_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Lambdas_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Lambdas_release_handle(handle);
-Pointer<Void> smoke_Lambdas_toFfi_nullable(Lambdas value) =>
+Pointer<Void> smoke_Lambdas_toFfi_nullable(Lambdas? value) =>
   value != null ? smoke_Lambdas_toFfi(value) : Pointer<Void>.fromAddress(0);
-Lambdas smoke_Lambdas_fromFfi_nullable(Pointer<Void> handle) =>
+Lambdas? smoke_Lambdas_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Lambdas_fromFfi(handle) : null;
 void smoke_Lambdas_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Lambdas_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -88,14 +88,14 @@ final _smoke_LambdasWithStructuredTypes_ClassCallback_get_value_nullable = __lib
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_ClassCallback_get_value_nullable'));
-Pointer<Void> smoke_LambdasWithStructuredTypes_ClassCallback_toFfi_nullable(LambdasWithStructuredTypes_ClassCallback value) {
+Pointer<Void> smoke_LambdasWithStructuredTypes_ClassCallback_toFfi_nullable(LambdasWithStructuredTypes_ClassCallback? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(value);
   final result = _smoke_LambdasWithStructuredTypes_ClassCallback_create_handle_nullable(_handle);
   smoke_LambdasWithStructuredTypes_ClassCallback_releaseFfiHandle(_handle);
   return result;
 }
-LambdasWithStructuredTypes_ClassCallback smoke_LambdasWithStructuredTypes_ClassCallback_fromFfi_nullable(Pointer<Void> handle) {
+LambdasWithStructuredTypes_ClassCallback? smoke_LambdasWithStructuredTypes_ClassCallback_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_LambdasWithStructuredTypes_ClassCallback_get_value_nullable(handle);
   final result = smoke_LambdasWithStructuredTypes_ClassCallback_fromFfi(_handle);
@@ -177,14 +177,14 @@ final _smoke_LambdasWithStructuredTypes_StructCallback_get_value_nullable = __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_StructCallback_get_value_nullable'));
-Pointer<Void> smoke_LambdasWithStructuredTypes_StructCallback_toFfi_nullable(LambdasWithStructuredTypes_StructCallback value) {
+Pointer<Void> smoke_LambdasWithStructuredTypes_StructCallback_toFfi_nullable(LambdasWithStructuredTypes_StructCallback? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_LambdasWithStructuredTypes_StructCallback_toFfi(value);
   final result = _smoke_LambdasWithStructuredTypes_StructCallback_create_handle_nullable(_handle);
   smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle(_handle);
   return result;
 }
-LambdasWithStructuredTypes_StructCallback smoke_LambdasWithStructuredTypes_StructCallback_fromFfi_nullable(Pointer<Void> handle) {
+LambdasWithStructuredTypes_StructCallback? smoke_LambdasWithStructuredTypes_StructCallback_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_LambdasWithStructuredTypes_StructCallback_get_value_nullable(handle);
   final result = smoke_LambdasWithStructuredTypes_StructCallback_fromFfi(_handle);
@@ -207,11 +207,11 @@ class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements Lambda
   LambdasWithStructuredTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_LambdasWithStructuredTypes_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   doClassStuff(LambdasWithStructuredTypes_ClassCallback callback) {
@@ -245,8 +245,8 @@ Pointer<Void> smoke_LambdasWithStructuredTypes_toFfi(LambdasWithStructuredTypes 
 LambdasWithStructuredTypes smoke_LambdasWithStructuredTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as LambdasWithStructuredTypes;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is LambdasWithStructuredTypes) return instance;
   final _copied_handle = _smoke_LambdasWithStructuredTypes_copy_handle(handle);
   final result = LambdasWithStructuredTypes$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -254,9 +254,9 @@ LambdasWithStructuredTypes smoke_LambdasWithStructuredTypes_fromFfi(Pointer<Void
 }
 void smoke_LambdasWithStructuredTypes_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_LambdasWithStructuredTypes_release_handle(handle);
-Pointer<Void> smoke_LambdasWithStructuredTypes_toFfi_nullable(LambdasWithStructuredTypes value) =>
+Pointer<Void> smoke_LambdasWithStructuredTypes_toFfi_nullable(LambdasWithStructuredTypes? value) =>
   value != null ? smoke_LambdasWithStructuredTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
-LambdasWithStructuredTypes smoke_LambdasWithStructuredTypes_fromFfi_nullable(Pointer<Void> handle) =>
+LambdasWithStructuredTypes? smoke_LambdasWithStructuredTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_LambdasWithStructuredTypes_fromFfi(handle) : null;
 void smoke_LambdasWithStructuredTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_LambdasWithStructuredTypes_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
@@ -35,7 +35,7 @@ class StandaloneProducer$Impl {
   }
 }
 int _StandaloneProducer_call_static(int _token, Pointer<Pointer<Void>> _result) {
-  String _result_object;
+  String? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as StandaloneProducer)();
     _result.value = String_toFfi(_result_object);
@@ -75,14 +75,14 @@ final _smoke_StandaloneProducer_get_value_nullable = __lib.catchArgumentError(()
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StandaloneProducer_get_value_nullable'));
-Pointer<Void> smoke_StandaloneProducer_toFfi_nullable(StandaloneProducer value) {
+Pointer<Void> smoke_StandaloneProducer_toFfi_nullable(StandaloneProducer? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StandaloneProducer_toFfi(value);
   final result = _smoke_StandaloneProducer_create_handle_nullable(_handle);
   smoke_StandaloneProducer_releaseFfiHandle(_handle);
   return result;
 }
-StandaloneProducer smoke_StandaloneProducer_fromFfi_nullable(Pointer<Void> handle) {
+StandaloneProducer? smoke_StandaloneProducer_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StandaloneProducer_get_value_nullable(handle);
   final result = smoke_StandaloneProducer_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/_token_cache.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/_token_cache.dart
@@ -6,7 +6,7 @@ int _instanceCounter = 1024;
 final Map<int, Object> instanceCache = {};
 final Map<Object, int> tokenCache = {};
 int cacheObject(Object obj) {
-  int token = tokenCache[obj];
+  int? token = tokenCache[obj];
   if (token == null) {
     token = _instanceCounter++;
     instanceCache[token] = obj;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -11,12 +11,12 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class CalculatorListener {
   CalculatorListener() {}
   factory CalculatorListener.fromLambdas({
-    @required void Function(double) lambda_onCalculationResult,
-    @required void Function(double) lambda_onCalculationResultConst,
-    @required void Function(CalculatorListener_ResultStruct) lambda_onCalculationResultStruct,
-    @required void Function(List<double>) lambda_onCalculationResultArray,
-    @required void Function(Map<String, double>) lambda_onCalculationResultMap,
-    @required void Function(CalculationResult) lambda_onCalculationResultInstance,
+    required void Function(double) lambda_onCalculationResult,
+    required void Function(double) lambda_onCalculationResultConst,
+    required void Function(CalculatorListener_ResultStruct) lambda_onCalculationResultStruct,
+    required void Function(List<double>) lambda_onCalculationResultArray,
+    required void Function(Map<String, double>) lambda_onCalculationResultMap,
+    required void Function(CalculationResult) lambda_onCalculationResultInstance,
   }) => CalculatorListener$Lambdas(
     lambda_onCalculationResult,
     lambda_onCalculationResultConst,
@@ -84,14 +84,14 @@ final _smoke_CalculatorListener_ResultStruct_get_value_nullable = __lib.catchArg
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_ResultStruct_get_value_nullable'));
-Pointer<Void> smoke_CalculatorListener_ResultStruct_toFfi_nullable(CalculatorListener_ResultStruct value) {
+Pointer<Void> smoke_CalculatorListener_ResultStruct_toFfi_nullable(CalculatorListener_ResultStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CalculatorListener_ResultStruct_toFfi(value);
   final result = _smoke_CalculatorListener_ResultStruct_create_handle_nullable(_handle);
   smoke_CalculatorListener_ResultStruct_releaseFfiHandle(_handle);
   return result;
 }
-CalculatorListener_ResultStruct smoke_CalculatorListener_ResultStruct_fromFfi_nullable(Pointer<Void> handle) {
+CalculatorListener_ResultStruct? smoke_CalculatorListener_ResultStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_CalculatorListener_ResultStruct_get_value_nullable(handle);
   final result = smoke_CalculatorListener_ResultStruct_fromFfi(_handle);
@@ -158,11 +158,11 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
   CalculatorListener$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_CalculatorListener_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   onCalculationResult(double calculationResult) {
@@ -309,8 +309,8 @@ Pointer<Void> smoke_CalculatorListener_toFfi(CalculatorListener value) {
 CalculatorListener smoke_CalculatorListener_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as CalculatorListener;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is CalculatorListener) return instance;
   final _type_id_handle = _smoke_CalculatorListener_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -323,9 +323,9 @@ CalculatorListener smoke_CalculatorListener_fromFfi(Pointer<Void> handle) {
 }
 void smoke_CalculatorListener_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_CalculatorListener_release_handle(handle);
-Pointer<Void> smoke_CalculatorListener_toFfi_nullable(CalculatorListener value) =>
+Pointer<Void> smoke_CalculatorListener_toFfi_nullable(CalculatorListener? value) =>
   value != null ? smoke_CalculatorListener_toFfi(value) : Pointer<Void>.fromAddress(0);
-CalculatorListener smoke_CalculatorListener_fromFfi_nullable(Pointer<Void> handle) =>
+CalculatorListener? smoke_CalculatorListener_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_CalculatorListener_fromFfi(handle) : null;
 void smoke_CalculatorListener_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_CalculatorListener_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
@@ -9,9 +9,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class InterfaceWithStatic {
   InterfaceWithStatic() {}
   factory InterfaceWithStatic.fromLambdas({
-    @required String Function() lambda_regularFunction,
-    @required String Function() lambda_regularProperty_get,
-    @required void Function(String) lambda_regularProperty_set,
+    required String Function() lambda_regularFunction,
+    required String Function() lambda_regularProperty_get,
+    required void Function(String) lambda_regularProperty_set,
   }) => InterfaceWithStatic$Lambdas(
     lambda_regularFunction,
     lambda_regularProperty_get,
@@ -69,11 +69,11 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
   InterfaceWithStatic$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_InterfaceWithStatic_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String regularFunction() {
@@ -140,7 +140,7 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
   }
 }
 int _InterfaceWithStatic_regularFunction_static(int _token, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as InterfaceWithStatic).regularFunction();
     _result.value = String_toFfi(_result_object);
@@ -176,8 +176,8 @@ Pointer<Void> smoke_InterfaceWithStatic_toFfi(InterfaceWithStatic value) {
 InterfaceWithStatic smoke_InterfaceWithStatic_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as InterfaceWithStatic;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is InterfaceWithStatic) return instance;
   final _type_id_handle = _smoke_InterfaceWithStatic_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -190,9 +190,9 @@ InterfaceWithStatic smoke_InterfaceWithStatic_fromFfi(Pointer<Void> handle) {
 }
 void smoke_InterfaceWithStatic_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_InterfaceWithStatic_release_handle(handle);
-Pointer<Void> smoke_InterfaceWithStatic_toFfi_nullable(InterfaceWithStatic value) =>
+Pointer<Void> smoke_InterfaceWithStatic_toFfi_nullable(InterfaceWithStatic? value) =>
   value != null ? smoke_InterfaceWithStatic_toFfi(value) : Pointer<Void>.fromAddress(0);
-InterfaceWithStatic smoke_InterfaceWithStatic_fromFfi_nullable(Pointer<Void> handle) =>
+InterfaceWithStatic? smoke_InterfaceWithStatic_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InterfaceWithStatic_fromFfi(handle) : null;
 void smoke_InterfaceWithStatic_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_InterfaceWithStatic_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -12,20 +12,20 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class ListenerWithProperties {
   ListenerWithProperties() {}
   factory ListenerWithProperties.fromLambdas({
-    @required String Function() lambda_message_get,
-    @required void Function(String) lambda_message_set,
-    @required CalculationResult Function() lambda_packedMessage_get,
-    @required void Function(CalculationResult) lambda_packedMessage_set,
-    @required ListenerWithProperties_ResultStruct Function() lambda_structuredMessage_get,
-    @required void Function(ListenerWithProperties_ResultStruct) lambda_structuredMessage_set,
-    @required ListenerWithProperties_ResultEnum Function() lambda_enumeratedMessage_get,
-    @required void Function(ListenerWithProperties_ResultEnum) lambda_enumeratedMessage_set,
-    @required List<String> Function() lambda_arrayedMessage_get,
-    @required void Function(List<String>) lambda_arrayedMessage_set,
-    @required Map<String, double> Function() lambda_mappedMessage_get,
-    @required void Function(Map<String, double>) lambda_mappedMessage_set,
-    @required Uint8List Function() lambda_bufferedMessage_get,
-    @required void Function(Uint8List) lambda_bufferedMessage_set
+    required String Function() lambda_message_get,
+    required void Function(String) lambda_message_set,
+    required CalculationResult Function() lambda_packedMessage_get,
+    required void Function(CalculationResult) lambda_packedMessage_set,
+    required ListenerWithProperties_ResultStruct Function() lambda_structuredMessage_get,
+    required void Function(ListenerWithProperties_ResultStruct) lambda_structuredMessage_set,
+    required ListenerWithProperties_ResultEnum Function() lambda_enumeratedMessage_get,
+    required void Function(ListenerWithProperties_ResultEnum) lambda_enumeratedMessage_set,
+    required List<String> Function() lambda_arrayedMessage_get,
+    required void Function(List<String>) lambda_arrayedMessage_set,
+    required Map<String, double> Function() lambda_mappedMessage_get,
+    required void Function(Map<String, double>) lambda_mappedMessage_set,
+    required Uint8List Function() lambda_bufferedMessage_get,
+    required void Function(Uint8List) lambda_bufferedMessage_set
   }) => ListenerWithProperties$Lambdas(
     lambda_message_get,
     lambda_message_set,
@@ -104,14 +104,14 @@ final _smoke_ListenerWithProperties_ResultEnum_get_value_nullable = __lib.catchA
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_ResultEnum_get_value_nullable'));
-Pointer<Void> smoke_ListenerWithProperties_ResultEnum_toFfi_nullable(ListenerWithProperties_ResultEnum value) {
+Pointer<Void> smoke_ListenerWithProperties_ResultEnum_toFfi_nullable(ListenerWithProperties_ResultEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ListenerWithProperties_ResultEnum_toFfi(value);
   final result = _smoke_ListenerWithProperties_ResultEnum_create_handle_nullable(_handle);
   smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(_handle);
   return result;
 }
-ListenerWithProperties_ResultEnum smoke_ListenerWithProperties_ResultEnum_fromFfi_nullable(Pointer<Void> handle) {
+ListenerWithProperties_ResultEnum? smoke_ListenerWithProperties_ResultEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ListenerWithProperties_ResultEnum_get_value_nullable(handle);
   final result = smoke_ListenerWithProperties_ResultEnum_fromFfi(_handle);
@@ -168,14 +168,14 @@ final _smoke_ListenerWithProperties_ResultStruct_get_value_nullable = __lib.catc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_ResultStruct_get_value_nullable'));
-Pointer<Void> smoke_ListenerWithProperties_ResultStruct_toFfi_nullable(ListenerWithProperties_ResultStruct value) {
+Pointer<Void> smoke_ListenerWithProperties_ResultStruct_toFfi_nullable(ListenerWithProperties_ResultStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ListenerWithProperties_ResultStruct_toFfi(value);
   final result = _smoke_ListenerWithProperties_ResultStruct_create_handle_nullable(_handle);
   smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(_handle);
   return result;
 }
-ListenerWithProperties_ResultStruct smoke_ListenerWithProperties_ResultStruct_fromFfi_nullable(Pointer<Void> handle) {
+ListenerWithProperties_ResultStruct? smoke_ListenerWithProperties_ResultStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ListenerWithProperties_ResultStruct_get_value_nullable(handle);
   final result = smoke_ListenerWithProperties_ResultStruct_fromFfi(_handle);
@@ -268,11 +268,11 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
   ListenerWithProperties$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ListenerWithProperties_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   String get message {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_message_get'));
@@ -546,8 +546,8 @@ Pointer<Void> smoke_ListenerWithProperties_toFfi(ListenerWithProperties value) {
 ListenerWithProperties smoke_ListenerWithProperties_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ListenerWithProperties;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ListenerWithProperties) return instance;
   final _type_id_handle = _smoke_ListenerWithProperties_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -560,9 +560,9 @@ ListenerWithProperties smoke_ListenerWithProperties_fromFfi(Pointer<Void> handle
 }
 void smoke_ListenerWithProperties_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ListenerWithProperties_release_handle(handle);
-Pointer<Void> smoke_ListenerWithProperties_toFfi_nullable(ListenerWithProperties value) =>
+Pointer<Void> smoke_ListenerWithProperties_toFfi_nullable(ListenerWithProperties? value) =>
   value != null ? smoke_ListenerWithProperties_toFfi(value) : Pointer<Void>.fromAddress(0);
-ListenerWithProperties smoke_ListenerWithProperties_fromFfi_nullable(Pointer<Void> handle) =>
+ListenerWithProperties? smoke_ListenerWithProperties_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ListenerWithProperties_fromFfi(handle) : null;
 void smoke_ListenerWithProperties_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ListenerWithProperties_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -11,13 +11,13 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class ListenersWithReturnValues {
   ListenersWithReturnValues() {}
   factory ListenersWithReturnValues.fromLambdas({
-    @required double Function() lambda_fetchDataDouble,
-    @required String Function() lambda_fetchDataString,
-    @required ListenersWithReturnValues_ResultStruct Function() lambda_fetchDataStruct,
-    @required ListenersWithReturnValues_ResultEnum Function() lambda_fetchDataEnum,
-    @required List<double> Function() lambda_fetchDataArray,
-    @required Map<String, double> Function() lambda_fetchDataMap,
-    @required CalculationResult Function() lambda_fetchDataInstance,
+    required double Function() lambda_fetchDataDouble,
+    required String Function() lambda_fetchDataString,
+    required ListenersWithReturnValues_ResultStruct Function() lambda_fetchDataStruct,
+    required ListenersWithReturnValues_ResultEnum Function() lambda_fetchDataEnum,
+    required List<double> Function() lambda_fetchDataArray,
+    required Map<String, double> Function() lambda_fetchDataMap,
+    required CalculationResult Function() lambda_fetchDataInstance,
   }) => ListenersWithReturnValues$Lambdas(
     lambda_fetchDataDouble,
     lambda_fetchDataString,
@@ -82,14 +82,14 @@ final _smoke_ListenersWithReturnValues_ResultEnum_get_value_nullable = __lib.cat
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_ResultEnum_get_value_nullable'));
-Pointer<Void> smoke_ListenersWithReturnValues_ResultEnum_toFfi_nullable(ListenersWithReturnValues_ResultEnum value) {
+Pointer<Void> smoke_ListenersWithReturnValues_ResultEnum_toFfi_nullable(ListenersWithReturnValues_ResultEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ListenersWithReturnValues_ResultEnum_toFfi(value);
   final result = _smoke_ListenersWithReturnValues_ResultEnum_create_handle_nullable(_handle);
   smoke_ListenersWithReturnValues_ResultEnum_releaseFfiHandle(_handle);
   return result;
 }
-ListenersWithReturnValues_ResultEnum smoke_ListenersWithReturnValues_ResultEnum_fromFfi_nullable(Pointer<Void> handle) {
+ListenersWithReturnValues_ResultEnum? smoke_ListenersWithReturnValues_ResultEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ListenersWithReturnValues_ResultEnum_get_value_nullable(handle);
   final result = smoke_ListenersWithReturnValues_ResultEnum_fromFfi(_handle);
@@ -146,14 +146,14 @@ final _smoke_ListenersWithReturnValues_ResultStruct_get_value_nullable = __lib.c
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_ResultStruct_get_value_nullable'));
-Pointer<Void> smoke_ListenersWithReturnValues_ResultStruct_toFfi_nullable(ListenersWithReturnValues_ResultStruct value) {
+Pointer<Void> smoke_ListenersWithReturnValues_ResultStruct_toFfi_nullable(ListenersWithReturnValues_ResultStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ListenersWithReturnValues_ResultStruct_toFfi(value);
   final result = _smoke_ListenersWithReturnValues_ResultStruct_create_handle_nullable(_handle);
   smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle(_handle);
   return result;
 }
-ListenersWithReturnValues_ResultStruct smoke_ListenersWithReturnValues_ResultStruct_fromFfi_nullable(Pointer<Void> handle) {
+ListenersWithReturnValues_ResultStruct? smoke_ListenersWithReturnValues_ResultStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_ListenersWithReturnValues_ResultStruct_get_value_nullable(handle);
   final result = smoke_ListenersWithReturnValues_ResultStruct_fromFfi(_handle);
@@ -225,11 +225,11 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
   ListenersWithReturnValues$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_ListenersWithReturnValues_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   double fetchDataDouble() {
@@ -310,7 +310,7 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
   }
 }
 int _ListenersWithReturnValues_fetchDataDouble_static(int _token, Pointer<Double> _result) {
-  double _result_object = null;
+  double? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataDouble();
     _result.value = (_result_object);
@@ -319,7 +319,7 @@ int _ListenersWithReturnValues_fetchDataDouble_static(int _token, Pointer<Double
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataString_static(int _token, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataString();
     _result.value = String_toFfi(_result_object);
@@ -328,7 +328,7 @@ int _ListenersWithReturnValues_fetchDataString_static(int _token, Pointer<Pointe
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataStruct_static(int _token, Pointer<Pointer<Void>> _result) {
-  ListenersWithReturnValues_ResultStruct _result_object = null;
+  ListenersWithReturnValues_ResultStruct? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataStruct();
     _result.value = smoke_ListenersWithReturnValues_ResultStruct_toFfi(_result_object);
@@ -337,7 +337,7 @@ int _ListenersWithReturnValues_fetchDataStruct_static(int _token, Pointer<Pointe
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataEnum_static(int _token, Pointer<Uint32> _result) {
-  ListenersWithReturnValues_ResultEnum _result_object = null;
+  ListenersWithReturnValues_ResultEnum? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataEnum();
     _result.value = smoke_ListenersWithReturnValues_ResultEnum_toFfi(_result_object);
@@ -346,7 +346,7 @@ int _ListenersWithReturnValues_fetchDataEnum_static(int _token, Pointer<Uint32> 
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataArray_static(int _token, Pointer<Pointer<Void>> _result) {
-  List<double> _result_object = null;
+  List<double>? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataArray();
     _result.value = foobar_ListOf_Double_toFfi(_result_object);
@@ -355,7 +355,7 @@ int _ListenersWithReturnValues_fetchDataArray_static(int _token, Pointer<Pointer
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataMap_static(int _token, Pointer<Pointer<Void>> _result) {
-  Map<String, double> _result_object = null;
+  Map<String, double>? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataMap();
     _result.value = foobar_MapOf_String_to_Double_toFfi(_result_object);
@@ -364,12 +364,12 @@ int _ListenersWithReturnValues_fetchDataMap_static(int _token, Pointer<Pointer<V
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataInstance_static(int _token, Pointer<Pointer<Void>> _result) {
-  CalculationResult _result_object = null;
+  CalculationResult? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataInstance();
     _result.value = smoke_CalculationResult_toFfi(_result_object);
   } finally {
-    if (_result_object != null) _result_object.release();
+    _result_object?.release();
   }
   return 0;
 }
@@ -392,8 +392,8 @@ Pointer<Void> smoke_ListenersWithReturnValues_toFfi(ListenersWithReturnValues va
 ListenersWithReturnValues smoke_ListenersWithReturnValues_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as ListenersWithReturnValues;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is ListenersWithReturnValues) return instance;
   final _type_id_handle = _smoke_ListenersWithReturnValues_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -406,9 +406,9 @@ ListenersWithReturnValues smoke_ListenersWithReturnValues_fromFfi(Pointer<Void> 
 }
 void smoke_ListenersWithReturnValues_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_ListenersWithReturnValues_release_handle(handle);
-Pointer<Void> smoke_ListenersWithReturnValues_toFfi_nullable(ListenersWithReturnValues value) =>
+Pointer<Void> smoke_ListenersWithReturnValues_toFfi_nullable(ListenersWithReturnValues? value) =>
   value != null ? smoke_ListenersWithReturnValues_toFfi(value) : Pointer<Void>.fromAddress(0);
-ListenersWithReturnValues smoke_ListenersWithReturnValues_fromFfi_nullable(Pointer<Void> handle) =>
+ListenersWithReturnValues? smoke_ListenersWithReturnValues_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ListenersWithReturnValues_fromFfi(handle) : null;
 void smoke_ListenersWithReturnValues_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_ListenersWithReturnValues_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -63,14 +63,14 @@ final _smoke_Locales_LocaleStruct_get_value_nullable = __lib.catchArgumentError(
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Locales_LocaleStruct_get_value_nullable'));
-Pointer<Void> smoke_Locales_LocaleStruct_toFfi_nullable(Locales_LocaleStruct value) {
+Pointer<Void> smoke_Locales_LocaleStruct_toFfi_nullable(Locales_LocaleStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Locales_LocaleStruct_toFfi(value);
   final result = _smoke_Locales_LocaleStruct_create_handle_nullable(_handle);
   smoke_Locales_LocaleStruct_releaseFfiHandle(_handle);
   return result;
 }
-Locales_LocaleStruct smoke_Locales_LocaleStruct_fromFfi_nullable(Pointer<Void> handle) {
+Locales_LocaleStruct? smoke_Locales_LocaleStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Locales_LocaleStruct_get_value_nullable(handle);
   final result = smoke_Locales_LocaleStruct_fromFfi(_handle);
@@ -93,11 +93,11 @@ class Locales$Impl extends __lib.NativeBase implements Locales {
   Locales$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_Locales_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   Locale localeMethod(Locale input) {
@@ -142,8 +142,8 @@ Pointer<Void> smoke_Locales_toFfi(Locales value) =>
 Locales smoke_Locales_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Locales;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Locales) return instance;
   final _copied_handle = _smoke_Locales_copy_handle(handle);
   final result = Locales$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -151,9 +151,9 @@ Locales smoke_Locales_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Locales_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Locales_release_handle(handle);
-Pointer<Void> smoke_Locales_toFfi_nullable(Locales value) =>
+Pointer<Void> smoke_Locales_toFfi_nullable(Locales? value) =>
   value != null ? smoke_Locales_toFfi(value) : Pointer<Void>.fromAddress(0);
-Locales smoke_Locales_fromFfi_nullable(Pointer<Void> handle) =>
+Locales? smoke_Locales_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Locales_fromFfi(handle) : null;
 void smoke_Locales_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Locales_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -80,14 +80,14 @@ final _smoke_MethodOverloads_Point_get_value_nullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_Point_get_value_nullable'));
-Pointer<Void> smoke_MethodOverloads_Point_toFfi_nullable(MethodOverloads_Point value) {
+Pointer<Void> smoke_MethodOverloads_Point_toFfi_nullable(MethodOverloads_Point? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_MethodOverloads_Point_toFfi(value);
   final result = _smoke_MethodOverloads_Point_create_handle_nullable(_handle);
   smoke_MethodOverloads_Point_releaseFfiHandle(_handle);
   return result;
 }
-MethodOverloads_Point smoke_MethodOverloads_Point_fromFfi_nullable(Pointer<Void> handle) {
+MethodOverloads_Point? smoke_MethodOverloads_Point_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_MethodOverloads_Point_get_value_nullable(handle);
   final result = smoke_MethodOverloads_Point_fromFfi(_handle);
@@ -110,11 +110,11 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
   MethodOverloads$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_MethodOverloads_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   bool isBoolean(bool input) {
@@ -256,8 +256,8 @@ Pointer<Void> smoke_MethodOverloads_toFfi(MethodOverloads value) =>
 MethodOverloads smoke_MethodOverloads_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as MethodOverloads;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is MethodOverloads) return instance;
   final _copied_handle = _smoke_MethodOverloads_copy_handle(handle);
   final result = MethodOverloads$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -265,9 +265,9 @@ MethodOverloads smoke_MethodOverloads_fromFfi(Pointer<Void> handle) {
 }
 void smoke_MethodOverloads_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_MethodOverloads_release_handle(handle);
-Pointer<Void> smoke_MethodOverloads_toFfi_nullable(MethodOverloads value) =>
+Pointer<Void> smoke_MethodOverloads_toFfi_nullable(MethodOverloads? value) =>
   value != null ? smoke_MethodOverloads_toFfi(value) : Pointer<Void>.fromAddress(0);
-MethodOverloads smoke_MethodOverloads_fromFfi_nullable(Pointer<Void> handle) =>
+MethodOverloads? smoke_MethodOverloads_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_MethodOverloads_fromFfi(handle) : null;
 void smoke_MethodOverloads_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_MethodOverloads_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -29,11 +29,11 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
   SpecialNames$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_SpecialNames_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   create() {
@@ -85,8 +85,8 @@ Pointer<Void> smoke_SpecialNames_toFfi(SpecialNames value) =>
 SpecialNames smoke_SpecialNames_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as SpecialNames;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is SpecialNames) return instance;
   final _copied_handle = _smoke_SpecialNames_copy_handle(handle);
   final result = SpecialNames$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -94,9 +94,9 @@ SpecialNames smoke_SpecialNames_fromFfi(Pointer<Void> handle) {
 }
 void smoke_SpecialNames_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SpecialNames_release_handle(handle);
-Pointer<Void> smoke_SpecialNames_toFfi_nullable(SpecialNames value) =>
+Pointer<Void> smoke_SpecialNames_toFfi_nullable(SpecialNames? value) =>
   value != null ? smoke_SpecialNames_toFfi(value) : Pointer<Void>.fromAddress(0);
-SpecialNames smoke_SpecialNames_fromFfi_nullable(Pointer<Void> handle) =>
+SpecialNames? smoke_SpecialNames_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SpecialNames_fromFfi(handle) : null;
 void smoke_SpecialNames_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SpecialNames_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_enum.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_enum.dart
@@ -2,7 +2,6 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 enum FreeEnum {
     foo,
     bar
@@ -45,14 +44,14 @@ final _smoke_FreeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_FreeEnum_get_value_nullable'));
-Pointer<Void> smoke_FreeEnum_toFfi_nullable(FreeEnum value) {
+Pointer<Void> smoke_FreeEnum_toFfi_nullable(FreeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_FreeEnum_toFfi(value);
   final result = _smoke_FreeEnum_create_handle_nullable(_handle);
   smoke_FreeEnum_releaseFfiHandle(_handle);
   return result;
 }
-FreeEnum smoke_FreeEnum_fromFfi_nullable(Pointer<Void> handle) {
+FreeEnum? smoke_FreeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_FreeEnum_get_value_nullable(handle);
   final result = smoke_FreeEnum_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_point.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_point.dart
@@ -73,14 +73,14 @@ final _smoke_FreePoint_get_value_nullable = __lib.catchArgumentError(() => __lib
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FreePoint_get_value_nullable'));
-Pointer<Void> smoke_FreePoint_toFfi_nullable(FreePoint value) {
+Pointer<Void> smoke_FreePoint_toFfi_nullable(FreePoint? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_FreePoint_toFfi(value);
   final result = _smoke_FreePoint_create_handle_nullable(_handle);
   smoke_FreePoint_releaseFfiHandle(_handle);
   return result;
 }
-FreePoint smoke_FreePoint_fromFfi_nullable(Pointer<Void> handle) {
+FreePoint? smoke_FreePoint_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_FreePoint_get_value_nullable(handle);
   final result = smoke_FreePoint_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -64,14 +64,14 @@ final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable = __l
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable'));
-Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_toFfi_nullable(LevelOne_LevelTwo_LevelThree_LevelFourEnum value) {
+Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_toFfi_nullable(LevelOne_LevelTwo_LevelThree_LevelFourEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_toFfi(value);
   final result = _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_create_handle_nullable(_handle);
   smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_releaseFfiHandle(_handle);
   return result;
 }
-LevelOne_LevelTwo_LevelThree_LevelFourEnum smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_fromFfi_nullable(Pointer<Void> handle) {
+LevelOne_LevelTwo_LevelThree_LevelFourEnum? smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable(handle);
   final result = smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_fromFfi(_handle);
@@ -138,14 +138,14 @@ final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable = __lib.c
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable'));
-Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi_nullable(LevelOne_LevelTwo_LevelThree_LevelFour value) {
+Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi_nullable(LevelOne_LevelTwo_LevelThree_LevelFour? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi(value);
   final result = _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle_nullable(_handle);
   smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(_handle);
   return result;
 }
-LevelOne_LevelTwo_LevelThree_LevelFour smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi_nullable(Pointer<Void> handle) {
+LevelOne_LevelTwo_LevelThree_LevelFour? smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable(handle);
   final result = smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi(_handle);
@@ -168,11 +168,11 @@ class LevelOne_LevelTwo_LevelThree$Impl extends __lib.NativeBase implements Leve
   LevelOne_LevelTwo_LevelThree$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   OuterInterface_InnerClass foo(OuterClass_InnerInterface input) {
@@ -193,8 +193,8 @@ Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi(LevelOne_LevelTwo_LevelTh
 LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as LevelOne_LevelTwo_LevelThree;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is LevelOne_LevelTwo_LevelThree) return instance;
   final _copied_handle = _smoke_LevelOne_LevelTwo_LevelThree_copy_handle(handle);
   final result = LevelOne_LevelTwo_LevelThree$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -202,9 +202,9 @@ LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi(Pointer<
 }
 void smoke_LevelOne_LevelTwo_LevelThree_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
-Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi_nullable(LevelOne_LevelTwo_LevelThree value) =>
+Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi_nullable(LevelOne_LevelTwo_LevelThree? value) =>
   value != null ? smoke_LevelOne_LevelTwo_LevelThree_toFfi(value) : Pointer<Void>.fromAddress(0);
-LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi_nullable(Pointer<Void> handle) =>
+LevelOne_LevelTwo_LevelThree? smoke_LevelOne_LevelTwo_LevelThree_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_LevelOne_LevelTwo_LevelThree_fromFfi(handle) : null;
 void smoke_LevelOne_LevelTwo_LevelThree_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
@@ -222,11 +222,11 @@ class LevelOne_LevelTwo$Impl extends __lib.NativeBase implements LevelOne_LevelT
   LevelOne_LevelTwo$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_LevelOne_LevelTwo_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 }
 Pointer<Void> smoke_LevelOne_LevelTwo_toFfi(LevelOne_LevelTwo value) =>
@@ -234,8 +234,8 @@ Pointer<Void> smoke_LevelOne_LevelTwo_toFfi(LevelOne_LevelTwo value) =>
 LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as LevelOne_LevelTwo;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is LevelOne_LevelTwo) return instance;
   final _copied_handle = _smoke_LevelOne_LevelTwo_copy_handle(handle);
   final result = LevelOne_LevelTwo$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -243,9 +243,9 @@ LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi(Pointer<Void> handle) {
 }
 void smoke_LevelOne_LevelTwo_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_LevelOne_LevelTwo_release_handle(handle);
-Pointer<Void> smoke_LevelOne_LevelTwo_toFfi_nullable(LevelOne_LevelTwo value) =>
+Pointer<Void> smoke_LevelOne_LevelTwo_toFfi_nullable(LevelOne_LevelTwo? value) =>
   value != null ? smoke_LevelOne_LevelTwo_toFfi(value) : Pointer<Void>.fromAddress(0);
-LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi_nullable(Pointer<Void> handle) =>
+LevelOne_LevelTwo? smoke_LevelOne_LevelTwo_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_LevelOne_LevelTwo_fromFfi(handle) : null;
 void smoke_LevelOne_LevelTwo_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_LevelOne_LevelTwo_release_handle(handle);
@@ -263,11 +263,11 @@ class LevelOne$Impl extends __lib.NativeBase implements LevelOne {
   LevelOne$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_LevelOne_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 }
 Pointer<Void> smoke_LevelOne_toFfi(LevelOne value) =>
@@ -275,8 +275,8 @@ Pointer<Void> smoke_LevelOne_toFfi(LevelOne value) =>
 LevelOne smoke_LevelOne_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as LevelOne;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is LevelOne) return instance;
   final _copied_handle = _smoke_LevelOne_copy_handle(handle);
   final result = LevelOne$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -284,9 +284,9 @@ LevelOne smoke_LevelOne_fromFfi(Pointer<Void> handle) {
 }
 void smoke_LevelOne_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_LevelOne_release_handle(handle);
-Pointer<Void> smoke_LevelOne_toFfi_nullable(LevelOne value) =>
+Pointer<Void> smoke_LevelOne_toFfi_nullable(LevelOne? value) =>
   value != null ? smoke_LevelOne_toFfi(value) : Pointer<Void>.fromAddress(0);
-LevelOne smoke_LevelOne_fromFfi_nullable(Pointer<Void> handle) =>
+LevelOne? smoke_LevelOne_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_LevelOne_fromFfi(handle) : null;
 void smoke_LevelOne_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_LevelOne_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -35,11 +35,11 @@ class OuterClass_InnerClass$Impl extends __lib.NativeBase implements OuterClass_
   OuterClass_InnerClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_OuterClass_InnerClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String foo(String input) {
@@ -60,8 +60,8 @@ Pointer<Void> smoke_OuterClass_InnerClass_toFfi(OuterClass_InnerClass value) =>
 OuterClass_InnerClass smoke_OuterClass_InnerClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as OuterClass_InnerClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is OuterClass_InnerClass) return instance;
   final _copied_handle = _smoke_OuterClass_InnerClass_copy_handle(handle);
   final result = OuterClass_InnerClass$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -69,9 +69,9 @@ OuterClass_InnerClass smoke_OuterClass_InnerClass_fromFfi(Pointer<Void> handle) 
 }
 void smoke_OuterClass_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterClass_InnerClass_release_handle(handle);
-Pointer<Void> smoke_OuterClass_InnerClass_toFfi_nullable(OuterClass_InnerClass value) =>
+Pointer<Void> smoke_OuterClass_InnerClass_toFfi_nullable(OuterClass_InnerClass? value) =>
   value != null ? smoke_OuterClass_InnerClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-OuterClass_InnerClass smoke_OuterClass_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
+OuterClass_InnerClass? smoke_OuterClass_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterClass_InnerClass_fromFfi(handle) : null;
 void smoke_OuterClass_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterClass_InnerClass_release_handle(handle);
@@ -79,7 +79,7 @@ void smoke_OuterClass_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle)
 abstract class OuterClass_InnerInterface {
   OuterClass_InnerInterface() {}
   factory OuterClass_InnerInterface.fromLambdas({
-    @required String Function(String) lambda_foo,
+    required String Function(String) lambda_foo,
   }) => OuterClass_InnerInterface$Lambdas(
     lambda_foo,
   );
@@ -122,11 +122,11 @@ class OuterClass_InnerInterface$Impl extends __lib.NativeBase implements OuterCl
   OuterClass_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_OuterClass_InnerInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String foo(String input) {
@@ -143,7 +143,7 @@ class OuterClass_InnerInterface$Impl extends __lib.NativeBase implements OuterCl
   }
 }
 int _OuterClass_InnerInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as OuterClass_InnerInterface).foo(String_fromFfi(input));
     _result.value = String_toFfi(_result_object);
@@ -165,8 +165,8 @@ Pointer<Void> smoke_OuterClass_InnerInterface_toFfi(OuterClass_InnerInterface va
 OuterClass_InnerInterface smoke_OuterClass_InnerInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as OuterClass_InnerInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is OuterClass_InnerInterface) return instance;
   final _type_id_handle = _smoke_OuterClass_InnerInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -179,9 +179,9 @@ OuterClass_InnerInterface smoke_OuterClass_InnerInterface_fromFfi(Pointer<Void> 
 }
 void smoke_OuterClass_InnerInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterClass_InnerInterface_release_handle(handle);
-Pointer<Void> smoke_OuterClass_InnerInterface_toFfi_nullable(OuterClass_InnerInterface value) =>
+Pointer<Void> smoke_OuterClass_InnerInterface_toFfi_nullable(OuterClass_InnerInterface? value) =>
   value != null ? smoke_OuterClass_InnerInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-OuterClass_InnerInterface smoke_OuterClass_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
+OuterClass_InnerInterface? smoke_OuterClass_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterClass_InnerInterface_fromFfi(handle) : null;
 void smoke_OuterClass_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterClass_InnerInterface_release_handle(handle);
@@ -199,11 +199,11 @@ class OuterClass$Impl extends __lib.NativeBase implements OuterClass {
   OuterClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_OuterClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String foo(String input) {
@@ -224,8 +224,8 @@ Pointer<Void> smoke_OuterClass_toFfi(OuterClass value) =>
 OuterClass smoke_OuterClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as OuterClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is OuterClass) return instance;
   final _copied_handle = _smoke_OuterClass_copy_handle(handle);
   final result = OuterClass$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -233,9 +233,9 @@ OuterClass smoke_OuterClass_fromFfi(Pointer<Void> handle) {
 }
 void smoke_OuterClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterClass_release_handle(handle);
-Pointer<Void> smoke_OuterClass_toFfi_nullable(OuterClass value) =>
+Pointer<Void> smoke_OuterClass_toFfi_nullable(OuterClass? value) =>
   value != null ? smoke_OuterClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-OuterClass smoke_OuterClass_fromFfi_nullable(Pointer<Void> handle) =>
+OuterClass? smoke_OuterClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterClass_fromFfi(handle) : null;
 void smoke_OuterClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterClass_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -36,11 +36,11 @@ class OuterClassWithInheritance_InnerClass$Impl extends __lib.NativeBase impleme
   OuterClassWithInheritance_InnerClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_OuterClassWithInheritance_InnerClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String bar(String input) {
@@ -61,8 +61,8 @@ Pointer<Void> smoke_OuterClassWithInheritance_InnerClass_toFfi(OuterClassWithInh
 OuterClassWithInheritance_InnerClass smoke_OuterClassWithInheritance_InnerClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as OuterClassWithInheritance_InnerClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is OuterClassWithInheritance_InnerClass) return instance;
   final _copied_handle = _smoke_OuterClassWithInheritance_InnerClass_copy_handle(handle);
   final result = OuterClassWithInheritance_InnerClass$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -70,9 +70,9 @@ OuterClassWithInheritance_InnerClass smoke_OuterClassWithInheritance_InnerClass_
 }
 void smoke_OuterClassWithInheritance_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterClassWithInheritance_InnerClass_release_handle(handle);
-Pointer<Void> smoke_OuterClassWithInheritance_InnerClass_toFfi_nullable(OuterClassWithInheritance_InnerClass value) =>
+Pointer<Void> smoke_OuterClassWithInheritance_InnerClass_toFfi_nullable(OuterClassWithInheritance_InnerClass? value) =>
   value != null ? smoke_OuterClassWithInheritance_InnerClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-OuterClassWithInheritance_InnerClass smoke_OuterClassWithInheritance_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
+OuterClassWithInheritance_InnerClass? smoke_OuterClassWithInheritance_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterClassWithInheritance_InnerClass_fromFfi(handle) : null;
 void smoke_OuterClassWithInheritance_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterClassWithInheritance_InnerClass_release_handle(handle);
@@ -80,7 +80,7 @@ void smoke_OuterClassWithInheritance_InnerClass_releaseFfiHandle_nullable(Pointe
 abstract class OuterClassWithInheritance_InnerInterface {
   OuterClassWithInheritance_InnerInterface() {}
   factory OuterClassWithInheritance_InnerInterface.fromLambdas({
-    @required String Function(String) lambda_baz,
+    required String Function(String) lambda_baz,
   }) => OuterClassWithInheritance_InnerInterface$Lambdas(
     lambda_baz,
   );
@@ -123,11 +123,11 @@ class OuterClassWithInheritance_InnerInterface$Impl extends __lib.NativeBase imp
   OuterClassWithInheritance_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_OuterClassWithInheritance_InnerInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String baz(String input) {
@@ -144,7 +144,7 @@ class OuterClassWithInheritance_InnerInterface$Impl extends __lib.NativeBase imp
   }
 }
 int _OuterClassWithInheritance_InnerInterface_baz_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as OuterClassWithInheritance_InnerInterface).baz(String_fromFfi(input));
     _result.value = String_toFfi(_result_object);
@@ -166,8 +166,8 @@ Pointer<Void> smoke_OuterClassWithInheritance_InnerInterface_toFfi(OuterClassWit
 OuterClassWithInheritance_InnerInterface smoke_OuterClassWithInheritance_InnerInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as OuterClassWithInheritance_InnerInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is OuterClassWithInheritance_InnerInterface) return instance;
   final _type_id_handle = _smoke_OuterClassWithInheritance_InnerInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -180,9 +180,9 @@ OuterClassWithInheritance_InnerInterface smoke_OuterClassWithInheritance_InnerIn
 }
 void smoke_OuterClassWithInheritance_InnerInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterClassWithInheritance_InnerInterface_release_handle(handle);
-Pointer<Void> smoke_OuterClassWithInheritance_InnerInterface_toFfi_nullable(OuterClassWithInheritance_InnerInterface value) =>
+Pointer<Void> smoke_OuterClassWithInheritance_InnerInterface_toFfi_nullable(OuterClassWithInheritance_InnerInterface? value) =>
   value != null ? smoke_OuterClassWithInheritance_InnerInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-OuterClassWithInheritance_InnerInterface smoke_OuterClassWithInheritance_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
+OuterClassWithInheritance_InnerInterface? smoke_OuterClassWithInheritance_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterClassWithInheritance_InnerInterface_fromFfi(handle) : null;
 void smoke_OuterClassWithInheritance_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterClassWithInheritance_InnerInterface_release_handle(handle);
@@ -204,11 +204,11 @@ class OuterClassWithInheritance$Impl extends ParentClass$Impl implements OuterCl
   OuterClassWithInheritance$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_OuterClassWithInheritance_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String foo(String input) {
@@ -229,8 +229,8 @@ Pointer<Void> smoke_OuterClassWithInheritance_toFfi(OuterClassWithInheritance va
 OuterClassWithInheritance smoke_OuterClassWithInheritance_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as OuterClassWithInheritance;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is OuterClassWithInheritance) return instance;
   final _type_id_handle = _smoke_OuterClassWithInheritance_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -243,9 +243,9 @@ OuterClassWithInheritance smoke_OuterClassWithInheritance_fromFfi(Pointer<Void> 
 }
 void smoke_OuterClassWithInheritance_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterClassWithInheritance_release_handle(handle);
-Pointer<Void> smoke_OuterClassWithInheritance_toFfi_nullable(OuterClassWithInheritance value) =>
+Pointer<Void> smoke_OuterClassWithInheritance_toFfi_nullable(OuterClassWithInheritance? value) =>
   value != null ? smoke_OuterClassWithInheritance_toFfi(value) : Pointer<Void>.fromAddress(0);
-OuterClassWithInheritance smoke_OuterClassWithInheritance_fromFfi_nullable(Pointer<Void> handle) =>
+OuterClassWithInheritance? smoke_OuterClassWithInheritance_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterClassWithInheritance_fromFfi(handle) : null;
 void smoke_OuterClassWithInheritance_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterClassWithInheritance_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -9,7 +9,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class OuterInterface {
   OuterInterface() {}
   factory OuterInterface.fromLambdas({
-    @required String Function(String) lambda_foo,
+    required String Function(String) lambda_foo,
   }) => OuterInterface$Lambdas(
     lambda_foo,
   );
@@ -41,11 +41,11 @@ class OuterInterface_InnerClass$Impl extends __lib.NativeBase implements OuterIn
   OuterInterface_InnerClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_OuterInterface_InnerClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String foo(String input) {
@@ -66,8 +66,8 @@ Pointer<Void> smoke_OuterInterface_InnerClass_toFfi(OuterInterface_InnerClass va
 OuterInterface_InnerClass smoke_OuterInterface_InnerClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as OuterInterface_InnerClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is OuterInterface_InnerClass) return instance;
   final _copied_handle = _smoke_OuterInterface_InnerClass_copy_handle(handle);
   final result = OuterInterface_InnerClass$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -75,9 +75,9 @@ OuterInterface_InnerClass smoke_OuterInterface_InnerClass_fromFfi(Pointer<Void> 
 }
 void smoke_OuterInterface_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterInterface_InnerClass_release_handle(handle);
-Pointer<Void> smoke_OuterInterface_InnerClass_toFfi_nullable(OuterInterface_InnerClass value) =>
+Pointer<Void> smoke_OuterInterface_InnerClass_toFfi_nullable(OuterInterface_InnerClass? value) =>
   value != null ? smoke_OuterInterface_InnerClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-OuterInterface_InnerClass smoke_OuterInterface_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
+OuterInterface_InnerClass? smoke_OuterInterface_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterInterface_InnerClass_fromFfi(handle) : null;
 void smoke_OuterInterface_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterInterface_InnerClass_release_handle(handle);
@@ -85,7 +85,7 @@ void smoke_OuterInterface_InnerClass_releaseFfiHandle_nullable(Pointer<Void> han
 abstract class OuterInterface_InnerInterface {
   OuterInterface_InnerInterface() {}
   factory OuterInterface_InnerInterface.fromLambdas({
-    @required String Function(String) lambda_foo,
+    required String Function(String) lambda_foo,
   }) => OuterInterface_InnerInterface$Lambdas(
     lambda_foo,
   );
@@ -128,11 +128,11 @@ class OuterInterface_InnerInterface$Impl extends __lib.NativeBase implements Out
   OuterInterface_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_OuterInterface_InnerInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String foo(String input) {
@@ -149,7 +149,7 @@ class OuterInterface_InnerInterface$Impl extends __lib.NativeBase implements Out
   }
 }
 int _OuterInterface_InnerInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as OuterInterface_InnerInterface).foo(String_fromFfi(input));
     _result.value = String_toFfi(_result_object);
@@ -171,8 +171,8 @@ Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi(OuterInterface_InnerInte
 OuterInterface_InnerInterface smoke_OuterInterface_InnerInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as OuterInterface_InnerInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is OuterInterface_InnerInterface) return instance;
   final _type_id_handle = _smoke_OuterInterface_InnerInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -185,9 +185,9 @@ OuterInterface_InnerInterface smoke_OuterInterface_InnerInterface_fromFfi(Pointe
 }
 void smoke_OuterInterface_InnerInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterInterface_InnerInterface_release_handle(handle);
-Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi_nullable(OuterInterface_InnerInterface value) =>
+Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi_nullable(OuterInterface_InnerInterface? value) =>
   value != null ? smoke_OuterInterface_InnerInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-OuterInterface_InnerInterface smoke_OuterInterface_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
+OuterInterface_InnerInterface? smoke_OuterInterface_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterInterface_InnerInterface_fromFfi(handle) : null;
 void smoke_OuterInterface_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterInterface_InnerInterface_release_handle(handle);
@@ -224,11 +224,11 @@ class OuterInterface$Impl extends __lib.NativeBase implements OuterInterface {
   OuterInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_OuterInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String foo(String input) {
@@ -245,7 +245,7 @@ class OuterInterface$Impl extends __lib.NativeBase implements OuterInterface {
   }
 }
 int _OuterInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as OuterInterface).foo(String_fromFfi(input));
     _result.value = String_toFfi(_result_object);
@@ -267,8 +267,8 @@ Pointer<Void> smoke_OuterInterface_toFfi(OuterInterface value) {
 OuterInterface smoke_OuterInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as OuterInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is OuterInterface) return instance;
   final _type_id_handle = _smoke_OuterInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -281,9 +281,9 @@ OuterInterface smoke_OuterInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_OuterInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterInterface_release_handle(handle);
-Pointer<Void> smoke_OuterInterface_toFfi_nullable(OuterInterface value) =>
+Pointer<Void> smoke_OuterInterface_toFfi_nullable(OuterInterface? value) =>
   value != null ? smoke_OuterInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-OuterInterface smoke_OuterInterface_fromFfi_nullable(Pointer<Void> handle) =>
+OuterInterface? smoke_OuterInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterInterface_fromFfi(handle) : null;
 void smoke_OuterInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -90,14 +90,14 @@ final _smoke_OuterStruct_InnerEnum_get_value_nullable = __lib.catchArgumentError
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerEnum_get_value_nullable'));
-Pointer<Void> smoke_OuterStruct_InnerEnum_toFfi_nullable(OuterStruct_InnerEnum value) {
+Pointer<Void> smoke_OuterStruct_InnerEnum_toFfi_nullable(OuterStruct_InnerEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_OuterStruct_InnerEnum_toFfi(value);
   final result = _smoke_OuterStruct_InnerEnum_create_handle_nullable(_handle);
   smoke_OuterStruct_InnerEnum_releaseFfiHandle(_handle);
   return result;
 }
-OuterStruct_InnerEnum smoke_OuterStruct_InnerEnum_fromFfi_nullable(Pointer<Void> handle) {
+OuterStruct_InnerEnum? smoke_OuterStruct_InnerEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_OuterStruct_InnerEnum_get_value_nullable(handle);
   final result = smoke_OuterStruct_InnerEnum_fromFfi(_handle);
@@ -169,14 +169,14 @@ final _smoke_OuterStruct_InnerStruct_get_value_nullable = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerStruct_get_value_nullable'));
-Pointer<Void> smoke_OuterStruct_InnerStruct_toFfi_nullable(OuterStruct_InnerStruct value) {
+Pointer<Void> smoke_OuterStruct_InnerStruct_toFfi_nullable(OuterStruct_InnerStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_OuterStruct_InnerStruct_toFfi(value);
   final result = _smoke_OuterStruct_InnerStruct_create_handle_nullable(_handle);
   smoke_OuterStruct_InnerStruct_releaseFfiHandle(_handle);
   return result;
 }
-OuterStruct_InnerStruct smoke_OuterStruct_InnerStruct_fromFfi_nullable(Pointer<Void> handle) {
+OuterStruct_InnerStruct? smoke_OuterStruct_InnerStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_OuterStruct_InnerStruct_get_value_nullable(handle);
   final result = smoke_OuterStruct_InnerStruct_fromFfi(_handle);
@@ -207,11 +207,11 @@ class OuterStruct_InnerClass$Impl extends __lib.NativeBase implements OuterStruc
   OuterStruct_InnerClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_OuterStruct_InnerClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   Set<Locale> fooBar() {
@@ -230,8 +230,8 @@ Pointer<Void> smoke_OuterStruct_InnerClass_toFfi(OuterStruct_InnerClass value) =
 OuterStruct_InnerClass smoke_OuterStruct_InnerClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as OuterStruct_InnerClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is OuterStruct_InnerClass) return instance;
   final _copied_handle = _smoke_OuterStruct_InnerClass_copy_handle(handle);
   final result = OuterStruct_InnerClass$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -239,9 +239,9 @@ OuterStruct_InnerClass smoke_OuterStruct_InnerClass_fromFfi(Pointer<Void> handle
 }
 void smoke_OuterStruct_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterStruct_InnerClass_release_handle(handle);
-Pointer<Void> smoke_OuterStruct_InnerClass_toFfi_nullable(OuterStruct_InnerClass value) =>
+Pointer<Void> smoke_OuterStruct_InnerClass_toFfi_nullable(OuterStruct_InnerClass? value) =>
   value != null ? smoke_OuterStruct_InnerClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-OuterStruct_InnerClass smoke_OuterStruct_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
+OuterStruct_InnerClass? smoke_OuterStruct_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterStruct_InnerClass_fromFfi(handle) : null;
 void smoke_OuterStruct_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterStruct_InnerClass_release_handle(handle);
@@ -249,7 +249,7 @@ void smoke_OuterStruct_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle
 abstract class OuterStruct_InnerInterface {
   OuterStruct_InnerInterface() {}
   factory OuterStruct_InnerInterface.fromLambdas({
-    @required Map<String, Uint8List> Function() lambda_barBaz,
+    required Map<String, Uint8List> Function() lambda_barBaz,
   }) => OuterStruct_InnerInterface$Lambdas(
     lambda_barBaz,
   );
@@ -292,11 +292,11 @@ class OuterStruct_InnerInterface$Impl extends __lib.NativeBase implements OuterS
   OuterStruct_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_OuterStruct_InnerInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   Map<String, Uint8List> barBaz() {
@@ -311,7 +311,7 @@ class OuterStruct_InnerInterface$Impl extends __lib.NativeBase implements OuterS
   }
 }
 int _OuterStruct_InnerInterface_barBaz_static(int _token, Pointer<Pointer<Void>> _result) {
-  Map<String, Uint8List> _result_object = null;
+  Map<String, Uint8List>? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as OuterStruct_InnerInterface).barBaz();
     _result.value = foobar_MapOf_String_to_Blob_toFfi(_result_object);
@@ -332,8 +332,8 @@ Pointer<Void> smoke_OuterStruct_InnerInterface_toFfi(OuterStruct_InnerInterface 
 OuterStruct_InnerInterface smoke_OuterStruct_InnerInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as OuterStruct_InnerInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is OuterStruct_InnerInterface) return instance;
   final _type_id_handle = _smoke_OuterStruct_InnerInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -346,9 +346,9 @@ OuterStruct_InnerInterface smoke_OuterStruct_InnerInterface_fromFfi(Pointer<Void
 }
 void smoke_OuterStruct_InnerInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_OuterStruct_InnerInterface_release_handle(handle);
-Pointer<Void> smoke_OuterStruct_InnerInterface_toFfi_nullable(OuterStruct_InnerInterface value) =>
+Pointer<Void> smoke_OuterStruct_InnerInterface_toFfi_nullable(OuterStruct_InnerInterface? value) =>
   value != null ? smoke_OuterStruct_InnerInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-OuterStruct_InnerInterface smoke_OuterStruct_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
+OuterStruct_InnerInterface? smoke_OuterStruct_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterStruct_InnerInterface_fromFfi(handle) : null;
 void smoke_OuterStruct_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_OuterStruct_InnerInterface_release_handle(handle);
@@ -396,14 +396,14 @@ final _smoke_OuterStruct_get_value_nullable = __lib.catchArgumentError(() => __l
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_get_value_nullable'));
-Pointer<Void> smoke_OuterStruct_toFfi_nullable(OuterStruct value) {
+Pointer<Void> smoke_OuterStruct_toFfi_nullable(OuterStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_OuterStruct_toFfi(value);
   final result = _smoke_OuterStruct_create_handle_nullable(_handle);
   smoke_OuterStruct_releaseFfiHandle(_handle);
   return result;
 }
-OuterStruct smoke_OuterStruct_fromFfi_nullable(Pointer<Void> handle) {
+OuterStruct? smoke_OuterStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_OuterStruct_get_value_nullable(handle);
   final result = smoke_OuterStruct_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -45,11 +45,11 @@ class UseFreeTypes$Impl extends __lib.NativeBase implements UseFreeTypes {
   UseFreeTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_UseFreeTypes_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   DateTime doStuff(FreePoint point, FreeEnum mode) {
@@ -83,8 +83,8 @@ Pointer<Void> smoke_UseFreeTypes_toFfi(UseFreeTypes value) =>
 UseFreeTypes smoke_UseFreeTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as UseFreeTypes;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is UseFreeTypes) return instance;
   final _copied_handle = _smoke_UseFreeTypes_copy_handle(handle);
   final result = UseFreeTypes$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -92,9 +92,9 @@ UseFreeTypes smoke_UseFreeTypes_fromFfi(Pointer<Void> handle) {
 }
 void smoke_UseFreeTypes_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_UseFreeTypes_release_handle(handle);
-Pointer<Void> smoke_UseFreeTypes_toFfi_nullable(UseFreeTypes value) =>
+Pointer<Void> smoke_UseFreeTypes_toFfi_nullable(UseFreeTypes? value) =>
   value != null ? smoke_UseFreeTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
-UseFreeTypes smoke_UseFreeTypes_fromFfi_nullable(Pointer<Void> handle) =>
+UseFreeTypes? smoke_UseFreeTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_UseFreeTypes_fromFfi(handle) : null;
 void smoke_UseFreeTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_UseFreeTypes_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/generic_types__conversion.dart
@@ -36,7 +36,7 @@ final _foobar_ListOf_Nullable_Date_iterator_get = __lib.catchArgumentError(() =>
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_Nullable_Date_iterator_get'));
-Pointer<Void> foobar_ListOf_Nullable_Date_toFfi(List<DateTime> value) {
+Pointer<Void> foobar_ListOf_Nullable_Date_toFfi(List<DateTime?> value) {
   final _result = _foobar_ListOf_Nullable_Date_create_handle();
   for (final element in value) {
     final _element_handle = Date_toFfi_nullable(element);
@@ -45,8 +45,8 @@ Pointer<Void> foobar_ListOf_Nullable_Date_toFfi(List<DateTime> value) {
   }
   return _result;
 }
-List<DateTime> foobar_ListOf_Nullable_Date_fromFfi(Pointer<Void> handle) {
-  final result = List<DateTime>();
+List<DateTime?> foobar_ListOf_Nullable_Date_fromFfi(Pointer<Void> handle) {
+  final result = List<DateTime?>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_Nullable_Date_iterator(handle);
   while (_foobar_ListOf_Nullable_Date_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_Nullable_Date_iterator_get(_iterator_handle);
@@ -73,14 +73,14 @@ final _foobar_ListOf_Nullable_Date_get_value_nullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Nullable_Date_get_value_nullable'));
-Pointer<Void> foobar_ListOf_Nullable_Date_toFfi_nullable(List<DateTime> value) {
+Pointer<Void> foobar_ListOf_Nullable_Date_toFfi_nullable(List<DateTime?>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_Nullable_Date_toFfi(value);
   final result = _foobar_ListOf_Nullable_Date_create_handle_nullable(_handle);
   foobar_ListOf_Nullable_Date_releaseFfiHandle(_handle);
   return result;
 }
-List<DateTime> foobar_ListOf_Nullable_Date_fromFfi_nullable(Pointer<Void> handle) {
+List<DateTime?>? foobar_ListOf_Nullable_Date_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_Nullable_Date_get_value_nullable(handle);
   final result = foobar_ListOf_Nullable_Date_fromFfi(_handle);
@@ -131,7 +131,7 @@ Pointer<Void> foobar_ListOf_String_toFfi(List<String> value) {
   return _result;
 }
 List<String> foobar_ListOf_String_fromFfi(Pointer<Void> handle) {
-  final result = List<String>();
+  final result = List<String>.empty(growable: true);
   final _iterator_handle = _foobar_ListOf_String_iterator(handle);
   while (_foobar_ListOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _element_handle = _foobar_ListOf_String_iterator_get(_iterator_handle);
@@ -158,14 +158,14 @@ final _foobar_ListOf_String_get_value_nullable = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_String_get_value_nullable'));
-Pointer<Void> foobar_ListOf_String_toFfi_nullable(List<String> value) {
+Pointer<Void> foobar_ListOf_String_toFfi_nullable(List<String>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_String_toFfi(value);
   final result = _foobar_ListOf_String_create_handle_nullable(_handle);
   foobar_ListOf_String_releaseFfiHandle(_handle);
   return result;
 }
-List<String> foobar_ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
+List<String>? foobar_ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_ListOf_String_get_value_nullable(handle);
   final result = foobar_ListOf_String_fromFfi(_handle);
@@ -210,7 +210,7 @@ final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value'));
-Pointer<Void> foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi(Map<int, Nullable_SomeStruct> value) {
+Pointer<Void> foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi(Map<int, Nullable_SomeStruct?> value) {
   final _result = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle();
   for (final entry in value.entries) {
     final _key_handle = (entry.key);
@@ -221,8 +221,8 @@ Pointer<Void> foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi(Map<i
   }
   return _result;
 }
-Map<int, Nullable_SomeStruct> foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final result = Map<int, Nullable_SomeStruct>();
+Map<int, Nullable_SomeStruct?> foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi(Pointer<Void> handle) {
+  final result = Map<int, Nullable_SomeStruct?>();
   final _iterator_handle = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator(handle);
   while (_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
     final _key_handle = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key(_iterator_handle);
@@ -252,14 +252,14 @@ final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable'));
-Pointer<Void> foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi_nullable(Map<int, Nullable_SomeStruct> value) {
+Pointer<Void> foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi_nullable(Map<int, Nullable_SomeStruct?>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi(value);
   final result = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable(_handle);
   foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, Nullable_SomeStruct> foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, Nullable_SomeStruct?>? foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable(handle);
   final result = foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi(_handle);
@@ -346,14 +346,14 @@ final _foobar_MapOf_Long_to_String_get_value_nullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Long_to_String_get_value_nullable'));
-Pointer<Void> foobar_MapOf_Long_to_String_toFfi_nullable(Map<int, String> value) {
+Pointer<Void> foobar_MapOf_Long_to_String_toFfi_nullable(Map<int, String>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Long_to_String_toFfi(value);
   final result = _foobar_MapOf_Long_to_String_create_handle_nullable(_handle);
   foobar_MapOf_Long_to_String_releaseFfiHandle(_handle);
   return result;
 }
-Map<int, String> foobar_MapOf_Long_to_String_fromFfi_nullable(Pointer<Void> handle) {
+Map<int, String>? foobar_MapOf_Long_to_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobar_MapOf_Long_to_String_get_value_nullable(handle);
   final result = foobar_MapOf_Long_to_String_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -13,36 +13,36 @@ abstract class Nullable {
   /// Call this to free memory when you no longer need this instance.
   /// Note that setting the instance to null will not destroy the underlying native object.
   void release();
-  String methodWithString(String input);
-  bool methodWithBoolean(bool input);
-  double methodWithDouble(double input);
-  int methodWithInt(int input);
-  Nullable_SomeStruct methodWithSomeStruct(Nullable_SomeStruct input);
-  Nullable_SomeEnum methodWithSomeEnum(Nullable_SomeEnum input);
-  List<String> methodWithSomeArray(List<String> input);
-  List<String> methodWithInlineArray(List<String> input);
-  Map<int, String> methodWithSomeMap(Map<int, String> input);
-  SomeInterface methodWithInstance(SomeInterface input);
-  String get stringProperty;
-  set stringProperty(String value);
-  bool get isBoolProperty;
-  set isBoolProperty(bool value);
-  double get doubleProperty;
-  set doubleProperty(double value);
-  int get intProperty;
-  set intProperty(int value);
-  Nullable_SomeStruct get structProperty;
-  set structProperty(Nullable_SomeStruct value);
-  Nullable_SomeEnum get enumProperty;
-  set enumProperty(Nullable_SomeEnum value);
-  List<String> get arrayProperty;
-  set arrayProperty(List<String> value);
-  List<String> get inlineArrayProperty;
-  set inlineArrayProperty(List<String> value);
-  Map<int, String> get mapProperty;
-  set mapProperty(Map<int, String> value);
-  SomeInterface get instanceProperty;
-  set instanceProperty(SomeInterface value);
+  String? methodWithString(String? input);
+  bool? methodWithBoolean(bool? input);
+  double? methodWithDouble(double? input);
+  int? methodWithInt(int? input);
+  Nullable_SomeStruct? methodWithSomeStruct(Nullable_SomeStruct? input);
+  Nullable_SomeEnum? methodWithSomeEnum(Nullable_SomeEnum? input);
+  List<String>? methodWithSomeArray(List<String>? input);
+  List<String>? methodWithInlineArray(List<String>? input);
+  Map<int, String>? methodWithSomeMap(Map<int, String>? input);
+  SomeInterface? methodWithInstance(SomeInterface? input);
+  String? get stringProperty;
+  set stringProperty(String? value);
+  bool? get isBoolProperty;
+  set isBoolProperty(bool? value);
+  double? get doubleProperty;
+  set doubleProperty(double? value);
+  int? get intProperty;
+  set intProperty(int? value);
+  Nullable_SomeStruct? get structProperty;
+  set structProperty(Nullable_SomeStruct? value);
+  Nullable_SomeEnum? get enumProperty;
+  set enumProperty(Nullable_SomeEnum? value);
+  List<String>? get arrayProperty;
+  set arrayProperty(List<String>? value);
+  List<String>? get inlineArrayProperty;
+  set inlineArrayProperty(List<String>? value);
+  Map<int, String>? get mapProperty;
+  set mapProperty(Map<int, String>? value);
+  SomeInterface? get instanceProperty;
+  set instanceProperty(SomeInterface? value);
 }
 enum Nullable_SomeEnum {
     on,
@@ -86,14 +86,14 @@ final _smoke_Nullable_SomeEnum_get_value_nullable = __lib.catchArgumentError(() 
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeEnum_get_value_nullable'));
-Pointer<Void> smoke_Nullable_SomeEnum_toFfi_nullable(Nullable_SomeEnum value) {
+Pointer<Void> smoke_Nullable_SomeEnum_toFfi_nullable(Nullable_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Nullable_SomeEnum_toFfi(value);
   final result = _smoke_Nullable_SomeEnum_create_handle_nullable(_handle);
   smoke_Nullable_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
-Nullable_SomeEnum smoke_Nullable_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
+Nullable_SomeEnum? smoke_Nullable_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Nullable_SomeEnum_get_value_nullable(handle);
   final result = smoke_Nullable_SomeEnum_fromFfi(_handle);
@@ -150,14 +150,14 @@ final _smoke_Nullable_SomeStruct_get_value_nullable = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_Nullable_SomeStruct_toFfi_nullable(Nullable_SomeStruct value) {
+Pointer<Void> smoke_Nullable_SomeStruct_toFfi_nullable(Nullable_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Nullable_SomeStruct_toFfi(value);
   final result = _smoke_Nullable_SomeStruct_create_handle_nullable(_handle);
   smoke_Nullable_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-Nullable_SomeStruct smoke_Nullable_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+Nullable_SomeStruct? smoke_Nullable_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Nullable_SomeStruct_get_value_nullable(handle);
   final result = smoke_Nullable_SomeStruct_fromFfi(_handle);
@@ -168,15 +168,15 @@ void smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =
   _smoke_Nullable_SomeStruct_release_handle_nullable(handle);
 // End of Nullable_SomeStruct "private" section.
 class Nullable_NullableStruct {
-  String stringField;
-  bool boolField;
-  double doubleField;
-  Nullable_SomeStruct structField;
-  Nullable_SomeEnum enumField;
-  List<String> arrayField;
-  List<String> inlineArrayField;
-  Map<int, String> mapField;
-  SomeInterface instanceField;
+  String? stringField;
+  bool? boolField;
+  double? doubleField;
+  Nullable_SomeStruct? structField;
+  Nullable_SomeEnum? enumField;
+  List<String>? arrayField;
+  List<String>? inlineArrayField;
+  Map<int, String>? mapField;
+  SomeInterface? instanceField;
   Nullable_NullableStruct(this.stringField, this.boolField, this.doubleField, this.structField, this.enumField, this.arrayField, this.inlineArrayField, this.mapField, this.instanceField);
 }
 // Nullable_NullableStruct "private" section, not exported.
@@ -294,14 +294,14 @@ final _smoke_Nullable_NullableStruct_get_value_nullable = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_value_nullable'));
-Pointer<Void> smoke_Nullable_NullableStruct_toFfi_nullable(Nullable_NullableStruct value) {
+Pointer<Void> smoke_Nullable_NullableStruct_toFfi_nullable(Nullable_NullableStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Nullable_NullableStruct_toFfi(value);
   final result = _smoke_Nullable_NullableStruct_create_handle_nullable(_handle);
   smoke_Nullable_NullableStruct_releaseFfiHandle(_handle);
   return result;
 }
-Nullable_NullableStruct smoke_Nullable_NullableStruct_fromFfi_nullable(Pointer<Void> handle) {
+Nullable_NullableStruct? smoke_Nullable_NullableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Nullable_NullableStruct_get_value_nullable(handle);
   final result = smoke_Nullable_NullableStruct_fromFfi(_handle);
@@ -312,14 +312,14 @@ void smoke_Nullable_NullableStruct_releaseFfiHandle_nullable(Pointer<Void> handl
   _smoke_Nullable_NullableStruct_release_handle_nullable(handle);
 // End of Nullable_NullableStruct "private" section.
 class Nullable_NullableIntsStruct {
-  int int8Field;
-  int int16Field;
-  int int32Field;
-  int int64Field;
-  int uint8Field;
-  int uint16Field;
-  int uint32Field;
-  int uint64Field;
+  int? int8Field;
+  int? int16Field;
+  int? int32Field;
+  int? int64Field;
+  int? uint8Field;
+  int? uint16Field;
+  int? uint32Field;
+  int? uint64Field;
   Nullable_NullableIntsStruct(this.int8Field, this.int16Field, this.int32Field, this.int64Field, this.uint8Field, this.uint16Field, this.uint32Field, this.uint64Field);
 }
 // Nullable_NullableIntsStruct "private" section, not exported.
@@ -428,14 +428,14 @@ final _smoke_Nullable_NullableIntsStruct_get_value_nullable = __lib.catchArgumen
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_get_value_nullable'));
-Pointer<Void> smoke_Nullable_NullableIntsStruct_toFfi_nullable(Nullable_NullableIntsStruct value) {
+Pointer<Void> smoke_Nullable_NullableIntsStruct_toFfi_nullable(Nullable_NullableIntsStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Nullable_NullableIntsStruct_toFfi(value);
   final result = _smoke_Nullable_NullableIntsStruct_create_handle_nullable(_handle);
   smoke_Nullable_NullableIntsStruct_releaseFfiHandle(_handle);
   return result;
 }
-Nullable_NullableIntsStruct smoke_Nullable_NullableIntsStruct_fromFfi_nullable(Pointer<Void> handle) {
+Nullable_NullableIntsStruct? smoke_Nullable_NullableIntsStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Nullable_NullableIntsStruct_get_value_nullable(handle);
   final result = smoke_Nullable_NullableIntsStruct_fromFfi(_handle);
@@ -458,14 +458,14 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
   Nullable$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_Nullable_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
-  String methodWithString(String input) {
+  String? methodWithString(String? input) {
     final _methodWithString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithString__String'));
     final _input_handle = String_toFfi_nullable(input);
     final _handle = this.handle;
@@ -478,7 +478,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  bool methodWithBoolean(bool input) {
+  bool? methodWithBoolean(bool? input) {
     final _methodWithBoolean_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithBoolean__Boolean'));
     final _input_handle = Boolean_toFfi_nullable(input);
     final _handle = this.handle;
@@ -491,7 +491,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  double methodWithDouble(double input) {
+  double? methodWithDouble(double? input) {
     final _methodWithDouble_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithDouble__Double'));
     final _input_handle = Double_toFfi_nullable(input);
     final _handle = this.handle;
@@ -504,7 +504,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  int methodWithInt(int input) {
+  int? methodWithInt(int? input) {
     final _methodWithInt_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInt__Long'));
     final _input_handle = Long_toFfi_nullable(input);
     final _handle = this.handle;
@@ -517,7 +517,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  Nullable_SomeStruct methodWithSomeStruct(Nullable_SomeStruct input) {
+  Nullable_SomeStruct? methodWithSomeStruct(Nullable_SomeStruct? input) {
     final _methodWithSomeStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeStruct__SomeStruct'));
     final _input_handle = smoke_Nullable_SomeStruct_toFfi_nullable(input);
     final _handle = this.handle;
@@ -530,7 +530,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  Nullable_SomeEnum methodWithSomeEnum(Nullable_SomeEnum input) {
+  Nullable_SomeEnum? methodWithSomeEnum(Nullable_SomeEnum? input) {
     final _methodWithSomeEnum_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeEnum__SomeEnum'));
     final _input_handle = smoke_Nullable_SomeEnum_toFfi_nullable(input);
     final _handle = this.handle;
@@ -543,7 +543,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  List<String> methodWithSomeArray(List<String> input) {
+  List<String>? methodWithSomeArray(List<String>? input) {
     final _methodWithSomeArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeArray__ListOf_1String'));
     final _input_handle = foobar_ListOf_String_toFfi_nullable(input);
     final _handle = this.handle;
@@ -556,7 +556,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  List<String> methodWithInlineArray(List<String> input) {
+  List<String>? methodWithInlineArray(List<String>? input) {
     final _methodWithInlineArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInlineArray__ListOf_1String'));
     final _input_handle = foobar_ListOf_String_toFfi_nullable(input);
     final _handle = this.handle;
@@ -569,7 +569,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  Map<int, String> methodWithSomeMap(Map<int, String> input) {
+  Map<int, String>? methodWithSomeMap(Map<int, String>? input) {
     final _methodWithSomeMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeMap__MapOf_1Long_1to_1String'));
     final _input_handle = foobar_MapOf_Long_to_String_toFfi_nullable(input);
     final _handle = this.handle;
@@ -582,7 +582,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  SomeInterface methodWithInstance(SomeInterface input) {
+  SomeInterface? methodWithInstance(SomeInterface? input) {
     final _methodWithInstance_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInstance__SomeInterface'));
     final _input_handle = smoke_SomeInterface_toFfi_nullable(input);
     final _handle = this.handle;
@@ -595,7 +595,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  String get stringProperty {
+  String? get stringProperty {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_stringProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
@@ -606,7 +606,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  set stringProperty(String value) {
+  set stringProperty(String? value) {
     final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_stringProperty_set__String'));
     final _value_handle = String_toFfi_nullable(value);
     final _handle = this.handle;
@@ -619,7 +619,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  bool get isBoolProperty {
+  bool? get isBoolProperty {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_isBoolProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
@@ -630,7 +630,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  set isBoolProperty(bool value) {
+  set isBoolProperty(bool? value) {
     final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_isBoolProperty_set__Boolean'));
     final _value_handle = Boolean_toFfi_nullable(value);
     final _handle = this.handle;
@@ -643,7 +643,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  double get doubleProperty {
+  double? get doubleProperty {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_doubleProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
@@ -654,7 +654,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  set doubleProperty(double value) {
+  set doubleProperty(double? value) {
     final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_doubleProperty_set__Double'));
     final _value_handle = Double_toFfi_nullable(value);
     final _handle = this.handle;
@@ -667,7 +667,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  int get intProperty {
+  int? get intProperty {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_intProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
@@ -678,7 +678,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  set intProperty(int value) {
+  set intProperty(int? value) {
     final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_intProperty_set__Long'));
     final _value_handle = Long_toFfi_nullable(value);
     final _handle = this.handle;
@@ -691,7 +691,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  Nullable_SomeStruct get structProperty {
+  Nullable_SomeStruct? get structProperty {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_structProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
@@ -702,7 +702,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  set structProperty(Nullable_SomeStruct value) {
+  set structProperty(Nullable_SomeStruct? value) {
     final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_structProperty_set__SomeStruct'));
     final _value_handle = smoke_Nullable_SomeStruct_toFfi_nullable(value);
     final _handle = this.handle;
@@ -715,7 +715,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  Nullable_SomeEnum get enumProperty {
+  Nullable_SomeEnum? get enumProperty {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_enumProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
@@ -726,7 +726,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  set enumProperty(Nullable_SomeEnum value) {
+  set enumProperty(Nullable_SomeEnum? value) {
     final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_enumProperty_set__SomeEnum'));
     final _value_handle = smoke_Nullable_SomeEnum_toFfi_nullable(value);
     final _handle = this.handle;
@@ -739,7 +739,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  List<String> get arrayProperty {
+  List<String>? get arrayProperty {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_arrayProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
@@ -750,7 +750,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  set arrayProperty(List<String> value) {
+  set arrayProperty(List<String>? value) {
     final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_arrayProperty_set__ListOf_1String'));
     final _value_handle = foobar_ListOf_String_toFfi_nullable(value);
     final _handle = this.handle;
@@ -763,7 +763,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  List<String> get inlineArrayProperty {
+  List<String>? get inlineArrayProperty {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_inlineArrayProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
@@ -774,7 +774,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  set inlineArrayProperty(List<String> value) {
+  set inlineArrayProperty(List<String>? value) {
     final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_inlineArrayProperty_set__ListOf_1String'));
     final _value_handle = foobar_ListOf_String_toFfi_nullable(value);
     final _handle = this.handle;
@@ -787,7 +787,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  Map<int, String> get mapProperty {
+  Map<int, String>? get mapProperty {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_mapProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
@@ -798,7 +798,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  set mapProperty(Map<int, String> value) {
+  set mapProperty(Map<int, String>? value) {
     final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_mapProperty_set__MapOf_1Long_1to_1String'));
     final _value_handle = foobar_MapOf_Long_to_String_toFfi_nullable(value);
     final _handle = this.handle;
@@ -811,7 +811,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  SomeInterface get instanceProperty {
+  SomeInterface? get instanceProperty {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_instanceProperty_get'));
     final _handle = this.handle;
     final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
@@ -822,7 +822,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  set instanceProperty(SomeInterface value) {
+  set instanceProperty(SomeInterface? value) {
     final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_instanceProperty_set__SomeInterface'));
     final _value_handle = smoke_SomeInterface_toFfi_nullable(value);
     final _handle = this.handle;
@@ -840,8 +840,8 @@ Pointer<Void> smoke_Nullable_toFfi(Nullable value) =>
 Nullable smoke_Nullable_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Nullable;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Nullable) return instance;
   final _copied_handle = _smoke_Nullable_copy_handle(handle);
   final result = Nullable$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -849,9 +849,9 @@ Nullable smoke_Nullable_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Nullable_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Nullable_release_handle(handle);
-Pointer<Void> smoke_Nullable_toFfi_nullable(Nullable value) =>
+Pointer<Void> smoke_Nullable_toFfi_nullable(Nullable? value) =>
   value != null ? smoke_Nullable_toFfi(value) : Pointer<Void>.fromAddress(0);
-Nullable smoke_Nullable_fromFfi_nullable(Pointer<Void> handle) =>
+Nullable? smoke_Nullable_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Nullable_fromFfi(handle) : null;
 void smoke_Nullable_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Nullable_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
@@ -60,14 +60,14 @@ final _smoke_off_NestedPackages_SomeStruct_get_value_nullable = __lib.catchArgum
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_SomeStruct_get_value_nullable'));
-Pointer<Void> smoke_off_NestedPackages_SomeStruct_toFfi_nullable(NestedPackages_SomeStruct value) {
+Pointer<Void> smoke_off_NestedPackages_SomeStruct_toFfi_nullable(NestedPackages_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_off_NestedPackages_SomeStruct_toFfi(value);
   final result = _smoke_off_NestedPackages_SomeStruct_create_handle_nullable(_handle);
   smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
-NestedPackages_SomeStruct smoke_off_NestedPackages_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
+NestedPackages_SomeStruct? smoke_off_NestedPackages_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_off_NestedPackages_SomeStruct_get_value_nullable(handle);
   final result = smoke_off_NestedPackages_SomeStruct_fromFfi(_handle);
@@ -90,11 +90,11 @@ class NestedPackages$Impl extends __lib.NativeBase implements NestedPackages {
   NestedPackages$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_off_NestedPackages_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static NestedPackages_SomeStruct basicMethod(NestedPackages_SomeStruct input) {
     final _basicMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_off_NestedPackages_basicMethod__SomeStruct'));
@@ -113,8 +113,8 @@ Pointer<Void> smoke_off_NestedPackages_toFfi(NestedPackages value) =>
 NestedPackages smoke_off_NestedPackages_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as NestedPackages;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is NestedPackages) return instance;
   final _copied_handle = _smoke_off_NestedPackages_copy_handle(handle);
   final result = NestedPackages$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -122,9 +122,9 @@ NestedPackages smoke_off_NestedPackages_fromFfi(Pointer<Void> handle) {
 }
 void smoke_off_NestedPackages_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_off_NestedPackages_release_handle(handle);
-Pointer<Void> smoke_off_NestedPackages_toFfi_nullable(NestedPackages value) =>
+Pointer<Void> smoke_off_NestedPackages_toFfi_nullable(NestedPackages? value) =>
   value != null ? smoke_off_NestedPackages_toFfi(value) : Pointer<Void>.fromAddress(0);
-NestedPackages smoke_off_NestedPackages_fromFfi_nullable(Pointer<Void> handle) =>
+NestedPackages? smoke_off_NestedPackages_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_off_NestedPackages_fromFfi(handle) : null;
 void smoke_off_NestedPackages_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_off_NestedPackages_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -30,11 +30,11 @@ class weeInterface$Impl extends __lib.NativeBase implements weeInterface {
   weeInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_PlatformNamesInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   weeInterface$Impl.make(String makeParameter) : super(_make(makeParameter)) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
@@ -89,8 +89,8 @@ Pointer<Void> smoke_PlatformNamesInterface_toFfi(weeInterface value) =>
 weeInterface smoke_PlatformNamesInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as weeInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is weeInterface) return instance;
   final _copied_handle = _smoke_PlatformNamesInterface_copy_handle(handle);
   final result = weeInterface$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -98,9 +98,9 @@ weeInterface smoke_PlatformNamesInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_PlatformNamesInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_PlatformNamesInterface_release_handle(handle);
-Pointer<Void> smoke_PlatformNamesInterface_toFfi_nullable(weeInterface value) =>
+Pointer<Void> smoke_PlatformNamesInterface_toFfi_nullable(weeInterface? value) =>
   value != null ? smoke_PlatformNamesInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-weeInterface smoke_PlatformNamesInterface_fromFfi_nullable(Pointer<Void> handle) =>
+weeInterface? smoke_PlatformNamesInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_PlatformNamesInterface_fromFfi(handle) : null;
 void smoke_PlatformNamesInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_PlatformNamesInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -9,7 +9,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class weeListener {
   weeListener() {}
   factory weeListener.fromLambdas({
-    @required void Function(String) lambda_WeeMethod,
+    required void Function(String) lambda_WeeMethod,
   }) => weeListener$Lambdas(
     lambda_WeeMethod,
   );
@@ -52,11 +52,11 @@ class weeListener$Impl extends __lib.NativeBase implements weeListener {
   weeListener$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_PlatformNamesListener_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   WeeMethod(String WeeParameter) {
@@ -93,8 +93,8 @@ Pointer<Void> smoke_PlatformNamesListener_toFfi(weeListener value) {
 weeListener smoke_PlatformNamesListener_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as weeListener;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is weeListener) return instance;
   final _type_id_handle = _smoke_PlatformNamesListener_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -107,9 +107,9 @@ weeListener smoke_PlatformNamesListener_fromFfi(Pointer<Void> handle) {
 }
 void smoke_PlatformNamesListener_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_PlatformNamesListener_release_handle(handle);
-Pointer<Void> smoke_PlatformNamesListener_toFfi_nullable(weeListener value) =>
+Pointer<Void> smoke_PlatformNamesListener_toFfi_nullable(weeListener? value) =>
   value != null ? smoke_PlatformNamesListener_toFfi(value) : Pointer<Void>.fromAddress(0);
-weeListener smoke_PlatformNamesListener_fromFfi_nullable(Pointer<Void> handle) =>
+weeListener? smoke_PlatformNamesListener_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_PlatformNamesListener_fromFfi(handle) : null;
 void smoke_PlatformNamesListener_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_PlatformNamesListener_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
@@ -38,14 +38,14 @@ final _smoke_PlatformNames_BasicEnum_get_value_nullable = __lib.catchArgumentErr
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicEnum_get_value_nullable'));
-Pointer<Void> smoke_PlatformNames_BasicEnum_toFfi_nullable(werrEnum value) {
+Pointer<Void> smoke_PlatformNames_BasicEnum_toFfi_nullable(werrEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PlatformNames_BasicEnum_toFfi(value);
   final result = _smoke_PlatformNames_BasicEnum_create_handle_nullable(_handle);
   smoke_PlatformNames_BasicEnum_releaseFfiHandle(_handle);
   return result;
 }
-werrEnum smoke_PlatformNames_BasicEnum_fromFfi_nullable(Pointer<Void> handle) {
+werrEnum? smoke_PlatformNames_BasicEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_PlatformNames_BasicEnum_get_value_nullable(handle);
   final result = smoke_PlatformNames_BasicEnum_fromFfi(_handle);
@@ -115,14 +115,14 @@ final _smoke_PlatformNames_BasicStruct_get_value_nullable = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicStruct_get_value_nullable'));
-Pointer<Void> smoke_PlatformNames_BasicStruct_toFfi_nullable(weeStruct value) {
+Pointer<Void> smoke_PlatformNames_BasicStruct_toFfi_nullable(weeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PlatformNames_BasicStruct_toFfi(value);
   final result = _smoke_PlatformNames_BasicStruct_create_handle_nullable(_handle);
   smoke_PlatformNames_BasicStruct_releaseFfiHandle(_handle);
   return result;
 }
-weeStruct smoke_PlatformNames_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
+weeStruct? smoke_PlatformNames_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_PlatformNames_BasicStruct_get_value_nullable(handle);
   final result = smoke_PlatformNames_BasicStruct_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
@@ -29,13 +29,13 @@ class CachedProperties$Impl extends __lib.NativeBase implements CachedProperties
   CachedProperties$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_CachedProperties_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
-  List<String> _cache_cachedProperty;
+  late List<String> _cache_cachedProperty;
   bool _is_cached_cachedProperty = false;
   @override
   List<String> get cachedProperty {
@@ -51,7 +51,7 @@ class CachedProperties$Impl extends __lib.NativeBase implements CachedProperties
     }
     return _cache_cachedProperty;
   }
-  static Uint8List _cache_staticCachedProperty;
+  static late Uint8List _cache_staticCachedProperty;
   static bool _is_cached_staticCachedProperty = false;
   static Uint8List get staticCachedProperty {
     if (!_is_cached_staticCachedProperty) {
@@ -72,8 +72,8 @@ Pointer<Void> smoke_CachedProperties_toFfi(CachedProperties value) =>
 CachedProperties smoke_CachedProperties_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as CachedProperties;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is CachedProperties) return instance;
   final _copied_handle = _smoke_CachedProperties_copy_handle(handle);
   final result = CachedProperties$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -81,9 +81,9 @@ CachedProperties smoke_CachedProperties_fromFfi(Pointer<Void> handle) {
 }
 void smoke_CachedProperties_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_CachedProperties_release_handle(handle);
-Pointer<Void> smoke_CachedProperties_toFfi_nullable(CachedProperties value) =>
+Pointer<Void> smoke_CachedProperties_toFfi_nullable(CachedProperties? value) =>
   value != null ? smoke_CachedProperties_toFfi(value) : Pointer<Void>.fromAddress(0);
-CachedProperties smoke_CachedProperties_fromFfi_nullable(Pointer<Void> handle) =>
+CachedProperties? smoke_CachedProperties_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_CachedProperties_fromFfi(handle) : null;
 void smoke_CachedProperties_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_CachedProperties_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -75,14 +75,14 @@ final _smoke_Properties_InternalErrorCode_get_value_nullable = __lib.catchArgume
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Properties_InternalErrorCode_get_value_nullable'));
-Pointer<Void> smoke_Properties_InternalErrorCode_toFfi_nullable(Properties_InternalErrorCode value) {
+Pointer<Void> smoke_Properties_InternalErrorCode_toFfi_nullable(Properties_InternalErrorCode? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Properties_InternalErrorCode_toFfi(value);
   final result = _smoke_Properties_InternalErrorCode_create_handle_nullable(_handle);
   smoke_Properties_InternalErrorCode_releaseFfiHandle(_handle);
   return result;
 }
-Properties_InternalErrorCode smoke_Properties_InternalErrorCode_fromFfi_nullable(Pointer<Void> handle) {
+Properties_InternalErrorCode? smoke_Properties_InternalErrorCode_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Properties_InternalErrorCode_get_value_nullable(handle);
   final result = smoke_Properties_InternalErrorCode_fromFfi(_handle);
@@ -139,14 +139,14 @@ final _smoke_Properties_ExampleStruct_get_value_nullable = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Properties_ExampleStruct_get_value_nullable'));
-Pointer<Void> smoke_Properties_ExampleStruct_toFfi_nullable(Properties_ExampleStruct value) {
+Pointer<Void> smoke_Properties_ExampleStruct_toFfi_nullable(Properties_ExampleStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Properties_ExampleStruct_toFfi(value);
   final result = _smoke_Properties_ExampleStruct_create_handle_nullable(_handle);
   smoke_Properties_ExampleStruct_releaseFfiHandle(_handle);
   return result;
 }
-Properties_ExampleStruct smoke_Properties_ExampleStruct_fromFfi_nullable(Pointer<Void> handle) {
+Properties_ExampleStruct? smoke_Properties_ExampleStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Properties_ExampleStruct_get_value_nullable(handle);
   final result = smoke_Properties_ExampleStruct_fromFfi(_handle);
@@ -169,11 +169,11 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
   Properties$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_Properties_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   int get builtInTypeProperty {
@@ -389,8 +389,8 @@ Pointer<Void> smoke_Properties_toFfi(Properties value) =>
 Properties smoke_Properties_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Properties;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Properties) return instance;
   final _copied_handle = _smoke_Properties_copy_handle(handle);
   final result = Properties$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -398,9 +398,9 @@ Properties smoke_Properties_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Properties_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Properties_release_handle(handle);
-Pointer<Void> smoke_Properties_toFfi_nullable(Properties value) =>
+Pointer<Void> smoke_Properties_toFfi_nullable(Properties? value) =>
   value != null ? smoke_Properties_toFfi(value) : Pointer<Void>.fromAddress(0);
-Properties smoke_Properties_fromFfi_nullable(Pointer<Void> handle) =>
+Properties? smoke_Properties_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Properties_fromFfi(handle) : null;
 void smoke_Properties_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Properties_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -9,8 +9,8 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class PropertiesInterface {
   PropertiesInterface() {}
   factory PropertiesInterface.fromLambdas({
-    @required PropertiesInterface_ExampleStruct Function() lambda_structProperty_get,
-    @required void Function(PropertiesInterface_ExampleStruct) lambda_structProperty_set
+    required PropertiesInterface_ExampleStruct Function() lambda_structProperty_get,
+    required void Function(PropertiesInterface_ExampleStruct) lambda_structProperty_set
   }) => PropertiesInterface$Lambdas(
     lambda_structProperty_get,
     lambda_structProperty_set
@@ -70,14 +70,14 @@ final _smoke_PropertiesInterface_ExampleStruct_get_value_nullable = __lib.catchA
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_ExampleStruct_get_value_nullable'));
-Pointer<Void> smoke_PropertiesInterface_ExampleStruct_toFfi_nullable(PropertiesInterface_ExampleStruct value) {
+Pointer<Void> smoke_PropertiesInterface_ExampleStruct_toFfi_nullable(PropertiesInterface_ExampleStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PropertiesInterface_ExampleStruct_toFfi(value);
   final result = _smoke_PropertiesInterface_ExampleStruct_create_handle_nullable(_handle);
   smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(_handle);
   return result;
 }
-PropertiesInterface_ExampleStruct smoke_PropertiesInterface_ExampleStruct_fromFfi_nullable(Pointer<Void> handle) {
+PropertiesInterface_ExampleStruct? smoke_PropertiesInterface_ExampleStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_PropertiesInterface_ExampleStruct_get_value_nullable(handle);
   final result = smoke_PropertiesInterface_ExampleStruct_fromFfi(_handle);
@@ -122,11 +122,11 @@ class PropertiesInterface$Impl extends __lib.NativeBase implements PropertiesInt
   PropertiesInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_PropertiesInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   PropertiesInterface_ExampleStruct get structProperty {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PropertiesInterface_structProperty_get'));
@@ -178,8 +178,8 @@ Pointer<Void> smoke_PropertiesInterface_toFfi(PropertiesInterface value) {
 PropertiesInterface smoke_PropertiesInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as PropertiesInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is PropertiesInterface) return instance;
   final _type_id_handle = _smoke_PropertiesInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -192,9 +192,9 @@ PropertiesInterface smoke_PropertiesInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_PropertiesInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_PropertiesInterface_release_handle(handle);
-Pointer<Void> smoke_PropertiesInterface_toFfi_nullable(PropertiesInterface value) =>
+Pointer<Void> smoke_PropertiesInterface_toFfi_nullable(PropertiesInterface? value) =>
   value != null ? smoke_PropertiesInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-PropertiesInterface smoke_PropertiesInterface_fromFfi_nullable(Pointer<Void> handle) =>
+PropertiesInterface? smoke_PropertiesInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_PropertiesInterface_fromFfi(handle) : null;
 void smoke_PropertiesInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_PropertiesInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
@@ -32,11 +32,11 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
   EnableIfEnabled$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_EnableIfEnabled_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static enableIfUnquoted() {
     final _enableIfUnquoted_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfUnquoted'));
@@ -107,8 +107,8 @@ Pointer<Void> smoke_EnableIfEnabled_toFfi(EnableIfEnabled value) =>
 EnableIfEnabled smoke_EnableIfEnabled_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as EnableIfEnabled;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is EnableIfEnabled) return instance;
   final _copied_handle = _smoke_EnableIfEnabled_copy_handle(handle);
   final result = EnableIfEnabled$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -116,9 +116,9 @@ EnableIfEnabled smoke_EnableIfEnabled_fromFfi(Pointer<Void> handle) {
 }
 void smoke_EnableIfEnabled_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_EnableIfEnabled_release_handle(handle);
-Pointer<Void> smoke_EnableIfEnabled_toFfi_nullable(EnableIfEnabled value) =>
+Pointer<Void> smoke_EnableIfEnabled_toFfi_nullable(EnableIfEnabled? value) =>
   value != null ? smoke_EnableIfEnabled_toFfi(value) : Pointer<Void>.fromAddress(0);
-EnableIfEnabled smoke_EnableIfEnabled_fromFfi_nullable(Pointer<Void> handle) =>
+EnableIfEnabled? smoke_EnableIfEnabled_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_EnableIfEnabled_fromFfi(handle) : null;
 void smoke_EnableIfEnabled_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_EnableIfEnabled_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
@@ -24,11 +24,11 @@ class EnableIfSkipped$Impl extends __lib.NativeBase implements EnableIfSkipped {
   EnableIfSkipped$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_EnableIfSkipped_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 }
 Pointer<Void> smoke_EnableIfSkipped_toFfi(EnableIfSkipped value) =>
@@ -36,8 +36,8 @@ Pointer<Void> smoke_EnableIfSkipped_toFfi(EnableIfSkipped value) =>
 EnableIfSkipped smoke_EnableIfSkipped_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as EnableIfSkipped;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is EnableIfSkipped) return instance;
   final _copied_handle = _smoke_EnableIfSkipped_copy_handle(handle);
   final result = EnableIfSkipped$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -45,9 +45,9 @@ EnableIfSkipped smoke_EnableIfSkipped_fromFfi(Pointer<Void> handle) {
 }
 void smoke_EnableIfSkipped_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_EnableIfSkipped_release_handle(handle);
-Pointer<Void> smoke_EnableIfSkipped_toFfi_nullable(EnableIfSkipped value) =>
+Pointer<Void> smoke_EnableIfSkipped_toFfi_nullable(EnableIfSkipped? value) =>
   value != null ? smoke_EnableIfSkipped_toFfi(value) : Pointer<Void>.fromAddress(0);
-EnableIfSkipped smoke_EnableIfSkipped_fromFfi_nullable(Pointer<Void> handle) =>
+EnableIfSkipped? smoke_EnableIfSkipped_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_EnableIfSkipped_fromFfi(handle) : null;
 void smoke_EnableIfSkipped_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_EnableIfSkipped_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -10,12 +10,12 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class InheritFromSkipped implements SkipProxy {
   InheritFromSkipped() {}
   factory InheritFromSkipped.fromLambdas({
-    @required String Function(String) lambda_notInJava,
-    @required bool Function(bool) lambda_notInSwift,
-    @required String Function() lambda_skippedInJava_get,
-    @required void Function(String) lambda_skippedInJava_set,
-    @required bool Function() lambda_isSkippedInSwift_get,
-    @required void Function(bool) lambda_isSkippedInSwift_set
+    required String Function(String) lambda_notInJava,
+    required bool Function(bool) lambda_notInSwift,
+    required String Function() lambda_skippedInJava_get,
+    required void Function(String) lambda_skippedInJava_set,
+    required bool Function() lambda_isSkippedInSwift_get,
+    required void Function(bool) lambda_isSkippedInSwift_set
   }) => InheritFromSkipped$Lambdas(
     lambda_notInJava,
     lambda_notInSwift,
@@ -83,11 +83,11 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
   InheritFromSkipped$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_InheritFromSkipped_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String notInJava(String input) {
@@ -161,7 +161,7 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
   }
 }
 int _InheritFromSkipped_notInJava_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as InheritFromSkipped).notInJava(String_fromFfi(input));
     _result.value = String_toFfi(_result_object);
@@ -171,7 +171,7 @@ int _InheritFromSkipped_notInJava_static(int _token, Pointer<Void> input, Pointe
   return 0;
 }
 int _InheritFromSkipped_notInSwift_static(int _token, int input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as InheritFromSkipped).notInSwift(Boolean_fromFfi(input));
     _result.value = Boolean_toFfi(_result_object);
@@ -224,8 +224,8 @@ Pointer<Void> smoke_InheritFromSkipped_toFfi(InheritFromSkipped value) {
 InheritFromSkipped smoke_InheritFromSkipped_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as InheritFromSkipped;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is InheritFromSkipped) return instance;
   final _type_id_handle = _smoke_InheritFromSkipped_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -238,9 +238,9 @@ InheritFromSkipped smoke_InheritFromSkipped_fromFfi(Pointer<Void> handle) {
 }
 void smoke_InheritFromSkipped_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_InheritFromSkipped_release_handle(handle);
-Pointer<Void> smoke_InheritFromSkipped_toFfi_nullable(InheritFromSkipped value) =>
+Pointer<Void> smoke_InheritFromSkipped_toFfi_nullable(InheritFromSkipped? value) =>
   value != null ? smoke_InheritFromSkipped_toFfi(value) : Pointer<Void>.fromAddress(0);
-InheritFromSkipped smoke_InheritFromSkipped_fromFfi_nullable(Pointer<Void> handle) =>
+InheritFromSkipped? smoke_InheritFromSkipped_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InheritFromSkipped_fromFfi(handle) : null;
 void smoke_InheritFromSkipped_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_InheritFromSkipped_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_auto_tag.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_auto_tag.dart
@@ -44,14 +44,14 @@ final _smoke_SkipEnumeratorAutoTag_get_value_nullable = __lib.catchArgumentError
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_SkipEnumeratorAutoTag_get_value_nullable'));
-Pointer<Void> smoke_SkipEnumeratorAutoTag_toFfi_nullable(SkipEnumeratorAutoTag value) {
+Pointer<Void> smoke_SkipEnumeratorAutoTag_toFfi_nullable(SkipEnumeratorAutoTag? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SkipEnumeratorAutoTag_toFfi(value);
   final result = _smoke_SkipEnumeratorAutoTag_create_handle_nullable(_handle);
   smoke_SkipEnumeratorAutoTag_releaseFfiHandle(_handle);
   return result;
 }
-SkipEnumeratorAutoTag smoke_SkipEnumeratorAutoTag_fromFfi_nullable(Pointer<Void> handle) {
+SkipEnumeratorAutoTag? smoke_SkipEnumeratorAutoTag_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_SkipEnumeratorAutoTag_get_value_nullable(handle);
   final result = smoke_SkipEnumeratorAutoTag_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_explicit_tag.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_explicit_tag.dart
@@ -51,14 +51,14 @@ final _smoke_SkipEnumeratorExplicitTag_get_value_nullable = __lib.catchArgumentE
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_SkipEnumeratorExplicitTag_get_value_nullable'));
-Pointer<Void> smoke_SkipEnumeratorExplicitTag_toFfi_nullable(SkipEnumeratorExplicitTag value) {
+Pointer<Void> smoke_SkipEnumeratorExplicitTag_toFfi_nullable(SkipEnumeratorExplicitTag? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SkipEnumeratorExplicitTag_toFfi(value);
   final result = _smoke_SkipEnumeratorExplicitTag_create_handle_nullable(_handle);
   smoke_SkipEnumeratorExplicitTag_releaseFfiHandle(_handle);
   return result;
 }
-SkipEnumeratorExplicitTag smoke_SkipEnumeratorExplicitTag_fromFfi_nullable(Pointer<Void> handle) {
+SkipEnumeratorExplicitTag? smoke_SkipEnumeratorExplicitTag_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_SkipEnumeratorExplicitTag_get_value_nullable(handle);
   final result = smoke_SkipEnumeratorExplicitTag_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -27,11 +27,11 @@ class SkipFunctions$Impl extends __lib.NativeBase implements SkipFunctions {
   SkipFunctions$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_SkipFunctions_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static String notInJava(String input) {
     final _notInJava_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_SkipFunctions_notInJava__String'));
@@ -61,8 +61,8 @@ Pointer<Void> smoke_SkipFunctions_toFfi(SkipFunctions value) =>
 SkipFunctions smoke_SkipFunctions_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as SkipFunctions;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is SkipFunctions) return instance;
   final _copied_handle = _smoke_SkipFunctions_copy_handle(handle);
   final result = SkipFunctions$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -70,9 +70,9 @@ SkipFunctions smoke_SkipFunctions_fromFfi(Pointer<Void> handle) {
 }
 void smoke_SkipFunctions_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SkipFunctions_release_handle(handle);
-Pointer<Void> smoke_SkipFunctions_toFfi_nullable(SkipFunctions value) =>
+Pointer<Void> smoke_SkipFunctions_toFfi_nullable(SkipFunctions? value) =>
   value != null ? smoke_SkipFunctions_toFfi(value) : Pointer<Void>.fromAddress(0);
-SkipFunctions smoke_SkipFunctions_fromFfi_nullable(Pointer<Void> handle) =>
+SkipFunctions? smoke_SkipFunctions_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SkipFunctions_fromFfi(handle) : null;
 void smoke_SkipFunctions_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SkipFunctions_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -9,12 +9,12 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class SkipProxy {
   SkipProxy() {}
   factory SkipProxy.fromLambdas({
-    @required String Function(String) lambda_notInJava,
-    @required bool Function(bool) lambda_notInSwift,
-    @required String Function() lambda_skippedInJava_get,
-    @required void Function(String) lambda_skippedInJava_set,
-    @required bool Function() lambda_isSkippedInSwift_get,
-    @required void Function(bool) lambda_isSkippedInSwift_set
+    required String Function(String) lambda_notInJava,
+    required bool Function(bool) lambda_notInSwift,
+    required String Function() lambda_skippedInJava_get,
+    required void Function(String) lambda_skippedInJava_set,
+    required bool Function() lambda_isSkippedInSwift_get,
+    required void Function(bool) lambda_isSkippedInSwift_set
   }) => SkipProxy$Lambdas(
     lambda_notInJava,
     lambda_notInSwift,
@@ -88,11 +88,11 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
   SkipProxy$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_SkipProxy_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   String notInJava(String input) {
@@ -166,7 +166,7 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
   }
 }
 int _SkipProxy_notInJava_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as SkipProxy).notInJava(String_fromFfi(input));
     _result.value = String_toFfi(_result_object);
@@ -176,7 +176,7 @@ int _SkipProxy_notInJava_static(int _token, Pointer<Void> input, Pointer<Pointer
   return 0;
 }
 int _SkipProxy_notInSwift_static(int _token, int input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool? _result_object = null;
   try {
     _result_object = (__lib.instanceCache[_token] as SkipProxy).notInSwift(Boolean_fromFfi(input));
     _result.value = Boolean_toFfi(_result_object);
@@ -229,8 +229,8 @@ Pointer<Void> smoke_SkipProxy_toFfi(SkipProxy value) {
 SkipProxy smoke_SkipProxy_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as SkipProxy;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is SkipProxy) return instance;
   final _type_id_handle = _smoke_SkipProxy_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -243,9 +243,9 @@ SkipProxy smoke_SkipProxy_fromFfi(Pointer<Void> handle) {
 }
 void smoke_SkipProxy_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SkipProxy_release_handle(handle);
-Pointer<Void> smoke_SkipProxy_toFfi_nullable(SkipProxy value) =>
+Pointer<Void> smoke_SkipProxy_toFfi_nullable(SkipProxy? value) =>
   value != null ? smoke_SkipProxy_toFfi(value) : Pointer<Void>.fromAddress(0);
-SkipProxy smoke_SkipProxy_fromFfi_nullable(Pointer<Void> handle) =>
+SkipProxy? smoke_SkipProxy_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SkipProxy_fromFfi(handle) : null;
 void smoke_SkipProxy_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SkipProxy_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
@@ -24,11 +24,11 @@ class SkipTagsOnly$Impl extends __lib.NativeBase implements SkipTagsOnly {
   SkipTagsOnly$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_SkipTagsOnly_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 }
 Pointer<Void> smoke_SkipTagsOnly_toFfi(SkipTagsOnly value) =>
@@ -36,8 +36,8 @@ Pointer<Void> smoke_SkipTagsOnly_toFfi(SkipTagsOnly value) =>
 SkipTagsOnly smoke_SkipTagsOnly_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as SkipTagsOnly;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is SkipTagsOnly) return instance;
   final _copied_handle = _smoke_SkipTagsOnly_copy_handle(handle);
   final result = SkipTagsOnly$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -45,9 +45,9 @@ SkipTagsOnly smoke_SkipTagsOnly_fromFfi(Pointer<Void> handle) {
 }
 void smoke_SkipTagsOnly_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SkipTagsOnly_release_handle(handle);
-Pointer<Void> smoke_SkipTagsOnly_toFfi_nullable(SkipTagsOnly value) =>
+Pointer<Void> smoke_SkipTagsOnly_toFfi_nullable(SkipTagsOnly? value) =>
   value != null ? smoke_SkipTagsOnly_toFfi(value) : Pointer<Void>.fromAddress(0);
-SkipTagsOnly smoke_SkipTagsOnly_fromFfi_nullable(Pointer<Void> handle) =>
+SkipTagsOnly? smoke_SkipTagsOnly_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SkipTagsOnly_fromFfi(handle) : null;
 void smoke_SkipTagsOnly_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SkipTagsOnly_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -59,14 +59,14 @@ final _smoke_SkipTypes_NotInJava_get_value_nullable = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInJava_get_value_nullable'));
-Pointer<Void> smoke_SkipTypes_NotInJava_toFfi_nullable(SkipTypes_NotInJava value) {
+Pointer<Void> smoke_SkipTypes_NotInJava_toFfi_nullable(SkipTypes_NotInJava? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SkipTypes_NotInJava_toFfi(value);
   final result = _smoke_SkipTypes_NotInJava_create_handle_nullable(_handle);
   smoke_SkipTypes_NotInJava_releaseFfiHandle(_handle);
   return result;
 }
-SkipTypes_NotInJava smoke_SkipTypes_NotInJava_fromFfi_nullable(Pointer<Void> handle) {
+SkipTypes_NotInJava? smoke_SkipTypes_NotInJava_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_SkipTypes_NotInJava_get_value_nullable(handle);
   final result = smoke_SkipTypes_NotInJava_fromFfi(_handle);
@@ -123,14 +123,14 @@ final _smoke_SkipTypes_NotInSwift_get_value_nullable = __lib.catchArgumentError(
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInSwift_get_value_nullable'));
-Pointer<Void> smoke_SkipTypes_NotInSwift_toFfi_nullable(SkipTypes_NotInSwift value) {
+Pointer<Void> smoke_SkipTypes_NotInSwift_toFfi_nullable(SkipTypes_NotInSwift? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SkipTypes_NotInSwift_toFfi(value);
   final result = _smoke_SkipTypes_NotInSwift_create_handle_nullable(_handle);
   smoke_SkipTypes_NotInSwift_releaseFfiHandle(_handle);
   return result;
 }
-SkipTypes_NotInSwift smoke_SkipTypes_NotInSwift_fromFfi_nullable(Pointer<Void> handle) {
+SkipTypes_NotInSwift? smoke_SkipTypes_NotInSwift_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_SkipTypes_NotInSwift_get_value_nullable(handle);
   final result = smoke_SkipTypes_NotInSwift_fromFfi(_handle);
@@ -153,11 +153,11 @@ class SkipTypes$Impl extends __lib.NativeBase implements SkipTypes {
   SkipTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_SkipTypes_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 }
 Pointer<Void> smoke_SkipTypes_toFfi(SkipTypes value) =>
@@ -165,8 +165,8 @@ Pointer<Void> smoke_SkipTypes_toFfi(SkipTypes value) =>
 SkipTypes smoke_SkipTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as SkipTypes;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is SkipTypes) return instance;
   final _copied_handle = _smoke_SkipTypes_copy_handle(handle);
   final result = SkipTypes$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -174,9 +174,9 @@ SkipTypes smoke_SkipTypes_fromFfi(Pointer<Void> handle) {
 }
 void smoke_SkipTypes_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SkipTypes_release_handle(handle);
-Pointer<Void> smoke_SkipTypes_toFfi_nullable(SkipTypes value) =>
+Pointer<Void> smoke_SkipTypes_toFfi_nullable(SkipTypes? value) =>
   value != null ? smoke_SkipTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
-SkipTypes smoke_SkipTypes_fromFfi_nullable(Pointer<Void> handle) =>
+SkipTypes? smoke_SkipTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SkipTypes_fromFfi(handle) : null;
 void smoke_SkipTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SkipTypes_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -61,14 +61,14 @@ final _smoke_Structs_FooBar_get_value_nullable = __lib.catchArgumentError(() => 
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_FooBar_get_value_nullable'));
-Pointer<Void> smoke_Structs_FooBar_toFfi_nullable(Structs_FooBar value) {
+Pointer<Void> smoke_Structs_FooBar_toFfi_nullable(Structs_FooBar? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_FooBar_toFfi(value);
   final result = _smoke_Structs_FooBar_create_handle_nullable(_handle);
   smoke_Structs_FooBar_releaseFfiHandle(_handle);
   return result;
 }
-Structs_FooBar smoke_Structs_FooBar_fromFfi_nullable(Pointer<Void> handle) {
+Structs_FooBar? smoke_Structs_FooBar_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Structs_FooBar_get_value_nullable(handle);
   final result = smoke_Structs_FooBar_fromFfi(_handle);
@@ -135,14 +135,14 @@ final _smoke_Structs_Point_get_value_nullable = __lib.catchArgumentError(() => _
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_Point_get_value_nullable'));
-Pointer<Void> smoke_Structs_Point_toFfi_nullable(Structs_Point value) {
+Pointer<Void> smoke_Structs_Point_toFfi_nullable(Structs_Point? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_Point_toFfi(value);
   final result = _smoke_Structs_Point_create_handle_nullable(_handle);
   smoke_Structs_Point_releaseFfiHandle(_handle);
   return result;
 }
-Structs_Point smoke_Structs_Point_fromFfi_nullable(Pointer<Void> handle) {
+Structs_Point? smoke_Structs_Point_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Structs_Point_get_value_nullable(handle);
   final result = smoke_Structs_Point_fromFfi(_handle);
@@ -209,14 +209,14 @@ final _smoke_Structs_Line_get_value_nullable = __lib.catchArgumentError(() => __
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_Line_get_value_nullable'));
-Pointer<Void> smoke_Structs_Line_toFfi_nullable(Structs_Line value) {
+Pointer<Void> smoke_Structs_Line_toFfi_nullable(Structs_Line? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_Line_toFfi(value);
   final result = _smoke_Structs_Line_create_handle_nullable(_handle);
   smoke_Structs_Line_releaseFfiHandle(_handle);
   return result;
 }
-Structs_Line smoke_Structs_Line_fromFfi_nullable(Pointer<Void> handle) {
+Structs_Line? smoke_Structs_Line_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Structs_Line_get_value_nullable(handle);
   final result = smoke_Structs_Line_fromFfi(_handle);
@@ -404,14 +404,14 @@ final _smoke_Structs_AllTypesStruct_get_value_nullable = __lib.catchArgumentErro
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_value_nullable'));
-Pointer<Void> smoke_Structs_AllTypesStruct_toFfi_nullable(Structs_AllTypesStruct value) {
+Pointer<Void> smoke_Structs_AllTypesStruct_toFfi_nullable(Structs_AllTypesStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_AllTypesStruct_toFfi(value);
   final result = _smoke_Structs_AllTypesStruct_create_handle_nullable(_handle);
   smoke_Structs_AllTypesStruct_releaseFfiHandle(_handle);
   return result;
 }
-Structs_AllTypesStruct smoke_Structs_AllTypesStruct_fromFfi_nullable(Pointer<Void> handle) {
+Structs_AllTypesStruct? smoke_Structs_AllTypesStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Structs_AllTypesStruct_get_value_nullable(handle);
   final result = smoke_Structs_AllTypesStruct_fromFfi(_handle);
@@ -468,14 +468,14 @@ final _smoke_Structs_NestingImmutableStruct_get_value_nullable = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_NestingImmutableStruct_get_value_nullable'));
-Pointer<Void> smoke_Structs_NestingImmutableStruct_toFfi_nullable(Structs_NestingImmutableStruct value) {
+Pointer<Void> smoke_Structs_NestingImmutableStruct_toFfi_nullable(Structs_NestingImmutableStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_NestingImmutableStruct_toFfi(value);
   final result = _smoke_Structs_NestingImmutableStruct_create_handle_nullable(_handle);
   smoke_Structs_NestingImmutableStruct_releaseFfiHandle(_handle);
   return result;
 }
-Structs_NestingImmutableStruct smoke_Structs_NestingImmutableStruct_fromFfi_nullable(Pointer<Void> handle) {
+Structs_NestingImmutableStruct? smoke_Structs_NestingImmutableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Structs_NestingImmutableStruct_get_value_nullable(handle);
   final result = smoke_Structs_NestingImmutableStruct_fromFfi(_handle);
@@ -532,14 +532,14 @@ final _smoke_Structs_DoubleNestingImmutableStruct_get_value_nullable = __lib.cat
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_DoubleNestingImmutableStruct_get_value_nullable'));
-Pointer<Void> smoke_Structs_DoubleNestingImmutableStruct_toFfi_nullable(Structs_DoubleNestingImmutableStruct value) {
+Pointer<Void> smoke_Structs_DoubleNestingImmutableStruct_toFfi_nullable(Structs_DoubleNestingImmutableStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_DoubleNestingImmutableStruct_toFfi(value);
   final result = _smoke_Structs_DoubleNestingImmutableStruct_create_handle_nullable(_handle);
   smoke_Structs_DoubleNestingImmutableStruct_releaseFfiHandle(_handle);
   return result;
 }
-Structs_DoubleNestingImmutableStruct smoke_Structs_DoubleNestingImmutableStruct_fromFfi_nullable(Pointer<Void> handle) {
+Structs_DoubleNestingImmutableStruct? smoke_Structs_DoubleNestingImmutableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Structs_DoubleNestingImmutableStruct_get_value_nullable(handle);
   final result = smoke_Structs_DoubleNestingImmutableStruct_fromFfi(_handle);
@@ -596,14 +596,14 @@ final _smoke_Structs_StructWithArrayOfImmutable_get_value_nullable = __lib.catch
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_StructWithArrayOfImmutable_get_value_nullable'));
-Pointer<Void> smoke_Structs_StructWithArrayOfImmutable_toFfi_nullable(Structs_StructWithArrayOfImmutable value) {
+Pointer<Void> smoke_Structs_StructWithArrayOfImmutable_toFfi_nullable(Structs_StructWithArrayOfImmutable? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_StructWithArrayOfImmutable_toFfi(value);
   final result = _smoke_Structs_StructWithArrayOfImmutable_create_handle_nullable(_handle);
   smoke_Structs_StructWithArrayOfImmutable_releaseFfiHandle(_handle);
   return result;
 }
-Structs_StructWithArrayOfImmutable smoke_Structs_StructWithArrayOfImmutable_fromFfi_nullable(Pointer<Void> handle) {
+Structs_StructWithArrayOfImmutable? smoke_Structs_StructWithArrayOfImmutable_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Structs_StructWithArrayOfImmutable_get_value_nullable(handle);
   final result = smoke_Structs_StructWithArrayOfImmutable_fromFfi(_handle);
@@ -661,14 +661,14 @@ final _smoke_Structs_ImmutableStructWithCppAccessors_get_value_nullable = __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ImmutableStructWithCppAccessors_get_value_nullable'));
-Pointer<Void> smoke_Structs_ImmutableStructWithCppAccessors_toFfi_nullable(Structs_ImmutableStructWithCppAccessors value) {
+Pointer<Void> smoke_Structs_ImmutableStructWithCppAccessors_toFfi_nullable(Structs_ImmutableStructWithCppAccessors? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_ImmutableStructWithCppAccessors_toFfi(value);
   final result = _smoke_Structs_ImmutableStructWithCppAccessors_create_handle_nullable(_handle);
   smoke_Structs_ImmutableStructWithCppAccessors_releaseFfiHandle(_handle);
   return result;
 }
-Structs_ImmutableStructWithCppAccessors smoke_Structs_ImmutableStructWithCppAccessors_fromFfi_nullable(Pointer<Void> handle) {
+Structs_ImmutableStructWithCppAccessors? smoke_Structs_ImmutableStructWithCppAccessors_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Structs_ImmutableStructWithCppAccessors_get_value_nullable(handle);
   final result = smoke_Structs_ImmutableStructWithCppAccessors_fromFfi(_handle);
@@ -725,14 +725,14 @@ final _smoke_Structs_MutableStructWithCppAccessors_get_value_nullable = __lib.ca
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_MutableStructWithCppAccessors_get_value_nullable'));
-Pointer<Void> smoke_Structs_MutableStructWithCppAccessors_toFfi_nullable(Structs_MutableStructWithCppAccessors value) {
+Pointer<Void> smoke_Structs_MutableStructWithCppAccessors_toFfi_nullable(Structs_MutableStructWithCppAccessors? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_MutableStructWithCppAccessors_toFfi(value);
   final result = _smoke_Structs_MutableStructWithCppAccessors_create_handle_nullable(_handle);
   smoke_Structs_MutableStructWithCppAccessors_releaseFfiHandle(_handle);
   return result;
 }
-Structs_MutableStructWithCppAccessors smoke_Structs_MutableStructWithCppAccessors_fromFfi_nullable(Pointer<Void> handle) {
+Structs_MutableStructWithCppAccessors? smoke_Structs_MutableStructWithCppAccessors_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_Structs_MutableStructWithCppAccessors_get_value_nullable(handle);
   final result = smoke_Structs_MutableStructWithCppAccessors_fromFfi(_handle);
@@ -755,11 +755,11 @@ class Structs$Impl extends __lib.NativeBase implements Structs {
   Structs$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_Structs_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static Structs_Point swapPointCoordinates(Structs_Point input) {
     final _swapPointCoordinates_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_swapPointCoordinates__Point'));
@@ -813,8 +813,8 @@ Pointer<Void> smoke_Structs_toFfi(Structs value) =>
 Structs smoke_Structs_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as Structs;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is Structs) return instance;
   final _copied_handle = _smoke_Structs_copy_handle(handle);
   final result = Structs$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -822,9 +822,9 @@ Structs smoke_Structs_fromFfi(Pointer<Void> handle) {
 }
 void smoke_Structs_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_Structs_release_handle(handle);
-Pointer<Void> smoke_Structs_toFfi_nullable(Structs value) =>
+Pointer<Void> smoke_Structs_toFfi_nullable(Structs? value) =>
   value != null ? smoke_Structs_toFfi(value) : Pointer<Void>.fromAddress(0);
-Structs smoke_Structs_fromFfi_nullable(Pointer<Void> handle) =>
+Structs? smoke_Structs_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Structs_fromFfi(handle) : null;
 void smoke_Structs_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_Structs_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_constants.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_constants.dart
@@ -63,14 +63,14 @@ final _smoke_StructsWithConstants_Route_get_value_nullable = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructsWithConstants_Route_get_value_nullable'));
-Pointer<Void> smoke_StructsWithConstants_Route_toFfi_nullable(Route value) {
+Pointer<Void> smoke_StructsWithConstants_Route_toFfi_nullable(Route? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructsWithConstants_Route_toFfi(value);
   final result = _smoke_StructsWithConstants_Route_create_handle_nullable(_handle);
   smoke_StructsWithConstants_Route_releaseFfiHandle(_handle);
   return result;
 }
-Route smoke_StructsWithConstants_Route_fromFfi_nullable(Pointer<Void> handle) {
+Route? smoke_StructsWithConstants_Route_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructsWithConstants_Route_get_value_nullable(handle);
   final result = smoke_StructsWithConstants_Route_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
@@ -166,14 +166,14 @@ final _smoke_StructsWithMethods_Vector_get_value_nullable = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_get_value_nullable'));
-Pointer<Void> smoke_StructsWithMethods_Vector_toFfi_nullable(Vector value) {
+Pointer<Void> smoke_StructsWithMethods_Vector_toFfi_nullable(Vector? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructsWithMethods_Vector_toFfi(value);
   final result = _smoke_StructsWithMethods_Vector_create_handle_nullable(_handle);
   smoke_StructsWithMethods_Vector_releaseFfiHandle(_handle);
   return result;
 }
-Vector smoke_StructsWithMethods_Vector_fromFfi_nullable(Pointer<Void> handle) {
+Vector? smoke_StructsWithMethods_Vector_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructsWithMethods_Vector_get_value_nullable(handle);
   final result = smoke_StructsWithMethods_Vector_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
@@ -33,11 +33,11 @@ class SomeClass$Impl extends __lib.NativeBase implements SomeClass {
   SomeClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_SomeClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   SomeClass fooBar() {
     final result = SomeClass$Impl(_fooBar());
@@ -119,8 +119,8 @@ Pointer<Void> smoke_SomeClass_toFfi(SomeClass value) =>
 SomeClass smoke_SomeClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as SomeClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is SomeClass) return instance;
   final _copied_handle = _smoke_SomeClass_copy_handle(handle);
   final result = SomeClass$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -128,9 +128,9 @@ SomeClass smoke_SomeClass_fromFfi(Pointer<Void> handle) {
 }
 void smoke_SomeClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_SomeClass_release_handle(handle);
-Pointer<Void> smoke_SomeClass_toFfi_nullable(SomeClass value) =>
+Pointer<Void> smoke_SomeClass_toFfi_nullable(SomeClass? value) =>
   value != null ? smoke_SomeClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-SomeClass smoke_SomeClass_fromFfi_nullable(Pointer<Void> handle) =>
+SomeClass? smoke_SomeClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SomeClass_fromFfi(handle) : null;
 void smoke_SomeClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_SomeClass_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_constructor.dart
@@ -68,14 +68,14 @@ final _smoke_StructWithConstructor_get_value_nullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithConstructor_get_value_nullable'));
-Pointer<Void> smoke_StructWithConstructor_toFfi_nullable(StructWithConstructor value) {
+Pointer<Void> smoke_StructWithConstructor_toFfi_nullable(StructWithConstructor? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithConstructor_toFfi(value);
   final result = _smoke_StructWithConstructor_create_handle_nullable(_handle);
   smoke_StructWithConstructor_releaseFfiHandle(_handle);
   return result;
 }
-StructWithConstructor smoke_StructWithConstructor_fromFfi_nullable(Pointer<Void> handle) {
+StructWithConstructor? smoke_StructWithConstructor_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructWithConstructor_get_value_nullable(handle);
   final result = smoke_StructWithConstructor_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
@@ -125,14 +125,14 @@ final _smoke_StructWithMethods_get_value_nullable = __lib.catchArgumentError(() 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithMethods_get_value_nullable'));
-Pointer<Void> smoke_StructWithMethods_toFfi_nullable(StructWithMethods value) {
+Pointer<Void> smoke_StructWithMethods_toFfi_nullable(StructWithMethods? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithMethods_toFfi(value);
   final result = _smoke_StructWithMethods_create_handle_nullable(_handle);
   smoke_StructWithMethods_releaseFfiHandle(_handle);
   return result;
 }
-StructWithMethods smoke_StructWithMethods_fromFfi_nullable(Pointer<Void> handle) {
+StructWithMethods? smoke_StructWithMethods_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_StructWithMethods_get_value_nullable(handle);
   final result = smoke_StructWithMethods_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -69,14 +69,14 @@ final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_value_nullable = __
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_value_nullable'));
-Pointer<Void> smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_toFfi_nullable(TypeDefs_StructHavingAliasFieldDefinedBelow value) {
+Pointer<Void> smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_toFfi_nullable(TypeDefs_StructHavingAliasFieldDefinedBelow? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_toFfi(value);
   final result = _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle_nullable(_handle);
   smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_releaseFfiHandle(_handle);
   return result;
 }
-TypeDefs_StructHavingAliasFieldDefinedBelow smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_fromFfi_nullable(Pointer<Void> handle) {
+TypeDefs_StructHavingAliasFieldDefinedBelow? smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_value_nullable(handle);
   final result = smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_fromFfi(_handle);
@@ -133,14 +133,14 @@ final _smoke_TypeDefs_TestStruct_get_value_nullable = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypeDefs_TestStruct_get_value_nullable'));
-Pointer<Void> smoke_TypeDefs_TestStruct_toFfi_nullable(TypeDefs_TestStruct value) {
+Pointer<Void> smoke_TypeDefs_TestStruct_toFfi_nullable(TypeDefs_TestStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypeDefs_TestStruct_toFfi(value);
   final result = _smoke_TypeDefs_TestStruct_create_handle_nullable(_handle);
   smoke_TypeDefs_TestStruct_releaseFfiHandle(_handle);
   return result;
 }
-TypeDefs_TestStruct smoke_TypeDefs_TestStruct_fromFfi_nullable(Pointer<Void> handle) {
+TypeDefs_TestStruct? smoke_TypeDefs_TestStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_TypeDefs_TestStruct_get_value_nullable(handle);
   final result = smoke_TypeDefs_TestStruct_fromFfi(_handle);
@@ -163,11 +163,11 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
   TypeDefs$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_TypeDefs_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static double methodWithPrimitiveTypeDef(double input) {
     final _methodWithPrimitiveTypeDef_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_methodWithPrimitiveTypeDef__Double'));
@@ -265,8 +265,8 @@ Pointer<Void> smoke_TypeDefs_toFfi(TypeDefs value) =>
 TypeDefs smoke_TypeDefs_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as TypeDefs;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is TypeDefs) return instance;
   final _copied_handle = _smoke_TypeDefs_copy_handle(handle);
   final result = TypeDefs$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -274,9 +274,9 @@ TypeDefs smoke_TypeDefs_fromFfi(Pointer<Void> handle) {
 }
 void smoke_TypeDefs_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_TypeDefs_release_handle(handle);
-Pointer<Void> smoke_TypeDefs_toFfi_nullable(TypeDefs value) =>
+Pointer<Void> smoke_TypeDefs_toFfi_nullable(TypeDefs? value) =>
   value != null ? smoke_TypeDefs_toFfi(value) : Pointer<Void>.fromAddress(0);
-TypeDefs smoke_TypeDefs_fromFfi_nullable(Pointer<Void> handle) =>
+TypeDefs? smoke_TypeDefs_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_TypeDefs_fromFfi(handle) : null;
 void smoke_TypeDefs_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_TypeDefs_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -28,11 +28,11 @@ class InternalClass$Impl extends __lib.NativeBase implements InternalClass {
   InternalClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_InternalClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   internal_fooBar() {
@@ -51,8 +51,8 @@ Pointer<Void> smoke_InternalClass_toFfi(InternalClass value) =>
 InternalClass smoke_InternalClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as InternalClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is InternalClass) return instance;
   final _copied_handle = _smoke_InternalClass_copy_handle(handle);
   final result = InternalClass$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -60,9 +60,9 @@ InternalClass smoke_InternalClass_fromFfi(Pointer<Void> handle) {
 }
 void smoke_InternalClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_InternalClass_release_handle(handle);
-Pointer<Void> smoke_InternalClass_toFfi_nullable(InternalClass value) =>
+Pointer<Void> smoke_InternalClass_toFfi_nullable(InternalClass? value) =>
   value != null ? smoke_InternalClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-InternalClass smoke_InternalClass_fromFfi_nullable(Pointer<Void> handle) =>
+InternalClass? smoke_InternalClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InternalClass_fromFfi(handle) : null;
 void smoke_InternalClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_InternalClass_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -32,11 +32,11 @@ class InternalClassWithFunctions$Impl extends __lib.NativeBase implements Intern
   InternalClassWithFunctions$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_InternalClassWithFunctions_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   InternalClassWithFunctions$Impl.internal_make() : super(_make()) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
@@ -73,8 +73,8 @@ Pointer<Void> smoke_InternalClassWithFunctions_toFfi(InternalClassWithFunctions 
 InternalClassWithFunctions smoke_InternalClassWithFunctions_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as InternalClassWithFunctions;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is InternalClassWithFunctions) return instance;
   final _copied_handle = _smoke_InternalClassWithFunctions_copy_handle(handle);
   final result = InternalClassWithFunctions$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -82,9 +82,9 @@ InternalClassWithFunctions smoke_InternalClassWithFunctions_fromFfi(Pointer<Void
 }
 void smoke_InternalClassWithFunctions_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_InternalClassWithFunctions_release_handle(handle);
-Pointer<Void> smoke_InternalClassWithFunctions_toFfi_nullable(InternalClassWithFunctions value) =>
+Pointer<Void> smoke_InternalClassWithFunctions_toFfi_nullable(InternalClassWithFunctions? value) =>
   value != null ? smoke_InternalClassWithFunctions_toFfi(value) : Pointer<Void>.fromAddress(0);
-InternalClassWithFunctions smoke_InternalClassWithFunctions_fromFfi_nullable(Pointer<Void> handle) =>
+InternalClassWithFunctions? smoke_InternalClassWithFunctions_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InternalClassWithFunctions_fromFfi(handle) : null;
 void smoke_InternalClassWithFunctions_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_InternalClassWithFunctions_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -30,11 +30,11 @@ class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements I
   InternalClassWithStaticProperty$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_InternalClassWithStaticProperty_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   static String get internal_fooBar {
     final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithStaticProperty_fooBar_get'));
@@ -62,8 +62,8 @@ Pointer<Void> smoke_InternalClassWithStaticProperty_toFfi(InternalClassWithStati
 InternalClassWithStaticProperty smoke_InternalClassWithStaticProperty_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as InternalClassWithStaticProperty;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is InternalClassWithStaticProperty) return instance;
   final _copied_handle = _smoke_InternalClassWithStaticProperty_copy_handle(handle);
   final result = InternalClassWithStaticProperty$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -71,9 +71,9 @@ InternalClassWithStaticProperty smoke_InternalClassWithStaticProperty_fromFfi(Po
 }
 void smoke_InternalClassWithStaticProperty_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_InternalClassWithStaticProperty_release_handle(handle);
-Pointer<Void> smoke_InternalClassWithStaticProperty_toFfi_nullable(InternalClassWithStaticProperty value) =>
+Pointer<Void> smoke_InternalClassWithStaticProperty_toFfi_nullable(InternalClassWithStaticProperty? value) =>
   value != null ? smoke_InternalClassWithStaticProperty_toFfi(value) : Pointer<Void>.fromAddress(0);
-InternalClassWithStaticProperty smoke_InternalClassWithStaticProperty_fromFfi_nullable(Pointer<Void> handle) =>
+InternalClassWithStaticProperty? smoke_InternalClassWithStaticProperty_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InternalClassWithStaticProperty_fromFfi(handle) : null;
 void smoke_InternalClassWithStaticProperty_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_InternalClassWithStaticProperty_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -10,7 +10,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 abstract class InternalInterface {
   InternalInterface() {}
   factory InternalInterface.fromLambdas({
-    @required void Function() lambda_fooBar,
+    required void Function() lambda_fooBar,
   }) => InternalInterface$Lambdas(
     lambda_fooBar,
   );
@@ -54,11 +54,11 @@ class InternalInterface$Impl extends __lib.NativeBase implements InternalInterfa
   InternalInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_InternalInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   internal_fooBar() {
@@ -92,8 +92,8 @@ Pointer<Void> smoke_InternalInterface_toFfi(InternalInterface value) {
 InternalInterface smoke_InternalInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as InternalInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is InternalInterface) return instance;
   final _type_id_handle = _smoke_InternalInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -106,9 +106,9 @@ InternalInterface smoke_InternalInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_InternalInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_InternalInterface_release_handle(handle);
-Pointer<Void> smoke_InternalInterface_toFfi_nullable(InternalInterface value) =>
+Pointer<Void> smoke_InternalInterface_toFfi_nullable(InternalInterface? value) =>
   value != null ? smoke_InternalInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-InternalInterface smoke_InternalInterface_fromFfi_nullable(Pointer<Void> handle) =>
+InternalInterface? smoke_InternalInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InternalInterface_fromFfi(handle) : null;
 void smoke_InternalInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_InternalInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -64,14 +64,14 @@ final _smoke_PublicClass_InternalEnum_get_value_nullable = __lib.catchArgumentEr
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalEnum_get_value_nullable'));
-Pointer<Void> smoke_PublicClass_InternalEnum_toFfi_nullable(PublicClass_InternalEnum value) {
+Pointer<Void> smoke_PublicClass_InternalEnum_toFfi_nullable(PublicClass_InternalEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicClass_InternalEnum_toFfi(value);
   final result = _smoke_PublicClass_InternalEnum_create_handle_nullable(_handle);
   smoke_PublicClass_InternalEnum_releaseFfiHandle(_handle);
   return result;
 }
-PublicClass_InternalEnum smoke_PublicClass_InternalEnum_fromFfi_nullable(Pointer<Void> handle) {
+PublicClass_InternalEnum? smoke_PublicClass_InternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_PublicClass_InternalEnum_get_value_nullable(handle);
   final result = smoke_PublicClass_InternalEnum_fromFfi(_handle);
@@ -130,14 +130,14 @@ final _smoke_PublicClass_InternalStruct_get_value_nullable = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalStruct_get_value_nullable'));
-Pointer<Void> smoke_PublicClass_InternalStruct_toFfi_nullable(PublicClass_InternalStruct value) {
+Pointer<Void> smoke_PublicClass_InternalStruct_toFfi_nullable(PublicClass_InternalStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicClass_InternalStruct_toFfi(value);
   final result = _smoke_PublicClass_InternalStruct_create_handle_nullable(_handle);
   smoke_PublicClass_InternalStruct_releaseFfiHandle(_handle);
   return result;
 }
-PublicClass_InternalStruct smoke_PublicClass_InternalStruct_fromFfi_nullable(Pointer<Void> handle) {
+PublicClass_InternalStruct? smoke_PublicClass_InternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_PublicClass_InternalStruct_get_value_nullable(handle);
   final result = smoke_PublicClass_InternalStruct_fromFfi(_handle);
@@ -195,14 +195,14 @@ final _smoke_PublicClass_PublicStruct_get_value_nullable = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStruct_get_value_nullable'));
-Pointer<Void> smoke_PublicClass_PublicStruct_toFfi_nullable(PublicClass_PublicStruct value) {
+Pointer<Void> smoke_PublicClass_PublicStruct_toFfi_nullable(PublicClass_PublicStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicClass_PublicStruct_toFfi(value);
   final result = _smoke_PublicClass_PublicStruct_create_handle_nullable(_handle);
   smoke_PublicClass_PublicStruct_releaseFfiHandle(_handle);
   return result;
 }
-PublicClass_PublicStruct smoke_PublicClass_PublicStruct_fromFfi_nullable(Pointer<Void> handle) {
+PublicClass_PublicStruct? smoke_PublicClass_PublicStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_PublicClass_PublicStruct_get_value_nullable(handle);
   final result = smoke_PublicClass_PublicStruct_fromFfi(_handle);
@@ -272,14 +272,14 @@ final _smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable = _
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable'));
-Pointer<Void> smoke_PublicClass_PublicStructWithInternalDefaults_toFfi_nullable(PublicClass_PublicStructWithInternalDefaults value) {
+Pointer<Void> smoke_PublicClass_PublicStructWithInternalDefaults_toFfi_nullable(PublicClass_PublicStructWithInternalDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicClass_PublicStructWithInternalDefaults_toFfi(value);
   final result = _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle_nullable(_handle);
   smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle(_handle);
   return result;
 }
-PublicClass_PublicStructWithInternalDefaults smoke_PublicClass_PublicStructWithInternalDefaults_fromFfi_nullable(Pointer<Void> handle) {
+PublicClass_PublicStructWithInternalDefaults? smoke_PublicClass_PublicStructWithInternalDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable(handle);
   final result = smoke_PublicClass_PublicStructWithInternalDefaults_fromFfi(_handle);
@@ -302,11 +302,11 @@ class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
   PublicClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_PublicClass_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
   @override
   PublicClass_InternalStruct internal_internalMethod(PublicClass_InternalStruct input) {
@@ -375,8 +375,8 @@ Pointer<Void> smoke_PublicClass_toFfi(PublicClass value) =>
 PublicClass smoke_PublicClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as PublicClass;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is PublicClass) return instance;
   final _copied_handle = _smoke_PublicClass_copy_handle(handle);
   final result = PublicClass$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
@@ -384,9 +384,9 @@ PublicClass smoke_PublicClass_fromFfi(Pointer<Void> handle) {
 }
 void smoke_PublicClass_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_PublicClass_release_handle(handle);
-Pointer<Void> smoke_PublicClass_toFfi_nullable(PublicClass value) =>
+Pointer<Void> smoke_PublicClass_toFfi_nullable(PublicClass? value) =>
   value != null ? smoke_PublicClass_toFfi(value) : Pointer<Void>.fromAddress(0);
-PublicClass smoke_PublicClass_fromFfi_nullable(Pointer<Void> handle) =>
+PublicClass? smoke_PublicClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_PublicClass_fromFfi(handle) : null;
 void smoke_PublicClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_PublicClass_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
@@ -63,14 +63,14 @@ final _smoke_PublicInterface_InternalStruct_get_value_nullable = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_InternalStruct_get_value_nullable'));
-Pointer<Void> smoke_PublicInterface_InternalStruct_toFfi_nullable(PublicInterface_InternalStruct value) {
+Pointer<Void> smoke_PublicInterface_InternalStruct_toFfi_nullable(PublicInterface_InternalStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicInterface_InternalStruct_toFfi(value);
   final result = _smoke_PublicInterface_InternalStruct_create_handle_nullable(_handle);
   smoke_PublicInterface_InternalStruct_releaseFfiHandle(_handle);
   return result;
 }
-PublicInterface_InternalStruct smoke_PublicInterface_InternalStruct_fromFfi_nullable(Pointer<Void> handle) {
+PublicInterface_InternalStruct? smoke_PublicInterface_InternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_PublicInterface_InternalStruct_get_value_nullable(handle);
   final result = smoke_PublicInterface_InternalStruct_fromFfi(_handle);
@@ -101,11 +101,11 @@ class PublicInterface$Impl extends __lib.NativeBase implements PublicInterface {
   PublicInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
-    if (handle == null) return;
+    if (handle.address == 0) return;
     __lib.uncacheObject(this);
     __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
     _smoke_PublicInterface_release_handle(handle);
-    handle = null;
+    handle = Pointer<Void>.fromAddress(0);
   }
 }
 Pointer<Void> smoke_PublicInterface_toFfi(PublicInterface value) {
@@ -120,8 +120,8 @@ Pointer<Void> smoke_PublicInterface_toFfi(PublicInterface value) {
 PublicInterface smoke_PublicInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
-  final instance = __lib.instanceCache[token] as PublicInterface;
-  if (instance != null) return instance;
+  final instance = __lib.instanceCache[token];
+  if (instance is PublicInterface) return instance;
   final _type_id_handle = _smoke_PublicInterface_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
@@ -134,9 +134,9 @@ PublicInterface smoke_PublicInterface_fromFfi(Pointer<Void> handle) {
 }
 void smoke_PublicInterface_releaseFfiHandle(Pointer<Void> handle) =>
   _smoke_PublicInterface_release_handle(handle);
-Pointer<Void> smoke_PublicInterface_toFfi_nullable(PublicInterface value) =>
+Pointer<Void> smoke_PublicInterface_toFfi_nullable(PublicInterface? value) =>
   value != null ? smoke_PublicInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
-PublicInterface smoke_PublicInterface_fromFfi_nullable(Pointer<Void> handle) =>
+PublicInterface? smoke_PublicInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_PublicInterface_fromFfi(handle) : null;
 void smoke_PublicInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
   _smoke_PublicInterface_release_handle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
@@ -73,14 +73,14 @@ final _smoke_PublicStructWithNonDefaultInternalField_get_value_nullable = __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicStructWithNonDefaultInternalField_get_value_nullable'));
-Pointer<Void> smoke_PublicStructWithNonDefaultInternalField_toFfi_nullable(PublicStructWithNonDefaultInternalField value) {
+Pointer<Void> smoke_PublicStructWithNonDefaultInternalField_toFfi_nullable(PublicStructWithNonDefaultInternalField? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicStructWithNonDefaultInternalField_toFfi(value);
   final result = _smoke_PublicStructWithNonDefaultInternalField_create_handle_nullable(_handle);
   smoke_PublicStructWithNonDefaultInternalField_releaseFfiHandle(_handle);
   return result;
 }
-PublicStructWithNonDefaultInternalField smoke_PublicStructWithNonDefaultInternalField_fromFfi_nullable(Pointer<Void> handle) {
+PublicStructWithNonDefaultInternalField? smoke_PublicStructWithNonDefaultInternalField_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_PublicStructWithNonDefaultInternalField_get_value_nullable(handle);
   final result = smoke_PublicStructWithNonDefaultInternalField_fromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
@@ -64,14 +64,14 @@ final _smoke_PublicTypeCollection_InternalStruct_get_value_nullable = __lib.catc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicTypeCollection_InternalStruct_get_value_nullable'));
-Pointer<Void> smoke_PublicTypeCollection_InternalStruct_toFfi_nullable(InternalStruct value) {
+Pointer<Void> smoke_PublicTypeCollection_InternalStruct_toFfi_nullable(InternalStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicTypeCollection_InternalStruct_toFfi(value);
   final result = _smoke_PublicTypeCollection_InternalStruct_create_handle_nullable(_handle);
   smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle(_handle);
   return result;
 }
-InternalStruct smoke_PublicTypeCollection_InternalStruct_fromFfi_nullable(Pointer<Void> handle) {
+InternalStruct? smoke_PublicTypeCollection_InternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smoke_PublicTypeCollection_InternalStruct_get_value_nullable(handle);
   final result = smoke_PublicTypeCollection_InternalStruct_fromFfi(_handle);


### PR DESCRIPTION
Updated Dart templates and name resolver to support null safety. Also updated Dart templates to accommodate API changes
introduced in Dart 2.12.

Resolves: #458
