### PR TITLE
Fix detection of Swift constructor overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed Swift compilation issue for overriding initializers in child classes.
+
 ## 8.9.5
 Release date: 2021-03-03
 ### Features:

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -262,6 +262,7 @@ feature(Inheritance cpp android swift dart SOURCES
     input/lime/ListenerInheritanceArrays.lime
     input/lime/CrossPackageInheritance.lime
     input/lime/InterfaceWithLambda.lime
+    input/lime/ConstructorOverride.lime
 )
 
 feature(Serialization android swift SOURCES

--- a/functional-tests/functional/input/lime/ConstructorOverride.lime
+++ b/functional-tests/functional/input/lime/ConstructorOverride.lime
@@ -1,0 +1,29 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+@Skip(Java) @Skip(Dart)
+open class ParentWithCustomConstructor {
+    # Constructor names should be different in parent and child to reproduce the issue.
+    constructor create()
+}
+
+@Skip(Java) @Skip(Dart)
+class ChildWithCustomConstructor: ParentWithCustomConstructor {
+    constructor make()
+}

--- a/functional-tests/functional/input/src/cpp/Inheritance.cpp
+++ b/functional-tests/functional/input/src/cpp/Inheritance.cpp
@@ -21,11 +21,13 @@
 #include "test/AnotherChildInterface.h"
 #include "test/AnotherConcreteChild.h"
 #include "test/AnotherConcreteGrandChild.h"
+#include "test/ChildWithCustomConstructor.h"
 #include "test/ChildConstructorOverloads.h"
 #include "test/ChildInterface.h"
 #include "test/ConcreteChild.h"
 #include "test/ConcreteGrandChild.h"
 #include "test/InheritanceTestHelper.h"
+#include "test/ParentWithCustomConstructor.h"
 #include "test/RootInterface.h"
 #include "test/ThrowingConstructor.h"
 #include "ChildClassImpl.h"
@@ -322,4 +324,20 @@ ChildConstructorOverloads::create( double input )
                       : std::error_code( ThrowingConstructor::ErrorEnum::CRASHED );
 }
 
-}  // namespace test
+class ParentWithCustomConstructorImpl: public ParentWithCustomConstructor {
+public:
+    virtual ~ParentWithCustomConstructorImpl( ) = default;
+};
+
+std::shared_ptr<ParentWithCustomConstructor>
+ParentWithCustomConstructor::create() { return std::make_shared<ParentWithCustomConstructorImpl>(); }
+
+class ChildWithCustomConstructorImpl: public ChildWithCustomConstructor {
+public:
+    virtual ~ChildWithCustomConstructorImpl( ) = default;
+};
+
+std::shared_ptr<ChildWithCustomConstructor>
+ChildWithCustomConstructor::make() { return std::make_shared<ChildWithCustomConstructorImpl>(); }
+
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
@@ -60,7 +60,7 @@ internal class SwiftGeneratorPredicates(limeReferenceMap: Map<String, LimeElemen
         },
         "isOverriding" to { limeFunction: Any ->
             limeFunction is LimeFunction && limeFunction.isConstructor &&
-                signatureResolver.hasSignatureClash(limeFunction)
+                signatureResolver.hasConstructorSignatureClash(limeFunction)
         },
         "isRefEquatable" to { limeField: Any ->
             limeField is LimeField && isRefEquatable(limeField)

--- a/gluecodium/src/test/resources/smoke/inheritance/input/ConstructorOverride.lime
+++ b/gluecodium/src/test/resources/smoke/inheritance/input/ConstructorOverride.lime
@@ -1,0 +1,29 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Skip(Java) @Skip(Dart)
+open class ParentWithCustomConstructor {
+    # Constructor names should be different in parent and child to reproduce the issue.
+    constructor create()
+}
+
+@Skip(Java) @Skip(Dart)
+class ChildWithCustomConstructor: ParentWithCustomConstructor {
+    constructor make()
+}

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildWithCustomConstructor.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildWithCustomConstructor.swift
@@ -1,0 +1,79 @@
+//
+//
+import Foundation
+public class ChildWithCustomConstructor: ParentWithCustomConstructor {
+    public override init() {
+        let _result = ChildWithCustomConstructor.make()
+        super.init(cParentWithCustomConstructor: _result)
+        smoke_ChildWithCustomConstructor_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
+    }
+    init(cChildWithCustomConstructor: _baseRef) {
+        super.init(cParentWithCustomConstructor: cChildWithCustomConstructor)
+    }
+    private static func make() -> _baseRef {
+        return moveFromCType(smoke_ChildWithCustomConstructor_make())
+    }
+}
+@_cdecl("_CBridgeInitsmoke_ChildWithCustomConstructor")
+internal func _CBridgeInitsmoke_ChildWithCustomConstructor(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = ChildWithCustomConstructor(cChildWithCustomConstructor: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: ChildWithCustomConstructor?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_ChildWithCustomConstructor_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_ChildWithCustomConstructor_release_handle)
+        : RefHolder(handle_copy)
+}
+internal func ChildWithCustomConstructor_copyFromCType(_ handle: _baseRef) -> ChildWithCustomConstructor {
+    if let swift_pointer = smoke_ChildWithCustomConstructor_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildWithCustomConstructor {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ChildWithCustomConstructor_get_typed(smoke_ChildWithCustomConstructor_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ChildWithCustomConstructor {
+        smoke_ChildWithCustomConstructor_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func ChildWithCustomConstructor_moveFromCType(_ handle: _baseRef) -> ChildWithCustomConstructor {
+    if let swift_pointer = smoke_ChildWithCustomConstructor_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildWithCustomConstructor {
+        smoke_ChildWithCustomConstructor_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ChildWithCustomConstructor_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ChildWithCustomConstructor {
+        smoke_ChildWithCustomConstructor_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func ChildWithCustomConstructor_copyFromCType(_ handle: _baseRef) -> ChildWithCustomConstructor? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ChildWithCustomConstructor_moveFromCType(handle) as ChildWithCustomConstructor
+}
+internal func ChildWithCustomConstructor_moveFromCType(_ handle: _baseRef) -> ChildWithCustomConstructor? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ChildWithCustomConstructor_moveFromCType(handle) as ChildWithCustomConstructor
+}
+internal func copyToCType(_ swiftClass: ChildWithCustomConstructor) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ChildWithCustomConstructor) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: ChildWithCustomConstructor?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ChildWithCustomConstructor?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeSignatureResolver.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeSignatureResolver.kt
@@ -51,17 +51,14 @@ open class LimeSignatureResolver(private val referenceMap: Map<String, LimeEleme
         return getAllFunctions(parentElement).filter { getFunctionName(it) == functionName }
     }
 
-    private fun getAllConstructorOverloads(limeFunction: LimeFunction): List<LimeFunction> {
-        val parentElement = referenceMap[limeFunction.path.parent.toString()]
-        return when (parentElement) {
-            is LimeContainer -> getAllContainerFunctions(parentElement).filter { it.isConstructor }
-            else -> emptyList()
+    private fun getAllConstructorOverloads(limeFunction: LimeFunction) =
+        when (val parentElement = referenceMap[limeFunction.path.parent.toString()]) {
+            is LimeContainer -> getAllFunctions(parentElement).filter { it.isConstructor }
+            else -> listOf(limeFunction)
         }
-    }
 
     private fun getAllFunctions(limeContainer: LimeContainer): List<LimeFunction> {
-        val parentContainer =
-            (limeContainer as? LimeContainerWithInheritance)?.parent?.type as? LimeContainer
+        val parentContainer = (limeContainer as? LimeContainerWithInheritance)?.parent?.type as? LimeContainer
         val parentFunctions = parentContainer?.let { getAllFunctions(it) } ?: emptyList()
         return parentFunctions + getAllContainerFunctions(limeContainer)
     }


### PR DESCRIPTION
Swift generator already had some logic for marking constructor overrides in child classes with `override` keyword. The
predicate for detecting such overrides, however, was incorrect and failed to recognize the case where IDL declarations
of constructors in parent and child classes had different function names.

Fixed the logic in SwiftGeneratorPredicates and LimeSignatureResolver. Added dedicated smoke and functional tests.

Resolves: #820
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>