### PR TITLE
Extract "include" collection logic from CppGenerator

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeImplIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeImplIncludeResolver.kt
@@ -63,7 +63,7 @@ internal class CBridgeImplIncludeResolver(
                 (limeElement.structs + limeElement.lambdas).flatMap { resolveIncludes(it) }
             limeElement is LimeContainerWithInheritance -> resolveClassInterfaceIncludes(limeElement)
             limeElement is LimeGenericType -> resolveGenericTypeIncludes(limeElement)
-            limeElement is LimeType -> cppIncludeResolver.resolveIncludes(limeElement)
+            limeElement is LimeType -> cppIncludeResolver.resolveElementImports(limeElement)
             else -> emptyList()
         }
 
@@ -87,7 +87,7 @@ internal class CBridgeImplIncludeResolver(
         limeStruct.fields.flatMap { resolveTypeRefIncludes(it.typeRef) } + cppIncludeResolver.optionalInclude
 
     private fun resolveContainerIncludes(limeContainer: LimeContainer) =
-        cppIncludeResolver.resolveIncludes(limeContainer) +
+        cppIncludeResolver.resolveElementImports(limeContainer) +
             listOf(CppLibraryIncludes.MEMORY, CppLibraryIncludes.NEW, BASE_HANDLE_IMPL_INCLUDE) +
             (
                 limeContainer.functions + limeContainer.properties + limeContainer.classes +
@@ -95,7 +95,7 @@ internal class CBridgeImplIncludeResolver(
                 ).flatMap { resolveIncludes(it) }
 
     private fun resolveTypeRefIncludes(limeTypeRef: LimeTypeRef): List<Include> =
-        cppIncludeResolver.resolveIncludes(limeTypeRef) +
+        cppIncludeResolver.resolveElementImports(limeTypeRef) +
             limeTypeRef.type.actualType.let { resolveGenericTypeIncludes(it) + resolveHandleIncludes(it) }
 
     private fun resolveHandleIncludes(limeType: LimeType): List<Include> {
@@ -110,9 +110,9 @@ internal class CBridgeImplIncludeResolver(
 
     private fun resolveGenericTypeIncludes(limeType: LimeType) =
         when (limeType) {
-            is LimeList -> cppIncludeResolver.resolveIncludes(limeType) + resolveTypeRefIncludes(limeType.elementType)
-            is LimeSet -> cppIncludeResolver.resolveIncludes(limeType) + resolveTypeRefIncludes(limeType.elementType)
-            is LimeMap -> cppIncludeResolver.resolveIncludes(limeType) + resolveTypeRefIncludes(limeType.keyType) +
+            is LimeList -> cppIncludeResolver.resolveElementImports(limeType) + resolveTypeRefIncludes(limeType.elementType)
+            is LimeSet -> cppIncludeResolver.resolveElementImports(limeType) + resolveTypeRefIncludes(limeType.elementType)
+            is LimeMap -> cppIncludeResolver.resolveElementImports(limeType) + resolveTypeRefIncludes(limeType.keyType) +
                 resolveTypeRefIncludes(limeType.valueType)
             else -> emptyList()
         }
@@ -123,7 +123,7 @@ internal class CBridgeImplIncludeResolver(
                 limeFunction.parameters.map { it.typeRef }
             ).flatMap { resolveTypeRefIncludes(it) }
 
-    private fun resolveLambdaIncludes(limeLambda: LimeLambda) = cppIncludeResolver.resolveIncludes(limeLambda) +
+    private fun resolveLambdaIncludes(limeLambda: LimeLambda) = cppIncludeResolver.resolveElementImports(limeLambda) +
         (limeLambda.parameters.map { it.typeRef } + limeLambda.returnType.typeRef).flatMap { resolveTypeRefIncludes(it) } +
         listOf(CppLibraryIncludes.NEW, BASE_HANDLE_IMPL_INCLUDE, CACHED_PROXY_BASE_INCLUDE, cppIncludeResolver.optionalInclude)
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/ImportsResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/ImportsResolver.kt
@@ -19,9 +19,9 @@
 
 package com.here.gluecodium.generator.common
 
-import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeElement
 
 /** Interface for resolving imports for the given element, but not any nested declarations. */
 fun interface ImportsResolver<T> {
-    fun resolveElementImports(limeElement: LimeNamedElement): List<T>
+    fun resolveElementImports(limeElement: LimeElement): List<T>
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppForwardDeclarationsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppForwardDeclarationsCollector.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.cpp
+
+import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeTypeHelper
+
+internal class CppForwardDeclarationsCollector(private val nameResolver: CppNameResolver) :
+    CppImportsCollector<CppForwardDeclarationGroup>() {
+
+    override fun collectImports(limeElement: LimeNamedElement): List<CppForwardDeclarationGroup> {
+        val allTypeRefs = collectTypeRefs(LimeTypeHelper.getAllTypes(limeElement))
+        val forwardDeclaredTypes = collectForwardDeclaredTypes(allTypeRefs).distinctBy { it.path }.sortedBy { it.path }
+        return createForwardDeclarationGroup("", forwardDeclaredTypes, 0, nameResolver).subGroups
+    }
+
+    private fun createForwardDeclarationGroup(
+        name: String,
+        paths: List<LimeNamedElement>,
+        level: Int,
+        nameResolver: NameResolver
+    ): CppForwardDeclarationGroup =
+        CppForwardDeclarationGroup(
+            name,
+            paths.filter { level == it.path.head.size }.map { nameResolver.resolveName(it) },
+            paths.filter { level < it.path.head.size }
+                .groupBy { it.path.head[level] }
+                .map { createForwardDeclarationGroup(it.key, it.value, level + 1, nameResolver) }
+        )
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppHeaderIncludesCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppHeaderIncludesCollector.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.cpp
+
+import com.here.gluecodium.generator.common.Include
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeEnumeration
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeType
+import com.here.gluecodium.model.lime.LimeTypeHelper
+
+internal class CppHeaderIncludesCollector(
+    private val includesResolver: CppIncludeResolver,
+    private val allErrorEnums: Set<String>
+) : CppImportsCollector<Include>() {
+
+    override fun collectImports(limeElement: LimeNamedElement): List<Include> {
+        val allTypes = LimeTypeHelper.getAllTypes(limeElement)
+        val errorEnums = allTypes.filter { allErrorEnums.contains(it.fullName) }.toSet()
+
+        val typeRegisteredClasses =
+            allTypes.filterIsInstance<LimeContainerWithInheritance>()
+                .filter {
+                    it.external?.cpp == null && it.parent == null &&
+                        (it is LimeInterface || it.visibility.isOpen)
+                }
+        val allTypeRefs = collectTypeRefs(allTypes)
+        val forwardDeclaredTypes = collectForwardDeclaredTypes(allTypeRefs)
+
+        val allValues = LimeTypeHelper.getAllValues(limeElement)
+        val equatableTypes = allTypes.filter { it.external?.cpp == null && it.attributes.have(LimeAttributeType.EQUATABLE) }
+        val additionalIncludes =
+            collectAdditionalIncludes(limeElement, allTypes, equatableTypes, errorEnums, typeRegisteredClasses)
+        return allTypes.filterIsInstance<LimeContainer>()
+            .flatMap { it.functions }
+            .flatMap { includesResolver.resolveElementImports(it) } +
+            allTypeRefs.flatMap { includesResolver.resolveElementImports(it) } +
+            allValues.flatMap { includesResolver.resolveElementImports(it) } +
+            allTypes.flatMap { includesResolver.resolveElementImports(it) } +
+            additionalIncludes - forwardDeclaredTypes.flatMap { includesResolver.resolveElementImports(it) }
+    }
+
+    private fun collectAdditionalIncludes(
+        limeElement: LimeNamedElement,
+        allTypes: List<LimeType>,
+        equatableTypes: List<LimeType>,
+        errorEnums: Set<LimeType>,
+        typeRegisteredClasses: List<LimeContainerWithInheritance>
+    ): List<Include> {
+        val parentIncludes = (limeElement as? LimeContainerWithInheritance)?.parent
+            ?.let { includesResolver.resolveElementImports(it.type) } ?: emptyList()
+        val additionalIncludes = parentIncludes.toMutableList()
+        if (allTypes.any { it is LimeEnumeration }) {
+            additionalIncludes += CppLibraryIncludes.INT_TYPES
+        }
+        if (equatableTypes.isNotEmpty()) {
+            additionalIncludes += includesResolver.hashInclude
+        }
+        if (errorEnums.isNotEmpty()) {
+            additionalIncludes += CppLibraryIncludes.SYSTEM_ERROR
+        }
+        if (typeRegisteredClasses.isNotEmpty()) {
+            additionalIncludes += includesResolver.typeRepositoryInclude
+        }
+        return additionalIncludes
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppImplIncludesCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppImplIncludesCollector.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.cpp
+
+import com.here.gluecodium.generator.common.Include
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeTypeHelper
+
+internal class CppImplIncludesCollector(
+    private val includesResolver: CppIncludeResolver,
+    private val allErrorEnums: Set<String>
+) : CppImportsCollector<Include>() {
+
+    override fun collectImports(limeElement: LimeNamedElement): List<Include> {
+        val allTypes = LimeTypeHelper.getAllTypes(limeElement)
+
+        val result = collectTypeRefs(allTypes).map { it.type }
+            .filterIsInstance<LimeContainerWithInheritance>()
+            .filter { !it.path.hasParent && it.external?.cpp == null }
+            .flatMap { includesResolver.resolveElementImports(it) }
+            .toMutableList()
+
+        val externalContainers = allTypes.filter { it is LimeContainer && it.external?.cpp != null }
+        if (externalContainers.isNotEmpty()) {
+            result += CppLibraryIncludes.TYPE_TRAITS
+            result += externalContainers.flatMap { includesResolver.resolveElementImports(it) }
+        }
+        if (allTypes.any { it is LimeStruct }) {
+            result += CppLibraryIncludes.UTILITY
+        }
+        val errorEnums = allTypes.filter { allErrorEnums.contains(it.fullName) }
+        if (errorEnums.isNotEmpty()) {
+            result += CppLibraryIncludes.STRING
+        }
+
+        return result
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppImportsCollector.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.cpp
+
+import com.here.gluecodium.generator.common.ImportsCollector
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeEnumeration
+import com.here.gluecodium.model.lime.LimeException
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeList
+import com.here.gluecodium.model.lime.LimeMap
+import com.here.gluecodium.model.lime.LimeSet
+import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeType
+import com.here.gluecodium.model.lime.LimeTypeAlias
+import com.here.gluecodium.model.lime.LimeTypeRef
+
+internal abstract class CppImportsCollector<T> : ImportsCollector<T> {
+
+    protected fun collectForwardDeclaredTypes(allTypeRefs: List<LimeTypeRef>) =
+        allTypeRefs.map { it.type }
+            .filterIsInstance<LimeContainerWithInheritance>()
+            .filter { !it.path.hasParent && it.external?.cpp == null }
+
+    protected fun collectTypeRefs(allTypes: List<LimeType>): List<LimeTypeRef> {
+        val containers = allTypes.filterIsInstance<LimeContainer>()
+        val classes = containers.filterIsInstance<LimeContainerWithInheritance>()
+        val typeRefs = containers.flatMap { it.constants }.map { it.typeRef } +
+            containers.filterIsInstance<LimeStruct>().flatMap { it.fields }.map { it.typeRef } +
+            containers.flatMap { it.functions }.flatMap { collectTypeRefs(it) } +
+            classes.flatMap { it.properties }.map { it.typeRef } +
+            allTypes.filterIsInstance<LimeTypeAlias>().map { it.typeRef } +
+            allTypes.filterIsInstance<LimeLambda>().flatMap { collectTypeRefs(it.asFunction()) } +
+            allTypes.filterIsInstance<LimeException>().map { it.errorType }
+
+        return typeRefs + typeRefs.flatMap { collectTypeRefs(it) }
+    }
+
+    private fun collectTypeRefs(limeFunction: LimeFunction) =
+        limeFunction.parameters.map { it.typeRef } +
+            limeFunction.returnType.typeRef +
+            listOfNotNull(
+                limeFunction.exception?.errorType?.takeIf { it.type.actualType !is LimeEnumeration }
+            )
+
+    private fun collectTypeRefs(limeTypeRef: LimeTypeRef): List<LimeTypeRef> =
+        when (val limeType = limeTypeRef.type) {
+            is LimeList -> collectTypeRefs(limeType.elementType) + limeType.elementType
+            is LimeSet -> collectTypeRefs(limeType.elementType) + limeType.elementType
+            is LimeMap -> collectTypeRefs(limeType.keyType) + collectTypeRefs(limeType.valueType) +
+                limeType.keyType + limeType.valueType
+            else -> emptyList()
+        }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -132,7 +132,7 @@ internal class JniTemplates(
         val conversionIncludes =
             jniIncludeResolver.collectConversionIncludes(limeStruct).distinct().minus(selfInclude).sorted()
         // Conversion includes need to be be added to the header file instead of the impl file, for unity builds.
-        val headerIncludes = cppIncludeResolver.resolveIncludes(limeStruct).distinct().sorted() + conversionIncludes
+        val headerIncludes = cppIncludeResolver.resolveElementImports(limeStruct).distinct().sorted() + conversionIncludes
 
         val mustacheData = mutableMapOf(
             "struct" to limeStruct,
@@ -156,7 +156,7 @@ internal class JniTemplates(
     private fun generateEnumConversionFiles(limeEnumeration: LimeEnumeration): List<GeneratedFile> {
         val mustacheData = mutableMapOf(
             "enum" to limeEnumeration,
-            "includes" to cppIncludeResolver.resolveIncludes(limeEnumeration).distinct().sorted(),
+            "includes" to cppIncludeResolver.resolveElementImports(limeEnumeration).distinct().sorted(),
             "internalNamespace" to internalNamespace
         )
 
@@ -181,7 +181,7 @@ internal class JniTemplates(
         val conversionIncludes =
             jniIncludeResolver.collectImplementationIncludes(limeElement).distinct().minus(selfInclude).sorted()
         // Conversion includes need to be be added to the header file instead of the impl file, for unity builds.
-        val headerIncludes = cppIncludeResolver.resolveIncludes(limeElement).distinct().sorted() + conversionIncludes
+        val headerIncludes = cppIncludeResolver.resolveElementImports(limeElement).distinct().sorted() + conversionIncludes
 
         val mustacheData = mutableMapOf(
             "model" to limeElement,
@@ -211,7 +211,7 @@ internal class JniTemplates(
     private fun generateCppProxyFiles(limeElement: LimeNamedElement): List<GeneratedFile> {
         val mustacheData = mutableMapOf(
             "container" to limeElement,
-            "includes" to cppIncludeResolver.resolveIncludes(limeElement).distinct().sorted(),
+            "includes" to cppIncludeResolver.resolveElementImports(limeElement).distinct().sorted(),
             "internalNamespace" to internalNamespace
         )
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/lime/LimeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/lime/LimeGenerator.kt
@@ -35,7 +35,7 @@ import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypesCollection
 
 internal class LimeGenerator : Generator {
-    private val importsCollector = LimeImportsCollector { listOf(it.path) }
+    private val importsCollector = LimeImportsCollector { listOfNotNull((it as? LimeNamedElement)?.path) }
 
     override val shortName = "lime"
 


### PR DESCRIPTION
Extracted collection logic for header includes, implementation includes, and forward declarations from CppGenerator
class into separate stand-alone classes.

See: #810
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
