### PR TITLE
Extract "imports" collection logic from JavaImportsResolver

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportCollector.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.java
+
+import com.here.gluecodium.generator.common.ImportsCollector
+import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
+import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
+import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeConstant
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeField
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeStruct
+
+internal class JavaImportCollector(private val importsResolver: JavaImportResolver) : ImportsCollector<JavaImport> {
+
+    override fun collectImports(limeElement: LimeNamedElement): List<JavaImport> {
+        if (limeElement.attributes.have(JAVA, SKIP)) return emptyList()
+
+        val nestedImports = when (limeElement) {
+            is LimeStruct ->
+                collectContainerImports(limeElement) + limeElement.fields.flatMap { collectImports(it) }
+            is LimeContainer -> collectContainerImports(limeElement)
+            is LimeFunction -> collectFunctionImports(limeElement)
+            is LimeLambda -> collectFunctionImports(limeElement.asFunction())
+            is LimeConstant -> importsResolver.resolveElementImports(limeElement.value)
+            is LimeField ->
+                limeElement.defaultValue?.let { importsResolver.resolveElementImports(it) } ?: emptyList()
+            else -> emptyList()
+        }
+        return importsResolver.resolveElementImports(limeElement) + nestedImports
+    }
+
+    fun collectImplImports(limeInterface: LimeInterface, defImports: List<JavaImport>): List<JavaImport> {
+        val parentTypeRef = limeInterface.parent ?: return defImports
+        val parentImport = importsResolver.createTopElementImport(parentTypeRef.type.actualType)
+        return defImports - parentImport +
+            (limeInterface.inheritedFunctions + limeInterface.inheritedProperties).flatMap { collectImports(it) }
+    }
+
+    private fun collectContainerImports(limeContainer: LimeContainer): List<JavaImport> {
+        val nestedElements = limeContainer.functions + limeContainer.properties + limeContainer.structs +
+            limeContainer.classes + limeContainer.interfaces + limeContainer.exceptions + limeContainer.lambdas +
+            limeContainer.constants
+        val inheritedElements =
+            when {
+                limeContainer !is LimeContainerWithInheritance -> emptyList()
+                (limeContainer is LimeClass && limeContainer.parent?.type?.actualType is LimeInterface) ||
+                    (limeContainer is LimeInterface && limeContainer.path.hasParent) ->
+                    limeContainer.inheritedFunctions + limeContainer.inheritedProperties
+                else -> emptyList()
+            }
+        return (nestedElements + inheritedElements).flatMap { collectImports(it) }
+    }
+
+    private fun collectFunctionImports(limeFunction: LimeFunction): List<JavaImport> {
+        return limeFunction.parameters.flatMap { importsResolver.resolveElementImports(it) }
+    }
+}


### PR DESCRIPTION
Extracted collection logic traversing nested elements from JavaImportResolver into a stand-alone class
JavaImportCollector. JavaImportResolver retains the logic for resolving imports of just one element.

Moved "interface impl imports" collection logic from JavaGenerator into a dedicated method in JavaImportCollector.

See: #810
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>