### PR TITLE
Extract "includes" collection logic from JniIncludeResolver

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
@@ -28,11 +28,13 @@ import com.here.gluecodium.model.lime.LimeBasicType.TypeId.BOOLEAN
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId.VOID
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.CONVERTER_NAME
 import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeTypeRef
 
 /**
@@ -82,4 +84,13 @@ internal class JniGeneratorPredicates(
                 limeFunction.returnType.typeRef.type is LimeClass
         }
     )
+
+    companion object {
+        fun hasThrowingFunctions(limeElement: LimeNamedElement) =
+            when (limeElement) {
+                is LimeContainerWithInheritance -> limeElement.functions + limeElement.inheritedFunctions
+                is LimeContainer -> limeElement.functions
+                else -> emptyList()
+            }.any { it.thrownType != null }
+    }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniIncludeCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniIncludeCollector.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.jni
+
+import com.here.gluecodium.generator.common.ImportsCollector
+import com.here.gluecodium.generator.common.Include
+import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
+import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeProperty
+import com.here.gluecodium.model.lime.LimeStruct
+
+internal class JniIncludeCollector(private val includeResolver: JniIncludeResolver) : ImportsCollector<Include> {
+
+    override fun collectImports(limeElement: LimeNamedElement) =
+        when (limeElement) {
+            is LimeLambda -> collectImplIncludes(limeElement)
+            is LimeContainerWithInheritance -> collectImplIncludes(limeElement) +
+                collectImplIncludes(limeElement.inheritedFunctions, limeElement.inheritedProperties)
+            is LimeContainer -> collectImplIncludes(limeElement)
+            else -> emptyList()
+        }
+
+    private fun collectFunctionTypes(limeFunction: LimeFunction) =
+        limeFunction.parameters.map { it.typeRef } + limeFunction.returnType.typeRef +
+            listOfNotNull(limeFunction.exception?.errorType)
+
+    private fun collectImplIncludes(functions: List<LimeFunction>, properties: List<LimeProperty>): List<Include> {
+        val allFunctions = functions +
+            properties.filterNot { it.attributes.have(JAVA, SKIP) }.flatMap { listOfNotNull(it.getter, it.setter) }
+        return allFunctions.filterNot { it.attributes.have(JAVA, SKIP) }
+            .flatMap { collectFunctionTypes(it) }
+            .flatMap { includeResolver.resolveElementImports(it) }
+    }
+
+    private fun collectImplIncludes(limeLambda: LimeLambda) =
+        collectFunctionTypes(limeLambda.asFunction()).flatMap { includeResolver.resolveElementImports(it) } +
+            includeResolver.resolveElementImports(limeLambda)
+
+    private fun collectImplIncludes(limeContainer: LimeContainer) =
+        collectImplIncludes(limeContainer.functions, limeContainer.properties) +
+            limeContainer.structs.flatMap { collectStructImplIncludes(it) } +
+            includeResolver.resolveElementImports(limeContainer)
+
+    private fun collectStructImplIncludes(limeStruct: LimeStruct): List<Include> {
+        val functionTypes = limeStruct.functions.flatMap { collectFunctionTypes(it) }
+        val fieldTypes = limeStruct.fields.map { it.typeRef }
+        return (functionTypes + fieldTypes).flatMap { includeResolver.resolveElementImports(it) }
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniIncludeResolver.kt
@@ -19,31 +19,32 @@
 
 package com.here.gluecodium.generator.jni
 
+import com.here.gluecodium.generator.common.ImportsResolver
 import com.here.gluecodium.generator.common.Include
-import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
-import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
-import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
-import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
-import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeRef
+import com.here.gluecodium.model.lime.LimeTypedElement
 
-internal class JniIncludeResolver(private val fileNameRules: JniFileNameRules) {
+internal class JniIncludeResolver(private val fileNameRules: JniFileNameRules) : ImportsResolver<Include> {
 
-    private fun getConversionIncludes(limeTypeRef: LimeTypeRef): List<Include> =
-        when (val limeType = limeTypeRef.type.actualType) {
+    override fun resolveElementImports(limeElement: LimeElement): List<Include> =
+        when (limeElement) {
+            is LimeTypeRef -> resolveElementImports(limeElement.type.actualType)
+            is LimeTypedElement -> resolveElementImports(limeElement.typeRef)
+            !is LimeType -> emptyList()
+            is LimeList -> resolveElementImports(limeElement.elementType)
+            is LimeSet -> resolveElementImports(limeElement.elementType)
+            is LimeMap -> resolveElementImports(limeElement.keyType) + resolveElementImports(limeElement.valueType)
             is LimeStruct, is LimeEnumeration, is LimeContainerWithInheritance, is LimeLambda ->
-                listOf(createConversionInclude(limeType))
-            is LimeList -> getConversionIncludes(limeType.elementType)
-            is LimeSet -> getConversionIncludes(limeType.elementType)
-            is LimeMap -> getConversionIncludes(limeType.keyType) + getConversionIncludes(limeType.valueType)
+                listOf(createConversionInclude(limeElement))
             else -> emptyList()
         }
 
@@ -52,47 +53,7 @@ internal class JniIncludeResolver(private val fileNameRules: JniFileNameRules) {
         return Include.createInternalInclude("$fileName.h")
     }
 
-    private fun collectFunctionTypes(limeFunction: LimeFunction) =
-        limeFunction.parameters.map { it.typeRef } + limeFunction.returnType.typeRef +
-            listOfNotNull(limeFunction.exception?.errorType)
-
-    fun collectImplementationIncludes(limeElement: LimeNamedElement): List<Include> {
-        if (limeElement is LimeLambda) {
-            return collectFunctionTypes(limeElement.asFunction()).flatMap { getConversionIncludes(it) } +
-                createConversionInclude(limeElement)
-        }
-        val limeContainer = limeElement as? LimeContainer ?: return emptyList()
-
-        val properties = limeContainer.properties +
-            ((limeContainer as? LimeContainerWithInheritance)?.inheritedProperties ?: emptyList())
-        val functions = limeContainer.functions +
-            ((limeContainer as? LimeContainerWithInheritance)?.inheritedFunctions ?: emptyList())
-        val allFunctions = properties
-            .filterNot { it.attributes.have(JAVA, SKIP) }
-            .flatMap { listOfNotNull(it.getter, it.setter) } + functions +
-            limeContainer.structs.flatMap { it.functions }
-        val types = limeContainer.structs.flatMap { it.fields }.map { it.typeRef } +
-            allFunctions.filterNot { it.attributes.have(JAVA, SKIP) }.flatMap { collectFunctionTypes(it) }
-        return types.flatMap { getConversionIncludes(it) } + createConversionInclude(limeContainer)
-    }
-
-    fun collectFunctionImplementationIncludes(limeStruct: LimeStruct): List<Include> {
-        val types =
-            limeStruct.functions.filterNot { it.attributes.have(JAVA, SKIP) }.flatMap { collectFunctionTypes(it) }
-        return types.flatMap { getConversionIncludes(it) } + createConversionInclude(limeStruct)
-    }
-
-    fun collectConversionIncludes(limeStruct: LimeStruct) =
-        limeStruct.fields.flatMap { getConversionIncludes(it.typeRef) }
-
-    fun collectExceptionIncludes(limeElement: LimeNamedElement): List<Include> {
-        val limeContainer = limeElement as? LimeContainer ?: return emptyList()
-        val allFunctions = limeContainer.functions +
-            ((limeContainer as? LimeContainerWithInheritance)?.inheritedFunctions ?: emptyList())
-        return listOfNotNull(exceptionThrowerInclude.takeIf { allFunctions.any { it.thrownType != null } })
-    }
-
     companion object {
-        private val exceptionThrowerInclude = Include.createInternalInclude("JniExceptionThrower.h")
+        val exceptionThrowerInclude = Include.createInternalInclude("JniExceptionThrower.h")
     }
 }


### PR DESCRIPTION
Extracted collection logic for traversing nested elements from JniIncludeResolver into a stand-alone class
JniIncludeCollector. JniIncludeResolver retains the logic for resolving conversion includes of just one element.

See: #810
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>