### PR TITLE
Don't force Dart nameless constructors

### DIFF
--- a/gluecodium/src/main/resources/templates/dart/DartRedirectConstructor.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartRedirectConstructor.mustache
@@ -20,6 +20,7 @@
   !}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
   factory {{resolveName parent}}{{#unless attributes.dart.default}}{{!!
+  }}{{#isEq constructors.size 1}}{{#if attributes.dart.name}}.{{resolveName}}{{/if}}{{/isEq}}{{!!
   }}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}{{/unless}}({{!!
   }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
   }}){{>dart/DartRedirectImpl}};

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -162,6 +162,8 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveN
 // End of {{resolveName}} "private" section.{{!!
 
 }}{{+dartConstructor}}{{#if attributes.immutable}}const {{/if}}{{resolveName parent}}{{#unless attributes.dart.default}}{{!!
+}}{{#isEq constructors.size 1}}{{#if attributes.dart.name}}.{{resolveName visibility}}{{resolveName}}{{/if}}{{!!
+}}{{#unless attributes.dart.name}}{{#if visibility.isInternal}}.{{resolveName visibility}}{{/if}}{{/unless}}{{/isEq}}{{!!
 }}{{#isNotEq constructors.size 1}}.{{resolveName visibility}}{{resolveName}}{{/isNotEq}}{{!!
 }}{{/unless}}({{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) : {{!!

--- a/gluecodium/src/test/resources/smoke/constructors/input/Constructors.lime
+++ b/gluecodium/src/test/resources/smoke/constructors/input/Constructors.lime
@@ -48,3 +48,14 @@ class ChildConstructors : Constructors {
     @Java(Name = "createCopyFromParent")
     constructor create(other: Constructors)
 }
+
+@Java(Skip) @Swift(Skip)
+class SingleNamelessConstructor {
+    constructor create()
+}
+
+@Java(Skip) @Swift(Skip)
+class SingleNamedConstructor {
+    @Dart("fooBar")
+    constructor create()
+}

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
@@ -1,0 +1,64 @@
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+abstract class SingleNamedConstructor {
+  factory SingleNamedConstructor.fooBar() => SingleNamedConstructor$Impl.fooBar();
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+}
+// SingleNamedConstructor "private" section, not exported.
+final _smoke_SingleNamedConstructor_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SingleNamedConstructor_copy_handle'));
+final _smoke_SingleNamedConstructor_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SingleNamedConstructor_release_handle'));
+class SingleNamedConstructor$Impl implements SingleNamedConstructor {
+  @protected
+  Pointer<Void> handle;
+  SingleNamedConstructor$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.uncacheObject(this);
+    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
+    _smoke_SingleNamedConstructor_release_handle(handle);
+    handle = null;
+  }
+  SingleNamedConstructor$Impl.fooBar() : handle = _fooBar() {
+    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+  }
+  static Pointer<Void> _fooBar() {
+    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_SingleNamedConstructor_create'));
+    final __result_handle = _fooBar_ffi(__lib.LibraryContext.isolateId);
+    return __result_handle;
+  }
+}
+Pointer<Void> smoke_SingleNamedConstructor_toFfi(SingleNamedConstructor value) =>
+  _smoke_SingleNamedConstructor_copy_handle((value as SingleNamedConstructor$Impl).handle);
+SingleNamedConstructor smoke_SingleNamedConstructor_fromFfi(Pointer<Void> handle) {
+  final isolateId = __lib.LibraryContext.isolateId;
+  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final instance = __lib.instanceCache[token] as SingleNamedConstructor;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_SingleNamedConstructor_copy_handle(handle);
+  final result = SingleNamedConstructor$Impl(_copied_handle);
+  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  return result;
+}
+void smoke_SingleNamedConstructor_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_SingleNamedConstructor_release_handle(handle);
+Pointer<Void> smoke_SingleNamedConstructor_toFfi_nullable(SingleNamedConstructor value) =>
+  value != null ? smoke_SingleNamedConstructor_toFfi(value) : Pointer<Void>.fromAddress(0);
+SingleNamedConstructor smoke_SingleNamedConstructor_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_SingleNamedConstructor_fromFfi(handle) : null;
+void smoke_SingleNamedConstructor_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_SingleNamedConstructor_release_handle(handle);
+// End of SingleNamedConstructor "private" section.

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
@@ -1,0 +1,64 @@
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+abstract class SingleNamelessConstructor {
+  factory SingleNamelessConstructor() => SingleNamelessConstructor$Impl.create();
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+}
+// SingleNamelessConstructor "private" section, not exported.
+final _smoke_SingleNamelessConstructor_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SingleNamelessConstructor_copy_handle'));
+final _smoke_SingleNamelessConstructor_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SingleNamelessConstructor_release_handle'));
+class SingleNamelessConstructor$Impl implements SingleNamelessConstructor {
+  @protected
+  Pointer<Void> handle;
+  SingleNamelessConstructor$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.uncacheObject(this);
+    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
+    _smoke_SingleNamelessConstructor_release_handle(handle);
+    handle = null;
+  }
+  SingleNamelessConstructor$Impl.create() : handle = _create() {
+    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+  }
+  static Pointer<Void> _create() {
+    final _create_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_SingleNamelessConstructor_create'));
+    final __result_handle = _create_ffi(__lib.LibraryContext.isolateId);
+    return __result_handle;
+  }
+}
+Pointer<Void> smoke_SingleNamelessConstructor_toFfi(SingleNamelessConstructor value) =>
+  _smoke_SingleNamelessConstructor_copy_handle((value as SingleNamelessConstructor$Impl).handle);
+SingleNamelessConstructor smoke_SingleNamelessConstructor_fromFfi(Pointer<Void> handle) {
+  final isolateId = __lib.LibraryContext.isolateId;
+  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final instance = __lib.instanceCache[token] as SingleNamelessConstructor;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_SingleNamelessConstructor_copy_handle(handle);
+  final result = SingleNamelessConstructor$Impl(_copied_handle);
+  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  return result;
+}
+void smoke_SingleNamelessConstructor_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_SingleNamelessConstructor_release_handle(handle);
+Pointer<Void> smoke_SingleNamelessConstructor_toFfi_nullable(SingleNamelessConstructor value) =>
+  value != null ? smoke_SingleNamelessConstructor_toFfi(value) : Pointer<Void>.fromAddress(0);
+SingleNamelessConstructor smoke_SingleNamelessConstructor_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_SingleNamelessConstructor_fromFfi(handle) : null;
+void smoke_SingleNamelessConstructor_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_SingleNamelessConstructor_release_handle(handle);
+// End of SingleNamelessConstructor "private" section.

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -6,7 +6,7 @@ import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class weeInterface {
-  factory weeInterface(String makeParameter) => weeInterface$Impl.make(makeParameter);
+  factory weeInterface.make(String makeParameter) => weeInterface$Impl.make(makeParameter);
   /// Destroys the underlying native object.
   ///
   /// Call this to free memory when you no longer need this instance.

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
@@ -59,7 +59,7 @@ class weeStruct {
   String WEE_FIELD;
   weeStruct._(this.WEE_FIELD);
   weeStruct._copy(weeStruct _other) : this._(_other.WEE_FIELD);
-  weeStruct(String WeeParameter) : this._copy(_WeeCreate(WeeParameter));
+  weeStruct.WeeCreate(String WeeParameter) : this._copy(_WeeCreate(WeeParameter));
   static weeStruct _WeeCreate(String WeeParameter) {
     final _WeeCreate_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_PlatformNames_BasicStruct_make__String'));
     final _WeeParameter_handle = String_toFfi(WeeParameter);


### PR DESCRIPTION
Updated name resolution logic for Dart constructors when there is a single custom constructor defined in IDL. Previously
this scenario ignored `@Dart("name")` attribute. The updated version does not.

This supports the scenario when a struct/class with two constructors get one constructor deprecated and removed.
Previously this led to the remaining constructor losing its name, breaking the API. New logic avoids this break.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
