### PR TITLE
Fix Dart positional defaults for collection types

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -21,5 +21,10 @@
       <option name="name" value="Google" />
       <option name="url" value="https://dl.google.com/dl/android/maven2/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed Dart compilation error for `@PositionalDefaults` structs with fields of List/Map/Set types.
+
 ## 8.12.0
 Release date: 2021-04-15
 ### Features:

--- a/functional-tests/functional/input/lime/PositionalDefaults.lime
+++ b/functional-tests/functional/input/lime/PositionalDefaults.lime
@@ -40,3 +40,14 @@ struct StructWithJavaPositionalDefaults {
     secondFreeField: Boolean
     thirdInitField: String = "\\Jonny \"Magic\" Smith\n"
 }
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct StructWithCollectionDefaults {
+    emptyListField: List<String> = []
+    emptyMapField: Map<String, String> = []
+    emptySetField: Set<String> = []
+    listField: List<String> = ["foo", "bar"]
+    mapField: Map<String, String> = ["foo": "bar"]
+    setField: Set<String> = ["foo", "bar"]
+}

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -202,7 +202,7 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveN
 }}{{#if attributes.dart.positionalDefaults initializedFields}}{{!!
 }}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}_internal{{/if}}({{!!
   }}{{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}, {{/uninitializedFields}}{{!!
-  }}[{{#initializedFields}}{{resolveName typeRef}} {{resolveName}} = {{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/initializedFields}}])
+  }}[{{#initializedFields}}{{resolveName typeRef}} {{resolveName}} = {{>constPrefix}}{{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/initializedFields}}])
     : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
 {{/if}}{{!!
 }}{{#unless attributes.dart.positionalDefaults initializedFields}}{{!!
@@ -223,4 +223,10 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveN
 
 }}{{+fromFfiFieldInit}}{{!!
 }}      {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle){{#if iter.hasNext}}, {{/if}}
-{{/fromFfiFieldInit}}
+{{/fromFfiFieldInit}}{{!!
+
+}}{{+constPrefix}}{{#set type=typeRef.type.actualType}}{{!!
+}}{{#instanceOf type "LimeList"}}const {{/instanceOf}}{{!!
+}}{{#instanceOf type "LimeMap"}}const {{/instanceOf}}{{!!
+}}{{#instanceOf type "LimeSet"}}const {{/instanceOf}}{{!!
+}}{{/set}}{{/constPrefix}}

--- a/gluecodium/src/test/resources/smoke/defaults/input/PositionalDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/PositionalDefaults.lime
@@ -47,3 +47,15 @@ struct StructWithJavaPositionalDefaults {
     // third should be last!
     thirdInitField: String = "\\Jonny \"Magic\" Smith\n"
 }
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct StructWithCollectionDefaults {
+    emptyListField: List<String> = []
+    emptyMapField: Map<String, String> = []
+    emptySetField: Set<String> = []
+    listField: List<String> = ["foo", "bar"]
+    mapField: Map<String, String> = ["foo": "bar"]
+    setField: Set<String> = ["foo", "bar"]
+}
+

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
@@ -1,0 +1,123 @@
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+class StructWithCollectionDefaults {
+  List<String> emptyListField;
+  Map<String, String> emptyMapField;
+  Set<String> emptySetField;
+  List<String> listField;
+  Map<String, String> mapField;
+  Set<String> setField;
+  StructWithCollectionDefaults([List<String> emptyListField = const [], Map<String, String> emptyMapField = const {}, Set<String> emptySetField = const {}, List<String> listField = const ["foo", "bar"], Map<String, String> mapField = const {"foo": "bar"}, Set<String> setField = const {"foo", "bar"}])
+    : emptyListField = emptyListField, emptyMapField = emptyMapField, emptySetField = emptySetField, listField = listField, mapField = mapField, setField = setField;
+  StructWithCollectionDefaults.withDefaults()
+    : emptyListField = [], emptyMapField = {}, emptySetField = {}, listField = ["foo", "bar"], mapField = {"foo": "bar"}, setField = {"foo", "bar"};
+}
+// StructWithCollectionDefaults "private" section, not exported.
+final _smoke_StructWithCollectionDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
+  >('library_smoke_StructWithCollectionDefaults_create_handle'));
+final _smoke_StructWithCollectionDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_StructWithCollectionDefaults_release_handle'));
+final _smoke_StructWithCollectionDefaults_get_field_emptyListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithCollectionDefaults_get_field_emptyListField'));
+final _smoke_StructWithCollectionDefaults_get_field_emptyMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithCollectionDefaults_get_field_emptyMapField'));
+final _smoke_StructWithCollectionDefaults_get_field_emptySetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithCollectionDefaults_get_field_emptySetField'));
+final _smoke_StructWithCollectionDefaults_get_field_listField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithCollectionDefaults_get_field_listField'));
+final _smoke_StructWithCollectionDefaults_get_field_mapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithCollectionDefaults_get_field_mapField'));
+final _smoke_StructWithCollectionDefaults_get_field_setField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithCollectionDefaults_get_field_setField'));
+Pointer<Void> smoke_StructWithCollectionDefaults_toFfi(StructWithCollectionDefaults value) {
+  final _emptyListField_handle = ListOf_String_toFfi(value.emptyListField);
+  final _emptyMapField_handle = MapOf_String_to_String_toFfi(value.emptyMapField);
+  final _emptySetField_handle = SetOf_String_toFfi(value.emptySetField);
+  final _listField_handle = ListOf_String_toFfi(value.listField);
+  final _mapField_handle = MapOf_String_to_String_toFfi(value.mapField);
+  final _setField_handle = SetOf_String_toFfi(value.setField);
+  final _result = _smoke_StructWithCollectionDefaults_create_handle(_emptyListField_handle, _emptyMapField_handle, _emptySetField_handle, _listField_handle, _mapField_handle, _setField_handle);
+  ListOf_String_releaseFfiHandle(_emptyListField_handle);
+  MapOf_String_to_String_releaseFfiHandle(_emptyMapField_handle);
+  SetOf_String_releaseFfiHandle(_emptySetField_handle);
+  ListOf_String_releaseFfiHandle(_listField_handle);
+  MapOf_String_to_String_releaseFfiHandle(_mapField_handle);
+  SetOf_String_releaseFfiHandle(_setField_handle);
+  return _result;
+}
+StructWithCollectionDefaults smoke_StructWithCollectionDefaults_fromFfi(Pointer<Void> handle) {
+  final _emptyListField_handle = _smoke_StructWithCollectionDefaults_get_field_emptyListField(handle);
+  final _emptyMapField_handle = _smoke_StructWithCollectionDefaults_get_field_emptyMapField(handle);
+  final _emptySetField_handle = _smoke_StructWithCollectionDefaults_get_field_emptySetField(handle);
+  final _listField_handle = _smoke_StructWithCollectionDefaults_get_field_listField(handle);
+  final _mapField_handle = _smoke_StructWithCollectionDefaults_get_field_mapField(handle);
+  final _setField_handle = _smoke_StructWithCollectionDefaults_get_field_setField(handle);
+  try {
+    return StructWithCollectionDefaults(
+      ListOf_String_fromFfi(_emptyListField_handle),
+      MapOf_String_to_String_fromFfi(_emptyMapField_handle),
+      SetOf_String_fromFfi(_emptySetField_handle),
+      ListOf_String_fromFfi(_listField_handle),
+      MapOf_String_to_String_fromFfi(_mapField_handle),
+      SetOf_String_fromFfi(_setField_handle)
+    );
+  } finally {
+    ListOf_String_releaseFfiHandle(_emptyListField_handle);
+    MapOf_String_to_String_releaseFfiHandle(_emptyMapField_handle);
+    SetOf_String_releaseFfiHandle(_emptySetField_handle);
+    ListOf_String_releaseFfiHandle(_listField_handle);
+    MapOf_String_to_String_releaseFfiHandle(_mapField_handle);
+    SetOf_String_releaseFfiHandle(_setField_handle);
+  }
+}
+void smoke_StructWithCollectionDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithCollectionDefaults_release_handle(handle);
+// Nullable StructWithCollectionDefaults
+final _smoke_StructWithCollectionDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithCollectionDefaults_create_handle_nullable'));
+final _smoke_StructWithCollectionDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_StructWithCollectionDefaults_release_handle_nullable'));
+final _smoke_StructWithCollectionDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithCollectionDefaults_get_value_nullable'));
+Pointer<Void> smoke_StructWithCollectionDefaults_toFfi_nullable(StructWithCollectionDefaults value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smoke_StructWithCollectionDefaults_toFfi(value);
+  final result = _smoke_StructWithCollectionDefaults_create_handle_nullable(_handle);
+  smoke_StructWithCollectionDefaults_releaseFfiHandle(_handle);
+  return result;
+}
+StructWithCollectionDefaults smoke_StructWithCollectionDefaults_fromFfi_nullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smoke_StructWithCollectionDefaults_get_value_nullable(handle);
+  final result = smoke_StructWithCollectionDefaults_fromFfi(_handle);
+  smoke_StructWithCollectionDefaults_releaseFfiHandle(_handle);
+  return result;
+}
+void smoke_StructWithCollectionDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_StructWithCollectionDefaults_release_handle_nullable(handle);
+// End of StructWithCollectionDefaults "private" section.


### PR DESCRIPTION
Updated Dart template to add `const` keyword when initializing constructor parameters with values of List/Map/Set types
for structs with `@Dart(PositionalDefaults)`. This fixes a compilation error.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>