### PR TITLE
Fix nesting+inheritance mixup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed compilation issues for all languages when a nested class/interface is declared in an outer class/interface
+    and the outer type has an inheritance parent.
+
 ## 8.12.2
 Release date: 2021-04-22
 ### Bug fixes:

--- a/functional-tests/functional/input/lime/NestedContainers.lime
+++ b/functional-tests/functional/input/lime/NestedContainers.lime
@@ -51,3 +51,19 @@ class LevelOne {
         }
     }
 }
+
+open class NestedContainersParentClass {
+    fun parentFun()
+    property parentProperty: String
+}
+
+class OuterClassWithInheritance : NestedContainersParentClass {
+    class OuterClassInnerClass {
+        fun bar(input: String): String
+    }
+    interface OuterClassInnerInterface {
+        fun baz(input: String): String
+    }
+
+    fun foo(input: String): String
+}

--- a/gluecodium/src/main/resources/templates/cpp/CppClass.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppClass.mustache
@@ -20,7 +20,8 @@
   !}}
 {{#unless external.cpp}}{{!!
 }}{{>cpp/CppDocComment}}
-class {{>cpp/CppExportMacro}}{{>cpp/CppAttributesInline}}{{resolveName}}{{#if parent}}: public {{resolveName parent.type "FQN"}}{{/if}} {
+class {{>cpp/CppExportMacro}}{{>cpp/CppAttributesInline}}{{resolveName}}{{!!
+}}{{#if this.parent}}: public {{resolveName this.parent.type "FQN"}}{{/if}} {
 public:
     {{resolveName}}();
     virtual ~{{resolveName}}() = 0;

--- a/gluecodium/src/main/resources/templates/cpp/CppClassImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppClassImpl.mustache
@@ -20,12 +20,12 @@
   !}}
 {{#unless external.cpp}}
 {{#parentName}}{{.}}::{{/parentName}}{{resolveName}}::{{resolveName}}() {
-{{#if parent}}
+{{#if this.parent}}
     {{>common/InternalNamespace}}get_type_repository().add_type(this, "{{#namespace}}{{.}}_{{/namespace}}{{resolveName}}");
 {{/if}}
 }
 {{#parentName}}{{.}}::{{/parentName}}{{resolveName}}::~{{resolveName}}() {
-{{#if parent}}
+{{#if this.parent}}
     {{>common/InternalNamespace}}get_type_repository().remove_type(this);
 {{/if}}
 }

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
-{{#unless testableMode}}abstract {{/unless}}class {{resolveName}} {{#if parent}}implements {{resolveName parent}} {{/if}}{
+{{#unless testableMode}}abstract {{/unless}}class {{resolveName}} {{#if this.parent}}implements {{resolveName this.parent}} {{/if}}{
 {{#set parent=this}}{{#constructors}}
 {{>dart/DartRedirectConstructor}}
 {{/constructors}}{{/set}}
@@ -73,7 +73,7 @@ final _{{resolveName "Ffi"}}_release_handle = __lib.catchArgumentError(() => __l
   >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle'));
 {{#if attributes.equatable}}{{>dart/DartFfiEqualityFunction}}{{/if}}{{!!
 }}{{#if attributes.pointerEquatable}}{{>dart/DartFfiEqualityFunction}}{{/if}}
-{{#if parent visibility.isOpen logic="or"}}
+{{#if this.parent visibility.isOpen logic="or"}}
 final _{{resolveName "Ffi"}}_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -103,7 +103,7 @@ class {{resolveName}}$Impl{{!!
     handle = null;
   }
 
-{{#set inheritanceParent=parent parent=this ignoreStatic=testableMode}}{{#constructors}}
+{{#set inheritanceParent=this.parent parent=this ignoreStatic=testableMode}}{{#constructors}}
 {{prefixPartial "dartConstructor" "  "}}
 {{/constructors}}
 {{#functions}}
@@ -115,17 +115,17 @@ class {{resolveName}}$Impl{{!!
 {{#unless isStatic}}  @override
 {{/unless}}
 {{prefixPartial "dart/DartFunction" "  "}}
-{{/inheritedFunctions}}{{/instanceOf}}{{/if}}{{/set}}
+{{/inheritedFunctions}}{{/instanceOf}}{{/if}}
 {{#set override=true skipDocs=true}}{{#properties}}{{#if attributes.cached}}
 {{prefixPartial "dartCachedProperty" "  "}}
 {{/if}}{{#unless attributes.cached}}
 {{prefixPartial "dart/DartProperty" "  "}}
 {{/unless}}{{/properties}}
-{{#if parent}}{{#instanceOf parent.type.actualType "LimeInterface"}}
+{{#if inheritanceParent}}{{#instanceOf inheritanceParent.type.actualType "LimeInterface"}}
 {{#inheritedProperties}}
 {{prefixPartial "dart/DartProperty" "  "}}
 {{/inheritedProperties}}
-{{/instanceOf}}{{/if}}{{/set}}
+{{/instanceOf}}{{/if}}{{/set}}{{/set}}
 {{#if attributes.equatable}}{{prefixPartial "dart/DartEqualityOperator" "  "}}{{/if}}{{!!
 }}{{#if attributes.pointerEquatable}}{{prefixPartial "dart/DartEqualityOperator" "  "}}{{/if}}
 }
@@ -139,14 +139,14 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) =>
   final instance = __lib.instanceCache[token] as {{resolveName}};
   if (instance != null) return instance;
 
-{{#if parent visibility.isOpen logic="or"}}
+{{#if this.parent visibility.isOpen logic="or"}}
   final _type_id_handle = _{{resolveName "Ffi"}}_get_type_id(handle);
   final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
   String_releaseFfiHandle(_type_id_handle);
 
 {{/if}}
   final _copied_handle = _{{resolveName "Ffi"}}_copy_handle(handle);
-  final result = {{#if parent visibility.isOpen logic="or"}}factoryConstructor != null
+  final result = {{#if this.parent visibility.isOpen logic="or"}}factoryConstructor != null
     ? factoryConstructor(_copied_handle)
     : {{/if}}{{resolveName}}$Impl(_copied_handle);
   __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
-abstract class {{resolveName}} {{#if parent}}implements {{resolveName parent}} {{/if}}{
+abstract class {{resolveName}} {{#if this.parent}}implements {{resolveName this.parent}} {{/if}}{
 {{#if inheritedFunctions functions inheritedProperties properties logic="or"}}
   {{resolveName}}() {}
 

--- a/gluecodium/src/main/resources/templates/java/JavaClass.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaClass.mustache
@@ -75,7 +75,7 @@
 {{/setter}}{{/set}}
 {{/unless}}{{/properties}}
 
-{{#if parent}}{{#instanceOf parent.type.actualType "LimeInterface"}}{{#set override=true classElement=this}}
+{{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}{{#set override=true classElement=this}}
 {{#set isClass=true}}{{#classElement.inheritedFunctions}}{{#unless attributes.java.skip}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/unless}}{{/classElement.inheritedFunctions}}{{/set}}

--- a/gluecodium/src/main/resources/templates/java/JavaInterface.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaInterface.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>java/JavaDocComment}}{{>java/JavaAttributes}}
-{{resolveName visibility}}interface {{resolveName}} {{#if this.parent}}extends {{resolveName parent "" ref}} {{/if}}{
+{{resolveName visibility}}interface {{resolveName}} {{#if this.parent}}extends {{resolveName this.parent "" ref}} {{/if}}{
 {{#constants}}{{prefixPartial "java/JavaConstant" "    "}}
 {{/constants}}
 {{>java/JavaContainerContents}}

--- a/gluecodium/src/main/resources/templates/jni/Header.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Header.mustache
@@ -37,7 +37,7 @@ extern "C" {
 
 {{/unless}}{{/properties}}
 
-{{#if parent}}{{#instanceOf parent.type.actualType "LimeInterface"}}
+{{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}
 {{#inheritedFunctions}}{{#unless attributes.java.skip}}
 {{>jniFunctionHeader}}
 

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -38,7 +38,7 @@ extern "C" {
 {{>jniPropertyImpl}}
 {{/unless}}{{/properties}}
 
-{{#if parent}}{{#instanceOf parent.type.actualType "LimeInterface"}}
+{{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}
 {{#inheritedFunctions}}{{#unless attributes.java.skip}}
 {{>jniMethodImpl}}
 

--- a/gluecodium/src/main/resources/templates/lime/LimeClass.mustache
+++ b/gluecodium/src/main/resources/templates/lime/LimeClass.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>lime/LimeDocumentation}}
-{{visibility}}class {{escapedName}} {{#parent}}: {{type.name}} {{/parent}}{
+{{visibility}}class {{escapedName}} {{#this.parent}}: {{type.name}} {{/this.parent}}{
 {{prefixPartial "lime/LimeExternalDescriptor" "    "}}
 {{>lime/LimeContainerContents}}
 }

--- a/gluecodium/src/main/resources/templates/lime/LimeInterface.mustache
+++ b/gluecodium/src/main/resources/templates/lime/LimeInterface.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>lime/LimeDocumentation}}
-{{visibility}}interface {{escapedName}} {{#parent}}: {{type.name}} {{/parent}}{
+{{visibility}}interface {{escapedName}} {{#this.parent}}: {{type.name}} {{/this.parent}}{
 {{prefixPartial "lime/LimeExternalDescriptor" "    "}}
 {{>lime/LimeContainerContents}}
 }

--- a/gluecodium/src/main/resources/templates/swift/CommonClassParts.mustache
+++ b/gluecodium/src/main/resources/templates/swift/CommonClassParts.mustache
@@ -21,7 +21,7 @@
 {{#constants}}
 {{>swift/SwiftConstant}}
 {{/constants}}
-{{#if parent}}{{#instanceOf parent.type.actualType "LimeInterface"}}
+{{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}
 {{#inheritedProperties}}{{#unless attributes.swift.skip}}
 {{>swift/SwiftProperty}}
 {{/unless}}{{/inheritedProperties}}
@@ -61,7 +61,7 @@ deinit {
 {{>swift/SwiftStructDefinition}}
 {{/structs}}{{/unless}}{{!!
 
-}}{{#if parent}}{{#instanceOf parent.type.actualType "LimeInterface"}}
+}}{{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}
 {{#inheritedFunctions}}{{#unless attributes.swift.skip}}
 {{>swift/SwiftFunctionSignature}} {{prefixPartial "swift/SwiftFunctionBody" "" skipFirstLine=true}}
 {{/unless}}{{/inheritedFunctions}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
@@ -20,7 +20,7 @@
   !}}
 {{>swift/SwiftComment}}{{>swift/SwiftAttributes}}{{!!
 }}{{resolveName visibility}} class {{resolveName}}{{!!
-}}{{#if parent}}: {{resolveName parent}}{{/if}}{{#unless parent}}{{/unless}} {
+}}{{#if this.parent}}: {{resolveName this.parent}}{{/if}} {
 
 {{#each typeAliases exceptions}}
 {{prefixPartial "swift/SwiftTypeAlias" "    "}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftInterfaceDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftInterfaceDefinition.mustache
@@ -20,7 +20,7 @@
   !}}
 {{>swift/SwiftComment}}{{>swift/SwiftAttributes}}{{!!
 }}{{resolveName visibility}} protocol {{resolveName}} : {{!!
-}}{{#if parent}}{{resolveName parent}}{{/if}}{{#unless parent}}AnyObject{{/unless}} {
+}}{{#if this.parent}}{{resolveName this.parent}}{{/if}}{{#unless this.parent}}AnyObject{{/unless}} {
 {{#set isInterface=true interface=this}}{{#each typeAliases exceptions}}
 {{prefixPartial "swift/SwiftTypeAlias" "    "}}
 {{/each}}

--- a/gluecodium/src/test/resources/smoke/nesting/input/NestedContainers.lime
+++ b/gluecodium/src/test/resources/smoke/nesting/input/NestedContainers.lime
@@ -62,10 +62,10 @@ open class ParentClass {
 
 class OuterClassWithInheritance : ParentClass {
     class InnerClass {
-        fun foo(input: String): String
+        fun bar(input: String): String
     }
     interface InnerInterface {
-        fun foo(input: String): String
+        fun baz(input: String): String
     }
 
     fun foo(input: String): String

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/OuterClassWithInheritance.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/OuterClassWithInheritance.java
@@ -20,7 +20,7 @@ public final class OuterClassWithInheritance extends ParentClass {
         }
         private static native void disposeNativeHandle(long nativeHandle);
         @NonNull
-        public native String foo(@NonNull final String input);
+        public native String bar(@NonNull final String input);
     }
     /**
      * @exclude
@@ -36,11 +36,11 @@ public final class OuterClassWithInheritance extends ParentClass {
         }
         private static native void disposeNativeHandle(long nativeHandle);
         @NonNull
-        public native String foo(@NonNull final String input);
+        public native String baz(@NonNull final String input);
     }
     public interface InnerInterface {
         @NonNull
-        String foo(@NonNull final String input);
+        String baz(@NonNull final String input);
     }
     /**
      * For internal use only.

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterClassWithInheritance.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterClassWithInheritance.h
@@ -1,0 +1,33 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium\ExportGluecodiumCpp.h"
+#include "gluecodium\TypeRepository.h"
+#include "smoke\ParentClass.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT OuterClassWithInheritance: public ::smoke::ParentClass {
+public:
+    OuterClassWithInheritance();
+    virtual ~OuterClassWithInheritance() = 0;
+public:
+    class _GLUECODIUM_CPP_EXPORT InnerClass {
+    public:
+        InnerClass();
+        virtual ~InnerClass() = 0;
+    public:
+        virtual ::std::string bar( const ::std::string& input ) = 0;
+    };
+    class _GLUECODIUM_CPP_EXPORT InnerInterface {
+    public:
+        InnerInterface();
+        virtual ~InnerInterface() = 0;
+    public:
+        virtual ::std::string baz( const ::std::string& input ) = 0;
+    };
+public:
+    virtual ::std::string foo( const ::std::string& input ) = 0;
+};
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/src/smoke/OuterClassWithInheritance.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/src/smoke/OuterClassWithInheritance.cpp
@@ -1,0 +1,21 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#include "smoke/OuterClassWithInheritance.h"
+namespace smoke {
+OuterClassWithInheritance::OuterClassWithInheritance() {
+    ::gluecodium::get_type_repository().add_type(this, "smoke_OuterClassWithInheritance");
+}
+OuterClassWithInheritance::~OuterClassWithInheritance() {
+    ::gluecodium::get_type_repository().remove_type(this);
+}
+OuterClassWithInheritance::InnerClass::InnerClass() {
+}
+OuterClassWithInheritance::InnerClass::~InnerClass() {
+}
+OuterClassWithInheritance::InnerInterface::InnerInterface() {
+}
+OuterClassWithInheritance::InnerInterface::~InnerInterface() {
+}
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -1,0 +1,254 @@
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/parent_class.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+abstract class OuterClassWithInheritance implements ParentClass {
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+  String foo(String input);
+}
+abstract class OuterClassWithInheritance_InnerClass {
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release();
+  String bar(String input);
+}
+// OuterClassWithInheritance_InnerClass "private" section, not exported.
+final _smoke_OuterClassWithInheritance_InnerClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInheritance_InnerClass_copy_handle'));
+final _smoke_OuterClassWithInheritance_InnerClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInheritance_InnerClass_release_handle'));
+class OuterClassWithInheritance_InnerClass$Impl implements OuterClassWithInheritance_InnerClass {
+  @protected
+  Pointer<Void> handle;
+  OuterClassWithInheritance_InnerClass$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.uncacheObject(this);
+    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
+    _smoke_OuterClassWithInheritance_InnerClass_release_handle(handle);
+    handle = null;
+  }
+  @override
+  String bar(String input) {
+    final _bar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClassWithInheritance_InnerClass_bar__String'));
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _bar_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
+  }
+}
+Pointer<Void> smoke_OuterClassWithInheritance_InnerClass_toFfi(OuterClassWithInheritance_InnerClass value) =>
+  _smoke_OuterClassWithInheritance_InnerClass_copy_handle((value as OuterClassWithInheritance_InnerClass$Impl).handle);
+OuterClassWithInheritance_InnerClass smoke_OuterClassWithInheritance_InnerClass_fromFfi(Pointer<Void> handle) {
+  final isolateId = __lib.LibraryContext.isolateId;
+  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final instance = __lib.instanceCache[token] as OuterClassWithInheritance_InnerClass;
+  if (instance != null) return instance;
+  final _copied_handle = _smoke_OuterClassWithInheritance_InnerClass_copy_handle(handle);
+  final result = OuterClassWithInheritance_InnerClass$Impl(_copied_handle);
+  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  return result;
+}
+void smoke_OuterClassWithInheritance_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_OuterClassWithInheritance_InnerClass_release_handle(handle);
+Pointer<Void> smoke_OuterClassWithInheritance_InnerClass_toFfi_nullable(OuterClassWithInheritance_InnerClass value) =>
+  value != null ? smoke_OuterClassWithInheritance_InnerClass_toFfi(value) : Pointer<Void>.fromAddress(0);
+OuterClassWithInheritance_InnerClass smoke_OuterClassWithInheritance_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_OuterClassWithInheritance_InnerClass_fromFfi(handle) : null;
+void smoke_OuterClassWithInheritance_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_OuterClassWithInheritance_InnerClass_release_handle(handle);
+// End of OuterClassWithInheritance_InnerClass "private" section.
+abstract class OuterClassWithInheritance_InnerInterface {
+  OuterClassWithInheritance_InnerInterface() {}
+  factory OuterClassWithInheritance_InnerInterface.fromLambdas({
+    @required String Function(String) lambda_baz,
+  }) => OuterClassWithInheritance_InnerInterface$Lambdas(
+    lambda_baz,
+  );
+  /// Destroys the underlying native object.
+  ///
+  /// Call this to free memory when you no longer need this instance.
+  /// Note that setting the instance to null will not destroy the underlying native object.
+  void release() {}
+  String baz(String input);
+}
+// OuterClassWithInheritance_InnerInterface "private" section, not exported.
+final _smoke_OuterClassWithInheritance_InnerInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInheritance_InnerInterface_copy_handle'));
+final _smoke_OuterClassWithInheritance_InnerInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInheritance_InnerInterface_release_handle'));
+final _smoke_OuterClassWithInheritance_InnerInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
+    Pointer<Void> Function(int, int, Pointer, Pointer)
+  >('library_smoke_OuterClassWithInheritance_InnerInterface_create_proxy'));
+final _smoke_OuterClassWithInheritance_InnerInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInheritance_InnerInterface_get_type_id'));
+class OuterClassWithInheritance_InnerInterface$Lambdas implements OuterClassWithInheritance_InnerInterface {
+  String Function(String) lambda_baz;
+  OuterClassWithInheritance_InnerInterface$Lambdas(
+    this.lambda_baz,
+  );
+  @override
+  void release() {}
+  @override
+  String baz(String input) =>
+    lambda_baz(input);
+}
+class OuterClassWithInheritance_InnerInterface$Impl implements OuterClassWithInheritance_InnerInterface {
+  Pointer<Void> handle;
+  OuterClassWithInheritance_InnerInterface$Impl(this.handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.uncacheObject(this);
+    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
+    _smoke_OuterClassWithInheritance_InnerInterface_release_handle(handle);
+    handle = null;
+  }
+  @override
+  String baz(String input) {
+    final _baz_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClassWithInheritance_InnerInterface_baz__String'));
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _baz_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
+  }
+}
+int _OuterClassWithInheritance_InnerInterface_baz_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
+  String _result_object = null;
+  try {
+    _result_object = (__lib.instanceCache[_token] as OuterClassWithInheritance_InnerInterface).baz(String_fromFfi(input));
+    _result.value = String_toFfi(_result_object);
+  } finally {
+    String_releaseFfiHandle(input);
+  }
+  return 0;
+}
+Pointer<Void> smoke_OuterClassWithInheritance_InnerInterface_toFfi(OuterClassWithInheritance_InnerInterface value) {
+  if (value is OuterClassWithInheritance_InnerInterface$Impl) return _smoke_OuterClassWithInheritance_InnerInterface_copy_handle(value.handle);
+  final result = _smoke_OuterClassWithInheritance_InnerInterface_create_proxy(
+    __lib.cacheObject(value),
+    __lib.LibraryContext.isolateId,
+    __lib.uncacheObjectFfi,
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterClassWithInheritance_InnerInterface_baz_static, __lib.unknownError)
+  );
+  return result;
+}
+OuterClassWithInheritance_InnerInterface smoke_OuterClassWithInheritance_InnerInterface_fromFfi(Pointer<Void> handle) {
+  final isolateId = __lib.LibraryContext.isolateId;
+  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final instance = __lib.instanceCache[token] as OuterClassWithInheritance_InnerInterface;
+  if (instance != null) return instance;
+  final _type_id_handle = _smoke_OuterClassWithInheritance_InnerInterface_get_type_id(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
+  String_releaseFfiHandle(_type_id_handle);
+  final _copied_handle = _smoke_OuterClassWithInheritance_InnerInterface_copy_handle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copied_handle)
+    : OuterClassWithInheritance_InnerInterface$Impl(_copied_handle);
+  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  return result;
+}
+void smoke_OuterClassWithInheritance_InnerInterface_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_OuterClassWithInheritance_InnerInterface_release_handle(handle);
+Pointer<Void> smoke_OuterClassWithInheritance_InnerInterface_toFfi_nullable(OuterClassWithInheritance_InnerInterface value) =>
+  value != null ? smoke_OuterClassWithInheritance_InnerInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
+OuterClassWithInheritance_InnerInterface smoke_OuterClassWithInheritance_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_OuterClassWithInheritance_InnerInterface_fromFfi(handle) : null;
+void smoke_OuterClassWithInheritance_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_OuterClassWithInheritance_InnerInterface_release_handle(handle);
+// End of OuterClassWithInheritance_InnerInterface "private" section.
+// OuterClassWithInheritance "private" section, not exported.
+final _smoke_OuterClassWithInheritance_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInheritance_copy_handle'));
+final _smoke_OuterClassWithInheritance_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInheritance_release_handle'));
+final _smoke_OuterClassWithInheritance_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInheritance_get_type_id'));
+class OuterClassWithInheritance$Impl extends ParentClass$Impl implements OuterClassWithInheritance {
+  OuterClassWithInheritance$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {
+    if (handle == null) return;
+    __lib.uncacheObject(this);
+    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
+    _smoke_OuterClassWithInheritance_release_handle(handle);
+    handle = null;
+  }
+  @override
+  String foo(String input) {
+    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClassWithInheritance_foo__String'));
+    final _input_handle = String_toFfi(input);
+    final _handle = this.handle;
+    final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
+    String_releaseFfiHandle(_input_handle);
+    try {
+      return String_fromFfi(__result_handle);
+    } finally {
+      String_releaseFfiHandle(__result_handle);
+    }
+  }
+}
+Pointer<Void> smoke_OuterClassWithInheritance_toFfi(OuterClassWithInheritance value) =>
+  _smoke_OuterClassWithInheritance_copy_handle((value as OuterClassWithInheritance$Impl).handle);
+OuterClassWithInheritance smoke_OuterClassWithInheritance_fromFfi(Pointer<Void> handle) {
+  final isolateId = __lib.LibraryContext.isolateId;
+  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final instance = __lib.instanceCache[token] as OuterClassWithInheritance;
+  if (instance != null) return instance;
+  final _type_id_handle = _smoke_OuterClassWithInheritance_get_type_id(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
+  String_releaseFfiHandle(_type_id_handle);
+  final _copied_handle = _smoke_OuterClassWithInheritance_copy_handle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copied_handle)
+    : OuterClassWithInheritance$Impl(_copied_handle);
+  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  return result;
+}
+void smoke_OuterClassWithInheritance_releaseFfiHandle(Pointer<Void> handle) =>
+  _smoke_OuterClassWithInheritance_release_handle(handle);
+Pointer<Void> smoke_OuterClassWithInheritance_toFfi_nullable(OuterClassWithInheritance value) =>
+  value != null ? smoke_OuterClassWithInheritance_toFfi(value) : Pointer<Void>.fromAddress(0);
+OuterClassWithInheritance smoke_OuterClassWithInheritance_fromFfi_nullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smoke_OuterClassWithInheritance_fromFfi(handle) : null;
+void smoke_OuterClassWithInheritance_releaseFfiHandle_nullable(Pointer<Void> handle) =>
+  _smoke_OuterClassWithInheritance_release_handle(handle);
+// End of OuterClassWithInheritance "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/lime/smoke/OuterClassWithInheritance.lime
+++ b/gluecodium/src/test/resources/smoke/nesting/output/lime/smoke/OuterClassWithInheritance.lime
@@ -1,0 +1,16 @@
+package smoke
+class OuterClassWithInheritance : ParentClass {
+    class InnerClass {
+        fun bar(
+            input: String
+        ): String
+    }
+    interface InnerInterface {
+        fun baz(
+            input: String
+        ): String
+    }
+    fun foo(
+        input: String
+    ): String
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClassWithInheritance.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterClassWithInheritance.swift
@@ -1,0 +1,272 @@
+//
+//
+import Foundation
+public class OuterClassWithInheritance: ParentClass {
+    init(cOuterClassWithInheritance: _baseRef) {
+        super.init(cParentClass: cOuterClassWithInheritance)
+    }
+    public class InnerClass {
+        let c_instance : _baseRef
+        init(cInnerClass: _baseRef) {
+            guard cInnerClass != 0 else {
+                fatalError("Nullptr value is not supported for initializers")
+            }
+            c_instance = cInnerClass
+        }
+        deinit {
+            smoke_OuterClassWithInheritance_InnerClass_remove_swift_object_from_wrapper_cache(c_instance)
+            smoke_OuterClassWithInheritance_InnerClass_release_handle(c_instance)
+        }
+        public func bar(input: String) -> String {
+            let c_input = moveToCType(input)
+            let c_result_handle = smoke_OuterClassWithInheritance_InnerClass_bar(self.c_instance, c_input.ref)
+            return moveFromCType(c_result_handle)
+        }
+    }
+    public func foo(input: String) -> String {
+        let c_input = moveToCType(input)
+        let c_result_handle = smoke_OuterClassWithInheritance_foo(self.c_instance, c_input.ref)
+        return moveFromCType(c_result_handle)
+    }
+}
+public protocol InnerInterface : AnyObject {
+    func baz(input: String) -> String
+}
+internal class _InnerInterface: InnerInterface {
+    let c_instance : _baseRef
+    init(cInnerInterface: _baseRef) {
+        guard cInnerInterface != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cInnerInterface
+    }
+    deinit {
+        smoke_OuterClassWithInheritance_InnerInterface_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_OuterClassWithInheritance_InnerInterface_release_handle(c_instance)
+    }
+    public func baz(input: String) -> String {
+        let c_input = moveToCType(input)
+        let c_result_handle = smoke_OuterClassWithInheritance_InnerInterface_baz(self.c_instance, c_input.ref)
+        return moveFromCType(c_result_handle)
+    }
+}
+@_cdecl("_CBridgeInitsmoke_OuterClassWithInheritance")
+internal func _CBridgeInitsmoke_OuterClassWithInheritance(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = OuterClassWithInheritance(cOuterClassWithInheritance: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: OuterClassWithInheritance?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_OuterClassWithInheritance_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_OuterClassWithInheritance_release_handle)
+        : RefHolder(handle_copy)
+}
+internal func OuterClassWithInheritance_copyFromCType(_ handle: _baseRef) -> OuterClassWithInheritance {
+    if let swift_pointer = smoke_OuterClassWithInheritance_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClassWithInheritance {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_OuterClassWithInheritance_get_typed(smoke_OuterClassWithInheritance_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? OuterClassWithInheritance {
+        smoke_OuterClassWithInheritance_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func OuterClassWithInheritance_moveFromCType(_ handle: _baseRef) -> OuterClassWithInheritance {
+    if let swift_pointer = smoke_OuterClassWithInheritance_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClassWithInheritance {
+        smoke_OuterClassWithInheritance_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_OuterClassWithInheritance_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? OuterClassWithInheritance {
+        smoke_OuterClassWithInheritance_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func OuterClassWithInheritance_copyFromCType(_ handle: _baseRef) -> OuterClassWithInheritance? {
+    guard handle != 0 else {
+        return nil
+    }
+    return OuterClassWithInheritance_moveFromCType(handle) as OuterClassWithInheritance
+}
+internal func OuterClassWithInheritance_moveFromCType(_ handle: _baseRef) -> OuterClassWithInheritance? {
+    guard handle != 0 else {
+        return nil
+    }
+    return OuterClassWithInheritance_moveFromCType(handle) as OuterClassWithInheritance
+}
+internal func copyToCType(_ swiftClass: OuterClassWithInheritance) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: OuterClassWithInheritance) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: OuterClassWithInheritance?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: OuterClassWithInheritance?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func getRef(_ ref: OuterClassWithInheritance.InnerClass?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_OuterClassWithInheritance_InnerClass_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_OuterClassWithInheritance_InnerClass_release_handle)
+        : RefHolder(handle_copy)
+}
+extension OuterClassWithInheritance.InnerClass: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+extension OuterClassWithInheritance.InnerClass: Hashable {
+    /// :nodoc:
+    public static func == (lhs: OuterClassWithInheritance.InnerClass, rhs: OuterClassWithInheritance.InnerClass) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    /// :nodoc:
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
+internal func OuterClassWithInheritance_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterClassWithInheritance.InnerClass {
+    if let swift_pointer = smoke_OuterClassWithInheritance_InnerClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClassWithInheritance.InnerClass {
+        return re_constructed
+    }
+    let result = OuterClassWithInheritance.InnerClass(cInnerClass: smoke_OuterClassWithInheritance_InnerClass_copy_handle(handle))
+    smoke_OuterClassWithInheritance_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func OuterClassWithInheritance_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterClassWithInheritance.InnerClass {
+    if let swift_pointer = smoke_OuterClassWithInheritance_InnerClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterClassWithInheritance.InnerClass {
+        smoke_OuterClassWithInheritance_InnerClass_release_handle(handle)
+        return re_constructed
+    }
+    let result = OuterClassWithInheritance.InnerClass(cInnerClass: handle)
+    smoke_OuterClassWithInheritance_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func OuterClassWithInheritance_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterClassWithInheritance.InnerClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return OuterClassWithInheritance_InnerClass_moveFromCType(handle) as OuterClassWithInheritance.InnerClass
+}
+internal func OuterClassWithInheritance_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterClassWithInheritance.InnerClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return OuterClassWithInheritance_InnerClass_moveFromCType(handle) as OuterClassWithInheritance.InnerClass
+}
+internal func copyToCType(_ swiftClass: OuterClassWithInheritance.InnerClass) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: OuterClassWithInheritance.InnerClass) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: OuterClassWithInheritance.InnerClass?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: OuterClassWithInheritance.InnerClass?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+@_cdecl("_CBridgeInitsmoke_OuterClassWithInheritance_InnerInterface")
+internal func _CBridgeInitsmoke_OuterClassWithInheritance_InnerInterface(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _InnerInterface(cInnerInterface: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: InnerInterface?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_OuterClassWithInheritance_InnerInterface_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_OuterClassWithInheritance_InnerInterface_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_OuterClassWithInheritance_InnerInterface_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    functions.smoke_OuterClassWithInheritance_InnerInterface_baz = {(swift_class_pointer, input) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! InnerInterface
+        return copyToCType(swift_class.baz(input: moveFromCType(input))).ref
+    }
+    let proxy = smoke_OuterClassWithInheritance_InnerInterface_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_OuterClassWithInheritance_InnerInterface_release_handle) : RefHolder(proxy)
+}
+extension _InnerInterface: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface {
+    if let swift_pointer = smoke_OuterClassWithInheritance_InnerInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_OuterClassWithInheritance_InnerInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_OuterClassWithInheritance_InnerInterface_get_typed(smoke_OuterClassWithInheritance_InnerInterface_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InnerInterface {
+        smoke_OuterClassWithInheritance_InnerInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface {
+    if let swift_pointer = smoke_OuterClassWithInheritance_InnerInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
+        smoke_OuterClassWithInheritance_InnerInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_OuterClassWithInheritance_InnerInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
+        smoke_OuterClassWithInheritance_InnerInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_OuterClassWithInheritance_InnerInterface_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? InnerInterface {
+        smoke_OuterClassWithInheritance_InnerInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return InnerInterface_moveFromCType(handle) as InnerInterface
+}
+internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return InnerInterface_moveFromCType(handle) as InnerInterface
+}
+internal func copyToCType(_ swiftClass: InnerInterface) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: InnerInterface) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: InnerInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: InnerInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}


### PR DESCRIPTION
Updated templates for all languages to avoid accidentally referring to an inheritance parent of an outer
class/interface when declaring a nested (inner) class/interface.

Added smoke test and compilation functional test.

Resolves: #868
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>