### PR TITLE
Introduce `NativeBase` in Dart 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed Dart runtime issue when passing a child class of an interface from C++ to Dart and then back to C++.
+
 ## 8.13.0
 Release date: 2021-04-27
 ### Implementation:

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -183,6 +183,7 @@ feature(Listeners cpp android swift dart SOURCES
     input/src/cpp/ListenerWithMaps.cpp
     input/src/cpp/MultiListener.cpp
     input/src/cpp/InterfaceWithStatic.cpp
+    input/src/cpp/ConvolutedRoundTrip.cpp
 
     input/lime/StringListeners.lime
     input/lime/ListenerRoundtrip.lime
@@ -190,6 +191,7 @@ feature(Listeners cpp android swift dart SOURCES
     input/lime/ListenerNameClash.lime
     input/lime/MultiListener.lime
     input/lime/InterfaceWithStatic.lime
+    input/lime/ConvolutedRoundTrip.lime
 )
 
 feature(ComplexListeners cpp android swift dart SOURCES

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerRoundtripTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerRoundtripTest.java
@@ -18,6 +18,9 @@
  */
 package com.here.android.test;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
 import android.os.Build;
 import com.here.android.RobolectricApplication;
 import org.junit.Test;
@@ -40,5 +43,22 @@ public class ListenerRoundtripTest {
   @Test
   public void stringListenerRoundTripDoesNotCrash() {
     Nlp.setRoute(new RouteProviderImpl(), new RouteImpl());
+  }
+
+  @Test
+  public void childClassRoundTrip() {
+    final SomeLifecycleListener listener = new SomeIndicator();
+
+    assertTrue(RealBase.compareListenerToInitial(listener));
+  }
+
+  @Test
+  public void convolutedRoundTrip() {
+    final SomeLifecycleListener listener = new SomeIndicator();
+    final SomeBase base = new RealBase();
+
+    base.addLifecycleListener(listener);
+
+    assertTrue(listener.isWeakPtrAlive());
   }
 }

--- a/functional-tests/functional/dart/test/Listeners_test.dart
+++ b/functional-tests/functional/dart/test/Listeners_test.dart
@@ -71,4 +71,22 @@ void main() {
 
     expect(result, isTrue);
   });
+  _testSuite.test("Child class round trip", () {
+    final listener = SomeIndicator();
+
+    expect(RealBase.compareListenerToInitial(listener), isTrue);
+
+    listener.release();
+  });
+  _testSuite.test("Convoluted round trip", () {
+    final listener = SomeIndicator();
+    final base = RealBase();
+
+    base.addLifecycleListener(listener);
+
+    expect(listener.isWeakPtrAlive(), isTrue);
+
+    base.release();
+    listener.release();
+  });
 }

--- a/functional-tests/functional/input/lime/ConvolutedRoundTrip.lime
+++ b/functional-tests/functional/input/lime/ConvolutedRoundTrip.lime
@@ -1,0 +1,39 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+@Swift("SomeLifecycleDelegate")
+interface SomeLifecycleListener {
+    fun on_attach(@Swift(Label = "to") some: SomeBase)
+    fun on_detach(@Swift(Label = "from") some: SomeBase)
+}
+
+class SomeIndicator: SomeLifecycleListener {
+    constructor create()
+    fun isWeakPtrAlive(): Boolean
+}
+
+interface SomeBase {
+    fun add_lifecycle_listener(@Swift(Label = "_") lifecycle_listener: SomeLifecycleListener)
+    fun remove_lifecycle_listener(@Swift(Label = "_") lifecycle_listener: SomeLifecycleListener)
+}
+
+class RealBase: SomeBase {
+    constructor create()
+    static fun compareListenerToInitial(@Swift(Label = "_") lifecycle_listener: SomeLifecycleListener): Boolean
+}

--- a/functional-tests/functional/input/src/cpp/ConvolutedRoundTrip.cpp
+++ b/functional-tests/functional/input/src/cpp/ConvolutedRoundTrip.cpp
@@ -1,0 +1,75 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/RealBase.h"
+#include "test/SomeIndicator.h"
+#include <memory>
+
+namespace test
+{
+namespace {
+
+void* s_stored = nullptr;
+
+class SomeIndicatorImpl: public SomeIndicator {
+public:
+    void on_attach(const std::shared_ptr<SomeBase>& some) override {
+        m_weak = some;
+    }
+
+    void on_detach(const std::shared_ptr<SomeBase>& some) override {
+        m_weak.reset();
+    }
+
+    bool is_weak_ptr_alive() override { return !m_weak.expired(); }
+
+private:
+    std::weak_ptr<SomeBase> m_weak;
+};
+
+class RealBaseImpl: public RealBase, public std::enable_shared_from_this<RealBaseImpl> {
+public:
+    void add_lifecycle_listener(const std::shared_ptr<SomeLifecycleListener>& lifecycle_listener) override {
+        lifecycle_listener->on_attach(shared_from_this());
+    }
+
+    void remove_lifecycle_listener(const std::shared_ptr<SomeLifecycleListener>& lifecycle_listener) override {
+        lifecycle_listener->on_detach(shared_from_this());
+    }
+};
+
+}
+
+std::shared_ptr<SomeIndicator>
+SomeIndicator::create() {
+    auto result = std::make_shared<SomeIndicatorImpl>();
+    s_stored = result.get();
+    return result;
+}
+
+std::shared_ptr<RealBase>
+RealBase::create() { return std::make_shared<RealBaseImpl>(); }
+
+bool
+RealBase::compare_listener_to_initial(const std::shared_ptr<SomeLifecycleListener>& lifecycle_listener) {
+    return lifecycle_listener.get() == s_stored;
+}
+
+}

--- a/functional-tests/functional/swift/Tests/ListenerRoundtripTests.swift
+++ b/functional-tests/functional/swift/Tests/ListenerRoundtripTests.swift
@@ -59,8 +59,25 @@ class ListenerRoundtripTests: XCTestCase {
         XCTAssertTrue(RouteStorage.route === route)
     }
 
+    func testChildClassRoundTrip() {
+        let listener = SomeIndicator()
+
+        XCTAssertTrue(RealBase.compareListenerToInitial(listener))
+    }
+
+    func testConvolutedRoundTrip() {
+        let listener = SomeIndicator()
+        let base = RealBase()
+
+        base.addLifecycleListener(listener)
+
+        XCTAssertTrue(listener.isWeakPtrAlive())
+    }
+
     static var allTests = [
         ("testListenerRoundTripPreservesType", testListenerRoundTripPreservesType),
-        ("testOriginalSwiftObjectIsReturnedBack", testOriginalSwiftObjectIsReturnedBack)
+        ("testOriginalSwiftObjectIsReturnedBack", testOriginalSwiftObjectIsReturnedBack),
+        ("testChildClassRoundTrip", testChildClassRoundTrip),
+        ("testConvolutedRoundTrip", testConvolutedRoundTrip)
     ]
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -419,6 +419,11 @@ internal class DartGenerator : Generator {
                 COMMON
             ),
             GeneratedFile(
+                TemplateEngine.render("dart/DartNativeBase", templateData, nameResolvers),
+                "$LIB_DIR/$SRC_DIR_SUFFIX/_native_base.dart",
+                COMMON
+            ),
+            GeneratedFile(
                 TemplateEngine.render("dart/DartPubspec", templateData, nameResolvers),
                 "$ROOT_DIR/pubspec.yaml",
                 COMMON

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
@@ -47,6 +47,7 @@ internal class DartImportResolver(
     private val typeRepositoryImport = DartImport("$srcPath/_type_repository", "__lib")
     private val tokenCacheImport = DartImport("$srcPath/_token_cache", "__lib")
     private val lazyListImport = DartImport("$srcPath/_lazy_list", "__lib")
+    private val nativeBaseImport = DartImport("$srcPath/_native_base", "__lib")
 
     fun resolveDeclarationImports(limeElement: LimeElement): List<DartImport> =
         when {
@@ -55,11 +56,11 @@ internal class DartImportResolver(
                 limeElement.attributes.have(LimeAttributeType.EQUATABLE) ->
                 listOf(collectionSystemImport, collectionPackageImport)
             limeElement is LimeInterface ->
-                listOf(builtInTypesConversionImport, typeRepositoryImport, tokenCacheImport)
+                listOf(builtInTypesConversionImport, typeRepositoryImport, tokenCacheImport, nativeBaseImport)
             limeElement is LimeClass &&
                 (limeElement.parent != null || limeElement.visibility.isOpen) ->
-                listOf(builtInTypesConversionImport, typeRepositoryImport, tokenCacheImport)
-            limeElement is LimeClass -> listOf(tokenCacheImport)
+                listOf(builtInTypesConversionImport, typeRepositoryImport, tokenCacheImport, nativeBaseImport)
+            limeElement is LimeClass -> listOf(tokenCacheImport, nativeBaseImport)
             else -> emptyList()
         } + listOfNotNull(
             resolveExternalImport(limeElement, IMPORT_PATH_NAME, useAlias = true),

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -86,15 +86,10 @@ final _{{resolveName "Ffi"}}_get_type_id = __lib.catchArgumentError(() => __lib.
 {{>dart/DartFunctionException}}
 
 {{/functions}}
-class {{resolveName}}$Impl{{!!
-}}{{#if hasClassParent}} extends {{resolveName parent}}$Impl{{/if}} implements {{resolveName}} {
-{{#unless hasClassParent}}
-  @protected
-  Pointer<Void> handle;
+class {{resolveName}}$Impl extends {{#if hasClassParent}}{{resolveName parent}}$Impl{{/if}}{{!!
+}}{{#unless hasClassParent}}__lib.NativeBase{{/unless}} implements {{resolveName}} {
 
-{{/unless}}
-  {{resolveName}}$Impl({{#if hasClassParent}}Pointer<Void> {{/if}}{{#unless hasClassParent}}this.{{/unless}}handle){{!!
-  }}{{#if hasClassParent}} : super(handle){{/if}};
+  {{resolveName}}$Impl(Pointer<Void> handle) : super(handle);
 
   @override
   void release() {
@@ -133,7 +128,7 @@ class {{resolveName}}$Impl{{!!
 }
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) =>
-  _{{resolveName "Ffi"}}_copy_handle((value as {{resolveName}}$Impl).handle);
+  _{{resolveName "Ffi"}}_copy_handle((value as __lib.NativeBase).handle);
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
@@ -181,9 +176,7 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 }}{{#unless testableMode}}
 {{resolveName parent}}$Impl.{{resolveName visibility}}{{resolveName}}({{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) : {{!!
-}}{{#unless hasClassParent}}handle = {{/unless}}{{#if hasClassParent}}super({{/if}}{{!!
-}}_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
-}}{{#if hasClassParent}}){{/if}} {
+}}super(_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}})) {
   __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
 }
 {{/unless}}{{/dartConstructor}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -143,9 +143,9 @@ class {{resolveName}}$Lambdas implements {{resolveName}} {
 }
 {{/if}}
 
-class {{resolveName}}$Impl implements {{resolveName}} {
-  Pointer<Void> handle;
-  {{resolveName}}$Impl(this.handle);
+class {{resolveName}}$Impl extends __lib.NativeBase implements {{resolveName}} {
+
+  {{resolveName}}$Impl(Pointer<Void> handle) : super(handle);
 
   @override
   void release() {
@@ -230,7 +230,7 @@ int _{{resolveName parent}}_{{resolveName}}_set_static(int _token, {{resolveName
 {{/unless}}{{/each}}{{/set}}
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
-  if (value is {{resolveName}}$Impl) return _{{resolveName "Ffi"}}_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _{{resolveName "Ffi"}}_copy_handle((value as __lib.NativeBase).handle);
 
   final result = _{{resolveName "Ffi"}}_create_proxy(
     __lib.cacheObject(value),

--- a/gluecodium/src/main/resources/templates/dart/DartNativeBase.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartNativeBase.mustache
@@ -1,0 +1,33 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2021 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#if copyrightHeader}}{{prefix copyrightHeader "// "}}{{/if}}
+
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+
+/// @nodoc
+class NativeBase {
+  @protected
+  Pointer<Void> handle;
+
+  NativeBase(this.handle);
+}

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -29,10 +30,8 @@ final _smoke_AttributesClass_release_handle = __lib.catchArgumentError(() => __l
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesClass_release_handle'));
-class AttributesClass$Impl implements AttributesClass {
-  @protected
-  Pointer<Void> handle;
-  AttributesClass$Impl(this.handle);
+class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
+  AttributesClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -82,7 +81,7 @@ class AttributesClass$Impl implements AttributesClass {
   }
 }
 Pointer<Void> smoke_AttributesClass_toFfi(AttributesClass value) =>
-  _smoke_AttributesClass_copy_handle((value as AttributesClass$Impl).handle);
+  _smoke_AttributesClass_copy_handle((value as __lib.NativeBase).handle);
 AttributesClass smoke_AttributesClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -67,9 +68,8 @@ class AttributesInterface$Lambdas implements AttributesInterface {
   @override
   set prop(String value) => lambda_prop_set(value);
 }
-class AttributesInterface$Impl implements AttributesInterface {
-  Pointer<Void> handle;
-  AttributesInterface$Impl(this.handle);
+class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInterface {
+  AttributesInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -138,7 +138,7 @@ int _AttributesInterface_prop_set_static(int _token, Pointer<Void> _value) {
   return 0;
 }
 Pointer<Void> smoke_AttributesInterface_toFfi(AttributesInterface value) {
-  if (value is AttributesInterface$Impl) return _smoke_AttributesInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_AttributesInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_AttributesInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -101,10 +102,8 @@ final _smoke_AttributesWithComments_release_handle = __lib.catchArgumentError(()
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_release_handle'));
-class AttributesWithComments$Impl implements AttributesWithComments {
-  @protected
-  Pointer<Void> handle;
-  AttributesWithComments$Impl(this.handle);
+class AttributesWithComments$Impl extends __lib.NativeBase implements AttributesWithComments {
+  AttributesWithComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -152,7 +151,7 @@ class AttributesWithComments$Impl implements AttributesWithComments {
   }
 }
 Pointer<Void> smoke_AttributesWithComments_toFfi(AttributesWithComments value) =>
-  _smoke_AttributesWithComments_copy_handle((value as AttributesWithComments$Impl).handle);
+  _smoke_AttributesWithComments_copy_handle((value as __lib.NativeBase).handle);
 AttributesWithComments smoke_AttributesWithComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -100,10 +101,8 @@ final _smoke_AttributesWithDeprecated_release_handle = __lib.catchArgumentError(
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_release_handle'));
-class AttributesWithDeprecated$Impl implements AttributesWithDeprecated {
-  @protected
-  Pointer<Void> handle;
-  AttributesWithDeprecated$Impl(this.handle);
+class AttributesWithDeprecated$Impl extends __lib.NativeBase implements AttributesWithDeprecated {
+  AttributesWithDeprecated$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -151,7 +150,7 @@ class AttributesWithDeprecated$Impl implements AttributesWithDeprecated {
   }
 }
 Pointer<Void> smoke_AttributesWithDeprecated_toFfi(AttributesWithDeprecated value) =>
-  _smoke_AttributesWithDeprecated_copy_handle((value as AttributesWithDeprecated$Impl).handle);
+  _smoke_AttributesWithDeprecated_copy_handle((value as __lib.NativeBase).handle);
 AttributesWithDeprecated smoke_AttributesWithDeprecated_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -40,10 +41,8 @@ final _smoke_MultipleAttributesDart_release_handle = __lib.catchArgumentError(()
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MultipleAttributesDart_release_handle'));
-class MultipleAttributesDart$Impl implements MultipleAttributesDart {
-  @protected
-  Pointer<Void> handle;
-  MultipleAttributesDart$Impl(this.handle);
+class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAttributesDart {
+  MultipleAttributesDart$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -109,7 +108,7 @@ class MultipleAttributesDart$Impl implements MultipleAttributesDart {
   }
 }
 Pointer<Void> smoke_MultipleAttributesDart_toFfi(MultipleAttributesDart value) =>
-  _smoke_MultipleAttributesDart_copy_handle((value as MultipleAttributesDart$Impl).handle);
+  _smoke_MultipleAttributesDart_copy_handle((value as __lib.NativeBase).handle);
 MultipleAttributesDart smoke_MultipleAttributesDart_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -24,10 +25,8 @@ final _smoke_SpecialAttributes_release_handle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SpecialAttributes_release_handle'));
-class SpecialAttributes$Impl implements SpecialAttributes {
-  @protected
-  Pointer<Void> handle;
-  SpecialAttributes$Impl(this.handle);
+class SpecialAttributes$Impl extends __lib.NativeBase implements SpecialAttributes {
+  SpecialAttributes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -60,7 +59,7 @@ class SpecialAttributes$Impl implements SpecialAttributes {
   }
 }
 Pointer<Void> smoke_SpecialAttributes_toFfi(SpecialAttributes value) =>
-  _smoke_SpecialAttributes_copy_handle((value as SpecialAttributes$Impl).handle);
+  _smoke_SpecialAttributes_copy_handle((value as __lib.NativeBase).handle);
 SpecialAttributes smoke_SpecialAttributes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -32,10 +33,8 @@ final _smoke_BasicTypes_release_handle = __lib.catchArgumentError(() => __lib.na
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_BasicTypes_release_handle'));
-class BasicTypes$Impl implements BasicTypes {
-  @protected
-  Pointer<Void> handle;
-  BasicTypes$Impl(this.handle);
+class BasicTypes$Impl extends __lib.NativeBase implements BasicTypes {
+  BasicTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -178,7 +177,7 @@ class BasicTypes$Impl implements BasicTypes {
   }
 }
 Pointer<Void> smoke_BasicTypes_toFfi(BasicTypes value) =>
-  _smoke_BasicTypes_copy_handle((value as BasicTypes$Impl).handle);
+  _smoke_BasicTypes_copy_handle((value as __lib.NativeBase).handle);
 BasicTypes smoke_BasicTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -335,10 +336,8 @@ final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() 
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_someMethodWithAllComments__String_return_has_error'));
-class Comments$Impl implements Comments {
-  @protected
-  Pointer<Void> handle;
-  Comments$Impl(this.handle);
+class Comments$Impl extends __lib.NativeBase implements Comments {
+  Comments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -534,7 +533,7 @@ class Comments$Impl implements Comments {
   }
 }
 Pointer<Void> smoke_Comments_toFfi(Comments value) =>
-  _smoke_Comments_copy_handle((value as Comments$Impl).handle);
+  _smoke_Comments_copy_handle((value as __lib.NativeBase).handle);
 Comments smoke_Comments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -296,9 +297,8 @@ class CommentsInterface$Lambdas implements CommentsInterface {
   @override
   set isSomeProperty(bool value) => lambda_isSomeProperty_set(value);
 }
-class CommentsInterface$Impl implements CommentsInterface {
-  Pointer<Void> handle;
-  CommentsInterface$Impl(this.handle);
+class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterface {
+  CommentsInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -556,7 +556,7 @@ int _CommentsInterface_isSomeProperty_set_static(int _token, int _value) {
   return 0;
 }
 Pointer<Void> smoke_CommentsInterface_toFfi(CommentsInterface value) {
-  if (value is CommentsInterface$Impl) return _smoke_CommentsInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_CommentsInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_CommentsInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/comments.dart';
@@ -157,10 +158,8 @@ final _randomMethod_return_has_error = __lib.catchArgumentError(() => __lib.nati
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_has_error'));
-class CommentsLinks$Impl implements CommentsLinks {
-  @protected
-  Pointer<Void> handle;
-  CommentsLinks$Impl(this.handle);
+class CommentsLinks$Impl extends __lib.NativeBase implements CommentsLinks {
+  CommentsLinks$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -210,7 +209,7 @@ class CommentsLinks$Impl implements CommentsLinks {
   }
 }
 Pointer<Void> smoke_CommentsLinks_toFfi(CommentsLinks value) =>
-  _smoke_CommentsLinks_copy_handle((value as CommentsLinks$Impl).handle);
+  _smoke_CommentsLinks_copy_handle((value as __lib.NativeBase).handle);
 CommentsLinks smoke_CommentsLinks_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -223,9 +224,8 @@ class DeprecationComments$Lambdas implements DeprecationComments {
   @override
   set propertyButNotAccessors(String value) => lambda_propertyButNotAccessors_set(value);
 }
-class DeprecationComments$Impl implements DeprecationComments {
-  Pointer<Void> handle;
-  DeprecationComments$Impl(this.handle);
+class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationComments {
+  DeprecationComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -336,7 +336,7 @@ int _DeprecationComments_propertyButNotAccessors_set_static(int _token, Pointer<
   return 0;
 }
 Pointer<Void> smoke_DeprecationComments_toFfi(DeprecationComments value) {
-  if (value is DeprecationComments$Impl) return _smoke_DeprecationComments_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_DeprecationComments_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_DeprecationComments_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -191,9 +192,8 @@ class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
   @override
   set isSomeProperty(bool value) => lambda_isSomeProperty_set(value);
 }
-class DeprecationCommentsOnly$Impl implements DeprecationCommentsOnly {
-  Pointer<Void> handle;
-  DeprecationCommentsOnly$Impl(this.handle);
+class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements DeprecationCommentsOnly {
+  DeprecationCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -264,7 +264,7 @@ int _DeprecationCommentsOnly_isSomeProperty_set_static(int _token, int _value) {
   return 0;
 }
 Pointer<Void> smoke_DeprecationCommentsOnly_toFfi(DeprecationCommentsOnly value) {
-  if (value is DeprecationCommentsOnly$Impl) return _smoke_DeprecationCommentsOnly_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_DeprecationCommentsOnly_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_DeprecationCommentsOnly_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -291,10 +292,8 @@ final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() 
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_someMethodWithAllComments__String_return_has_error'));
-class ExcludedComments$Impl implements ExcludedComments {
-  @protected
-  Pointer<Void> handle;
-  ExcludedComments$Impl(this.handle);
+class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments {
+  ExcludedComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -364,7 +363,7 @@ class ExcludedComments$Impl implements ExcludedComments {
   }
 }
 Pointer<Void> smoke_ExcludedComments_toFfi(ExcludedComments value) =>
-  _smoke_ExcludedComments_copy_handle((value as ExcludedComments$Impl).handle);
+  _smoke_ExcludedComments_copy_handle((value as __lib.NativeBase).handle);
 ExcludedComments smoke_ExcludedComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -31,9 +32,8 @@ final _smoke_ExcludedCommentsInterface_get_type_id = __lib.catchArgumentError(()
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsInterface_get_type_id'));
-class ExcludedCommentsInterface$Impl implements ExcludedCommentsInterface {
-  Pointer<Void> handle;
-  ExcludedCommentsInterface$Impl(this.handle);
+class ExcludedCommentsInterface$Impl extends __lib.NativeBase implements ExcludedCommentsInterface {
+  ExcludedCommentsInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -44,7 +44,7 @@ class ExcludedCommentsInterface$Impl implements ExcludedCommentsInterface {
   }
 }
 Pointer<Void> smoke_ExcludedCommentsInterface_toFfi(ExcludedCommentsInterface value) {
-  if (value is ExcludedCommentsInterface$Impl) return _smoke_ExcludedCommentsInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_ExcludedCommentsInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_ExcludedCommentsInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -267,10 +268,8 @@ final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() 
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String_return_has_error'));
-class ExcludedCommentsOnly$Impl implements ExcludedCommentsOnly {
-  @protected
-  Pointer<Void> handle;
-  ExcludedCommentsOnly$Impl(this.handle);
+class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedCommentsOnly {
+  ExcludedCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -340,7 +339,7 @@ class ExcludedCommentsOnly$Impl implements ExcludedCommentsOnly {
   }
 }
 Pointer<Void> smoke_ExcludedCommentsOnly_toFfi(ExcludedCommentsOnly value) =>
-  _smoke_ExcludedCommentsOnly_copy_handle((value as ExcludedCommentsOnly$Impl).handle);
+  _smoke_ExcludedCommentsOnly_copy_handle((value as __lib.NativeBase).handle);
 ExcludedCommentsOnly smoke_ExcludedCommentsOnly_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -26,10 +27,8 @@ final _smoke_InternalClassWithComments_release_handle = __lib.catchArgumentError
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClassWithComments_release_handle'));
-class InternalClassWithComments$Impl implements InternalClassWithComments {
-  @protected
-  Pointer<Void> handle;
-  InternalClassWithComments$Impl(this.handle);
+class InternalClassWithComments$Impl extends __lib.NativeBase implements InternalClassWithComments {
+  InternalClassWithComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -51,7 +50,7 @@ class InternalClassWithComments$Impl implements InternalClassWithComments {
   }
 }
 Pointer<Void> smoke_InternalClassWithComments_toFfi(InternalClassWithComments value) =>
-  _smoke_InternalClassWithComments_copy_handle((value as InternalClassWithComments$Impl).handle);
+  _smoke_InternalClassWithComments_copy_handle((value as __lib.NativeBase).handle);
 InternalClassWithComments smoke_InternalClassWithComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -112,10 +113,8 @@ final _smoke_MapScene_release_handle = __lib.catchArgumentError(() => __lib.nati
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MapScene_release_handle'));
-class MapScene$Impl implements MapScene {
-  @protected
-  Pointer<Void> handle;
-  MapScene$Impl(this.handle);
+class MapScene$Impl extends __lib.NativeBase implements MapScene {
+  MapScene$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -156,7 +155,7 @@ class MapScene$Impl implements MapScene {
   }
 }
 Pointer<Void> smoke_MapScene_toFfi(MapScene value) =>
-  _smoke_MapScene_copy_handle((value as MapScene$Impl).handle);
+  _smoke_MapScene_copy_handle((value as __lib.NativeBase).handle);
 MapScene smoke_MapScene_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -53,10 +54,8 @@ final _smoke_MultiLineComments_release_handle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MultiLineComments_release_handle'));
-class MultiLineComments$Impl implements MultiLineComments {
-  @protected
-  Pointer<Void> handle;
-  MultiLineComments$Impl(this.handle);
+class MultiLineComments$Impl extends __lib.NativeBase implements MultiLineComments {
+  MultiLineComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -82,7 +81,7 @@ class MultiLineComments$Impl implements MultiLineComments {
   }
 }
 Pointer<Void> smoke_MultiLineComments_toFfi(MultiLineComments value) =>
-  _smoke_MultiLineComments_copy_handle((value as MultiLineComments$Impl).handle);
+  _smoke_MultiLineComments_copy_handle((value as __lib.NativeBase).handle);
 MultiLineComments smoke_MultiLineComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -182,10 +183,8 @@ final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() 
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_has_error'));
-class PlatformComments$Impl implements PlatformComments {
-  @protected
-  Pointer<Void> handle;
-  PlatformComments$Impl(this.handle);
+class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments {
+  PlatformComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -253,7 +252,7 @@ class PlatformComments$Impl implements PlatformComments {
   }
 }
 Pointer<Void> smoke_PlatformComments_toFfi(PlatformComments value) =>
-  _smoke_PlatformComments_copy_handle((value as PlatformComments$Impl).handle);
+  _smoke_PlatformComments_copy_handle((value as __lib.NativeBase).handle);
 PlatformComments smoke_PlatformComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/comments.dart';
@@ -46,10 +47,8 @@ final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() 
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_has_error'));
-class UnicodeComments$Impl implements UnicodeComments {
-  @protected
-  Pointer<Void> handle;
-  UnicodeComments$Impl(this.handle);
+class UnicodeComments$Impl extends __lib.NativeBase implements UnicodeComments {
+  UnicodeComments$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -84,7 +83,7 @@ class UnicodeComments$Impl implements UnicodeComments {
   }
 }
 Pointer<Void> smoke_UnicodeComments_toFfi(UnicodeComments value) =>
-  _smoke_UnicodeComments_copy_handle((value as UnicodeComments$Impl).handle);
+  _smoke_UnicodeComments_copy_handle((value as __lib.NativeBase).handle);
 UnicodeComments smoke_UnicodeComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -23,10 +24,8 @@ final _smoke_CollectionConstants_release_handle = __lib.catchArgumentError(() =>
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CollectionConstants_release_handle'));
-class CollectionConstants$Impl implements CollectionConstants {
-  @protected
-  Pointer<Void> handle;
-  CollectionConstants$Impl(this.handle);
+class CollectionConstants$Impl extends __lib.NativeBase implements CollectionConstants {
+  CollectionConstants$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -37,7 +36,7 @@ class CollectionConstants$Impl implements CollectionConstants {
   }
 }
 Pointer<Void> smoke_CollectionConstants_toFfi(CollectionConstants value) =>
-  _smoke_CollectionConstants_copy_handle((value as CollectionConstants$Impl).handle);
+  _smoke_CollectionConstants_copy_handle((value as __lib.NativeBase).handle);
 CollectionConstants smoke_CollectionConstants_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -85,10 +86,8 @@ final _smoke_ConstantsInterface_release_handle = __lib.catchArgumentError(() => 
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ConstantsInterface_release_handle'));
-class ConstantsInterface$Impl implements ConstantsInterface {
-  @protected
-  Pointer<Void> handle;
-  ConstantsInterface$Impl(this.handle);
+class ConstantsInterface$Impl extends __lib.NativeBase implements ConstantsInterface {
+  ConstantsInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -99,7 +98,7 @@ class ConstantsInterface$Impl implements ConstantsInterface {
   }
 }
 Pointer<Void> smoke_ConstantsInterface_toFfi(ConstantsInterface value) =>
-  _smoke_ConstantsInterface_copy_handle((value as ConstantsInterface$Impl).handle);
+  _smoke_ConstantsInterface_copy_handle((value as __lib.NativeBase).handle);
 ConstantsInterface smoke_ConstantsInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -160,10 +161,8 @@ final _smoke_StructConstants_release_handle = __lib.catchArgumentError(() => __l
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructConstants_release_handle'));
-class StructConstants$Impl implements StructConstants {
-  @protected
-  Pointer<Void> handle;
-  StructConstants$Impl(this.handle);
+class StructConstants$Impl extends __lib.NativeBase implements StructConstants {
+  StructConstants$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -174,7 +173,7 @@ class StructConstants$Impl implements StructConstants {
   }
 }
 Pointer<Void> smoke_StructConstants_toFfi(StructConstants value) =>
-  _smoke_StructConstants_copy_handle((value as StructConstants$Impl).handle);
+  _smoke_StructConstants_copy_handle((value as __lib.NativeBase).handle);
 StructConstants smoke_StructConstants_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -111,10 +112,8 @@ final _fromString_return_has_error = __lib.catchArgumentError(() => __lib.native
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_has_error'));
-class Constructors$Impl implements Constructors {
-  @protected
-  Pointer<Void> handle;
-  Constructors$Impl(this.handle);
+class Constructors$Impl extends __lib.NativeBase implements Constructors {
+  Constructors$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -123,22 +122,22 @@ class Constructors$Impl implements Constructors {
     _smoke_Constructors_release_handle(handle);
     handle = null;
   }
-  Constructors$Impl.$init() : handle = _$init() {
+  Constructors$Impl.$init() : super(_$init()) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
-  Constructors$Impl.fromOther(Constructors other) : handle = _fromOther(other) {
+  Constructors$Impl.fromOther(Constructors other) : super(_fromOther(other)) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
-  Constructors$Impl.fromMulti(String foo, int bar) : handle = _fromMulti(foo, bar) {
+  Constructors$Impl.fromMulti(String foo, int bar) : super(_fromMulti(foo, bar)) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
-  Constructors$Impl.fromString(String input) : handle = _fromString(input) {
+  Constructors$Impl.fromString(String input) : super(_fromString(input)) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
-  Constructors$Impl.fromList(List<double> input) : handle = _fromList(input) {
+  Constructors$Impl.fromList(List<double> input) : super(_fromList(input)) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
-  Constructors$Impl.create(int input) : handle = _create(input) {
+  Constructors$Impl.create(int input) : super(_create(input)) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   static Pointer<Void> _$init() {
@@ -196,7 +195,7 @@ class Constructors$Impl implements Constructors {
   }
 }
 Pointer<Void> smoke_Constructors_toFfi(Constructors value) =>
-  _smoke_Constructors_copy_handle((value as Constructors$Impl).handle);
+  _smoke_Constructors_copy_handle((value as __lib.NativeBase).handle);
 Constructors smoke_Constructors_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -20,10 +21,8 @@ final _smoke_SingleNamedConstructor_release_handle = __lib.catchArgumentError(()
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SingleNamedConstructor_release_handle'));
-class SingleNamedConstructor$Impl implements SingleNamedConstructor {
-  @protected
-  Pointer<Void> handle;
-  SingleNamedConstructor$Impl(this.handle);
+class SingleNamedConstructor$Impl extends __lib.NativeBase implements SingleNamedConstructor {
+  SingleNamedConstructor$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -32,7 +31,7 @@ class SingleNamedConstructor$Impl implements SingleNamedConstructor {
     _smoke_SingleNamedConstructor_release_handle(handle);
     handle = null;
   }
-  SingleNamedConstructor$Impl.fooBar() : handle = _fooBar() {
+  SingleNamedConstructor$Impl.fooBar() : super(_fooBar()) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   static Pointer<Void> _fooBar() {
@@ -42,7 +41,7 @@ class SingleNamedConstructor$Impl implements SingleNamedConstructor {
   }
 }
 Pointer<Void> smoke_SingleNamedConstructor_toFfi(SingleNamedConstructor value) =>
-  _smoke_SingleNamedConstructor_copy_handle((value as SingleNamedConstructor$Impl).handle);
+  _smoke_SingleNamedConstructor_copy_handle((value as __lib.NativeBase).handle);
 SingleNamedConstructor smoke_SingleNamedConstructor_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -20,10 +21,8 @@ final _smoke_SingleNamelessConstructor_release_handle = __lib.catchArgumentError
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SingleNamelessConstructor_release_handle'));
-class SingleNamelessConstructor$Impl implements SingleNamelessConstructor {
-  @protected
-  Pointer<Void> handle;
-  SingleNamelessConstructor$Impl(this.handle);
+class SingleNamelessConstructor$Impl extends __lib.NativeBase implements SingleNamelessConstructor {
+  SingleNamelessConstructor$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -32,7 +31,7 @@ class SingleNamelessConstructor$Impl implements SingleNamelessConstructor {
     _smoke_SingleNamelessConstructor_release_handle(handle);
     handle = null;
   }
-  SingleNamelessConstructor$Impl.create() : handle = _create() {
+  SingleNamelessConstructor$Impl.create() : super(_create()) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   static Pointer<Void> _create() {
@@ -42,7 +41,7 @@ class SingleNamelessConstructor$Impl implements SingleNamelessConstructor {
   }
 }
 Pointer<Void> smoke_SingleNamelessConstructor_toFfi(SingleNamelessConstructor value) =>
-  _smoke_SingleNamelessConstructor_copy_handle((value as SingleNamelessConstructor$Impl).handle);
+  _smoke_SingleNamelessConstructor_copy_handle((value as __lib.NativeBase).handle);
 SingleNamelessConstructor smoke_SingleNamelessConstructor_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -87,10 +88,8 @@ final _smoke_Dates_release_handle = __lib.catchArgumentError(() => __lib.nativeL
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Dates_release_handle'));
-class Dates$Impl implements Dates {
-  @protected
-  Pointer<Void> handle;
-  Dates$Impl(this.handle);
+class Dates$Impl extends __lib.NativeBase implements Dates {
+  Dates$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -138,7 +137,7 @@ class Dates$Impl implements Dates {
   }
 }
 Pointer<Void> smoke_Dates_toFfi(Dates value) =>
-  _smoke_Dates_copy_handle((value as Dates$Impl).handle);
+  _smoke_Dates_copy_handle((value as __lib.NativeBase).handle);
 Dates smoke_Dates_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
@@ -710,10 +711,8 @@ final _smoke_DefaultValues_release_handle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_release_handle'));
-class DefaultValues$Impl implements DefaultValues {
-  @protected
-  Pointer<Void> handle;
-  DefaultValues$Impl(this.handle);
+class DefaultValues$Impl extends __lib.NativeBase implements DefaultValues {
+  DefaultValues$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -735,7 +734,7 @@ class DefaultValues$Impl implements DefaultValues {
   }
 }
 Pointer<Void> smoke_DefaultValues_toFfi(DefaultValues value) =>
-  _smoke_DefaultValues_copy_handle((value as DefaultValues$Impl).handle);
+  _smoke_DefaultValues_copy_handle((value as __lib.NativeBase).handle);
 DefaultValues smoke_DefaultValues_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -216,10 +217,8 @@ final _smoke_Enums_release_handle = __lib.catchArgumentError(() => __lib.nativeL
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Enums_release_handle'));
-class Enums$Impl implements Enums {
-  @protected
-  Pointer<Void> handle;
-  Enums$Impl(this.handle);
+class Enums$Impl extends __lib.NativeBase implements Enums {
+  Enums$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -276,7 +275,7 @@ class Enums$Impl implements Enums {
   }
 }
 Pointer<Void> smoke_Enums_toFfi(Enums value) =>
-  _smoke_Enums_copy_handle((value as Enums$Impl).handle);
+  _smoke_Enums_copy_handle((value as __lib.NativeBase).handle);
 Enums smoke_Enums_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -32,9 +33,8 @@ final __are_equal = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFun
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EquatableInterface_get_type_id'));
-class EquatableInterface$Impl implements EquatableInterface {
-  Pointer<Void> handle;
-  EquatableInterface$Impl(this.handle);
+class EquatableInterface$Impl extends __lib.NativeBase implements EquatableInterface {
+  EquatableInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -51,7 +51,7 @@ class EquatableInterface$Impl implements EquatableInterface {
   }
 }
 Pointer<Void> smoke_EquatableInterface_toFfi(EquatableInterface value) {
-  if (value is EquatableInterface$Impl) return _smoke_EquatableInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_EquatableInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_EquatableInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/payload.dart';
@@ -231,10 +232,8 @@ final _methodWithPayloadErrorAndReturnValue_return_has_error = __lib.catchArgume
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_has_error'));
-class Errors$Impl implements Errors {
-  @protected
-  Pointer<Void> handle;
-  Errors$Impl(this.handle);
+class Errors$Impl extends __lib.NativeBase implements Errors {
+  Errors$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -345,7 +344,7 @@ class Errors$Impl implements Errors {
   }
 }
 Pointer<Void> smoke_Errors_toFfi(Errors value) =>
-  _smoke_Errors_copy_handle((value as Errors$Impl).handle);
+  _smoke_Errors_copy_handle((value as __lib.NativeBase).handle);
 Errors smoke_Errors_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -271,9 +272,8 @@ class ErrorsInterface$Lambdas implements ErrorsInterface {
   String methodWithErrorsAndReturnValue() =>
     lambda_methodWithErrorsAndReturnValue();
 }
-class ErrorsInterface$Impl implements ErrorsInterface {
-  Pointer<Void> handle;
-  ErrorsInterface$Impl(this.handle);
+class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
+  ErrorsInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -430,7 +430,7 @@ int _ErrorsInterface_methodWithErrorsAndReturnValue_static(int _token, Pointer<P
   return _error_flag ? 1 : 0;
 }
 Pointer<Void> smoke_ErrorsInterface_toFfi(ErrorsInterface value) {
-  if (value is ErrorsInterface$Impl) return _smoke_ErrorsInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_ErrorsInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_ErrorsInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -48,10 +49,8 @@ final _fun_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_has_error'));
-class Class$Impl implements Class {
-  @protected
-  Pointer<Void> handle;
-  Class$Impl(this.handle);
+class Class$Impl extends __lib.NativeBase implements Class {
+  Class$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -60,7 +59,7 @@ class Class$Impl implements Class {
     _package_Class_release_handle(handle);
     handle = null;
   }
-  Class$Impl.constructor() : handle = _constructor() {
+  Class$Impl.constructor() : super(_constructor()) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   static Pointer<Void> _constructor() {
@@ -118,7 +117,7 @@ class Class$Impl implements Class {
   }
 }
 Pointer<Void> package_Class_toFfi(Class value) =>
-  _package_Class_copy_handle((value as Class$Impl).handle);
+  _package_Class_copy_handle((value as __lib.NativeBase).handle);
 Class package_Class_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -29,9 +30,8 @@ final _package_Interface_get_type_id = __lib.catchArgumentError(() => __lib.nati
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Interface_get_type_id'));
-class Interface$Impl implements Interface {
-  Pointer<Void> handle;
-  Interface$Impl(this.handle);
+class Interface$Impl extends __lib.NativeBase implements Interface {
+  Interface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -42,7 +42,7 @@ class Interface$Impl implements Interface {
   }
 }
 Pointer<Void> package_Interface_toFfi(Interface value) {
-  if (value is Interface$Impl) return _package_Interface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _package_Interface_copy_handle((value as __lib.NativeBase).handle);
   final result = _package_Interface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -139,10 +140,8 @@ final _smoke_Enums_release_handle = __lib.catchArgumentError(() => __lib.nativeL
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Enums_release_handle'));
-class Enums$Impl implements Enums {
-  @protected
-  Pointer<Void> handle;
-  Enums$Impl(this.handle);
+class Enums$Impl extends __lib.NativeBase implements Enums {
+  Enums$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -164,7 +163,7 @@ class Enums$Impl implements Enums {
   }
 }
 Pointer<Void> smoke_Enums_toFfi(Enums value) =>
-  _smoke_Enums_copy_handle((value as Enums$Impl).handle);
+  _smoke_Enums_copy_handle((value as __lib.NativeBase).handle);
 Enums smoke_Enums_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -138,10 +139,8 @@ final _smoke_ExternalClass_release_handle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExternalClass_release_handle'));
-class ExternalClass$Impl implements ExternalClass {
-  @protected
-  Pointer<Void> handle;
-  ExternalClass$Impl(this.handle);
+class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
+  ExternalClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -176,7 +175,7 @@ class ExternalClass$Impl implements ExternalClass {
   }
 }
 Pointer<Void> smoke_ExternalClass_toFfi(ExternalClass value) =>
-  _smoke_ExternalClass_copy_handle((value as ExternalClass$Impl).handle);
+  _smoke_ExternalClass_copy_handle((value as __lib.NativeBase).handle);
 ExternalClass smoke_ExternalClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -170,9 +171,8 @@ class ExternalInterface$Lambdas implements ExternalInterface {
   @override
   String get someProperty => lambda_someProperty_get();
 }
-class ExternalInterface$Impl implements ExternalInterface {
-  Pointer<Void> handle;
-  ExternalInterface$Impl(this.handle);
+class ExternalInterface$Impl extends __lib.NativeBase implements ExternalInterface {
+  ExternalInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -218,7 +218,7 @@ int _ExternalInterface_someProperty_get_static(int _token, Pointer<Pointer<Void>
   return 0;
 }
 Pointer<Void> smoke_ExternalInterface_toFfi(ExternalInterface value) {
-  if (value is ExternalInterface$Impl) return _smoke_ExternalInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_ExternalInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_ExternalInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
@@ -181,10 +182,8 @@ final _smoke_Structs_release_handle = __lib.catchArgumentError(() => __lib.nativ
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_release_handle'));
-class Structs$Impl implements Structs {
-  @protected
-  Pointer<Void> handle;
-  Structs$Impl(this.handle);
+class Structs$Impl extends __lib.NativeBase implements Structs {
+  Structs$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -213,7 +212,7 @@ class Structs$Impl implements Structs {
   }
 }
 Pointer<Void> smoke_Structs_toFfi(Structs value) =>
-  _smoke_Structs_copy_handle((value as Structs$Impl).handle);
+  _smoke_Structs_copy_handle((value as __lib.NativeBase).handle);
 Structs smoke_Structs_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 import 'package:foo/bar.dart' as bar;
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/smoke/http_client_response_compression_state.dart';
 import 'package:library/src/smoke/int.dart';
@@ -29,10 +30,8 @@ final _smoke_UseDartExternalTypes_release_handle = __lib.catchArgumentError(() =
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseDartExternalTypes_release_handle'));
-class UseDartExternalTypes$Impl implements UseDartExternalTypes {
-  @protected
-  Pointer<Void> handle;
-  UseDartExternalTypes$Impl(this.handle);
+class UseDartExternalTypes$Impl extends __lib.NativeBase implements UseDartExternalTypes {
+  UseDartExternalTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -87,7 +86,7 @@ class UseDartExternalTypes$Impl implements UseDartExternalTypes {
   }
 }
 Pointer<Void> smoke_UseDartExternalTypes_toFfi(UseDartExternalTypes value) =>
-  _smoke_UseDartExternalTypes_copy_handle((value as UseDartExternalTypes$Impl).handle);
+  _smoke_UseDartExternalTypes_copy_handle((value as __lib.NativeBase).handle);
 UseDartExternalTypes smoke_UseDartExternalTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
@@ -117,10 +118,8 @@ final _smoke_GenericTypesWithBasicTypes_release_handle = __lib.catchArgumentErro
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_release_handle'));
-class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
-  @protected
-  Pointer<Void> handle;
-  GenericTypesWithBasicTypes$Impl(this.handle);
+class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements GenericTypesWithBasicTypes {
+  GenericTypesWithBasicTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -281,7 +280,7 @@ class GenericTypesWithBasicTypes$Impl implements GenericTypesWithBasicTypes {
   }
 }
 Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi(GenericTypesWithBasicTypes value) =>
-  _smoke_GenericTypesWithBasicTypes_copy_handle((value as GenericTypesWithBasicTypes$Impl).handle);
+  _smoke_GenericTypesWithBasicTypes_copy_handle((value as __lib.NativeBase).handle);
 GenericTypesWithBasicTypes smoke_GenericTypesWithBasicTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
@@ -277,10 +278,8 @@ final _smoke_GenericTypesWithCompoundTypes_release_handle = __lib.catchArgumentE
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_release_handle'));
-class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundTypes {
-  @protected
-  Pointer<Void> handle;
-  GenericTypesWithCompoundTypes$Impl(this.handle);
+class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements GenericTypesWithCompoundTypes {
+  GenericTypesWithCompoundTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -395,7 +394,7 @@ class GenericTypesWithCompoundTypes$Impl implements GenericTypesWithCompoundType
   }
 }
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_toFfi(GenericTypesWithCompoundTypes value) =>
-  _smoke_GenericTypesWithCompoundTypes_copy_handle((value as GenericTypesWithCompoundTypes$Impl).handle);
+  _smoke_GenericTypesWithCompoundTypes_copy_handle((value as __lib.NativeBase).handle);
 GenericTypesWithCompoundTypes smoke_GenericTypesWithCompoundTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
@@ -28,10 +29,8 @@ final _smoke_GenericTypesWithGenericTypes_release_handle = __lib.catchArgumentEr
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithGenericTypes_release_handle'));
-class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes {
-  @protected
-  Pointer<Void> handle;
-  GenericTypesWithGenericTypes$Impl(this.handle);
+class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements GenericTypesWithGenericTypes {
+  GenericTypesWithGenericTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -133,7 +132,7 @@ class GenericTypesWithGenericTypes$Impl implements GenericTypesWithGenericTypes 
   }
 }
 Pointer<Void> smoke_GenericTypesWithGenericTypes_toFfi(GenericTypesWithGenericTypes value) =>
-  _smoke_GenericTypesWithGenericTypes_copy_handle((value as GenericTypesWithGenericTypes$Impl).handle);
+  _smoke_GenericTypesWithGenericTypes_copy_handle((value as __lib.NativeBase).handle);
 GenericTypesWithGenericTypes smoke_GenericTypesWithGenericTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/_lazy_list.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/unreasonably_lazy_class.dart';
@@ -49,10 +50,8 @@ final _smoke_UseOptimizedList_smoke_VeryBigStructLazyList_release_handle = __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseOptimizedList_smoke_VeryBigStructLazyList_release_handle'));
-class UseOptimizedList$Impl implements UseOptimizedList {
-  @protected
-  Pointer<Void> handle;
-  UseOptimizedList$Impl(this.handle);
+class UseOptimizedList$Impl extends __lib.NativeBase implements UseOptimizedList {
+  UseOptimizedList$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -93,7 +92,7 @@ class UseOptimizedList$Impl implements UseOptimizedList {
   }
 }
 Pointer<Void> smoke_UseOptimizedList_toFfi(UseOptimizedList value) =>
-  _smoke_UseOptimizedList_copy_handle((value as UseOptimizedList$Impl).handle);
+  _smoke_UseOptimizedList_copy_handle((value as __lib.NativeBase).handle);
 UseOptimizedList smoke_UseOptimizedList_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -50,7 +51,7 @@ class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFro
   }
 }
 Pointer<Void> smoke_ChildClassFromClass_toFfi(ChildClassFromClass value) =>
-  _smoke_ChildClassFromClass_copy_handle((value as ChildClassFromClass$Impl).handle);
+  _smoke_ChildClassFromClass_copy_handle((value as __lib.NativeBase).handle);
 ChildClassFromClass smoke_ChildClassFromClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -27,10 +28,8 @@ final _smoke_ChildClassFromInterface_get_type_id = __lib.catchArgumentError(() =
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildClassFromInterface_get_type_id'));
-class ChildClassFromInterface$Impl implements ChildClassFromInterface {
-  @protected
-  Pointer<Void> handle;
-  ChildClassFromInterface$Impl(this.handle);
+class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClassFromInterface {
+  ChildClassFromInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -87,7 +86,7 @@ class ChildClassFromInterface$Impl implements ChildClassFromInterface {
   }
 }
 Pointer<Void> smoke_ChildClassFromInterface_toFfi(ChildClassFromInterface value) =>
-  _smoke_ChildClassFromInterface_copy_handle((value as ChildClassFromInterface$Impl).handle);
+  _smoke_ChildClassFromInterface_copy_handle((value as __lib.NativeBase).handle);
 ChildClassFromInterface smoke_ChildClassFromInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -67,9 +68,8 @@ class ChildInterface$Lambdas implements ChildInterface {
   @override
   set rootProperty(String value) => lambda_rootProperty_set(value);
 }
-class ChildInterface$Impl implements ChildInterface {
-  Pointer<Void> handle;
-  ChildInterface$Impl(this.handle);
+class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
+  ChildInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -151,7 +151,7 @@ int _ChildInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
   return 0;
 }
 Pointer<Void> smoke_ChildInterface_toFfi(ChildInterface value) {
-  if (value is ChildInterface$Impl) return _smoke_ChildInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_ChildInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_ChildInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -28,10 +29,8 @@ final _smoke_ChildWithParentClassReferences_get_type_id = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildWithParentClassReferences_get_type_id'));
-class ChildWithParentClassReferences$Impl implements ChildWithParentClassReferences {
-  @protected
-  Pointer<Void> handle;
-  ChildWithParentClassReferences$Impl(this.handle);
+class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements ChildWithParentClassReferences {
+  ChildWithParentClassReferences$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -77,7 +76,7 @@ class ChildWithParentClassReferences$Impl implements ChildWithParentClassReferen
   }
 }
 Pointer<Void> smoke_ChildWithParentClassReferences_toFfi(ChildWithParentClassReferences value) =>
-  _smoke_ChildWithParentClassReferences_copy_handle((value as ChildWithParentClassReferences$Impl).handle);
+  _smoke_ChildWithParentClassReferences_copy_handle((value as __lib.NativeBase).handle);
 ChildWithParentClassReferences smoke_ChildWithParentClassReferences_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -28,10 +29,8 @@ final _smoke_ParentClass_get_type_id = __lib.catchArgumentError(() => __lib.nati
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ParentClass_get_type_id'));
-class ParentClass$Impl implements ParentClass {
-  @protected
-  Pointer<Void> handle;
-  ParentClass$Impl(this.handle);
+class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
+  ParentClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -77,7 +76,7 @@ class ParentClass$Impl implements ParentClass {
   }
 }
 Pointer<Void> smoke_ParentClass_toFfi(ParentClass value) =>
-  _smoke_ParentClass_copy_handle((value as ParentClass$Impl).handle);
+  _smoke_ParentClass_copy_handle((value as __lib.NativeBase).handle);
 ParentClass smoke_ParentClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -61,9 +62,8 @@ class ParentInterface$Lambdas implements ParentInterface {
   @override
   set rootProperty(String value) => lambda_rootProperty_set(value);
 }
-class ParentInterface$Impl implements ParentInterface {
-  Pointer<Void> handle;
-  ParentInterface$Impl(this.handle);
+class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
+  ParentInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -127,7 +127,7 @@ int _ParentInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
   return 0;
 }
 Pointer<Void> smoke_ParentInterface_toFfi(ParentInterface value) {
-  if (value is ParentInterface$Impl) return _smoke_ParentInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_ParentInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_ParentInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/_native_base.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/_native_base.dart
@@ -1,0 +1,9 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+/// @nodoc
+class NativeBase {
+  @protected
+  Pointer<Void> handle;
+  NativeBase(this.handle);
+}

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -22,10 +23,8 @@ final _smoke_SimpleClass_release_handle = __lib.catchArgumentError(() => __lib.n
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SimpleClass_release_handle'));
-class SimpleClass$Impl implements SimpleClass {
-  @protected
-  Pointer<Void> handle;
-  SimpleClass$Impl(this.handle);
+class SimpleClass$Impl extends __lib.NativeBase implements SimpleClass {
+  SimpleClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -60,7 +59,7 @@ class SimpleClass$Impl implements SimpleClass {
   }
 }
 Pointer<Void> smoke_SimpleClass_toFfi(SimpleClass value) =>
-  _smoke_SimpleClass_copy_handle((value as SimpleClass$Impl).handle);
+  _smoke_SimpleClass_copy_handle((value as __lib.NativeBase).handle);
 SimpleClass smoke_SimpleClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -55,9 +56,8 @@ class SimpleInterface$Lambdas implements SimpleInterface {
   SimpleInterface useSimpleInterface(SimpleInterface input) =>
     lambda_useSimpleInterface(input);
 }
-class SimpleInterface$Impl implements SimpleInterface {
-  Pointer<Void> handle;
-  SimpleInterface$Impl(this.handle);
+class SimpleInterface$Impl extends __lib.NativeBase implements SimpleInterface {
+  SimpleInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -112,7 +112,7 @@ int _SimpleInterface_useSimpleInterface_static(int _token, Pointer<Void> input, 
   return 0;
 }
 Pointer<Void> smoke_SimpleInterface_toFfi(SimpleInterface value) {
-  if (value is SimpleInterface$Impl) return _smoke_SimpleInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_SimpleInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_SimpleInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -113,10 +114,8 @@ final _smoke_ClassWithInternalLambda_release_handle = __lib.catchArgumentError((
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ClassWithInternalLambda_release_handle'));
-class ClassWithInternalLambda$Impl implements ClassWithInternalLambda {
-  @protected
-  Pointer<Void> handle;
-  ClassWithInternalLambda$Impl(this.handle);
+class ClassWithInternalLambda$Impl extends __lib.NativeBase implements ClassWithInternalLambda {
+  ClassWithInternalLambda$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -140,7 +139,7 @@ class ClassWithInternalLambda$Impl implements ClassWithInternalLambda {
   }
 }
 Pointer<Void> smoke_ClassWithInternalLambda_toFfi(ClassWithInternalLambda value) =>
-  _smoke_ClassWithInternalLambda_copy_handle((value as ClassWithInternalLambda$Impl).handle);
+  _smoke_ClassWithInternalLambda_copy_handle((value as __lib.NativeBase).handle);
 ClassWithInternalLambda smoke_ClassWithInternalLambda_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
@@ -477,10 +478,8 @@ final _smoke_Lambdas_release_handle = __lib.catchArgumentError(() => __lib.nativ
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_release_handle'));
-class Lambdas$Impl implements Lambdas {
-  @protected
-  Pointer<Void> handle;
-  Lambdas$Impl(this.handle);
+class Lambdas$Impl extends __lib.NativeBase implements Lambdas {
+  Lambdas$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -519,7 +518,7 @@ class Lambdas$Impl implements Lambdas {
   }
 }
 Pointer<Void> smoke_Lambdas_toFfi(Lambdas value) =>
-  _smoke_Lambdas_copy_handle((value as Lambdas$Impl).handle);
+  _smoke_Lambdas_copy_handle((value as __lib.NativeBase).handle);
 Lambdas smoke_Lambdas_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/lambdas_declaration_order.dart';
@@ -202,10 +203,8 @@ final _smoke_LambdasWithStructuredTypes_release_handle = __lib.catchArgumentErro
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_release_handle'));
-class LambdasWithStructuredTypes$Impl implements LambdasWithStructuredTypes {
-  @protected
-  Pointer<Void> handle;
-  LambdasWithStructuredTypes$Impl(this.handle);
+class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements LambdasWithStructuredTypes {
+  LambdasWithStructuredTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -242,7 +241,7 @@ class LambdasWithStructuredTypes$Impl implements LambdasWithStructuredTypes {
   }
 }
 Pointer<Void> smoke_LambdasWithStructuredTypes_toFfi(LambdasWithStructuredTypes value) =>
-  _smoke_LambdasWithStructuredTypes_copy_handle((value as LambdasWithStructuredTypes$Impl).handle);
+  _smoke_LambdasWithStructuredTypes_copy_handle((value as __lib.NativeBase).handle);
 LambdasWithStructuredTypes smoke_LambdasWithStructuredTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -153,9 +154,8 @@ class CalculatorListener$Lambdas implements CalculatorListener {
   onCalculationResultInstance(CalculationResult calculationResult) =>
     lambda_onCalculationResultInstance(calculationResult);
 }
-class CalculatorListener$Impl implements CalculatorListener {
-  Pointer<Void> handle;
-  CalculatorListener$Impl(this.handle);
+class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorListener {
+  CalculatorListener$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -292,7 +292,7 @@ int _CalculatorListener_onCalculationResultInstance_static(int _token, Pointer<V
   return 0;
 }
 Pointer<Void> smoke_CalculatorListener_toFfi(CalculatorListener value) {
-  if (value is CalculatorListener$Impl) return _smoke_CalculatorListener_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_CalculatorListener_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_CalculatorListener_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -64,9 +65,8 @@ class InterfaceWithStatic$Lambdas implements InterfaceWithStatic {
   @override
   set regularProperty(String value) => lambda_regularProperty_set(value);
 }
-class InterfaceWithStatic$Impl implements InterfaceWithStatic {
-  Pointer<Void> handle;
-  InterfaceWithStatic$Impl(this.handle);
+class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWithStatic {
+  InterfaceWithStatic$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -162,7 +162,7 @@ int _InterfaceWithStatic_regularProperty_set_static(int _token, Pointer<Void> _v
   return 0;
 }
 Pointer<Void> smoke_InterfaceWithStatic_toFfi(InterfaceWithStatic value) {
-  if (value is InterfaceWithStatic$Impl) return _smoke_InterfaceWithStatic_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_InterfaceWithStatic_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_InterfaceWithStatic_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -263,9 +264,8 @@ class ListenerWithProperties$Lambdas implements ListenerWithProperties {
   @override
   set bufferedMessage(Uint8List value) => lambda_bufferedMessage_set(value);
 }
-class ListenerWithProperties$Impl implements ListenerWithProperties {
-  Pointer<Void> handle;
-  ListenerWithProperties$Impl(this.handle);
+class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWithProperties {
+  ListenerWithProperties$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -521,7 +521,7 @@ int _ListenerWithProperties_bufferedMessage_set_static(int _token, Pointer<Void>
   return 0;
 }
 Pointer<Void> smoke_ListenerWithProperties_toFfi(ListenerWithProperties value) {
-  if (value is ListenerWithProperties$Impl) return _smoke_ListenerWithProperties_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_ListenerWithProperties_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_ListenerWithProperties_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -220,9 +221,8 @@ class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
   CalculationResult fetchDataInstance() =>
     lambda_fetchDataInstance();
 }
-class ListenersWithReturnValues$Impl implements ListenersWithReturnValues {
-  Pointer<Void> handle;
-  ListenersWithReturnValues$Impl(this.handle);
+class ListenersWithReturnValues$Impl extends __lib.NativeBase implements ListenersWithReturnValues {
+  ListenersWithReturnValues$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -374,7 +374,7 @@ int _ListenersWithReturnValues_fetchDataInstance_static(int _token, Pointer<Poin
   return 0;
 }
 Pointer<Void> smoke_ListenersWithReturnValues_toFfi(ListenersWithReturnValues value) {
-  if (value is ListenersWithReturnValues$Impl) return _smoke_ListenersWithReturnValues_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_ListenersWithReturnValues_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_ListenersWithReturnValues_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -1,4 +1,5 @@
 import 'package:intl/locale.dart';
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -88,10 +89,8 @@ final _smoke_Locales_release_handle = __lib.catchArgumentError(() => __lib.nativ
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Locales_release_handle'));
-class Locales$Impl implements Locales {
-  @protected
-  Pointer<Void> handle;
-  Locales$Impl(this.handle);
+class Locales$Impl extends __lib.NativeBase implements Locales {
+  Locales$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -139,7 +138,7 @@ class Locales$Impl implements Locales {
   }
 }
 Pointer<Void> smoke_Locales_toFfi(Locales value) =>
-  _smoke_Locales_copy_handle((value as Locales$Impl).handle);
+  _smoke_Locales_copy_handle((value as __lib.NativeBase).handle);
 Locales smoke_Locales_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
@@ -105,10 +106,8 @@ final _smoke_MethodOverloads_release_handle = __lib.catchArgumentError(() => __l
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_release_handle'));
-class MethodOverloads$Impl implements MethodOverloads {
-  @protected
-  Pointer<Void> handle;
-  MethodOverloads$Impl(this.handle);
+class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
+  MethodOverloads$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -253,7 +252,7 @@ class MethodOverloads$Impl implements MethodOverloads {
   }
 }
 Pointer<Void> smoke_MethodOverloads_toFfi(MethodOverloads value) =>
-  _smoke_MethodOverloads_copy_handle((value as MethodOverloads$Impl).handle);
+  _smoke_MethodOverloads_copy_handle((value as __lib.NativeBase).handle);
 MethodOverloads smoke_MethodOverloads_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -24,10 +25,8 @@ final _smoke_SpecialNames_release_handle = __lib.catchArgumentError(() => __lib.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SpecialNames_release_handle'));
-class SpecialNames$Impl implements SpecialNames {
-  @protected
-  Pointer<Void> handle;
-  SpecialNames$Impl(this.handle);
+class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
+  SpecialNames$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -82,7 +81,7 @@ class SpecialNames$Impl implements SpecialNames {
   }
 }
 Pointer<Void> smoke_SpecialNames_toFfi(SpecialNames value) =>
-  _smoke_SpecialNames_copy_handle((value as SpecialNames$Impl).handle);
+  _smoke_SpecialNames_copy_handle((value as __lib.NativeBase).handle);
 SpecialNames smoke_SpecialNames_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/outer_class.dart';
@@ -163,10 +164,8 @@ final _smoke_LevelOne_LevelTwo_LevelThree_release_handle = __lib.catchArgumentEr
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_release_handle'));
-class LevelOne_LevelTwo_LevelThree$Impl implements LevelOne_LevelTwo_LevelThree {
-  @protected
-  Pointer<Void> handle;
-  LevelOne_LevelTwo_LevelThree$Impl(this.handle);
+class LevelOne_LevelTwo_LevelThree$Impl extends __lib.NativeBase implements LevelOne_LevelTwo_LevelThree {
+  LevelOne_LevelTwo_LevelThree$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -190,7 +189,7 @@ class LevelOne_LevelTwo_LevelThree$Impl implements LevelOne_LevelTwo_LevelThree 
   }
 }
 Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi(LevelOne_LevelTwo_LevelThree value) =>
-  _smoke_LevelOne_LevelTwo_LevelThree_copy_handle((value as LevelOne_LevelTwo_LevelThree$Impl).handle);
+  _smoke_LevelOne_LevelTwo_LevelThree_copy_handle((value as __lib.NativeBase).handle);
 LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
@@ -219,10 +218,8 @@ final _smoke_LevelOne_LevelTwo_release_handle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_release_handle'));
-class LevelOne_LevelTwo$Impl implements LevelOne_LevelTwo {
-  @protected
-  Pointer<Void> handle;
-  LevelOne_LevelTwo$Impl(this.handle);
+class LevelOne_LevelTwo$Impl extends __lib.NativeBase implements LevelOne_LevelTwo {
+  LevelOne_LevelTwo$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -233,7 +230,7 @@ class LevelOne_LevelTwo$Impl implements LevelOne_LevelTwo {
   }
 }
 Pointer<Void> smoke_LevelOne_LevelTwo_toFfi(LevelOne_LevelTwo value) =>
-  _smoke_LevelOne_LevelTwo_copy_handle((value as LevelOne_LevelTwo$Impl).handle);
+  _smoke_LevelOne_LevelTwo_copy_handle((value as __lib.NativeBase).handle);
 LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
@@ -262,10 +259,8 @@ final _smoke_LevelOne_release_handle = __lib.catchArgumentError(() => __lib.nati
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LevelOne_release_handle'));
-class LevelOne$Impl implements LevelOne {
-  @protected
-  Pointer<Void> handle;
-  LevelOne$Impl(this.handle);
+class LevelOne$Impl extends __lib.NativeBase implements LevelOne {
+  LevelOne$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -276,7 +271,7 @@ class LevelOne$Impl implements LevelOne {
   }
 }
 Pointer<Void> smoke_LevelOne_toFfi(LevelOne value) =>
-  _smoke_LevelOne_copy_handle((value as LevelOne$Impl).handle);
+  _smoke_LevelOne_copy_handle((value as __lib.NativeBase).handle);
 LevelOne smoke_LevelOne_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -30,10 +31,8 @@ final _smoke_OuterClass_InnerClass_release_handle = __lib.catchArgumentError(() 
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClass_InnerClass_release_handle'));
-class OuterClass_InnerClass$Impl implements OuterClass_InnerClass {
-  @protected
-  Pointer<Void> handle;
-  OuterClass_InnerClass$Impl(this.handle);
+class OuterClass_InnerClass$Impl extends __lib.NativeBase implements OuterClass_InnerClass {
+  OuterClass_InnerClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -57,7 +56,7 @@ class OuterClass_InnerClass$Impl implements OuterClass_InnerClass {
   }
 }
 Pointer<Void> smoke_OuterClass_InnerClass_toFfi(OuterClass_InnerClass value) =>
-  _smoke_OuterClass_InnerClass_copy_handle((value as OuterClass_InnerClass$Impl).handle);
+  _smoke_OuterClass_InnerClass_copy_handle((value as __lib.NativeBase).handle);
 OuterClass_InnerClass smoke_OuterClass_InnerClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
@@ -119,9 +118,8 @@ class OuterClass_InnerInterface$Lambdas implements OuterClass_InnerInterface {
   String foo(String input) =>
     lambda_foo(input);
 }
-class OuterClass_InnerInterface$Impl implements OuterClass_InnerInterface {
-  Pointer<Void> handle;
-  OuterClass_InnerInterface$Impl(this.handle);
+class OuterClass_InnerInterface$Impl extends __lib.NativeBase implements OuterClass_InnerInterface {
+  OuterClass_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -155,7 +153,7 @@ int _OuterClass_InnerInterface_foo_static(int _token, Pointer<Void> input, Point
   return 0;
 }
 Pointer<Void> smoke_OuterClass_InnerInterface_toFfi(OuterClass_InnerInterface value) {
-  if (value is OuterClass_InnerInterface$Impl) return _smoke_OuterClass_InnerInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_OuterClass_InnerInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_OuterClass_InnerInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
@@ -197,10 +195,8 @@ final _smoke_OuterClass_release_handle = __lib.catchArgumentError(() => __lib.na
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClass_release_handle'));
-class OuterClass$Impl implements OuterClass {
-  @protected
-  Pointer<Void> handle;
-  OuterClass$Impl(this.handle);
+class OuterClass$Impl extends __lib.NativeBase implements OuterClass {
+  OuterClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -224,7 +220,7 @@ class OuterClass$Impl implements OuterClass {
   }
 }
 Pointer<Void> smoke_OuterClass_toFfi(OuterClass value) =>
-  _smoke_OuterClass_copy_handle((value as OuterClass$Impl).handle);
+  _smoke_OuterClass_copy_handle((value as __lib.NativeBase).handle);
 OuterClass smoke_OuterClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -31,10 +32,8 @@ final _smoke_OuterClassWithInheritance_InnerClass_release_handle = __lib.catchAr
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_InnerClass_release_handle'));
-class OuterClassWithInheritance_InnerClass$Impl implements OuterClassWithInheritance_InnerClass {
-  @protected
-  Pointer<Void> handle;
-  OuterClassWithInheritance_InnerClass$Impl(this.handle);
+class OuterClassWithInheritance_InnerClass$Impl extends __lib.NativeBase implements OuterClassWithInheritance_InnerClass {
+  OuterClassWithInheritance_InnerClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -58,7 +57,7 @@ class OuterClassWithInheritance_InnerClass$Impl implements OuterClassWithInherit
   }
 }
 Pointer<Void> smoke_OuterClassWithInheritance_InnerClass_toFfi(OuterClassWithInheritance_InnerClass value) =>
-  _smoke_OuterClassWithInheritance_InnerClass_copy_handle((value as OuterClassWithInheritance_InnerClass$Impl).handle);
+  _smoke_OuterClassWithInheritance_InnerClass_copy_handle((value as __lib.NativeBase).handle);
 OuterClassWithInheritance_InnerClass smoke_OuterClassWithInheritance_InnerClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
@@ -120,9 +119,8 @@ class OuterClassWithInheritance_InnerInterface$Lambdas implements OuterClassWith
   String baz(String input) =>
     lambda_baz(input);
 }
-class OuterClassWithInheritance_InnerInterface$Impl implements OuterClassWithInheritance_InnerInterface {
-  Pointer<Void> handle;
-  OuterClassWithInheritance_InnerInterface$Impl(this.handle);
+class OuterClassWithInheritance_InnerInterface$Impl extends __lib.NativeBase implements OuterClassWithInheritance_InnerInterface {
+  OuterClassWithInheritance_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -156,7 +154,7 @@ int _OuterClassWithInheritance_InnerInterface_baz_static(int _token, Pointer<Voi
   return 0;
 }
 Pointer<Void> smoke_OuterClassWithInheritance_InnerInterface_toFfi(OuterClassWithInheritance_InnerInterface value) {
-  if (value is OuterClassWithInheritance_InnerInterface$Impl) return _smoke_OuterClassWithInheritance_InnerInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_OuterClassWithInheritance_InnerInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_OuterClassWithInheritance_InnerInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
@@ -227,7 +225,7 @@ class OuterClassWithInheritance$Impl extends ParentClass$Impl implements OuterCl
   }
 }
 Pointer<Void> smoke_OuterClassWithInheritance_toFfi(OuterClassWithInheritance value) =>
-  _smoke_OuterClassWithInheritance_copy_handle((value as OuterClassWithInheritance$Impl).handle);
+  _smoke_OuterClassWithInheritance_copy_handle((value as __lib.NativeBase).handle);
 OuterClassWithInheritance smoke_OuterClassWithInheritance_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -36,10 +37,8 @@ final _smoke_OuterInterface_InnerClass_release_handle = __lib.catchArgumentError
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterInterface_InnerClass_release_handle'));
-class OuterInterface_InnerClass$Impl implements OuterInterface_InnerClass {
-  @protected
-  Pointer<Void> handle;
-  OuterInterface_InnerClass$Impl(this.handle);
+class OuterInterface_InnerClass$Impl extends __lib.NativeBase implements OuterInterface_InnerClass {
+  OuterInterface_InnerClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -63,7 +62,7 @@ class OuterInterface_InnerClass$Impl implements OuterInterface_InnerClass {
   }
 }
 Pointer<Void> smoke_OuterInterface_InnerClass_toFfi(OuterInterface_InnerClass value) =>
-  _smoke_OuterInterface_InnerClass_copy_handle((value as OuterInterface_InnerClass$Impl).handle);
+  _smoke_OuterInterface_InnerClass_copy_handle((value as __lib.NativeBase).handle);
 OuterInterface_InnerClass smoke_OuterInterface_InnerClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
@@ -125,9 +124,8 @@ class OuterInterface_InnerInterface$Lambdas implements OuterInterface_InnerInter
   String foo(String input) =>
     lambda_foo(input);
 }
-class OuterInterface_InnerInterface$Impl implements OuterInterface_InnerInterface {
-  Pointer<Void> handle;
-  OuterInterface_InnerInterface$Impl(this.handle);
+class OuterInterface_InnerInterface$Impl extends __lib.NativeBase implements OuterInterface_InnerInterface {
+  OuterInterface_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -161,7 +159,7 @@ int _OuterInterface_InnerInterface_foo_static(int _token, Pointer<Void> input, P
   return 0;
 }
 Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi(OuterInterface_InnerInterface value) {
-  if (value is OuterInterface_InnerInterface$Impl) return _smoke_OuterInterface_InnerInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_OuterInterface_InnerInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_OuterInterface_InnerInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
@@ -222,9 +220,8 @@ class OuterInterface$Lambdas implements OuterInterface {
   String foo(String input) =>
     lambda_foo(input);
 }
-class OuterInterface$Impl implements OuterInterface {
-  Pointer<Void> handle;
-  OuterInterface$Impl(this.handle);
+class OuterInterface$Impl extends __lib.NativeBase implements OuterInterface {
+  OuterInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -258,7 +255,7 @@ int _OuterInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<
   return 0;
 }
 Pointer<Void> smoke_OuterInterface_toFfi(OuterInterface value) {
-  if (value is OuterInterface$Impl) return _smoke_OuterInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_OuterInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_OuterInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 import 'package:intl/locale.dart';
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -202,10 +203,8 @@ final _smoke_OuterStruct_InnerClass_release_handle = __lib.catchArgumentError(()
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerClass_release_handle'));
-class OuterStruct_InnerClass$Impl implements OuterStruct_InnerClass {
-  @protected
-  Pointer<Void> handle;
-  OuterStruct_InnerClass$Impl(this.handle);
+class OuterStruct_InnerClass$Impl extends __lib.NativeBase implements OuterStruct_InnerClass {
+  OuterStruct_InnerClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -227,7 +226,7 @@ class OuterStruct_InnerClass$Impl implements OuterStruct_InnerClass {
   }
 }
 Pointer<Void> smoke_OuterStruct_InnerClass_toFfi(OuterStruct_InnerClass value) =>
-  _smoke_OuterStruct_InnerClass_copy_handle((value as OuterStruct_InnerClass$Impl).handle);
+  _smoke_OuterStruct_InnerClass_copy_handle((value as __lib.NativeBase).handle);
 OuterStruct_InnerClass smoke_OuterStruct_InnerClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);
@@ -289,9 +288,8 @@ class OuterStruct_InnerInterface$Lambdas implements OuterStruct_InnerInterface {
   Map<String, Uint8List> barBaz() =>
     lambda_barBaz();
 }
-class OuterStruct_InnerInterface$Impl implements OuterStruct_InnerInterface {
-  Pointer<Void> handle;
-  OuterStruct_InnerInterface$Impl(this.handle);
+class OuterStruct_InnerInterface$Impl extends __lib.NativeBase implements OuterStruct_InnerInterface {
+  OuterStruct_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -322,7 +320,7 @@ int _OuterStruct_InnerInterface_barBaz_static(int _token, Pointer<Pointer<Void>>
   return 0;
 }
 Pointer<Void> smoke_OuterStruct_InnerInterface_toFfi(OuterStruct_InnerInterface value) {
-  if (value is OuterStruct_InnerInterface$Impl) return _smoke_OuterStruct_InnerInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_OuterStruct_InnerInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_OuterStruct_InnerInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/free_enum.dart';
@@ -40,10 +41,8 @@ final _doStuff_return_has_error = __lib.catchArgumentError(() => __lib.nativeLib
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_has_error'));
-class UseFreeTypes$Impl implements UseFreeTypes {
-  @protected
-  Pointer<Void> handle;
-  UseFreeTypes$Impl(this.handle);
+class UseFreeTypes$Impl extends __lib.NativeBase implements UseFreeTypes {
+  UseFreeTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -80,7 +79,7 @@ class UseFreeTypes$Impl implements UseFreeTypes {
   }
 }
 Pointer<Void> smoke_UseFreeTypes_toFfi(UseFreeTypes value) =>
-  _smoke_UseFreeTypes_copy_handle((value as UseFreeTypes$Impl).handle);
+  _smoke_UseFreeTypes_copy_handle((value as __lib.NativeBase).handle);
 UseFreeTypes smoke_UseFreeTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
@@ -453,10 +454,8 @@ final _smoke_Nullable_release_handle = __lib.catchArgumentError(() => __lib.nati
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Nullable_release_handle'));
-class Nullable$Impl implements Nullable {
-  @protected
-  Pointer<Void> handle;
-  Nullable$Impl(this.handle);
+class Nullable$Impl extends __lib.NativeBase implements Nullable {
+  Nullable$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -837,7 +836,7 @@ class Nullable$Impl implements Nullable {
   }
 }
 Pointer<Void> smoke_Nullable_toFfi(Nullable value) =>
-  _smoke_Nullable_copy_handle((value as Nullable$Impl).handle);
+  _smoke_Nullable_copy_handle((value as __lib.NativeBase).handle);
 Nullable smoke_Nullable_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -85,10 +86,8 @@ final _smoke_off_NestedPackages_release_handle = __lib.catchArgumentError(() => 
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_release_handle'));
-class NestedPackages$Impl implements NestedPackages {
-  @protected
-  Pointer<Void> handle;
-  NestedPackages$Impl(this.handle);
+class NestedPackages$Impl extends __lib.NativeBase implements NestedPackages {
+  NestedPackages$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -110,7 +109,7 @@ class NestedPackages$Impl implements NestedPackages {
   }
 }
 Pointer<Void> smoke_off_NestedPackages_toFfi(NestedPackages value) =>
-  _smoke_off_NestedPackages_copy_handle((value as NestedPackages$Impl).handle);
+  _smoke_off_NestedPackages_copy_handle((value as __lib.NativeBase).handle);
 NestedPackages smoke_off_NestedPackages_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/wee_types.dart';
@@ -25,10 +26,8 @@ final _smoke_PlatformNamesInterface_release_handle = __lib.catchArgumentError(()
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformNamesInterface_release_handle'));
-class weeInterface$Impl implements weeInterface {
-  @protected
-  Pointer<Void> handle;
-  weeInterface$Impl(this.handle);
+class weeInterface$Impl extends __lib.NativeBase implements weeInterface {
+  weeInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -37,7 +36,7 @@ class weeInterface$Impl implements weeInterface {
     _smoke_PlatformNamesInterface_release_handle(handle);
     handle = null;
   }
-  weeInterface$Impl.make(String makeParameter) : handle = _make(makeParameter) {
+  weeInterface$Impl.make(String makeParameter) : super(_make(makeParameter)) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   @override
@@ -86,7 +85,7 @@ class weeInterface$Impl implements weeInterface {
   }
 }
 Pointer<Void> smoke_PlatformNamesInterface_toFfi(weeInterface value) =>
-  _smoke_PlatformNamesInterface_copy_handle((value as weeInterface$Impl).handle);
+  _smoke_PlatformNamesInterface_copy_handle((value as __lib.NativeBase).handle);
 weeInterface smoke_PlatformNamesInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -47,9 +48,8 @@ class weeListener$Lambdas implements weeListener {
   WeeMethod(String WeeParameter) =>
     lambda_WeeMethod(WeeParameter);
 }
-class weeListener$Impl implements weeListener {
-  Pointer<Void> handle;
-  weeListener$Impl(this.handle);
+class weeListener$Impl extends __lib.NativeBase implements weeListener {
+  weeListener$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -81,7 +81,7 @@ int _weeListener_WeeMethod_static(int _token, Pointer<Void> WeeParameter) {
   return 0;
 }
 Pointer<Void> smoke_PlatformNamesListener_toFfi(weeListener value) {
-  if (value is weeListener$Impl) return _smoke_PlatformNamesListener_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_PlatformNamesListener_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_PlatformNamesListener_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
@@ -24,10 +25,8 @@ final _smoke_CachedProperties_release_handle = __lib.catchArgumentError(() => __
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CachedProperties_release_handle'));
-class CachedProperties$Impl implements CachedProperties {
-  @protected
-  Pointer<Void> handle;
-  CachedProperties$Impl(this.handle);
+class CachedProperties$Impl extends __lib.NativeBase implements CachedProperties {
+  CachedProperties$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -69,7 +68,7 @@ class CachedProperties$Impl implements CachedProperties {
   }
 }
 Pointer<Void> smoke_CachedProperties_toFfi(CachedProperties value) =>
-  _smoke_CachedProperties_copy_handle((value as CachedProperties$Impl).handle);
+  _smoke_CachedProperties_copy_handle((value as __lib.NativeBase).handle);
 CachedProperties smoke_CachedProperties_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
@@ -164,10 +165,8 @@ final _smoke_Properties_release_handle = __lib.catchArgumentError(() => __lib.na
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Properties_release_handle'));
-class Properties$Impl implements Properties {
-  @protected
-  Pointer<Void> handle;
-  Properties$Impl(this.handle);
+class Properties$Impl extends __lib.NativeBase implements Properties {
+  Properties$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -386,7 +385,7 @@ class Properties$Impl implements Properties {
   }
 }
 Pointer<Void> smoke_Properties_toFfi(Properties value) =>
-  _smoke_Properties_copy_handle((value as Properties$Impl).handle);
+  _smoke_Properties_copy_handle((value as __lib.NativeBase).handle);
 Properties smoke_Properties_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -117,9 +118,8 @@ class PropertiesInterface$Lambdas implements PropertiesInterface {
   @override
   set structProperty(PropertiesInterface_ExampleStruct value) => lambda_structProperty_set(value);
 }
-class PropertiesInterface$Impl implements PropertiesInterface {
-  Pointer<Void> handle;
-  PropertiesInterface$Impl(this.handle);
+class PropertiesInterface$Impl extends __lib.NativeBase implements PropertiesInterface {
+  PropertiesInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -165,7 +165,7 @@ int _PropertiesInterface_structProperty_set_static(int _token, Pointer<Void> _va
   return 0;
 }
 Pointer<Void> smoke_PropertiesInterface_toFfi(PropertiesInterface value) {
-  if (value is PropertiesInterface$Impl) return _smoke_PropertiesInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_PropertiesInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_PropertiesInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -27,10 +28,8 @@ final _smoke_EnableIfEnabled_release_handle = __lib.catchArgumentError(() => __l
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EnableIfEnabled_release_handle'));
-class EnableIfEnabled$Impl implements EnableIfEnabled {
-  @protected
-  Pointer<Void> handle;
-  EnableIfEnabled$Impl(this.handle);
+class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
+  EnableIfEnabled$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -104,7 +103,7 @@ class EnableIfEnabled$Impl implements EnableIfEnabled {
   }
 }
 Pointer<Void> smoke_EnableIfEnabled_toFfi(EnableIfEnabled value) =>
-  _smoke_EnableIfEnabled_copy_handle((value as EnableIfEnabled$Impl).handle);
+  _smoke_EnableIfEnabled_copy_handle((value as __lib.NativeBase).handle);
 EnableIfEnabled smoke_EnableIfEnabled_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -19,10 +20,8 @@ final _smoke_EnableIfSkipped_release_handle = __lib.catchArgumentError(() => __l
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EnableIfSkipped_release_handle'));
-class EnableIfSkipped$Impl implements EnableIfSkipped {
-  @protected
-  Pointer<Void> handle;
-  EnableIfSkipped$Impl(this.handle);
+class EnableIfSkipped$Impl extends __lib.NativeBase implements EnableIfSkipped {
+  EnableIfSkipped$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -33,7 +32,7 @@ class EnableIfSkipped$Impl implements EnableIfSkipped {
   }
 }
 Pointer<Void> smoke_EnableIfSkipped_toFfi(EnableIfSkipped value) =>
-  _smoke_EnableIfSkipped_copy_handle((value as EnableIfSkipped$Impl).handle);
+  _smoke_EnableIfSkipped_copy_handle((value as __lib.NativeBase).handle);
 EnableIfSkipped smoke_EnableIfSkipped_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -78,9 +79,8 @@ class InheritFromSkipped$Lambdas implements InheritFromSkipped {
   @override
   set isSkippedInSwift(bool value) => lambda_isSkippedInSwift_set(value);
 }
-class InheritFromSkipped$Impl implements InheritFromSkipped {
-  Pointer<Void> handle;
-  InheritFromSkipped$Impl(this.handle);
+class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSkipped {
+  InheritFromSkipped$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -207,7 +207,7 @@ int _InheritFromSkipped_isSkippedInSwift_set_static(int _token, int _value) {
   return 0;
 }
 Pointer<Void> smoke_InheritFromSkipped_toFfi(InheritFromSkipped value) {
-  if (value is InheritFromSkipped$Impl) return _smoke_InheritFromSkipped_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_InheritFromSkipped_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_InheritFromSkipped_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -22,10 +23,8 @@ final _smoke_SkipFunctions_release_handle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipFunctions_release_handle'));
-class SkipFunctions$Impl implements SkipFunctions {
-  @protected
-  Pointer<Void> handle;
-  SkipFunctions$Impl(this.handle);
+class SkipFunctions$Impl extends __lib.NativeBase implements SkipFunctions {
+  SkipFunctions$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -58,7 +57,7 @@ class SkipFunctions$Impl implements SkipFunctions {
   }
 }
 Pointer<Void> smoke_SkipFunctions_toFfi(SkipFunctions value) =>
-  _smoke_SkipFunctions_copy_handle((value as SkipFunctions$Impl).handle);
+  _smoke_SkipFunctions_copy_handle((value as __lib.NativeBase).handle);
 SkipFunctions smoke_SkipFunctions_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -83,9 +84,8 @@ class SkipProxy$Lambdas implements SkipProxy {
   @override
   set isSkippedInSwift(bool value) => lambda_isSkippedInSwift_set(value);
 }
-class SkipProxy$Impl implements SkipProxy {
-  Pointer<Void> handle;
-  SkipProxy$Impl(this.handle);
+class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
+  SkipProxy$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -212,7 +212,7 @@ int _SkipProxy_isSkippedInSwift_set_static(int _token, int _value) {
   return 0;
 }
 Pointer<Void> smoke_SkipProxy_toFfi(SkipProxy value) {
-  if (value is SkipProxy$Impl) return _smoke_SkipProxy_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_SkipProxy_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_SkipProxy_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
@@ -19,10 +20,8 @@ final _smoke_SkipTagsOnly_release_handle = __lib.catchArgumentError(() => __lib.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipTagsOnly_release_handle'));
-class SkipTagsOnly$Impl implements SkipTagsOnly {
-  @protected
-  Pointer<Void> handle;
-  SkipTagsOnly$Impl(this.handle);
+class SkipTagsOnly$Impl extends __lib.NativeBase implements SkipTagsOnly {
+  SkipTagsOnly$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -33,7 +32,7 @@ class SkipTagsOnly$Impl implements SkipTagsOnly {
   }
 }
 Pointer<Void> smoke_SkipTagsOnly_toFfi(SkipTagsOnly value) =>
-  _smoke_SkipTagsOnly_copy_handle((value as SkipTagsOnly$Impl).handle);
+  _smoke_SkipTagsOnly_copy_handle((value as __lib.NativeBase).handle);
 SkipTagsOnly smoke_SkipTagsOnly_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -148,10 +149,8 @@ final _smoke_SkipTypes_release_handle = __lib.catchArgumentError(() => __lib.nat
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipTypes_release_handle'));
-class SkipTypes$Impl implements SkipTypes {
-  @protected
-  Pointer<Void> handle;
-  SkipTypes$Impl(this.handle);
+class SkipTypes$Impl extends __lib.NativeBase implements SkipTypes {
+  SkipTypes$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -162,7 +161,7 @@ class SkipTypes$Impl implements SkipTypes {
   }
 }
 Pointer<Void> smoke_SkipTypes_toFfi(SkipTypes value) =>
-  _smoke_SkipTypes_copy_handle((value as SkipTypes$Impl).handle);
+  _smoke_SkipTypes_copy_handle((value as __lib.NativeBase).handle);
 SkipTypes smoke_SkipTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
@@ -750,10 +751,8 @@ final _smoke_Structs_release_handle = __lib.catchArgumentError(() => __lib.nativ
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_release_handle'));
-class Structs$Impl implements Structs {
-  @protected
-  Pointer<Void> handle;
-  Structs$Impl(this.handle);
+class Structs$Impl extends __lib.NativeBase implements Structs {
+  Structs$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -810,7 +809,7 @@ class Structs$Impl implements Structs {
   }
 }
 Pointer<Void> smoke_Structs_toFfi(Structs value) =>
-  _smoke_Structs_copy_handle((value as Structs$Impl).handle);
+  _smoke_Structs_copy_handle((value as __lib.NativeBase).handle);
 Structs smoke_Structs_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -28,10 +29,8 @@ final _smoke_SomeClass_release_handle = __lib.catchArgumentError(() => __lib.nat
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SomeClass_release_handle'));
-class SomeClass$Impl implements SomeClass {
-  @protected
-  Pointer<Void> handle;
-  SomeClass$Impl(this.handle);
+class SomeClass$Impl extends __lib.NativeBase implements SomeClass {
+  SomeClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -116,7 +115,7 @@ class SomeClass$Impl implements SomeClass {
   }
 }
 Pointer<Void> smoke_SomeClass_toFfi(SomeClass value) =>
-  _smoke_SomeClass_copy_handle((value as SomeClass$Impl).handle);
+  _smoke_SomeClass_copy_handle((value as __lib.NativeBase).handle);
 SomeClass smoke_SomeClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
@@ -158,10 +159,8 @@ final _smoke_TypeDefs_release_handle = __lib.catchArgumentError(() => __lib.nati
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypeDefs_release_handle'));
-class TypeDefs$Impl implements TypeDefs {
-  @protected
-  Pointer<Void> handle;
-  TypeDefs$Impl(this.handle);
+class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
+  TypeDefs$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -262,7 +261,7 @@ class TypeDefs$Impl implements TypeDefs {
   }
 }
 Pointer<Void> smoke_TypeDefs_toFfi(TypeDefs value) =>
-  _smoke_TypeDefs_copy_handle((value as TypeDefs$Impl).handle);
+  _smoke_TypeDefs_copy_handle((value as __lib.NativeBase).handle);
 TypeDefs smoke_TypeDefs_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -23,10 +24,8 @@ final _smoke_InternalClass_release_handle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClass_release_handle'));
-class InternalClass$Impl implements InternalClass {
-  @protected
-  Pointer<Void> handle;
-  InternalClass$Impl(this.handle);
+class InternalClass$Impl extends __lib.NativeBase implements InternalClass {
+  InternalClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -48,7 +47,7 @@ class InternalClass$Impl implements InternalClass {
   }
 }
 Pointer<Void> smoke_InternalClass_toFfi(InternalClass value) =>
-  _smoke_InternalClass_copy_handle((value as InternalClass$Impl).handle);
+  _smoke_InternalClass_copy_handle((value as __lib.NativeBase).handle);
 InternalClass smoke_InternalClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -27,10 +28,8 @@ final _smoke_InternalClassWithFunctions_release_handle = __lib.catchArgumentErro
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClassWithFunctions_release_handle'));
-class InternalClassWithFunctions$Impl implements InternalClassWithFunctions {
-  @protected
-  Pointer<Void> handle;
-  InternalClassWithFunctions$Impl(this.handle);
+class InternalClassWithFunctions$Impl extends __lib.NativeBase implements InternalClassWithFunctions {
+  InternalClassWithFunctions$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -39,10 +38,10 @@ class InternalClassWithFunctions$Impl implements InternalClassWithFunctions {
     _smoke_InternalClassWithFunctions_release_handle(handle);
     handle = null;
   }
-  InternalClassWithFunctions$Impl.internal_make() : handle = _make() {
+  InternalClassWithFunctions$Impl.internal_make() : super(_make()) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
-  InternalClassWithFunctions$Impl.internal_remake(String foo) : handle = _remake(foo) {
+  InternalClassWithFunctions$Impl.internal_remake(String foo) : super(_remake(foo)) {
     __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   @override
@@ -70,7 +69,7 @@ class InternalClassWithFunctions$Impl implements InternalClassWithFunctions {
   }
 }
 Pointer<Void> smoke_InternalClassWithFunctions_toFfi(InternalClassWithFunctions value) =>
-  _smoke_InternalClassWithFunctions_copy_handle((value as InternalClassWithFunctions$Impl).handle);
+  _smoke_InternalClassWithFunctions_copy_handle((value as __lib.NativeBase).handle);
 InternalClassWithFunctions smoke_InternalClassWithFunctions_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -25,10 +26,8 @@ final _smoke_InternalClassWithStaticProperty_release_handle = __lib.catchArgumen
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClassWithStaticProperty_release_handle'));
-class InternalClassWithStaticProperty$Impl implements InternalClassWithStaticProperty {
-  @protected
-  Pointer<Void> handle;
-  InternalClassWithStaticProperty$Impl(this.handle);
+class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements InternalClassWithStaticProperty {
+  InternalClassWithStaticProperty$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -59,7 +58,7 @@ class InternalClassWithStaticProperty$Impl implements InternalClassWithStaticPro
   }
 }
 Pointer<Void> smoke_InternalClassWithStaticProperty_toFfi(InternalClassWithStaticProperty value) =>
-  _smoke_InternalClassWithStaticProperty_copy_handle((value as InternalClassWithStaticProperty$Impl).handle);
+  _smoke_InternalClassWithStaticProperty_copy_handle((value as __lib.NativeBase).handle);
 InternalClassWithStaticProperty smoke_InternalClassWithStaticProperty_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -49,9 +50,8 @@ class InternalInterface$Lambdas implements InternalInterface {
   internal_fooBar() =>
     lambda_fooBar();
 }
-class InternalInterface$Impl implements InternalInterface {
-  Pointer<Void> handle;
-  InternalInterface$Impl(this.handle);
+class InternalInterface$Impl extends __lib.NativeBase implements InternalInterface {
+  InternalInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -80,7 +80,7 @@ int _InternalInterface_fooBar_static(int _token) {
   return 0;
 }
 Pointer<Void> smoke_InternalInterface_toFfi(InternalInterface value) {
-  if (value is InternalInterface$Impl) return _smoke_InternalInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_InternalInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_InternalInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
@@ -297,10 +298,8 @@ final _smoke_PublicClass_release_handle = __lib.catchArgumentError(() => __lib.n
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicClass_release_handle'));
-class PublicClass$Impl implements PublicClass {
-  @protected
-  Pointer<Void> handle;
-  PublicClass$Impl(this.handle);
+class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
+  PublicClass$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -372,7 +371,7 @@ class PublicClass$Impl implements PublicClass {
   }
 }
 Pointer<Void> smoke_PublicClass_toFfi(PublicClass value) =>
-  _smoke_PublicClass_copy_handle((value as PublicClass$Impl).handle);
+  _smoke_PublicClass_copy_handle((value as __lib.NativeBase).handle);
 PublicClass smoke_PublicClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
   final token = __lib.ffi_get_cached_token(handle, isolateId);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
@@ -1,3 +1,4 @@
+import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
@@ -96,9 +97,8 @@ final _smoke_PublicInterface_get_type_id = __lib.catchArgumentError(() => __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_get_type_id'));
-class PublicInterface$Impl implements PublicInterface {
-  Pointer<Void> handle;
-  PublicInterface$Impl(this.handle);
+class PublicInterface$Impl extends __lib.NativeBase implements PublicInterface {
+  PublicInterface$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {
     if (handle == null) return;
@@ -109,7 +109,7 @@ class PublicInterface$Impl implements PublicInterface {
   }
 }
 Pointer<Void> smoke_PublicInterface_toFfi(PublicInterface value) {
-  if (value is PublicInterface$Impl) return _smoke_PublicInterface_copy_handle(value.handle);
+  if (value is __lib.NativeBase) return _smoke_PublicInterface_copy_handle((value as __lib.NativeBase).handle);
   final result = _smoke_PublicInterface_create_proxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,


### PR DESCRIPTION
Added internal `NativeBase` class to generated code in Dart. This class serves the same purpose similarly named classes
in Java and Swift generated code already do: providing a single base class to obtain the opaque handle from.

This fixes the runtime issue where declaring an inteface and a child class inheriting from it in IDL, and then passing
an instance of that child class from C++ to Dart and back to C++, created a double-wrapped object on C++ side instead of
correctly resolving into the original C++ object.

Added functional tests that also serve as regression tests for that issue.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>