### PR TITLE
Extract imports and includes collection logic for Dart

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.dart
+
+import com.here.gluecodium.generator.dart.DartImport.ImportType
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.CONVERTER_IMPORT_NAME
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.IMPORT_PATH_NAME
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeStruct
+
+internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolverBase() {
+
+    private val builtInTypesConversionImport = DartImport("$srcPath/${"builtin_types"}__conversion")
+    private val typeRepositoryImport = DartImport("$srcPath/_type_repository", "__lib")
+    private val tokenCacheImport = DartImport("$srcPath/_token_cache", "__lib")
+    private val nativeBaseImport = DartImport("$srcPath/_native_base", "__lib")
+
+    override fun resolveElementImports(limeElement: LimeElement): List<DartImport> =
+        when {
+            limeElement is LimeLambda -> listOf(tokenCacheImport)
+            limeElement is LimeStruct && limeElement.external?.dart == null &&
+                limeElement.attributes.have(LimeAttributeType.EQUATABLE) ->
+                listOf(collectionSystemImport, collectionPackageImport)
+            limeElement is LimeInterface ->
+                listOf(builtInTypesConversionImport, typeRepositoryImport, tokenCacheImport, nativeBaseImport)
+            limeElement is LimeClass &&
+                (limeElement.parent != null || limeElement.visibility.isOpen) ->
+                listOf(builtInTypesConversionImport, typeRepositoryImport, tokenCacheImport, nativeBaseImport)
+            limeElement is LimeClass -> listOf(tokenCacheImport, nativeBaseImport)
+            else -> emptyList()
+        } + listOfNotNull(
+            resolveExternalImport(limeElement, IMPORT_PATH_NAME, useAlias = true),
+            resolveExternalImport(limeElement, CONVERTER_IMPORT_NAME, useAlias = false)
+        )
+
+    companion object {
+        private val collectionSystemImport = DartImport("collection", importType = ImportType.SYSTEM)
+        private val collectionPackageImport = DartImport("collection/collection")
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportsCollector.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.dart
+
+import com.here.gluecodium.generator.common.ImportsCollector
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeTypeAlias
+import com.here.gluecodium.model.lime.LimeTypeHelper
+
+internal class DartDeclarationImportsCollector(
+    private val importResolver: DartDeclarationImportResolver
+) : ImportsCollector<DartImport> {
+
+    override fun collectImports(limeElement: LimeNamedElement): List<DartImport> {
+        val allTypes = LimeTypeHelper.getAllTypes(limeElement).filterNot { it is LimeTypeAlias }
+        return allTypes.flatMap { importResolver.resolveElementImports(it) }
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolverBase.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolverBase.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.dart
+
+import com.here.gluecodium.generator.common.ImportsResolver
+import com.here.gluecodium.generator.dart.DartImport.ImportType
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeNamedElement
+
+internal abstract class DartImportResolverBase : ImportsResolver<DartImport> {
+    protected fun resolveExternalImport(
+        limeElement: LimeElement,
+        key: String,
+        useAlias: Boolean
+    ): DartImport? {
+        val importPath = (limeElement as? LimeNamedElement)?.external?.dart?.get(key) ?: return null
+        val components = importPath.split(':')
+        val alias = if (useAlias) DartNameResolver.computeAlias(importPath) else null
+        return when (components.first()) {
+            "dart" -> DartImport(components.last(), importType = ImportType.SYSTEM, asAlias = alias)
+            "package" -> DartImport(components.last().removeSuffix(".dart"), asAlias = alias)
+            else -> DartImport(
+                components.last().removeSuffix(".dart"),
+                importType = ImportType.RELATIVE,
+                asAlias = alias
+            )
+        }
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportsCollector.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.dart
+
+import com.here.gluecodium.generator.common.ImportsCollector
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeException
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeType
+import com.here.gluecodium.model.lime.LimeTypeAlias
+import com.here.gluecodium.model.lime.LimeTypeHelper
+import com.here.gluecodium.model.lime.LimeTypeRef
+
+internal class DartImportsCollector(private val importResolver: DartImportResolver) : ImportsCollector<DartImport> {
+
+    override fun collectImports(limeElement: LimeNamedElement): List<DartImport> {
+        val allTypes = LimeTypeHelper.getAllTypes(limeElement).filterNot { it is LimeTypeAlias }
+        val parentTypeRefs = listOfNotNull((limeElement as? LimeContainerWithInheritance)?.parent)
+        return (collectTypeRefs(allTypes) + parentTypeRefs).flatMap { importResolver.resolveElementImports(it) }
+    }
+
+    private fun collectTypeRefs(allTypes: List<LimeType>): List<LimeTypeRef> {
+        val classes = allTypes.filterIsInstance<LimeContainerWithInheritance>()
+        val functions = allTypes.filterIsInstance<LimeContainer>().flatMap { it.functions } +
+            classes.flatMap { it.inheritedFunctions }
+        val properties = classes.flatMap { it.properties + it.inheritedProperties }
+        val lambdas = allTypes.filterIsInstance<LimeLambda>()
+        val exceptions = allTypes.filterIsInstance<LimeException>()
+        val structs = allTypes.filterIsInstance<LimeStruct>()
+        return structs.flatMap { it.fields + it.constants }.map { it.typeRef } +
+            functions.flatMap { collectTypeRefs(it) } + properties.map { it.typeRef } +
+            lambdas.flatMap { collectTypeRefs(it.asFunction()) } +
+            exceptions.map { it.errorType }
+    }
+
+    private fun collectTypeRefs(limeFunction: LimeFunction) =
+        limeFunction.parameters.map { it.typeRef } +
+            limeFunction.returnType.typeRef +
+            listOfNotNull(limeFunction.thrownType?.typeRef, limeFunction.exception?.errorType)
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -22,6 +22,7 @@ package com.here.gluecodium.generator.dart
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.generator.common.CommentsProcessor
+import com.here.gluecodium.generator.common.NameHelper
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.NameRules
 import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
@@ -80,6 +81,9 @@ internal class DartNameResolver(
             is LimeType -> resolveTypeRefName(LimeDirectTypeRef(element))
             else -> null
         }
+
+    fun resolveFileName(limeElement: LimeNamedElement) =
+        NameHelper.toLowerSnakeCase(resolveName(limeElement)).replace('<', '_').replace('>', '_')
 
     private fun resolveVisibility(limeVisibility: LimeVisibility) =
         when (limeVisibility) {
@@ -200,9 +204,7 @@ internal class DartNameResolver(
 
     private fun resolveTypeRefName(limeTypeRef: LimeTypeRef): String {
         val typeName = resolveName(limeTypeRef.type)
-        val alias = limeTypeRef.type.actualType.external?.dart?.get(IMPORT_PATH_NAME)?.let {
-            DartImportResolver.computeAlias(it)
-        }
+        val alias = limeTypeRef.type.actualType.external?.dart?.get(IMPORT_PATH_NAME)?.let { computeAlias(it) }
         return listOfNotNull(alias, typeName).joinToString(".")
     }
 
@@ -231,5 +233,7 @@ internal class DartNameResolver(
 
     companion object {
         private val END_OF_SENTENCE = "\\.\\s+".toRegex()
+
+        fun computeAlias(importPath: String) = importPath.split(':').last().split('/').last().split('.').first()
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeCollector.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.ffi
+
+import com.here.gluecodium.generator.common.ImportsCollector
+import com.here.gluecodium.generator.common.Include
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeEnumeration
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeTypeHelper
+
+internal class FfiCppIncludeCollector(val includeResolver: FfiCppIncludeResolver) : ImportsCollector<Include> {
+
+    override fun collectImports(limeElement: LimeNamedElement): List<Include> {
+        val allTypes = LimeTypeHelper.getAllTypes(limeElement)
+
+        val structs = allTypes.filterIsInstance<LimeStruct>()
+        val containers = allTypes.filterIsInstance<LimeContainer>()
+        val functions =
+            containers.flatMap { it.functions } + allTypes.filterIsInstance<LimeLambda>().map { it.asFunction() } +
+                containers.flatMap { it.properties }.flatMap { listOfNotNull(it.getter, it.setter) }
+
+        return includeResolver.resolveElementImports(limeElement) +
+            functions.flatMap { collectTypeRefs(it) }.flatMap { includeResolver.resolveElementImports(it) } +
+            containers.flatMap { includeResolver.resolveElementImports(it) } +
+            structs.flatMap { it.fields }.map { it.typeRef }.flatMap { includeResolver.resolveElementImports(it) } +
+            allTypes.filterIsInstance<LimeEnumeration>().flatMap { includeResolver.resolveElementImports(it) } +
+            allTypes.filterIsInstance<LimeLambda>().flatMap { includeResolver.resolveElementImports(it) }
+    }
+
+    private fun collectTypeRefs(limeFunction: LimeFunction) =
+        limeFunction.parameters.map { it.typeRef } +
+            limeFunction.returnType.typeRef +
+            listOfNotNull(limeFunction.exception?.errorType)
+}


### PR DESCRIPTION
Extracted logic for collecting imports and includes from Dart/FFI generator into dedicated Resolver/Collector classes.
This is a prerequisite step for the following generalization of this logic across different generators.

See: #810
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>