### PR TITLE
Fix missing imports for Swift external types used in collections

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftImportsCollector.kt
@@ -22,11 +22,7 @@ package com.here.gluecodium.generator.swift
 import com.here.gluecodium.common.LimeTypeRefsVisitor
 import com.here.gluecodium.generator.common.ImportsCollector
 import com.here.gluecodium.generator.common.ImportsResolver
-import com.here.gluecodium.model.lime.LimeGenericType
-import com.here.gluecodium.model.lime.LimeList
-import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeNamedElement
-import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeHelper
 import com.here.gluecodium.model.lime.LimeTypeRef
@@ -41,17 +37,9 @@ internal class SwiftImportsCollector(private val importsResolver: ImportsResolve
             .flatMap { importsResolver.resolveElementImports(it) }
     }
 
-    private class ReferredTypesCollector : LimeTypeRefsVisitor<List<LimeType>>() {
-        override fun visitTypeRef(parentElement: LimeNamedElement, limeTypeRef: LimeTypeRef?): List<LimeType> =
-            when (val limeType = limeTypeRef?.type?.actualType) {
-                null -> emptyList()
-                !is LimeGenericType -> listOf(limeType)
-                is LimeList -> listOf(limeType) + visitTypeRef(parentElement, limeType.elementType)
-                is LimeSet -> listOf(limeType) + visitTypeRef(parentElement, limeType.elementType)
-                is LimeMap -> listOf(limeType) + visitTypeRef(parentElement, limeType.keyType) +
-                    visitTypeRef(parentElement, limeType.valueType)
-                else -> emptyList()
-            }
+    private class ReferredTypesCollector : LimeTypeRefsVisitor<List<LimeTypeRef>>() {
+        override fun visitTypeRef(parentElement: LimeNamedElement, limeTypeRef: LimeTypeRef?) =
+            listOfNotNull(limeTypeRef)
 
         fun getAllReferredTypes(types: List<LimeType>) = traverseTypes(types).flatten()
     }

--- a/gluecodium/src/test/resources/smoke/external_types/input/SwiftExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/SwiftExternalTypes.lime
@@ -75,8 +75,8 @@ class UseSwiftExternalTypes {
 }
 
 @Java(Skip) @Dart(Skip)
-typealias ExternalList = List<DateInterval>
+typealias ExternalList = List<PseudoColor>
 @Java(Skip) @Dart(Skip)
-typealias ExternalSet = Set<Persistence>
+typealias ExternalSet = Set<PseudoColor>
 @Java(Skip) @Dart(Skip)
-typealias ExternalMap = Map<Persistence, DateInterval>
+typealias ExternalMap = Map<Persistence, PseudoColor>

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/Collections.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/Collections.swift
@@ -1,59 +1,7 @@
 //
 //
 import Foundation
-internal func foobar_copyFromCType(_ handle: _baseRef) -> [DateInterval] {
-    var result: [DateInterval] = []
-    let count = foobar_ArrayOf_smoke_DateInterval_count(handle)
-    for idx in 0..<count {
-        result.append(copyFromCType(foobar_ArrayOf_smoke_DateInterval_get(handle, idx)))
-    }
-    return result
-}
-internal func foobar_moveFromCType(_ handle: _baseRef) -> [DateInterval] {
-    defer {
-        foobar_ArrayOf_smoke_DateInterval_release_handle(handle)
-    }
-    return foobar_copyFromCType(handle)
-}
-internal func foobar_copyToCType(_ swiftArray: [DateInterval]) -> RefHolder {
-    let handle = foobar_ArrayOf_smoke_DateInterval_create_handle()
-    for item in swiftArray {
-        let _item = moveToCType(item)
-        foobar_ArrayOf_smoke_DateInterval_append(handle, _item.ref)
-    }
-    return RefHolder(handle)
-}
-internal func foobar_moveToCType(_ swiftArray: [DateInterval]) -> RefHolder {
-    return RefHolder(ref: foobar_copyToCType(swiftArray).ref, release: foobar_ArrayOf_smoke_DateInterval_release_handle)
-}
-internal func foobar_copyToCType(_ swiftArray: [DateInterval]?) -> RefHolder {
-    guard let swiftArray = swiftArray else {
-        return RefHolder(0)
-    }
-    let optionalHandle = foobar_ArrayOf_smoke_DateInterval_create_optional_handle()
-    let handle = foobar_ArrayOf_smoke_DateInterval_unwrap_optional_handle(optionalHandle)
-    for item in swiftArray {
-        let _item = moveToCType(item)
-        foobar_ArrayOf_smoke_DateInterval_append(handle, _item.ref)
-    }
-    return RefHolder(optionalHandle)
-}
-internal func foobar_moveToCType(_ swiftType: [DateInterval]?) -> RefHolder {
-    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: foobar_ArrayOf_smoke_DateInterval_release_optional_handle)
-}
-internal func foobar_copyFromCType(_ handle: _baseRef) -> [DateInterval]? {
-    guard handle != 0 else {
-        return nil
-    }
-    let unwrappedHandle = foobar_ArrayOf_smoke_DateInterval_unwrap_optional_handle(handle)
-    return foobar_copyFromCType(unwrappedHandle) as [DateInterval]
-}
-internal func foobar_moveFromCType(_ handle: _baseRef) -> [DateInterval]? {
-    defer {
-        foobar_ArrayOf_smoke_DateInterval_release_optional_handle(handle)
-    }
-    return foobar_copyFromCType(handle)
-}
+import UIKit
 internal func foobar_copyFromCType(_ handle: _baseRef) -> [Int8] {
     var result: [Int8] = []
     let count = foobar_ArrayOf__Byte_count(handle)
@@ -157,6 +105,59 @@ internal func foobar_copyFromCType(_ handle: _baseRef) -> [String]? {
 internal func foobar_moveFromCType(_ handle: _baseRef) -> [String]? {
     defer {
         foobar_ArrayOf__String_release_optional_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> [UIColor] {
+    var result: [UIColor] = []
+    let count = foobar_ArrayOf_smoke_UIColor_count(handle)
+    for idx in 0..<count {
+        result.append(copyFromCType(foobar_ArrayOf_smoke_UIColor_get(handle, idx)))
+    }
+    return result
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> [UIColor] {
+    defer {
+        foobar_ArrayOf_smoke_UIColor_release_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyToCType(_ swiftArray: [UIColor]) -> RefHolder {
+    let handle = foobar_ArrayOf_smoke_UIColor_create_handle()
+    for item in swiftArray {
+        let _item = moveToCType(item)
+        foobar_ArrayOf_smoke_UIColor_append(handle, _item.ref)
+    }
+    return RefHolder(handle)
+}
+internal func foobar_moveToCType(_ swiftArray: [UIColor]) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftArray).ref, release: foobar_ArrayOf_smoke_UIColor_release_handle)
+}
+internal func foobar_copyToCType(_ swiftArray: [UIColor]?) -> RefHolder {
+    guard let swiftArray = swiftArray else {
+        return RefHolder(0)
+    }
+    let optionalHandle = foobar_ArrayOf_smoke_UIColor_create_optional_handle()
+    let handle = foobar_ArrayOf_smoke_UIColor_unwrap_optional_handle(optionalHandle)
+    for item in swiftArray {
+        let _item = moveToCType(item)
+        foobar_ArrayOf_smoke_UIColor_append(handle, _item.ref)
+    }
+    return RefHolder(optionalHandle)
+}
+internal func foobar_moveToCType(_ swiftType: [UIColor]?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: foobar_ArrayOf_smoke_UIColor_release_optional_handle)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> [UIColor]? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = foobar_ArrayOf_smoke_UIColor_unwrap_optional_handle(handle)
+    return foobar_copyFromCType(unwrappedHandle) as [UIColor]
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> [UIColor]? {
+    defer {
+        foobar_ArrayOf_smoke_UIColor_release_optional_handle(handle)
     }
     return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/Dictionaries.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/Dictionaries.swift
@@ -1,59 +1,60 @@
 import Foundation
-internal func foobar_copyFromCType(_ handle: _baseRef) -> [URLCredential.Persistence: DateInterval] {
-    var swiftDict: [URLCredential.Persistence: DateInterval] = [:]
-    let iterator_handle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator(handle)
-    while foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_is_valid(handle, iterator_handle) {
-        swiftDict[moveFromCType(foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_key(iterator_handle))] =
-            moveFromCType(foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_value(iterator_handle)) as DateInterval
-        foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_increment(iterator_handle)
+import UIKit
+internal func foobar_copyFromCType(_ handle: _baseRef) -> [URLCredential.Persistence: UIColor] {
+    var swiftDict: [URLCredential.Persistence: UIColor] = [:]
+    let iterator_handle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_iterator(handle)
+    while foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_iterator_is_valid(handle, iterator_handle) {
+        swiftDict[moveFromCType(foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_iterator_key(iterator_handle))] =
+            moveFromCType(foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_iterator_value(iterator_handle)) as UIColor
+        foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_iterator_increment(iterator_handle)
     }
-    foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_iterator_release_handle(iterator_handle)
+    foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_iterator_release_handle(iterator_handle)
     return swiftDict
 }
-internal func foobar_moveFromCType(_ handle: _baseRef) -> [URLCredential.Persistence: DateInterval] {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> [URLCredential.Persistence: UIColor] {
     defer {
-        foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_release_handle(handle)
+        foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_release_handle(handle)
     }
     return foobar_copyFromCType(handle)
 }
-internal func foobar_copyToCType(_ swiftDict: [URLCredential.Persistence: DateInterval]) -> RefHolder {
-    let c_handle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_create_handle()
+internal func foobar_copyToCType(_ swiftDict: [URLCredential.Persistence: UIColor]) -> RefHolder {
+    let c_handle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_create_handle()
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
         let c_value = moveToCType(value)
-        foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_put(c_handle, c_key.ref, c_value.ref)
+        foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_put(c_handle, c_key.ref, c_value.ref)
     }
     return RefHolder(c_handle)
 }
-internal func foobar_moveToCType(_ swiftDict: [URLCredential.Persistence: DateInterval]) -> RefHolder {
-    return RefHolder(ref: foobar_copyToCType(swiftDict).ref, release: foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_release_handle)
+internal func foobar_moveToCType(_ swiftDict: [URLCredential.Persistence: UIColor]) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftDict).ref, release: foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_release_handle)
 }
-internal func foobar_copyFromCType(_ handle: _baseRef) -> [URLCredential.Persistence: DateInterval]? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> [URLCredential.Persistence: UIColor]? {
     guard handle != 0 else {
         return nil
     }
-    let unwrappedHandle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_unwrap_optional_handle(handle)
-    return foobar_copyFromCType(unwrappedHandle) as [URLCredential.Persistence: DateInterval]
+    let unwrappedHandle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_unwrap_optional_handle(handle)
+    return foobar_copyFromCType(unwrappedHandle) as [URLCredential.Persistence: UIColor]
 }
-internal func foobar_moveFromCType(_ handle: _baseRef) -> [URLCredential.Persistence: DateInterval]? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> [URLCredential.Persistence: UIColor]? {
     defer {
-        foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_release_optional_handle(handle)
+        foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_release_optional_handle(handle)
     }
     return foobar_copyFromCType(handle)
 }
-internal func foobar_copyToCType(_ swiftDict: [URLCredential.Persistence: DateInterval]?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftDict: [URLCredential.Persistence: UIColor]?) -> RefHolder {
     guard let swiftDict = swiftDict else {
         return RefHolder(0)
     }
-    let optionalHandle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_create_optional_handle()
-    let handle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_unwrap_optional_handle(optionalHandle)
+    let optionalHandle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_create_optional_handle()
+    let handle = foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_unwrap_optional_handle(optionalHandle)
     for (key, value) in swiftDict {
         let c_key = moveToCType(key)
         let c_value = moveToCType(value)
-        foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_put(handle, c_key.ref, c_value.ref)
+        foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_put(handle, c_key.ref, c_value.ref)
     }
     return RefHolder(optionalHandle)
 }
-internal func foobar_moveToCType(_ swiftType: [URLCredential.Persistence: DateInterval]?) -> RefHolder {
-    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_DateInterval_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: [URLCredential.Persistence: UIColor]?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: foobar_MapOf_smoke_URLCredential_1Persistence_To_smoke_UIColor_release_optional_handle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/Sets.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/Sets.swift
@@ -1,58 +1,59 @@
 //
 //
 import Foundation
-internal func foobar_copyFromCType(_ handle: _baseRef) -> Set<URLCredential.Persistence> {
-    var result: Set<URLCredential.Persistence> = []
-    let iterator_handle = foobar_SetOf_smoke_URLCredential_1Persistence_iterator(handle)
-    while foobar_SetOf_smoke_URLCredential_1Persistence_iterator_is_valid(handle, iterator_handle) {
-        result.insert(copyFromCType(foobar_SetOf_smoke_URLCredential_1Persistence_iterator_get(iterator_handle)))
-        foobar_SetOf_smoke_URLCredential_1Persistence_iterator_increment(iterator_handle)
+import UIKit
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Set<UIColor> {
+    var result: Set<UIColor> = []
+    let iterator_handle = foobar_SetOf_smoke_UIColor_iterator(handle)
+    while foobar_SetOf_smoke_UIColor_iterator_is_valid(handle, iterator_handle) {
+        result.insert(copyFromCType(foobar_SetOf_smoke_UIColor_iterator_get(iterator_handle)))
+        foobar_SetOf_smoke_UIColor_iterator_increment(iterator_handle)
     }
-    foobar_SetOf_smoke_URLCredential_1Persistence_iterator_release_handle(iterator_handle)
+    foobar_SetOf_smoke_UIColor_iterator_release_handle(iterator_handle)
     return result
 }
-internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<URLCredential.Persistence> {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<UIColor> {
     defer {
-        foobar_SetOf_smoke_URLCredential_1Persistence_release_handle(handle)
+        foobar_SetOf_smoke_UIColor_release_handle(handle)
     }
     return foobar_copyFromCType(handle)
 }
-internal func foobar_copyToCType(_ swiftSet: Set<URLCredential.Persistence>) -> RefHolder {
-    let handle = foobar_SetOf_smoke_URLCredential_1Persistence_create_handle()
+internal func foobar_copyToCType(_ swiftSet: Set<UIColor>) -> RefHolder {
+    let handle = foobar_SetOf_smoke_UIColor_create_handle()
     for item in swiftSet {
         let _item = moveToCType(item)
-        foobar_SetOf_smoke_URLCredential_1Persistence_insert(handle, _item.ref)
+        foobar_SetOf_smoke_UIColor_insert(handle, _item.ref)
     }
     return RefHolder(handle)
 }
-internal func foobar_moveToCType(_ swiftSet: Set<URLCredential.Persistence>) -> RefHolder {
-    return RefHolder(ref: foobar_copyToCType(swiftSet).ref, release: foobar_SetOf_smoke_URLCredential_1Persistence_release_handle)
+internal func foobar_moveToCType(_ swiftSet: Set<UIColor>) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftSet).ref, release: foobar_SetOf_smoke_UIColor_release_handle)
 }
-internal func foobar_copyToCType(_ swiftSet: Set<URLCredential.Persistence>?) -> RefHolder {
+internal func foobar_copyToCType(_ swiftSet: Set<UIColor>?) -> RefHolder {
     guard let swiftSet = swiftSet else {
         return RefHolder(0)
     }
-    let optionalHandle = foobar_SetOf_smoke_URLCredential_1Persistence_create_optional_handle()
-    let handle = foobar_SetOf_smoke_URLCredential_1Persistence_unwrap_optional_handle(optionalHandle)
+    let optionalHandle = foobar_SetOf_smoke_UIColor_create_optional_handle()
+    let handle = foobar_SetOf_smoke_UIColor_unwrap_optional_handle(optionalHandle)
     for item in swiftSet {
         let _item = moveToCType(item)
-        foobar_SetOf_smoke_URLCredential_1Persistence_insert(handle, _item.ref)
+        foobar_SetOf_smoke_UIColor_insert(handle, _item.ref)
     }
     return RefHolder(optionalHandle)
 }
-internal func foobar_moveToCType(_ swiftType: Set<URLCredential.Persistence>?) -> RefHolder {
-    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: foobar_SetOf_smoke_URLCredential_1Persistence_release_optional_handle)
+internal func foobar_moveToCType(_ swiftType: Set<UIColor>?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: foobar_SetOf_smoke_UIColor_release_optional_handle)
 }
-internal func foobar_copyFromCType(_ handle: _baseRef) -> Set<URLCredential.Persistence>? {
+internal func foobar_copyFromCType(_ handle: _baseRef) -> Set<UIColor>? {
     guard handle != 0 else {
         return nil
     }
-    let unwrappedHandle = foobar_SetOf_smoke_URLCredential_1Persistence_unwrap_optional_handle(handle)
-    return foobar_copyFromCType(unwrappedHandle) as Set<URLCredential.Persistence>
+    let unwrappedHandle = foobar_SetOf_smoke_UIColor_unwrap_optional_handle(handle)
+    return foobar_copyFromCType(unwrappedHandle) as Set<UIColor>
 }
-internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<URLCredential.Persistence>? {
+internal func foobar_moveFromCType(_ handle: _baseRef) -> Set<UIColor>? {
     defer {
-        foobar_SetOf_smoke_URLCredential_1Persistence_release_optional_handle(handle)
+        foobar_SetOf_smoke_UIColor_release_optional_handle(handle)
     }
     return foobar_copyFromCType(handle)
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalMap.swift
+++ b/gluecodium/src/test/resources/smoke/external_types/output/swift/smoke/ExternalMap.swift
@@ -1,0 +1,5 @@
+//
+//
+import Foundation
+import UIKit
+public typealias ExternalMap = [URLCredential.Persistence: UIColor]


### PR DESCRIPTION
Updated Swift resolution and collection logic for external types imports to properly include such imports in collection
conversion files.

Updated related smoke test to better cover this use case.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>