### PR TITLE
Fix missing imports for constants in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed missing imports for constants in Dart.
+
 ## 9.0.0
 Release date: 2021-05-05
 ### Features:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/GenericImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/GenericImportsCollector.kt
@@ -55,7 +55,10 @@ internal class GenericImportsCollector<T>(
             if (collectTypeAliasImports)
                 allTypes.filterIsInstance<LimeTypeAlias>().flatMap { importsResolver.resolveElementImports(it.typeRef) }
             else emptyList()
-        return typeRefImports + ownImports + parentImports + typeAliasImports
+        val constantImports = allTypes.filterIsInstance<LimeContainer>().flatMap { it.constants }
+            .flatMap { importsResolver.resolveElementImports(it) }
+
+        return typeRefImports + ownImports + parentImports + typeAliasImports + constantImports
     }
 
     private fun collectTypeRefs(allTypes: List<LimeType>): List<LimeTypeRef> {
@@ -65,7 +68,7 @@ internal class GenericImportsCollector<T>(
         val lambdas = allTypes.filterIsInstance<LimeLambda>()
         val exceptions = allTypes.filterIsInstance<LimeException>()
         val structs = allTypes.filterIsInstance<LimeStruct>()
-        return structs.flatMap { it.fields + it.constants }.map { it.typeRef } +
+        return structs.flatMap { it.fields }.map { it.typeRef } +
             functions.flatMap { collectTypeRefs(it) } + properties.map { it.typeRef } +
             lambdas.flatMap { collectTypeRefs(it.asFunction()) } +
             exceptions.map { it.errorType }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeResolver.kt
@@ -28,6 +28,7 @@ import com.here.gluecodium.generator.cpp.CppLibraryIncludes
 import com.here.gluecodium.generator.cpp.CppNameRules
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId
+import com.here.gluecodium.model.lime.LimeConstant
 import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeElement
@@ -53,7 +54,7 @@ internal class FfiCppIncludeResolver(
     override fun resolveElementImports(limeElement: LimeElement): List<Include> =
         when (limeElement) {
             is LimeTypeRef -> getTypeRefIncludes(limeElement)
-            is LimeTypesCollection, is LimeException, is LimeTypeAlias -> emptyList()
+            is LimeTypesCollection, is LimeException, is LimeTypeAlias, is LimeConstant -> emptyList()
             is LimeInterface -> getTypeIncludes(limeElement) + getThrownTypeIncludes(limeElement) +
                 getContainerIncludes(limeElement) + proxyIncludes
             is LimeContainer -> getTypeIncludes(limeElement) + getContainerIncludes(limeElement)

--- a/gluecodium/src/test/resources/smoke/constants/input/Constants.lime
+++ b/gluecodium/src/test/resources/smoke/constants/input/Constants.lime
@@ -66,3 +66,8 @@ class CollectionConstants {
     const mapConstant: Map<String, String> = ["foo": "bar"]
     const mixedConstant: Map<List<String>, Set<String>> = [["foo"]: ["bar"]]
 }
+
+@Java(Skip) @Swift(Skip)
+types CrossFileConstants {
+    const fooBar: Constants.StateEnum = Constants.StateEnum.ON
+}

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/cross_file_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/cross_file_constants.dart
@@ -1,0 +1,6 @@
+import 'package:library/src/smoke/constants.dart';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+final StateEnum fooBar = StateEnum.on;


### PR DESCRIPTION
Updated GenericImportsCollector to properly collect imports for constants. Updated DartImportResolver to resolve imports
for constants. As the constants do not require conversion imports, refactored the existing type/typeRef import
resolution logic to separate conversion and non-conversion imports into two separate functions.

Added a dedicated test case for the "constants" smoke test.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>