### PR TITLE
Add Dart overloads validation for structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed missing imports for constants in Dart.
+  * Added missing Dart overloads validation for functions/constructors of structs.
 
 ## 9.0.0
 Release date: 2021-05-05

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartOverloadsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartOverloadsValidator.kt
@@ -22,6 +22,7 @@ package com.here.gluecodium.generator.dart
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.model.lime.LimeAttributeType.DART
 import com.here.gluecodium.model.lime.LimeAttributeValueType.DEFAULT
+import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeNamedElement
@@ -38,15 +39,14 @@ internal class DartOverloadsValidator(
         if (werror) LimeLogger::error else LimeLogger::warning
 
     fun validate(limeElements: List<LimeNamedElement>): Boolean {
-        val validationResults = limeElements
-            .filterIsInstance<LimeContainerWithInheritance>()
-            .map { validateContainer(it) }
+        val validationResults = limeElements.filterIsInstance<LimeContainer>().map { validateContainer(it) }
 
         return !werror || !validationResults.contains(false)
     }
 
-    private fun validateContainer(limeContainer: LimeContainerWithInheritance): Boolean {
-        val allFunctions = limeContainer.functions + limeContainer.inheritedFunctions
+    private fun validateContainer(limeContainer: LimeContainer): Boolean {
+        val allFunctions = limeContainer.functions +
+            ((limeContainer as? LimeContainerWithInheritance)?.inheritedFunctions ?: emptyList())
         val constructors = allFunctions.filter { it.isConstructor }
 
         val overloadedFunctions = (allFunctions - constructors)

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/dart/DartOverloadsValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/dart/DartOverloadsValidatorTest.kt
@@ -23,33 +23,36 @@ import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeAttributes
 import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimePath
+import com.here.gluecodium.model.lime.LimeStruct
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
+import org.junit.runners.Parameterized
 
-@RunWith(JUnit4::class)
-class DartOverloadsValidatorTest {
+@RunWith(Parameterized::class)
+class DartOverloadsValidatorTest(factory: (List<LimeFunction>) -> LimeContainer, private val hasConstructors: Boolean) {
 
     private val fooFunction = LimeFunction(LimePath.EMPTY_PATH)
     private val barFunction = LimeFunction(LimePath.EMPTY_PATH)
     private val fooConstructor = LimeFunction(LimePath.EMPTY_PATH, isConstructor = true)
     private val barConstructor = LimeFunction(LimePath.EMPTY_PATH, isConstructor = true)
     private val functions = mutableListOf<LimeFunction>()
-    private val limeClass = LimeClass(LimePath.EMPTY_PATH, functions = functions)
     private val dartDefaultAttributes = LimeAttributes.Builder()
         .addAttribute(LimeAttributeType.DART, LimeAttributeValueType.DEFAULT)
         .build()
 
-    private val allElements = listOf(limeClass)
+    private val allElements = listOf(factory(functions))
 
     @MockK private lateinit var nameResolver: DartNameResolver
 
@@ -83,6 +86,8 @@ class DartOverloadsValidatorTest {
 
     @Test
     fun validateConstructorsNoOverloads() {
+        assumeTrue(hasConstructors)
+
         every { nameResolver.resolveName(fooConstructor) } returns "foo"
         every { nameResolver.resolveName(barConstructor) } returns "bar"
         functions += fooConstructor
@@ -93,6 +98,8 @@ class DartOverloadsValidatorTest {
 
     @Test
     fun validateConstructorsWithOverloads() {
+        assumeTrue(hasConstructors)
+
         every { nameResolver.resolveName(fooConstructor) } returns "foo"
         every { nameResolver.resolveName(barConstructor) } returns "foo"
         functions += fooConstructor
@@ -103,6 +110,8 @@ class DartOverloadsValidatorTest {
 
     @Test
     fun validateDefaultConstructorsNoOverloads() {
+        assumeTrue(hasConstructors)
+
         val fooDefaultConstructor = LimeFunction(
             LimePath.EMPTY_PATH,
             isConstructor = true,
@@ -118,6 +127,8 @@ class DartOverloadsValidatorTest {
 
     @Test
     fun validateDefaultConstructorsWithOverloads() {
+        assumeTrue(hasConstructors)
+
         val fooDefaultConstructor = LimeFunction(
             LimePath.EMPTY_PATH,
             isConstructor = true,
@@ -134,5 +145,15 @@ class DartOverloadsValidatorTest {
         functions += barDefaultConstructor
 
         assertFalse(validator.validate(allElements))
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun testData(): Collection<Array<Any>> = listOf(
+            arrayOf({ functions: List<LimeFunction> -> LimeClass(LimePath.EMPTY_PATH, functions = functions) }, true),
+            arrayOf({ functions: List<LimeFunction> -> LimeInterface(LimePath.EMPTY_PATH, functions = functions) }, false),
+            arrayOf({ functions: List<LimeFunction> -> LimeStruct(LimePath.EMPTY_PATH, functions = functions) }, true)
+        )
     }
 }


### PR DESCRIPTION
Updated DartOverloadsValidator to traverse structs, not just classes and interfaces as before. Added corresponding unit
tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>